### PR TITLE
selected_company fixes, take 3

### DIFF
--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -189,7 +189,10 @@ module View
 
         case @role
         when :map
-          return process_action(Engine::Action::Assign.new(@entity, target: @hex)) if @actions.include?('assign')
+          if @actions.include?('assign')
+            process_action(Engine::Action::Assign.new(@entity, target: @hex))
+            return store(:selected_company, nil, skip: true)
+          end
 
           step = @game.round.active_step
           if @actions.include?('remove_hex_token') && @hex.tokens.find { |t| t.corporation == @entity }

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -26,6 +26,7 @@ module View
     module Round
       class Operating < Snabberb::Component
         needs :game
+        needs :selected_company, default: nil, store: true
 
         def render
           round = @game.round
@@ -34,6 +35,12 @@ module View
           @current_actions = round.actions_for(entity)
 
           entity = entity.owner if entity.company? && !round.active_entities.one?
+
+          if !entity.company? &&
+             @game.purchasable_companies(entity).empty? &&
+             !@game.abilities(@selected_company)
+            store(:selected_company, nil, skip: true)
+          end
 
           convert_track = @step.respond_to?(:conversion?) && @step.conversion?
 
@@ -108,7 +115,7 @@ module View
 
               @step.assignable_corporations(company).each do |corporation|
                 component = View::Game::Corporation.new(@root, corporation: corporation, selected_company: company)
-                component.store(:selected_company, company, skip: true)
+                store(:selected_company, company, skip: true)
                 left << h(:div, props, [component.render])
               end
             end

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -133,7 +133,6 @@ module View
 
           if n_id == o_id + 1
             game_data['actions'] << data
-            store(:selected_company, nil, skip: true)
             store(:game_data, game_data, skip: true)
             store(:game, game.process_action(data))
           else

--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -983,6 +983,12 @@ module Engine
 
           false
         end
+
+        def purchasable_companies(entity = nil)
+          return [] if entity&.minor?
+
+          super
+        end
       end
     end
   end


### PR DESCRIPTION
Previous attempts:

* take 1: #9527 - cleared `selected_company` when processing action made by another player, regardless of the action type

* take 2: #9573 - intended to clear `selected_company` when rendering after every action, but also did it on other UI interactions, most notably attempting to select a company; so a company would be selected and immediately cleared, breaking a lot of things (#9574, #9576), so this was reverted in ddcfd9f

Manually tested here:

* 1822 bidding no longer disrupted by chat messages from opponents (fixes #9563)

* 1846 steamboat assignment working (verifies #5604 still ok)

* companies can still be bought (verifies #9574 still ok)

* company blocking/track laying works as expected (verifies #9576 still ok)

* tested the different views that update the `store`'s `:selected_company`, and tested views wherever `abilities()` is called with the `@selected_company` passed in, such as with abilities of type `:exchange` or `:borrow_train`; tested int titles: 1822, 1830, 1846, 1848, 1856, 1861, 1868 Wyoming, TOP 1871
