### PR TITLE
[18Tokaido] beta candidate; adds waterfall optional rule

### DIFF
--- a/lib/engine/game/g_18_tokaido/meta.rb
+++ b/lib/engine/game/g_18_tokaido/meta.rb
@@ -8,11 +8,11 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :alpha
+        DEV_STAGE = :beta
         PROTOTYPE = true
         DEPENDS_ON = '18 Los Angeles'
 
-        GAME_TITLE = '18 Tokaido'
+        GAME_TITLE = '18Tokaido'
         GAME_ISSUE_LABEL = '18Tokaido'
         GAME_DESIGNER = 'Douglas Triggs'
         GAME_LOCATION = 'Central Japan'
@@ -38,6 +38,11 @@ module Engine
             sym: :limited_express,
             short_name: 'Limited Express',
             desc: 'removes one of the 6 trains from the game',
+          },
+          {
+            sym: :waterfall_auction,
+            short_name: 'Waterfall Auction',
+            desc: 'standard waterfall auction instead of snake draft',
           },
         ].freeze
       end


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

- Moves 18Tokaido to beta.
- Adds a variant that uses the regular waterfall auction rather than the snake draft
- Changes name of to remove the space from '18 Tokaido' -- don't _think_ this will break anything.  There don't seem to be any games currently in progress anyway.
