### PR TITLE
Bugfix/18 gb prevent corporations floating when converted to 10 share

### DIFF
--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -611,9 +611,10 @@ module Engine
         end
 
         def convert_to_ten_share(corporation, price_drops = 0, blame_president = false)
-          # Check if the corporation is floated. Conversion does not affect this status so store the result
+          # Check if the corporation is floated.
+          # Conversion should never affect this status so store the result rather than re-checking later.
           floated = corporation.floated?
-          
+
           # update corporation type and report conversion
           corporation.type = :'10-share'
           @log << (if blame_president

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -611,6 +611,9 @@ module Engine
         end
 
         def convert_to_ten_share(corporation, price_drops = 0, blame_president = false)
+          # Check if the corporation is floated. Conversion does not affect this status so store the result
+          floated = corporation.floated?
+          
           # update corporation type and report conversion
           corporation.type = :'10-share'
           @log << (if blame_president
@@ -627,7 +630,7 @@ module Engine
           original_shares.each { |s| corporation.share_holders[s.owner] += s.percent }
 
           # create new shares
-          owner = corporation.floated? ? @share_pool : corporation
+          owner = floated ? @share_pool : corporation
           shares = Array.new(5) { |i| Share.new(corporation, percent: 10, index: i + 4, owner: owner) }
           shares.each do |share|
             add_new_share(share)
@@ -649,7 +652,7 @@ module Engine
           end
 
           # add new capital
-          return unless corporation.floated?
+          return unless floated
 
           capital = corporation.share_price.price * 5
           @bank.spend(capital, corporation)


### PR DESCRIPTION
Fixes #9583

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* This is a small change that fixes a bug in 18GB where unfloated corporations would be incorrectly floated when converted to 10-share corporations from 5-share. The root cause was doing a float check after converting the 5-share shares from 20% -> 10% each and then checking if the corp was floated. The existence of only 50% worth of shares at the time of the check caused any unfloated corps to be floated. The simple fix for this was to check the float status at the beginning of the conversion and store the result because conversion should never result in a changed status.