### PR TITLE
Changed interface messages: end of game description and choice explanations

### DIFF
--- a/assets/app/view/game/choose.rb
+++ b/assets/app/view/game/choose.rb
@@ -55,6 +55,10 @@ module View
         div_class = choice_buttons.size < 5 ? '.inline' : ''
         children << h("div#{div_class}", { style: { marginTop: '0.5rem' } }, "#{step.choice_name}: ") if step.choice_name
         children << h(:div, choice_buttons)
+        if step.respond_to?(:choice_explanation) && (explanation = step.choice_explanation)
+          paragraphs = explanation.map { |text_block| h(:p, text_block) }
+          children << h(:div, { style: { marginTop: '0.5rem' } }, paragraphs)
+        end
         h(:div, children)
       end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2653,7 +2653,11 @@ module Engine
                            " : Game Ends at conclusion of this round (#{turn})"
                          end
                        when :current_or
-                         " : Game Ends at conclusion of this OR (#{turn}.#{@round.round_num})"
+                         if @round.is_a?(Round::Operating)
+                           " : Game Ends at conclusion of this OR (#{turn}.#{@round.round_num})"
+                         else
+                           " : Game Ends at conclusion of the next OR (#{turn}.#{@round.round_num})"
+                         end
                        when :full_or
                          if @round.is_a?(Round::Operating)
                            " : Game Ends at conclusion of #{round_end.short_name} #{turn}.#{operating_rounds}"

--- a/lib/engine/game/g_1858/step/private_closure.rb
+++ b/lib/engine/game/g_1858/step/private_closure.rb
@@ -42,6 +42,21 @@ module Engine
             "Exchange #{current_entity.id} for a share"
           end
 
+          def choice_explanation
+            [
+              'To exchange for a treasury share you need the approval of the ' \
+              'public company’s president.',
+
+              'If a public company has both ' \
+              'treasury and market shares available, then you can only ' \
+              'exchange for a market share if you have first requested the ' \
+              'exchange for a treasury share.',
+
+              'If a public company only has ' \
+              'market shares available then you do not need approval.',
+            ]
+          end
+
           def choices
             choices = {}
             exchange_corporations(current_entity).each do |corporation|


### PR DESCRIPTION
This is two unrelated changes to messages shown to players:

## Game end message for `:current_or` timing

For a game with a game end timing of `:current_or`, if the bank breaks during a stock round you finish the stock round and play one operating round. But the game end message is a bit confusing during the stock round, it says something like:

> Stock Round 7 - Sell then Buy Shares - Bank Broken : Game Ends at conclusion of this OR (7.1)

This changes the message to say 'the next OR' if we are not already in an operating round.


## Extra explanatory text for Choice groups

This allows extra text to be shown underneath a group of Choice buttons. If the step has `choice_explanation` method that returns an array of strings then these will be added, with a `<p>` element for each string.

![image](https://github.com/tobymao/18xx/assets/11144854/378f11db-2b3a-4236-8b09-851bbafba7ff)
git