### PR TITLE
[1868 Wyoming] fix auction sometimes blocking the company choice

### DIFF
--- a/lib/engine/game/g_1868_wy/step/waterfall_auction.rb
+++ b/lib/engine/game/g_1868_wy/step/waterfall_auction.rb
@@ -145,6 +145,11 @@ module Engine
             super
             maybe_all_passed!
           end
+
+          # if @choosing, the company is already paid for
+          def min_bid(company)
+            @choosing && @company_choices.include?(company) ? 0 : super
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #9591

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`