### PR TITLE
Don't return `nil` in methods returning rendered items

### DIFF
--- a/assets/app/view/game/bank.rb
+++ b/assets/app/view/game/bank.rb
@@ -105,7 +105,7 @@ module View
           ])
         end
 
-        return if trs.empty?
+        return '' if trs.empty?
 
         h('div#bank.card', [
           h('div.title', title_props, 'The Bank'),

--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -371,7 +371,7 @@ module View
 
       def render_warranty(depot_trains)
         @warranty_input = nil
-        return if depot_trains.empty? || !@step.respond_to?(:warranty_max)
+        return [] if depot_trains.empty? || !@step.respond_to?(:warranty_max)
 
         @warranty_input =
           h(

--- a/assets/app/view/game/corporate_buy_shares.rb
+++ b/assets/app/view/game/corporate_buy_shares.rb
@@ -43,7 +43,7 @@ module View
       end
 
       def render_player_input(player)
-        return unless @step.current_actions.include?('corporate_buy_shares')
+        return '' unless @step.current_actions.include?('corporate_buy_shares')
 
         input = player.shares.group_by(&:corporation).values.map do |corp_shares|
           render_buttons(corp_shares.reject(&:president).group_by(&:percent).values.map(&:first),
@@ -54,7 +54,7 @@ module View
       end
 
       def render_corporation_input(corporation)
-        return unless @step.current_actions.include?('corporate_buy_shares')
+        return '' unless @step.current_actions.include?('corporate_buy_shares')
 
         pool_shares = @game.share_pool.shares_by_corporation[corporation].group_by(&:percent).values.map(&:first)
         input = [render_buttons(pool_shares)].compact

--- a/assets/app/view/game/flexible_buy.rb
+++ b/assets/app/view/game/flexible_buy.rb
@@ -56,7 +56,7 @@ module View
             price = input.JS['elm'].JS['value'].to_i
             price_percent = bundle.corporation.type == :major ? 10 : 20
             share_price = (price * price_percent / bundle.percent).to_i
-            return unless @step.flexible_can_buy_shares?(@current_entity, bundle.shares, price)
+            return '' unless @step.flexible_can_buy_shares?(@current_entity, bundle.shares, price)
 
             buy_shares = lambda do
               process_action(

--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -18,7 +18,7 @@ module View
         @depot = @game.depot
         @dimmed_font_style = { style: { color: convert_hex_to_rgba(color_for(:font), 0.7) } }
 
-        return if @layout && @depot.trains.empty?
+        return '' if @layout && @depot.trains.empty?
 
         case @layout
         when :discarded_trains

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -44,7 +44,7 @@ module View
       needs :highlight, default: false
 
       def render
-        return nil if @hex.empty
+        return '' if @hex.empty
 
         @selected = @hex == @tile_selector&.hex || @selected_route&.last_node&.hex == @hex
         @tile =

--- a/assets/app/view/game/issue_shares.rb
+++ b/assets/app/view/game/issue_shares.rb
@@ -53,7 +53,7 @@ module View
           end
         end
 
-        return nil if shares.empty?
+        return '' if shares.empty?
 
         h(:div, [
           h('div.inline-block.margined', description),

--- a/assets/app/view/game/map_controls.rb
+++ b/assets/app/view/game/map_controls.rb
@@ -68,14 +68,14 @@ module View
       end
 
       def route_controls
-        return unless @game
+        return '' unless @game
 
         step = @game.round.active_step
         actions = step&.actions(step&.current_entity) || []
         # Route controls are disabled during dividend and run routes step
         if (%w[run_routes dividend] & actions).any?
           store(:historical_routes, []) if @historical_routes.any?
-          return
+          return ''
         end
 
         all_operators = @game.operated_operators

--- a/assets/app/view/game/par_chart.rb
+++ b/assets/app/view/game/par_chart.rb
@@ -29,7 +29,7 @@ module View
       end
 
       def par_choices
-        return unless @corporation_to_par
+        return '' unless @corporation_to_par
 
         props = {
           style: {

--- a/assets/app/view/game/round/unordered.rb
+++ b/assets/app/view/game/round/unordered.rb
@@ -29,7 +29,7 @@ module View
         end
 
         def render_offers
-          return nil if (offers = @step.offers).empty?
+          return '' if (offers = @step.offers).empty?
 
           section_props = {
             style: {

--- a/assets/app/view/game/scrap_trains.rb
+++ b/assets/app/view/game/scrap_trains.rb
@@ -13,7 +13,7 @@ module View
         @step = @game.round.step_for(@corporation, 'scrap_train')
 
         scrappable_trains = @step.scrappable_trains(@corporation)
-        return nil if scrappable_trains.empty?
+        return '' if scrappable_trains.empty?
 
         if @step.respond_to?(:scrap_trains_button_only?) && @step.scrap_trains_button_only?
           render_buttons(scrappable_trains)

--- a/assets/app/view/game/tranches.rb
+++ b/assets/app/view/game/tranches.rb
@@ -10,7 +10,7 @@ module View
       needs :game
 
       def render
-        return nil unless @game.respond_to?(:tranches)
+        return '' unless @game.respond_to?(:tranches)
 
         title_props = {
           style: {
@@ -71,7 +71,7 @@ module View
           trs << h(:tr, slots)
         end
 
-        return if trs.empty?
+        return '' if trs.empty?
 
         h('div#tranches.card', [
           h('div.title', title_props, 'Tranches'),

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -165,7 +165,7 @@ module View
 
     def render_optional_rules
       selected_rules = @gdata.dig('settings', 'optional_rules') || []
-      return if selected_rules.empty?
+      return '' if selected_rules.empty?
 
       rendered_rules = Engine.meta_by_title(@gdata['title'])::OPTIONAL_RULES
         .select { |r| selected_rules.include?(r[:sym]) }

--- a/assets/app/view/game_row_filters.rb
+++ b/assets/app/view/game_row_filters.rb
@@ -9,7 +9,7 @@ module View
 
     def render
       url_search_params = Lib::Params::URLSearchParams.new
-      return if url_search_params.unsupported
+      return '' if url_search_params.unsupported
 
       h('div#game_filters.game_row', { key: @header }, [
         h(:h2, 'Filters'),


### PR DESCRIPTION
Trying to get ahead of more potential render problems for Opal 1.6 like #9556 and #9560

Methods to fix were identified by temporarily enabling `Style/ReturnNil` and checking with both possible `EnforcedStyle` settings. See [Style/ReturnNil docs](https://docs.rubocop.org/rubocop/cops_style.html#stylereturnnil).

In some cases the caller adds the return value to an Array and then calls `compact`, so the nil/undefined value doesn't end up being sent to the DOM, so not every `return` or `return nil` case is changed here.

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`