### PR TITLE
Upgrade to Opal 1.6.1 (longer stacktraces!); disable opal builder prefork

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  OPAL_PREFORK_DISABLE: "true"
+
 jobs:
   build:
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     mini_racer (0.6.2)
       libv8-node (~> 16.10.0.0)
     newrelic_rpm (8.6.0)
-    opal (1.5.0)
+    opal (1.6.1)
       ast (>= 2.3.0)
       parser (~> 3.0, >= 3.0.3.2)
     parallel (1.22.1)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,6 +6,7 @@ x-rack: &rack
     DATABASE_URL: postgres://root:password@db:5432/18xx_development
     RACK_ENV: development
     RUBYOPTS: --yjit
+    OPAL_PREFORK_DISABLE: "true"
   build:
     args:
       RACK_ENV: development

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,6 +12,7 @@ x-rack: &rack
     SLACK_WEBHOOK_URL: $SLACK_WEBHOOK_URL
     RUBYOPTS: --yjit
     PORT: 9292
+    OPAL_PREFORK_DISABLE: "true"
   restart: always
   build:
     args:


### PR DESCRIPTION
* see [opal/opal #2505](https://www.github.com/opal/opal/issues/2505) for note on `OPAL_PREFORK_DISABLE`

Feeling more confident after more local manual testing and #9556, #9560, and #9593

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`


