### PR TITLE
Upgrade to Opal 1.7.3 and Ruby 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Ruby 3.0
+    - name: Set up Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0
+        ruby-version: 3.2
     - name: Build and test with Rake
       run: |
         gem install bundler

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 require: rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 3.0.2
+  TargetRubyVersion: 3.0.2  # TODO: upgrade to 3.2, configure new cops
   NewCops: enable
   SuggestExtensions: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1
+FROM ruby:3.2
 
 ARG RACK_ENV
 RUN mkdir /18xx
@@ -9,6 +9,10 @@ RUN if [ "$RACK_ENV" = "development" ]; \
       curl -s https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.36.tgz | tar xz; \
       mv package/bin/esbuild /usr/local/bin && rm -rf package; \
     fi;
+
+# git 2.35.2 and above don't like having the git repo directory owned by a
+# non-root user while running as root
+RUN git config --global --add safe.directory /18xx
 
 COPY Gemfile Gemfile.lock ./
 RUN if [ "$RACK_ENV" = "production" ]; \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    argon2 (2.1.1)
-      ffi (~> 1.14)
+    argon2 (2.2.0)
+      ffi (~> 1.15)
       ffi-compiler (~> 1.0)
     ast (2.4.2)
     byebug (11.1.3)
@@ -23,7 +23,7 @@ GEM
     kgio (2.11.4)
     libv8-node (16.10.0.0)
     libv8-node (16.10.0.0-x86_64-linux)
-    listen (3.7.1)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     message_bus (4.2.0)
@@ -32,7 +32,7 @@ GEM
     mini_racer (0.6.2)
       libv8-node (~> 16.10.0.0)
     newrelic_rpm (8.6.0)
-    opal (1.6.1)
+    opal (1.7.3)
       ast (>= 2.3.0)
       parser (~> 3.0, >= 3.0.3.2)
     parallel (1.22.1)
@@ -48,17 +48,17 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     raabro (1.4.0)
-    rack (3.0.6.1)
+    rack (3.0.8)
     rainbow (3.1.1)
     raindrops (0.20.0)
     rake (13.0.6)
-    rb-fsevent (0.11.1)
+    rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.6.0)
     regexp_parser (2.3.0)
     require_all (3.0.0)
-    rerun (0.13.1)
+    rerun (0.14.0)
       listen (~> 3.0)
     rexml (3.2.5)
     roda (3.55.0)
@@ -145,4 +145,4 @@ DEPENDENCIES
   unicorn-worker-killer
 
 BUNDLED WITH
-   2.3.7
+   2.4.10

--- a/assets/app/lib/params.rb
+++ b/assets/app/lib/params.rb
@@ -34,7 +34,13 @@ module Lib
       end
 
       def to_query_string
-        @native&.toString() || ''
+        # TODO: after https://github.com/opal/opal/pull/2584 is included in a
+        # release, upgrade Opal to that release and revert this function to:
+        #
+        # @native&.toString() || ''
+
+        # https://github.com/opal/opal/issues/2583#issuecomment-1718381113
+        `Opal.truthy(self.native) ? self.native.native.toString() : nil` || ''
       end
     end
   end


### PR DESCRIPTION
* Opal 1.7 adds support for `Set` and Ruby 3.2, see the [Opal Change Log](https://github.com/opal/opal/blob/master/CHANGELOG.md) for more

* Ruby 3.2 upgrade requires updating bundler and some additional gems: argon, rerun, and their dependencies listen, rack, rb-fsevent

* the method name caching added in Opal 1.7 has a bug with toString; I've submitted a PR to fix this, but have also included a temporary fix to unblock our code, courtesy of hmdne; see https://github.com/opal/opal/issues/2583#issuecomment-1718381113

* the Ruby 3.2 docker image includes a newer version of git, which will show a "dubious ownership" error message and breaks `rake precompile` without the `git config` added in the Dockerfile here; see the [GitHub blog](https://github.blog/2022-04-18-highlights-from-git-2-36/#stricter-repository-ownership-checks) for more detail

* add note in rubocop config about upgrading the configured target version; even without upgrading the rubocop version, upgrading the target ruby version activates more cops, so I'm saving that for another time