### PR TITLE
[1858] Private railway exchange approval. Move to public alpha status.

### DIFF
--- a/lib/engine/game/g_1858/entities.rb
+++ b/lib/engine/game/g_1858/entities.rb
@@ -116,7 +116,7 @@ module Engine
           {
             sym: 'H&G',
             name: 'Havana and Güines Railway',
-            desc: 'P1. Revenue 30. ' \
+            desc: 'P1. Revenue 10, face value 30. ' \
                   'Cannot be used to start a public company or exchanged for a share.',
             value: 30,
             discount: 0,

--- a/lib/engine/game/g_1858/game.rb
+++ b/lib/engine/game/g_1858/game.rb
@@ -184,6 +184,7 @@ module Engine
         def stock_round
           Engine::Round::Stock.new(self, [
             G1858::Step::Exchange,
+            G1858::Step::ExchangeApproval,
             G1858::Step::HomeToken,
             G1858::Step::BuySellParShares,
           ])
@@ -317,19 +318,6 @@ module Engine
         # Returns true if the hex is this private railway's home hex.
         def home_hex?(operator, hex)
           operator.coordinates.include?(hex.coordinates)
-        end
-
-        # Constent for a share purchase is only needed in one circumstance:
-        # - A private railway company is being exchanged for a share.
-        # - The share is from the corporation's treasury (not the market).
-        # - The private railway and corporation are controlled by different players.
-        def consenter_for_buy_shares(entity, bundle)
-          return unless entity.minor?
-          return unless bundle.share_price.nil?
-          return if entity.owner == bundle.corporation.owner
-          return unless bundle.shares.first.owner.corporation?
-
-          bundle.corporation.owner
         end
 
         def tile_lays(entity)

--- a/lib/engine/game/g_1858/game.rb
+++ b/lib/engine/game/g_1858/game.rb
@@ -209,6 +209,7 @@ module Engine
 
         def closure_round(round_num)
           G1858::Round::Closure.new(self, [
+            G1858::Step::ExchangeApproval,
             G1858::Step::HomeToken,
             G1858::Step::PrivateClosure,
           ], round_num: round_num)
@@ -329,17 +330,6 @@ module Engine
           return unless bundle.shares.first.owner.corporation?
 
           bundle.corporation.owner
-        end
-
-        # Consent for a share exchange in the private closure round is needed
-        # if the corporation whose share is being taken is not run by the same
-        # player as the private railway company being exchanged, and the share
-        # is from the corporation's treasury.
-        def consenter_for_choice(minor, choice, _label)
-          return if choice['from'] == 'market'
-
-          corporation = @corporations.find { |c| c.id == choice['corporation'] }
-          corporation.owner unless corporation.owner == minor.owner
         end
 
         def tile_lays(entity)

--- a/lib/engine/game/g_1858/meta.rb
+++ b/lib/engine/game/g_1858/meta.rb
@@ -7,7 +7,7 @@ module Engine
     module G1858
       module Meta
         include Game::Meta
-        DEV_STAGE = :prealpha
+        DEV_STAGE = :alpha
 
         GAME_TITLE = '1858'
         GAME_SUBTITLE = 'The Railways of Iberia'

--- a/lib/engine/game/g_1858/step/exchange.rb
+++ b/lib/engine/game/g_1858/step/exchange.rb
@@ -32,11 +32,15 @@ module Engine
             if bundle.percent == 40
               exchange_for_presidency(bundle, corporation, minor, player)
               @round.current_actions << action
-            else
+            elsif corporation.owner == minor.owner
               exchange_for_share(bundle, corporation, minor, player, true)
               # Need to add an action to the action log, but this can't be a
               # buy shares action as that would end the current player's turn.
               @round.current_actions << Engine::Action::Base.new(minor)
+            else
+              log_request(corporation, minor)
+              @round.pending_approval = corporation
+              @round.minor = minor
             end
           end
 

--- a/lib/engine/game/g_1858/step/exchange.rb
+++ b/lib/engine/game/g_1858/step/exchange.rb
@@ -29,31 +29,30 @@ module Engine
                                'for a single share of a public company.'
             end
 
-            acquire_private(corporation, minor)
             if bundle.percent == 40
               exchange_for_presidency(bundle, corporation, minor, player)
               @round.current_actions << action
             else
-              exchange_for_share(bundle, corporation, minor, player)
-              claim_token(corporation, minor)
+              exchange_for_share(bundle, corporation, minor, player, true)
               # Need to add an action to the action log, but this can't be a
               # buy shares action as that would end the current player's turn.
               @round.current_actions << Engine::Action::Base.new(minor)
             end
           end
 
-          def exchange_for_presidency(bundle, corporation, company, player)
+          def exchange_for_presidency(bundle, corporation, minor, player)
             raise GameError, "#{corporation.name} cannot be parred" unless @game.can_par?(corporation, player)
 
-            share_price = @game.par_price(company)
+            acquire_private(corporation, minor)
+            share_price = @game.par_price(minor)
             @game.stock_market.set_par(corporation, share_price)
             @round.players_bought[player][corporation] += bundle.percent
-            @log << "#{player.name} exchanges #{company.name} and " \
+            @log << "#{player.name} exchanges #{minor.name} and " \
                     "#{@game.format_currency(share_price.price)} for a " \
                     "#{bundle.percent}% share of #{corporation.id}"
             buy_shares(player,
                        bundle,
-                       exchange: company,
+                       exchange: minor,
                        exchange_price: share_price.price,
                        silent: true)
             @game.after_par(corporation)

--- a/lib/engine/game/g_1858/step/exchange_approval.rb
+++ b/lib/engine/game/g_1858/step/exchange_approval.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative 'private_exchange'
+
+module Engine
+  module Game
+    module G1858
+      module Step
+        class ExchangeApproval < Engine::Step::Base
+          include PrivateExchange
+
+          def actions(entity)
+            return [] unless entity == corporation
+
+            ['choose']
+          end
+
+          def active?
+            pending_approval
+          end
+
+          def current_entity
+            corporation
+          end
+
+          def corporation
+            pending_approval
+          end
+
+          def minor
+            @round.minor
+          end
+
+          def approver
+            corporation.owner
+          end
+
+          def requester
+            minor.owner
+          end
+
+          def pending_approval
+            @round.pending_approval
+          end
+
+          def description
+            'xyzzy'
+          end
+
+          def choice_name
+            "Allow #{requester.name} to exchange #{minor.id} for a treasury share"
+          end
+
+          def choices
+            {
+              'approve' => 'Allow exchange',
+              'deny' => 'Do not allow exchange',
+            }
+          end
+
+          def process_choose(action)
+            approved = (action.choice == 'approve')
+            verb = approved ? 'approved' : 'denied'
+            msg = "• #{verb} #{requester.name}’s request to exchange " \
+                  "#{minor.name} for a #{corporation.id} treasury share."
+            @round.process_action(Engine::Action::Log.new(approver, message: msg))
+
+            if approved
+              share = corporation.shares.first
+              exchange_for_share(share, corporation, minor, minor.owner, true)
+              @game.close_private(minor)
+            else
+              @round.approvals[corporation] = :denied
+              if corporation.num_market_shares.positive?
+                @game.log << "#{minor.name} may now be exchanged for a " \
+                             "#{corporation.id} market share."
+              end
+            end
+            @round.pending_approval = nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1858/step/exchange_approval.rb
+++ b/lib/engine/game/g_1858/step/exchange_approval.rb
@@ -30,6 +30,10 @@ module Engine
             pending_approval
           end
 
+          def active_entities
+            in_pcr? ? [corporation] : [approver]
+          end
+
           def current_entity
             corporation
           end

--- a/lib/engine/game/g_1858/step/home_token.rb
+++ b/lib/engine/game/g_1858/step/home_token.rb
@@ -21,6 +21,10 @@ module Engine
             'Do not place station token'
           end
 
+          def active_entities
+            [pending_entity.owner]
+          end
+
           def process_place_token(action)
             if action.entity.companies.empty? && action.entity.placed_tokens.empty?
               # This is a public company floated directly after the start of phase 5.

--- a/lib/engine/game/g_1858/step/private_closure.rb
+++ b/lib/engine/game/g_1858/step/private_closure.rb
@@ -82,19 +82,17 @@ module Engine
 
           def process_choose(action)
             choice = action.choice
-            corporation = @game.corporations.find { |c| c.id == choice['corporation'] }
+            corporation = @game.corporation_by_id(choice['corporation'])
             share_location = choice['from']
             minor = action.entity
             company = @game.private_company(minor)
             player = company.owner
 
             share = share_chosen(corporation, share_location)
-            exchange_for_share(share, corporation, minor, player)
+            treasury_share = (share_location == 'treasury')
+            exchange_for_share(share, corporation, minor, player, treasury_share)
 
-            if share_location == 'treasury'
-              acquire_private(corporation, minor)
-              claim_token(corporation, minor)
-            else
+            unless treasury_share
               company.owner = @game.bank
               player.companies.delete(company)
             end

--- a/lib/engine/game/g_1858/step/private_closure.rb
+++ b/lib/engine/game/g_1858/step/private_closure.rb
@@ -10,16 +10,6 @@ module Engine
         class PrivateClosure < Engine::Step::Base
           include PrivateExchange
 
-          def round_state
-            super.merge(
-              {
-                minor: nil,
-                approvals: {},
-                pending_approval: nil,
-              }
-            )
-          end
-
           def setup
             minor = current_entity
             @round.minor = minor
@@ -137,12 +127,8 @@ module Engine
 
             if share_location == 'treasury' &&
                 @round.approvals[corporation] != :approved
-              approver = corporation.owner
-              msg = "• requested #{approver.name}’s permission to " \
-                    "exchange #{minor.name} for a #{corporation.id} " \
-                    'treasury share.'
-              @round.process_action(Engine::Action::Log.new(player, message: msg))
-              @round.pending_approval = @game.corporation_by_id(choice['corporation'])
+              log_request(corporation, minor)
+              @round.pending_approval = corporation
             else
               share = share_chosen(corporation, share_location)
               treasury_share = (share_location == 'treasury')

--- a/lib/engine/game/g_1858/step/private_closure.rb
+++ b/lib/engine/game/g_1858/step/private_closure.rb
@@ -10,6 +10,25 @@ module Engine
         class PrivateClosure < Engine::Step::Base
           include PrivateExchange
 
+          def round_state
+            super.merge(
+              {
+                minor: nil,
+                approvals: {},
+                pending_approval: nil,
+              }
+            )
+          end
+
+          def setup
+            minor = current_entity
+            @round.minor = minor
+            @round.approvals = @game.corporations.select(&:floated).to_h do |corporation|
+              approval = corporation.owner == minor.owner ? :approved : :pending
+              [corporation, approval]
+            end
+          end
+
           def actions(entity)
             return [] unless entity == current_entity
 
@@ -50,7 +69,9 @@ module Engine
               'If a public company has both ' \
               'treasury and market shares available, then you can only ' \
               'exchange for a market share if you have first requested the ' \
-              'exchange for a treasury share.',
+              'exchange for a treasury share. An asterisk on the button ' \
+              'indicates a public company that has market shares that will ' \
+              'become available if a request for a treasury share is denied.',
 
               'If a public company only has ' \
               'market shares available then you do not need approval.',
@@ -60,15 +81,34 @@ module Engine
           def choices
             choices = {}
             exchange_corporations(current_entity).each do |corporation|
-              add_choice(choices, corporation, 'treasury') if corporation.num_treasury_shares.positive?
-              add_choice(choices, corporation, 'market') if corporation.num_market_shares.positive?
+              if corporation.num_treasury_shares.positive?
+                # Should we indicate whether there are market shares that would
+                # be available after a request for a treasury share is denied?
+                market_shares = corporation.num_market_shares.positive? &&
+                                  @round.approvals[corporation] == :pending
+                add_choice(choices, corporation, 'treasury', market_shares)
+              end
+
+              # The private can only be swapped for a market share if:
+              #   - there are no treasury shares of that public company
+              #     available, or
+              #   - the public company's president has refused a request to
+              #     exchange the private for a treasury share, or
+              #   - the private and public companies are owned by the same
+              #     player.
+              next if corporation.num_market_shares.zero?
+              next if corporation.num_treasury_shares.positive? &&
+                      @round.approvals[corporation] != :denied &&
+                      corporation.owner != current_entity.owner
+
+              add_choice(choices, corporation, 'market', false)
             end
             choices
           end
 
-          def add_choice(choices, corporation, location)
+          def add_choice(choices, corporation, location, footnote)
             k = { 'corporation' => corporation.id, 'from' => location }
-            v = "#{corporation.id} #{location} share"
+            v = "#{corporation.id} #{location} share#{footnote ? '*' : ''}"
             choices[k] = v
           end
 
@@ -88,15 +128,32 @@ module Engine
             company = @game.private_company(minor)
             player = company.owner
 
-            share = share_chosen(corporation, share_location)
-            treasury_share = (share_location == 'treasury')
-            exchange_for_share(share, corporation, minor, player, treasury_share)
-
-            unless treasury_share
-              company.owner = @game.bank
-              player.companies.delete(company)
+            if share_location == 'market' &&
+                corporation.num_treasury_shares.positive? &&
+                @round.approvals[corporation] == :pending
+              raise GameError, 'Cannot exchange for a treasury share unless ' \
+                               'a request for a treasury share has been denied.'
             end
-            @game.close_private(company)
+
+            if share_location == 'treasury' &&
+                @round.approvals[corporation] != :approved
+              approver = corporation.owner
+              msg = "• requested #{approver.name}’s permission to " \
+                    "exchange #{minor.name} for a #{corporation.id} " \
+                    'treasury share.'
+              @round.process_action(Engine::Action::Log.new(player, message: msg))
+              @round.pending_approval = @game.corporation_by_id(choice['corporation'])
+            else
+              share = share_chosen(corporation, share_location)
+              treasury_share = (share_location == 'treasury')
+              exchange_for_share(share, corporation, minor, player, treasury_share)
+
+              unless treasury_share
+                company.owner = @game.bank
+                player.companies.delete(company)
+              end
+              @game.close_private(company)
+            end
           end
 
           def exchange_corporations(minor)

--- a/lib/engine/game/g_1858/step/private_exchange.rb
+++ b/lib/engine/game/g_1858/step/private_exchange.rb
@@ -31,12 +31,16 @@ module Engine
             company.add_ability(blocker)
           end
 
-          def exchange_for_share(bundle, corporation, minor, player)
+          def exchange_for_share(bundle, corporation, minor, player, treasury_share)
             if !@game.loading && !@game.corporation_private_connected?(corporation, minor)
               raise GameError, "#{minor.name} is not connected to #{corporation.full_name}"
             end
 
             @game.share_pool.buy_shares(player, bundle, exchange: :free)
+            if treasury_share
+              acquire_private(corporation, minor)
+              claim_token(corporation, minor)
+            end
           end
 
           def claim_token(corporation, minor)

--- a/lib/engine/game/g_1858/step/private_exchange.rb
+++ b/lib/engine/game/g_1858/step/private_exchange.rb
@@ -72,6 +72,24 @@ module Engine
               corporation.add_ability(reservation)
             end
           end
+
+          def log_request(corporation, minor)
+            requester = minor.owner
+            approver = corporation.owner
+            msg = "• requested #{approver.name}’s permission to " \
+                  "exchange #{minor.name} for a #{corporation.id} " \
+                  'treasury share.'
+            @round.process_action(Engine::Action::Log.new(requester, message: msg))
+          end
+
+          def log_response(corporation, minor, approved)
+            requester = minor.owner
+            approver = corporation.owner
+            verb = approved ? 'approved' : 'denied'
+            msg = "• #{verb} #{requester.name}’s request to exchange " \
+                  "#{minor.name} for a #{corporation.id} treasury share."
+            @round.process_action(Engine::Action::Log.new(approver, message: msg))
+          end
         end
       end
     end

--- a/lib/engine/game/g_1858/step/private_exchange.rb
+++ b/lib/engine/game/g_1858/step/private_exchange.rb
@@ -37,10 +37,10 @@ module Engine
             end
 
             @game.share_pool.buy_shares(player, bundle, exchange: :free)
-            if treasury_share
-              acquire_private(corporation, minor)
-              claim_token(corporation, minor)
-            end
+            return unless treasury_share
+
+            acquire_private(corporation, minor)
+            claim_token(corporation, minor)
           end
 
           def claim_token(corporation, minor)


### PR DESCRIPTION
This moves 1858 from pre-alpha to alpha status.

There is one new feature added in this pull request: a clearer process for exchanging private railway companies for shares in public companies.

When you get to the private closure round (which occurs at the end of the operating round in which the first 5E/4M train is bought), all remaining private railway companies must be exchanged for shares in public companies, or sold back to the bank. The rules for exchanging privates for shares in public companies run by other players are fairly subtle:

- If the only available shares in a public company are in the bank pool, then the private can be swapped for a share without the consent of the public company's director.
- If the only available shares in a public company are in the company's treasury, then the private can only be swapped for a share if the director agrees.
- If the public company has both treasury and pool shares, then the director must first be offered the chance to exchange the private for a treasury share. Only if the director refuses this exchange can the private be swapped for a pool share.

This doesn't work well with the existing confirmation system. For some options the player would have to confirm that the director has agreed to an exchange, for others that the director refused an exchange. That's just going to lead to mistakes.

So instead I've added a simple step to get the director to respond to exchange requests. This is done using a choice action, with approve and deny options. No core code needed to be modified to do this. Round state is used to track where a rejection has been received, and then allow an exchange for a pool share.

## Screenshots

#### R&T private company's turn. AVT and TBF have both treasury and market shares available, W only treasury shares.
![image](https://github.com/tobymao/18xx/assets/11144854/bd2046fa-77ca-403d-9a3f-1a1104091ed3)

#### An attempt is made to exchange R&T for a TBF treasury share.
![image](https://github.com/tobymao/18xx/assets/11144854/e95ba193-ba21-4208-85b5-c4860858a179)

#### After the exchange is refused, R&T can be exchanged for a TBF market share.
![image](https://github.com/tobymao/18xx/assets/11144854/25051b8e-fb6e-402f-9248-9dcd4e7d95a8)

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
- ~~Add the `pins` label if this change will break existing games~~
