### PR TITLE
[1822Africa] Add P8 (Reserve Three Tiles)

### DIFF
--- a/lib/engine/game/g_1822_africa/entities.rb
+++ b/lib/engine/game/g_1822_africa/entities.rb
@@ -93,10 +93,9 @@ module Engine
             color: nil,
           },
           {
-            name: 'P8 (Reserve Three Tiles) [N/A]',
+            name: 'P8 (Reserve Three Tiles)',
             sym: 'P8',
-            desc: '[NOT YET FUNCTIONAL] '\
-                  'MAJOR/MINOR, Phase 1. Upon acquisition, owning company must reserve three tiles from the stock '\
+            desc: 'MAJOR/MINOR, Phase 1. Upon acquisition, owning company must reserve three tiles from the stock '\
                   'of unplayed tiles for future placement. No other company may use these tiles held in reserve. '\
                   'The revenue of this private company changes to A5x the number of tiles it holds. '\
                   'Once the owning company reserves tiles, it may not place any other tiles '\


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
After P8 is purchased by minor/major, it allows to reserve three tiles from a choices menu containing all unplaced tiles. These tiles are removed from available and are only added during the turn of the associated major/minor. It can only lay these three tiles if all other rules permit.

* **Screenshots**
<img width="357" alt="Screenshot 2023-09-15 at 00 18 22" src="https://github.com/tobymao/18xx/assets/576786/0e43d452-44f8-4984-9b2d-5c06168beaf9">

* **Any Assumptions / Hacks**
Tile selection menu is made using generic choices component so player will have to either know tile ids or reference the Tiles tab to understand what they are reserving
