### PR TITLE
[1822Africa] Add P18 (Safari Train)

### DIFF
--- a/lib/engine/game/g_1822_africa/entities.rb
+++ b/lib/engine/game/g_1822_africa/entities.rb
@@ -300,10 +300,9 @@ module Engine
             color: nil,
           },
           {
-            name: 'P18 (Safari Bonus) [N/A]',
+            name: 'P18 (Safari Bonus)',
             sym: 'P18',
-            desc: '[NOT YET FUNCTIONAL] '\
-                  'MAJOR/MINOR, Phase 3. The Safari Bonus can be added to a train owned by the company. '\
+            desc: 'MAJOR/MINOR, Phase 3. The Safari Bonus can be added to a train owned by the company. '\
                   'It converts the train into a safari train that counts an extra 20 to the earnings for reaching '\
                   'each of the game reserves. Does not count against train limit and does not count as a train '\
                   'for the purposes of train ownership. Can’t be sold to another company.',

--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -62,11 +62,11 @@ module Engine
 
         PRIVATES_IN_GAME = 12
 
-        EXTRA_TRAINS = %w[2P P+ LP].freeze
+        EXTRA_TRAINS = %w[2P P+ LP S].freeze
         EXTRA_TRAIN_PERMANENTS = %w[2P LP].freeze
         EXPRESS_TRAIN_MULTIPLIER = 2
 
-        PRIVATE_TRAINS = %w[P1 P2 P3 P4 P5].freeze
+        PRIVATE_TRAINS = %w[P1 P2 P3 P4 P5 P18].freeze
         PRIVATE_MAIL_CONTRACTS = [].freeze # Stub
         PRIVATE_PHASE_REVENUE = %w[P16].freeze
         PRIVATE_REMOVE_REVENUE = %w[P13].freeze
@@ -89,6 +89,8 @@ module Engine
 
         GAME_RESERVE_TILE = 'GR'
         GAME_RESERVE_MULTIPLIER = 5
+
+        SAFARI_TRAIN_BONUS = 20
 
         MINOR_BIDBOX_PRICE = 100
         BIDDING_BOX_MINOR_COUNT = 3
@@ -364,6 +366,12 @@ module Engine
             num: 1,
             price: 160,
           },
+          {
+            name: 'S',
+            distance: 2,
+            num: 1,
+            price: 0,
+          },
         ].freeze
 
         UPGRADE_COST_L_TO_2 = 70
@@ -415,6 +423,7 @@ module Engine
           @company_trains['P3'] = find_and_remove_train_by_id('2P-1', buyable: false)
           @company_trains['P4'] = find_and_remove_train_by_id('P+-0', buyable: false)
           @company_trains['P5'] = find_and_remove_train_by_id('P+-1', buyable: false)
+          @company_trains['P18'] = find_and_remove_train_by_id('S-0', buyable: false)
 
           @recycled_trains = [
             find_and_remove_train_by_id('LR-0', buyable: false),
@@ -501,7 +510,7 @@ module Engine
             G1822::Step::Track,
             G1822::Step::DestinationToken,
             G1822::Step::Token,
-            G1822::Step::Route,
+            G1822Africa::Step::Route,
             G1822::Step::Dividend,
             G1822Africa::Step::BuyTrain,
             G1822Africa::Step::MinorAcquisition,
@@ -653,6 +662,7 @@ module Engine
           revenue += plantation_bonus(route)
           revenue += gold_mine_bonus(route, stops)
           revenue += destination_bonus_for(route)
+          revenue += safari_train_bonus(route)
 
           return revenue unless can_be_express?(route.train)
           return revenue unless includes_two_tokens?(route)
@@ -682,6 +692,12 @@ module Engine
           return 0 if !@gold_mine_token || stops&.none? { |s| s.hex == @gold_mine_token.hex }
 
           self.class::GOLD_MINE_BONUS
+        end
+
+        def safari_train_bonus(route)
+          return 0 unless safari_train_attached?(route.train)
+
+          self.class::SAFARI_TRAIN_BONUS * find_game_reserves(route.all_hexes).count
         end
 
         def destination_bonus_for(route)
@@ -721,9 +737,14 @@ module Engine
 
         def revenue_str(route)
           str = super
+
           str += ' [Express]' if runs_as_express?(route)
           str += ' +20 (Coffee Plantation) ' if plantation_bonus(route).positive?
           str += ' +20 (Gold Mine)' if gold_mine_bonus(route, route.stops).positive?
+
+          safari_bonus = safari_train_bonus(route)
+          str += " + #{safari_bonus} (Safari)" if safari_bonus.positive?
+
           str
         end
 
@@ -761,6 +782,18 @@ module Engine
           :normal
         end
 
+        def route_trains(entity)
+          entity.runnable_trains.reject { |t| pullman_train?(t) || safari_train?(t) }
+        end
+
+        def safari_train?(t)
+          t.name == 'S'
+        end
+
+        def safari_train_attached?(t)
+          t.name.end_with?('S')
+        end
+
         def can_be_express?(train)
           train.name[-1] == 'E'
         end
@@ -794,8 +827,12 @@ module Engine
           current_entity == company_reserve_tiles&.owner
         end
 
+        def find_game_reserves(hexes)
+          hexes.select { |h| h.tile.color == :purple }
+        end
+
         def pay_game_reserve_bonus!(entity)
-          reserves = hexes.select { |h| h.tile.color == :purple }
+          reserves = find_game_reserves(hexes)
           bonus = hex_crow_distance_not_inclusive(*reserves) * self.class::GAME_RESERVE_MULTIPLIER
 
           return if bonus.zero?

--- a/lib/engine/game/g_1822_africa/step/route.rb
+++ b/lib/engine/game/g_1822_africa/step/route.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1822/step/route'
+
+module Engine
+  module Game
+    module G1822Africa
+      module Step
+        class Route < G1822::Step::Route
+          def choosing?(entity)
+            choosing_pullman?(entity) || choosing_safari?(entity)
+          end
+
+          def choices
+            if choosing_pullman?(current_entity)
+              pullman_choices
+            elsif choosing_safari?(current_entity)
+              safari_choices
+            else
+              {}
+            end
+          end
+
+          def choice_name
+            if choosing_pullman?(current_entity)
+              'Attach pullman (P+) to a train'
+            elsif choosing_safari?(current_entity)
+              'Which train will be a safari train (S)'
+            end
+          end
+
+          def choice_explanation
+            if choosing_pullman?(current_entity)
+              description = ['Selected train will be able to count any number of towns']
+              description << 'You will be able to select Safari Train next' if find_safari_train(current_entity)
+              description
+            elsif choosing_safari?(current_entity)
+              ['Selected train will get +20 bonus for each Game Reserve visited']
+            end
+          end
+
+          def process_choose(action)
+            if choosing_pullman?(current_entity)
+              process_pullman_choice(action)
+            elsif choosing_safari?(current_entity)
+              process_safari_choice(action)
+            end
+          end
+
+          def pullman_choices
+            choices = {}
+            pullman_train_choices(current_entity).each_with_index do |train, index|
+              choices[index.to_s] = "#{train.name} train"
+            end
+            choices['None'] = 'None'
+            choices
+          end
+
+          def process_pullman_choice(action)
+            entity = action.entity
+
+            if action.choice == 'None'
+              @pullman_train = true
+              @log << "#{entity.id} chooses not to attach the pullman to a train"
+            else
+              @pullman_train = pullman_train_choices(entity)[action.choice.to_i]
+              @log << "#{entity.id} attaches the pullman to a #{@pullman_train.name} train"
+              attach_pullman
+            end
+          end
+
+          def detach_pullman
+            return super unless @pullman_train == true
+
+            @pullman_train = nil
+          end
+
+          def choosing_safari?(entity)
+            @safari_train ||= nil
+            !@safari_train && find_safari_train(entity) && !safari_train_choices(entity).empty?
+          end
+
+          def find_safari_train(entity)
+            entity.trains.find { |t| @game.safari_train?(t) }
+          end
+
+          def safari_choices
+            choices = {}
+            safari_train_choices(current_entity).each_with_index do |train, index|
+              choices[index.to_s] = "#{train.name} train"
+            end
+            choices['None'] = 'None'
+            choices
+          end
+
+          def safari_train_choices(entity)
+            pullman_train_choices(entity).reject { |t| t.name.include?('+') }
+          end
+
+          def process_safari_choice(action)
+            entity = action.entity
+
+            if action.choice == 'None'
+              @safari_train = true
+              @log << "#{entity.id} chooses to not use a safari train"
+            else
+              @safari_train = safari_train_choices(entity)[action.choice.to_i]
+              @log << "#{entity.id} makes #{@safari_train.name} a safari train"
+
+              attach_safari_train
+            end
+          end
+
+          def attach_safari_train
+            @safari_original_train = @safari_train.dup
+            @safari_train.name += 'S'
+          end
+
+          def detach_safari_train
+            @safari_train.name = @safari_original_train.name
+
+            @safari_original_train = nil
+            @safari_train = nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Safari Bonus acts like a Pullman car, but simply adds bonus revenue if visiting Game Reserve hexes so it was implemented similarly.

* **Any Assumptions / Hacks**
A multi-step choose was implemented to handle cases when company has both Pullman and Safari Bonus