### PR TITLE
[1822Africa] Refactor E trains

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -17,6 +17,7 @@ module View
 
     def render_notification
       message = <<~MESSAGE
+        <p><a href="https://boardgamegeek.com/thread/3131296/1822africa-design-diaryfeedback" target="_blank">1822Africa</a> is now in beta.</p>
         <p>1840 is now (finally) in production.</p>
         <p>1847 AE and 1868 Wyoming are now in alpha.</p>
         <p>Learn how to get <a href='https://github.com/tobymao/18xx/wiki/Notifications'>notifications</a> by email, Slack, Discord, and Telegram.</p>

--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -66,7 +66,6 @@ module Engine
 
         EXTRA_TRAINS = %w[2P P+ LP S].freeze
         EXTRA_TRAIN_PERMANENTS = %w[2P LP].freeze
-        EXPRESS_TRAIN_MULTIPLIER = 2
 
         PRIVATE_TRAINS = %w[P1 P2 P3 P4 P5 P18].freeze
         PRIVATE_MAIL_CONTRACTS = [].freeze # Stub
@@ -611,70 +610,14 @@ module Engine
           help
         end
 
-        # This repeats the logic from the base game because our determination of train type is based on route
-        def check_overlap(routes)
-          # Tracks by e-train and normal trains
-          tracks_by_type = Hash.new { |h, k| h[k] = [] }
-
-          # Check local train not use the same token more then one time
-          local_cities = []
-
-          routes.each do |route|
-            local_cities.concat(route.visited_stops.select(&:city?)) if route.train.local? && !route.chains.empty?
-
-            route.paths.each do |path|
-              a = path.a
-              b = path.b
-
-              tracks = tracks_by_type[route_train_type(route)]
-              tracks << [path.hex, a.num, path.lanes[0][1]] if a.edge?
-              tracks << [path.hex, b.num, path.lanes[1][1]] if b.edge?
-
-              if b.edge? && a.town? && (nedge = a.tile.preferred_city_town_edges[a]) && nedge != b.num
-                tracks << [path.hex, a, path.lanes[0][1]]
-              end
-              if a.edge? && b.town? && (nedge = b.tile.preferred_city_town_edges[b]) && nedge != a.num
-                tracks << [path.hex, b, path.lanes[1][1]]
-              end
-            end
-          end
-
-          tracks_by_type.each do |_type, tracks|
-            tracks.group_by(&:itself).each do |k, v|
-              raise GameError, "Route can't reuse track on #{k[0].id}" if v.size > 1
-            end
-          end
-
-          local_cities.group_by(&:itself).each do |k, v|
-            raise GameError, "Local train can only use each token on #{k.hex.id} once" if v.size > 1
-          end
-        end
-
-        def compute_other_paths(routes, route)
-          routes.flat_map do |r|
-            next if r == route || route_train_type(route) != route_train_type(r)
-
-            r.paths
-          end
-        end
-
-        # This repeats the logic from the base game, but with changes to how */E trains are calculated
         def revenue_for(route, stops)
           revenue = super
+
           revenue += plantation_bonus(route)
           revenue += gold_mine_bonus(route, stops)
-          revenue += destination_bonus_for(route)
           revenue += safari_train_bonus(route)
 
-          return revenue unless can_be_express?(route.train)
-          return revenue unless includes_two_tokens?(route)
-
-          express_revenue = revenue_for_express(route, stops)
-          express_revenue += destination_bonus_for(route) * self.class::EXPRESS_TRAIN_MULTIPLIER
-
-          return express_revenue if train_over_distance?(route)
-
-          [revenue, express_revenue].max
+          revenue
         end
 
         def plantation_bonus(route)
@@ -702,45 +645,9 @@ module Engine
           self.class::SAFARI_TRAIN_BONUS * find_game_reserves(route.all_hexes).count
         end
 
-        def destination_bonus_for(route)
-          destination_bonus = destination_bonus(route.routes)
-
-          return destination_bonus[:revenue] if destination_bonus && destination_bonus[:route] == route
-
-          0
-        end
-
-        def revenue_for_express(route, stops)
-          entity = route.train.owner
-
-          stops.sum do |stop|
-            next 0 unless stop.city?
-
-            if stop.tokened_by?(entity)
-              stop.route_base_revenue(route.phase, route.train) * self.class::EXPRESS_TRAIN_MULTIPLIER
-            else
-              0
-            end
-          end
-        end
-
-        def runs_as_express?(route)
-          return false unless can_be_express?(route.train)
-          return false unless includes_two_tokens?(route)
-          return true if train_over_distance?(route)
-
-          stops = route.stops
-
-          normal_revenue = G1822::Game.instance_method(:revenue_for).bind_call(self, route, stops)
-          express_revenue = revenue_for_express(route, stops)
-
-          express_revenue > normal_revenue
-        end
-
         def revenue_str(route)
           str = super
 
-          str += ' [Express]' if runs_as_express?(route)
           str += ' +20 (Coffee Plantation) ' if plantation_bonus(route).positive?
           str += ' +20 (Gold Mine)' if gold_mine_bonus(route, route.stops).positive?
 
@@ -750,38 +657,8 @@ module Engine
           str
         end
 
-        def check_distance(route, visits, train = nil)
-          return if can_be_express?(route.train)
-
-          super
-        end
-
-        def train_over_distance?(route)
-          train_distance = route.train.distance
-          visits = route.visited_stops
-
-          return false unless train_distance.is_a?(Numeric)
-
-          route_distance = visits.sum(&:visit_cost)
-
-          route_distance > train_distance
-        end
-
-        def includes_two_tokens?(route)
-          entity = route.train.owner
-
-          tokened_stops = route.stops.count do |stop|
-            stop.city? && stop.tokened_by?(entity)
-          end
-
-          tokened_stops > 1
-        end
-
-        def route_train_type(route)
-          return :normal unless can_be_express?(route.train)
-          return :express if runs_as_express?(route)
-
-          :normal
+        def train_type(train)
+          train.name[0] == 'E' ? :etrain : :normal
         end
 
         def route_trains(entity)
@@ -793,7 +670,7 @@ module Engine
         end
 
         def safari_train_attached?(t)
-          t.name.end_with?('S')
+          t.name[-1] == 'S'
         end
 
         def can_be_express?(train)

--- a/lib/engine/game/g_1822_africa/meta.rb
+++ b/lib/engine/game/g_1822_africa/meta.rb
@@ -9,7 +9,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :alpha
+        DEV_STAGE = :beta
         PROTOTYPE = true
         DEPENDS_ON = '1822'
 

--- a/lib/engine/game/g_1822_africa/step/choose_express_train.rb
+++ b/lib/engine/game/g_1822_africa/step/choose_express_train.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1822Africa
+      module ChooseExpressTrain
+        def express_choice_name
+          'Select the train you want to run as Express'
+        end
+
+        def choosing_express?(entity)
+          @express_train ||= nil
+          !@express_train && !express_train_choices(entity).empty?
+        end
+
+        def express_train_choices(entity)
+          entity.trains.select { |t| @game.can_be_express?(t) }
+        end
+
+        def express_choices
+          choices = {}
+          express_train_choices(current_entity).each_with_index do |train, index|
+            choices[index.to_s] = "#{train.name} train"
+          end
+          choices['Skip'] = 'Skip'
+          choices
+        end
+
+        def process_express_choice(action)
+          entity = action.entity
+
+          if action.choice == 'Skip'
+            @express_train = true
+            @log << "#{entity.id} chooses to not use an Express train"
+          else
+            @express_train = express_train_choices(entity)[action.choice.to_i]
+            @log << "#{entity.id} makes #{@express_train.name} train Express"
+
+            convert_express_train
+          end
+        end
+
+        def convert_express_train
+          @express_original_train = @express_train.dup
+          @express_train.name = 'E/' + @express_train.name[0]
+          @express_train.distance = 99
+          @express_train.multiplier = 2
+        end
+
+        def detach_express_train
+          @express_train.name = @express_original_train.name
+          @express_train.distance = @express_original_train.distance
+          @express_train.multiplier = @express_original_train.multiplier
+
+          @express_original_train = nil
+          @express_train = nil
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822_africa/step/choose_safari_train.rb
+++ b/lib/engine/game/g_1822_africa/step/choose_safari_train.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1822Africa
+      module ChooseSafariTrain
+        def safari_choice_name
+          'Which train will be a safari train (S)'
+        end
+
+        def choosing_safari?(entity)
+          @safari_train ||= nil
+          !@safari_train && find_safari_train(entity) && !safari_train_choices(entity).empty?
+        end
+
+        def find_safari_train(entity)
+          entity.trains.find { |t| @game.safari_train?(t) }
+        end
+
+        def safari_choices
+          choices = {}
+          safari_train_choices(current_entity).each_with_index do |train, index|
+            choices[index.to_s] = "#{train.name} train"
+          end
+          choices['Skip'] = 'Skip'
+          choices
+        end
+
+        def safari_train_choices(entity)
+          pullman_train_choices(entity).reject { |t| t.name.include?('+') }
+        end
+
+        def process_safari_choice(action)
+          entity = action.entity
+
+          if action.choice == 'Skip'
+            @safari_train = true
+            @log << "#{entity.id} chooses to not use a safari train"
+          else
+            @safari_train = safari_train_choices(entity)[action.choice.to_i]
+            @log << "#{entity.id} makes #{@safari_train.name} a safari train"
+
+            attach_safari_train
+          end
+        end
+
+        def attach_safari_train
+          @safari_original_train = @safari_train.dup
+          @safari_train.name += 'S'
+        end
+
+        def detach_safari_train
+          @safari_train.name = @safari_original_train.name
+
+          @safari_original_train = nil
+          @safari_train = nil
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822_africa/step/route.rb
+++ b/lib/engine/game/g_1822_africa/step/route.rb
@@ -1,18 +1,25 @@
 # frozen_string_literal: true
 
 require_relative '../../g_1822/step/route'
+require_relative 'choose_safari_train'
+require_relative 'choose_express_train'
 
 module Engine
   module Game
     module G1822Africa
       module Step
         class Route < G1822::Step::Route
+          include G1822Africa::ChooseSafariTrain
+          include G1822Africa::ChooseExpressTrain
+
           def choosing?(entity)
-            choosing_pullman?(entity) || choosing_safari?(entity)
+            choosing_express?(entity) || choosing_pullman?(entity) || choosing_safari?(entity)
           end
 
           def choices
-            if choosing_pullman?(current_entity)
+            if choosing_express?(current_entity)
+              express_choices
+            elsif choosing_pullman?(current_entity)
               pullman_choices
             elsif choosing_safari?(current_entity)
               safari_choices
@@ -22,28 +29,48 @@ module Engine
           end
 
           def choice_name
-            if choosing_pullman?(current_entity)
-              'Attach pullman (P+) to a train'
+            if choosing_express?(current_entity)
+              express_choice_name
+            elsif choosing_pullman?(current_entity)
+              super
             elsif choosing_safari?(current_entity)
-              'Which train will be a safari train (S)'
+              safari_choice_name
             end
           end
 
           def choice_explanation
-            if choosing_pullman?(current_entity)
-              description = ['Selected train will be able to count any number of towns']
+            description = []
+
+            if choosing_express?(current_entity)
+              description << 'You will be able to attach Pullman next' if find_pullman_train(current_entity)
+              description << 'You will be able to select Safari Train afterwards' if find_safari_train(current_entity)
+            elsif choosing_pullman?(current_entity)
+              description << 'Selected train will be able to count any number of towns'
               description << 'You will be able to select Safari Train next' if find_safari_train(current_entity)
-              description
             elsif choosing_safari?(current_entity)
-              ['Selected train will get +20 bonus for each Game Reserve visited']
+              description << 'Selected train will get +20 bonus for each Game Reserve visited'
             end
+
+            description
           end
 
           def process_choose(action)
-            if choosing_pullman?(current_entity)
+            if choosing_express?(current_entity)
+              process_express_choice(action)
+            elsif choosing_pullman?(current_entity)
               process_pullman_choice(action)
             elsif choosing_safari?(current_entity)
               process_safari_choice(action)
+            end
+          end
+
+          def only_e_train?(entity)
+            @game.route_trains(entity).none? { |t| @game.train_type(t) == :normal }
+          end
+
+          def pullman_train_choices(entity)
+            @game.route_trains(entity).reject do |t|
+              @game.class::LOCAL_TRAINS.include?(t.name) || @game.train_type(t) == :etrain
             end
           end
 
@@ -52,14 +79,14 @@ module Engine
             pullman_train_choices(current_entity).each_with_index do |train, index|
               choices[index.to_s] = "#{train.name} train"
             end
-            choices['None'] = 'None'
+            choices['Skip'] = 'Skip'
             choices
           end
 
           def process_pullman_choice(action)
             entity = action.entity
 
-            if action.choice == 'None'
+            if action.choice == 'Skip'
               @pullman_train = true
               @log << "#{entity.id} chooses not to attach the pullman to a train"
             else
@@ -73,54 +100,6 @@ module Engine
             return super unless @pullman_train == true
 
             @pullman_train = nil
-          end
-
-          def choosing_safari?(entity)
-            @safari_train ||= nil
-            !@safari_train && find_safari_train(entity) && !safari_train_choices(entity).empty?
-          end
-
-          def find_safari_train(entity)
-            entity.trains.find { |t| @game.safari_train?(t) }
-          end
-
-          def safari_choices
-            choices = {}
-            safari_train_choices(current_entity).each_with_index do |train, index|
-              choices[index.to_s] = "#{train.name} train"
-            end
-            choices['None'] = 'None'
-            choices
-          end
-
-          def safari_train_choices(entity)
-            pullman_train_choices(entity).reject { |t| t.name.include?('+') }
-          end
-
-          def process_safari_choice(action)
-            entity = action.entity
-
-            if action.choice == 'None'
-              @safari_train = true
-              @log << "#{entity.id} chooses to not use a safari train"
-            else
-              @safari_train = safari_train_choices(entity)[action.choice.to_i]
-              @log << "#{entity.id} makes #{@safari_train.name} a safari train"
-
-              attach_safari_train
-            end
-          end
-
-          def attach_safari_train
-            @safari_original_train = @safari_train.dup
-            @safari_train.name += 'S'
-          end
-
-          def detach_safari_train
-            @safari_train.name = @safari_original_train.name
-
-            @safari_original_train = nil
-            @safari_train = nil
           end
         end
       end

--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -8,8 +8,8 @@ module Engine
     include Ownable
 
     attr_accessor :obsolete, :events, :variants, :obsolete_on, :rusted, :rusts_on, :index, :name,
-                  :distance, :reserved, :no_local
-    attr_reader :available_on, :discount, :multiplier, :sym, :variant, :requires_token, :ever_operated, :operated, :salvage
+                  :distance, :reserved, :no_local, :multiplier
+    attr_reader :available_on, :discount, :sym, :variant, :requires_token, :ever_operated, :operated, :salvage
     attr_writer :buyable
 
     def initialize(name:, distance:, price:, index: 0, **opts)


### PR DESCRIPTION
Fixes #9550

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
As per discussion with designer in #9550 only one */E train can run as Express so it was decided to implement a selector to choose which train should be the E train. It was done using Choices action during Run Routes step.
This also allowed to remove all custom routing and revenue calculation code and simply reuse it from 1822.

* **Any Assumptions / Hacks**
I had to make train `multiplier` field writable to avoid complicated shenanigans with train substitution

* **Screenshots** 
<img width="349" alt="Screenshot 2023-09-18 at 12 08 41" src="https://github.com/tobymao/18xx/assets/576786/3bd32a2e-7b3e-4621-b13d-ada774a19540">
