### PR TITLE
Corrects spelling of 'layed' to 'laid' throughout site.

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -256,7 +256,7 @@ remains open but the discount can no longer be used. Default false.
   connect to each other. Default true.
 - `blocks`: If true and `when` is `sold`, then the step
   `TrackLayWhenCompanySold` will require a tile lay. Default false.
-- `reachable`: If true, when tile layed, a check is done if one of the
+- `reachable`: If true, when tile laid, a check is done if one of the
   controlling corporation's station tokens are reachable; if not a game
   error is triggered. Default false.
 - `must_lay_together`: If true and `count` is greater than 1, all the tile lays

--- a/lib/engine/game/g_1825/step/track_and_token.rb
+++ b/lib/engine/game/g_1825/step/track_and_token.rb
@@ -77,7 +77,7 @@ module Engine
             raise GameError, 'Cannot upgrade now' if upgrade && !(tile_lay && tile_lay[:upgrade])
             raise GameError, 'Cannot lay a tile now' if !upgrade && !(tile_lay && tile_lay[:lay])
             if tile_lay[:cannot_reuse_same_hex] && @round.laid_hexes.include?(action.hex)
-              raise GameError, "#{action.hex.id} cannot be layed as this hex was already layed on this turn"
+              raise GameError, "#{action.hex.id} cannot be laid as this hex was already laid on this turn"
             end
 
             raise GameError, 'Only the NS can place tiles 887/888 on Q13' if protect_ns?(tile, action.hex, entity)

--- a/lib/engine/game/g_1860/step/tracker.rb
+++ b/lib/engine/game/g_1860/step/tracker.rb
@@ -32,7 +32,7 @@ module Engine
           raise GameError, 'Cannot lay an yellow now' if tile.color == :yellow && !tile_lay[:lay]
           raise GameError, 'Cannot lay a city tile now' if tile.cities.any? && @round.num_laid_track.positive?
           if tile_lay[:cannot_reuse_same_hex] && @round.laid_hexes.include?(action.hex)
-            raise GameError, "#{action.hex.id} cannot be layed as this hex was already layed on this turn"
+            raise GameError, "#{action.hex.id} cannot be laid as this hex was already laid on this turn"
           end
 
           @saved_revenues = revenues(action.hex.tile, action.entity)

--- a/lib/engine/game/g_1882/game.rb
+++ b/lib/engine/game/g_1882/game.rb
@@ -283,7 +283,7 @@ module Engine
             )
           end
 
-          # CN's tokens use a neutral logo, but as layed become owned by cn but don't block other players
+          # CN's tokens use a neutral logo, but as laid become owned by cn but don't block other players
           cn_corp = corporations.find { |x| x.name == 'CN' }
           logo = '/logos/1882/neutral.svg'
           corporations.each do |x|

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -61,7 +61,7 @@ module Engine
                                                                        action.hex) && !(tile_lay && tile_lay[:upgrade])
         raise GameError, 'Cannot lay a yellow now' if tile.color == :yellow && !(tile_lay && tile_lay[:lay])
         if tile_lay[:cannot_reuse_same_hex] && @round.laid_hexes.include?(action.hex)
-          raise GameError, "#{action.hex.id} cannot be layed as this hex was already layed on this turn"
+          raise GameError, "#{action.hex.id} cannot be laid as this hex was already laid on this turn"
         end
 
         extra_cost = tile.color == :yellow ? tile_lay[:cost] : tile_lay[:upgrade_cost]


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

The word is spelled "laid", not "layed". This is one of those internet spelling mistakes that have caught on, but are incorrect.

https://brians.wsu.edu/2016/05/19/layed-laid/#:~:text=Although%20%E2%80%9Clayed%E2%80%9D%20is%20an%20extremely,You%20laid%20down%20the%20law.
