### PR TITLE
[1822CA] fix placing M13's home token in Toronto

### DIFF
--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -322,7 +322,7 @@ module Engine
 
         def operating_round(round_num)
           Engine::Round::Operating.new(self, [
-            G1822::Step::PendingToken,
+            G1822CA::Step::PendingToken,
             G1822::Step::FirstTurnHousekeeping,
             Engine::Step::AcquireCompany,
             G1822CA::Step::DiscardTrain,
@@ -338,7 +338,7 @@ module Engine
             G1822::Step::BuyTrain,
             G1822CA::Step::MinorAcquisition,
             G1822CA::Step::AcquisitionTrack,
-            G1822::Step::PendingToken,
+            G1822CA::Step::PendingToken,
             G1822CA::Step::DiscardTrain,
             G1822CA::Step::IssueShares,
           ], round_num: round_num)

--- a/lib/engine/game/g_1822_ca/step/pending_token.rb
+++ b/lib/engine/game/g_1822_ca/step/pending_token.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1822/step/pending_token'
+
+module Engine
+  module Game
+    module G1822CA
+      module Step
+        class PendingToken < G1822::Step::PendingToken
+          def setup_m14_track_rights(_m14); end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
M13 is roughly equivalent to 1822's M14, but in 1822, M14 can have a say in track laid adjacent to the London hex, which is not the case for M13 in Toronto

#9376
