### PR TITLE
[1822/CA scenarios] show change of L-train upgrade cost on info page

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -324,6 +324,8 @@ module Engine
           'minor_float_phase3on' => ['Minors receive winning bid as capital',
                                      'Minors receive entire winning bid as capital '\
                                      'and float at between 50 to 100 stock value based on bid'],
+          'l_upgrade' => ['£70 L-train upgrades',
+                          'The cost to upgrade an L-train to a 2-train is reduced from £80 to £70.'],
         ).freeze
 
         BIDDING_BOX_MINOR_COUNT = 4

--- a/lib/engine/game/g_1822/scenario.rb
+++ b/lib/engine/game/g_1822/scenario.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1822
+      module Scenario
+        PHASES = [
+          {
+            name: '1',
+            on: '',
+            train_limit: { minor: 2, major: 4 },
+            tiles: [:yellow],
+            status: ['minor_float_phase1'],
+            operating_rounds: 1,
+          },
+          {
+            name: '2',
+            on: %w[2 3],
+            train_limit: { minor: 2, major: 4 },
+            tiles: [:yellow],
+            status: %w[can_convert_concessions minor_float_phase2 l_upgrade],
+            operating_rounds: 2,
+          },
+          {
+            name: '3',
+            on: '3',
+            train_limit: { minor: 2, major: 4 },
+            tiles: %i[yellow green],
+            status: %w[can_buy_trains can_convert_concessions minor_float_phase3on],
+            operating_rounds: 2,
+          },
+          {
+            name: '4',
+            on: '4',
+            train_limit: { minor: 1, major: 3 },
+            tiles: %i[yellow green],
+            status: %w[can_buy_trains can_convert_concessions minor_float_phase3on],
+            operating_rounds: 2,
+          },
+          {
+            name: '5',
+            on: '5',
+            train_limit: { minor: 1, major: 2 },
+            tiles: %i[yellow green brown],
+            status: %w[can_buy_trains
+                       can_acquire_minor_bidbox
+                       can_par
+                       minors_green_upgrade
+                       minor_float_phase3on],
+            operating_rounds: 2,
+          },
+          {
+            name: '6',
+            on: '6',
+            train_limit: { minor: 1, major: 2 },
+            tiles: %i[yellow green brown],
+            status: %w[can_buy_trains
+                       can_acquire_minor_bidbox
+                       can_par
+                       full_capitalisation
+                       minors_green_upgrade
+                       minor_float_phase3on],
+            operating_rounds: 2,
+          },
+          {
+            name: '7',
+            on: '7',
+            train_limit: { minor: 1, major: 2 },
+            tiles: %i[yellow green brown gray],
+            status: %w[can_buy_trains
+                       can_acquire_minor_bidbox
+                       can_par
+                       full_capitalisation
+                       minors_green_upgrade
+                       minor_float_phase3on],
+            operating_rounds: 2,
+          },
+        ].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -241,9 +241,14 @@ module Engine
 
         MUST_SELL_IN_BLOCKS = true
 
-        EVENTS_TEXT = Base::EVENTS_TEXT.merge(
+        EVENTS_TEXT = G1822::Game::EVENTS_TEXT.merge(
           'open_detroit_duluth' => ['Open Detroit-Duluth',
                                     'Phase 3: the connection between Detroit (Y29) and Duluth (P18) opens'],
+        )
+
+        STATUS_TEXT = G1822::Game::STATUS_TEXT.merge(
+          'l_upgrade' => ['$70 L-train upgrades',
+                          'The cost to upgrade an L-train to a 2-train is reduced from $80 to $70.']
         )
 
         attr_accessor :sawmill_hex, :sawmill_owner, :train_with_grain, :train_with_pullman

--- a/lib/engine/game/g_1822_ca/scenario.rb
+++ b/lib/engine/game/g_1822_ca/scenario.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../g_1822/scenario'
+
 module Engine
   module Game
     module G1822CA
@@ -15,6 +17,8 @@ module Engine
           %w[5y 10y 15y 20y 25y 30y 35y 40y 45y 50p 60xp 70xp 80xp 90xp 100xp 110 120 135 150 165 180 200 220
              245 270 300 330 360 400 450 500e 550e 600e],
         ].freeze
+
+        PHASES = G1822::Scenario::PHASES
 
         TRAINS = [
           {

--- a/lib/engine/game/g_1822_mrs/game.rb
+++ b/lib/engine/game/g_1822_mrs/game.rb
@@ -49,6 +49,8 @@ module Engine
           %w[5y 10y 15y 20y 25y],
         ].freeze
 
+        PHASES = G1822::Scenario::PHASES
+
         TRAINS = [
           {
             name: 'L',

--- a/lib/engine/game/g_1822_nrs/game.rb
+++ b/lib/engine/game/g_1822_nrs/game.rb
@@ -47,6 +47,8 @@ module Engine
           %w[5y 10y 15y 20y 25y],
         ].freeze
 
+        PHASES = G1822::Scenario::PHASES
+
         TRAINS = [
           {
             name: 'L',


### PR DESCRIPTION
In standard 1822, it is always $80 to upgrade an L to a 2; in 1822MRS, 1822NRS, 1822CA ERS, and 1822CA WRS, it is only $70 after Phase 2.

#9376