### PR TITLE
[1858] Fix incorrect home hex descriptions on privates

### DIFF
--- a/lib/engine/game/g_1858/entities.rb
+++ b/lib/engine/game/g_1858/entities.rb
@@ -151,7 +151,7 @@ module Engine
           {
             sym: 'M&A',
             name: 'Madrid and Aranjuez Railway',
-            desc: 'P3. Revenue 25/38, face value 125. Home hexes are H9 and H11. ' \
+            desc: 'P3. Revenue 25/38, face value 125. Home hexes are H11 and H13. ' \
                   'Can be used to start a public company in Madrid.',
             value: 125,
             discount: 25,
@@ -198,7 +198,7 @@ module Engine
           {
             sym: 'V&J',
             name: 'Valencia and Jativa Railway',
-            desc: 'P5. Revenue 20/30, face value 100. Home hex is L11. ' \
+            desc: 'P5. Revenue 20/30, face value 100. Home hex is L13. ' \
                   'Can be used to start a public company in Valencia.',
             value: 100,
             discount: 20,
@@ -425,7 +425,7 @@ module Engine
           {
             sym: 'M&C',
             name: 'Murcia and Cartagena Railway',
-            desc: 'P15. Revenue 14/21, face value 70. Home hex is K18. ' \
+            desc: 'P15. Revenue 14/21, face value 70. Home hexes are K18 and L19. ' \
                   'Can be used to start a public company in Murcia.',
             value: 70,
             discount: 15,


### PR DESCRIPTION
M&A, V&J and M&C all had mistakes in their descriptions, giving the wrong home hex coordinates.

Fixes #9641.

- [x] Branch is derived from the latest `master`
- ~~Add the `pins` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`