### PR TITLE
[18EU] fixes auction when players have zero cash. 

### DIFF
--- a/lib/engine/game/g_18_eu/step/modified_dutch_auction.rb
+++ b/lib/engine/game/g_18_eu/step/modified_dutch_auction.rb
@@ -244,7 +244,7 @@ module Engine
             reduce_price
             entities.each(&:unpass!)
             next_entity!
-            force_purchase(@auction_triggerer, @auctioning) if min_bid(@auctioning).zero?
+            force_purchase(@auction_triggerer, @auctioning) if @auctioning && min_bid(@auctioning).zero?
           end
 
           def resolve_bids


### PR DESCRIPTION
Fixes #9662 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games <- to be honest, I'm not sure we will need to pin anything, since any game in that situation would have blocked on that step. 
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
By adding the @auctioning && check, The code checks that min_bid is only called when @auctioning is not nil, which prevents the "undefined method `zero?' for nil" error and allows the proper next steps to follow.
