### PR TITLE
[1868 Wyoming] fix pure oil placement

### DIFF
--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -1772,10 +1772,12 @@ module Engine
               town = Part::Town.new(revenue, **opts)
               town.tile = hex.tile
               hex.tile.towns << town
+              hex.tile.city_towns << town
             else
               city = Part::City.new(revenue, **opts)
               city.tile = hex.tile
               hex.tile.cities << city
+              hex.tile.city_towns << city
             end
           else
             tile_name = PURE_OIL_CAMP_TILES[hex.tile.name]


### PR DESCRIPTION
The new city/town was not added to the tile's `city_towns`, which is what is checked for determining if boomtown/boom city tiles should be used.

Fixes #9651
