### PR TITLE
Fix map rendering with TileSelector for Opal 1.6

### DIFF
--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -105,18 +105,20 @@ module View
               # Add tiles that aren't part of all_upgrades (Mitsubishi ferry)
               select_tiles.append(*tiles.map { |t| [t, nil] })
 
-              return h(:div) if select_tiles.empty?
+              if select_tiles.empty?
+                h(:div)
+              else
+                distance = TileSelector::DISTANCE * map_zoom
+                width, height = map_size
+                ts_ds = [TileSelector::DROP_SHADOW_SIZE - 5, 0].max # ignore up to 5px of ds (< 2vmin padding of #app)
+                left_col = left < distance
+                right_col = width - left < distance + ts_ds
+                top_row = top < distance
+                bottom_row = height - top < distance + ts_ds
 
-              distance = TileSelector::DISTANCE * map_zoom
-              width, height = map_size
-              ts_ds = [TileSelector::DROP_SHADOW_SIZE - 5, 0].max # ignore up to 5px of ds (< 2vmin padding of #app)
-              left_col = left < distance
-              right_col = width - left < distance + ts_ds
-              top_row = top < distance
-              bottom_row = height - top < distance + ts_ds
-
-              h(TileSelector, layout: @layout, tiles: select_tiles, actions: actions, zoom: map_zoom, top_row: top_row,
-                              left_col: left_col, right_col: right_col, bottom_row: bottom_row)
+                h(TileSelector, layout: @layout, tiles: select_tiles, actions: actions, zoom: map_zoom,
+                                top_row: top_row, left_col: left_col, right_col: right_col, bottom_row: bottom_row)
+              end
             end
 
           # Move the position to the middle of the hex


### PR DESCRIPTION
Fixes #9605 for Opal 1.6 (progress for #9608); the issue is not present with Opal 1.5.

**Explanation of Change**

The `selector` variable is set here with an `if` block, like this:

```
selector =
  if ...
    ...
  end
 ```

In Opal, this is compiled as `selector = (function() { ... })();`.

The problematic line is:

```
return h(:div) if select_tiles.empty?
```

In Opal 1.5, this `return` is incorrectly applied to the function wrapping the
`if` block for defining `selector`:

```
if ($truthy(select_tiles['$empty?']())) {
  return self.$h("div")
};
```

That bug is fixed in Opal 1.6, and the line is compiled so that the `render`
function is the one that returns, causing the whole map to be rendered as an
empty `<div>`, instead of only the `TileSelector` being rendered as an empty
`<div>`:

```
if ($truthy(select_tiles['$empty?']())) {
  $t_return.$throw(self.$h("div"))
};
```

So, with this change, the map and `TileSelector` still behave correctly in Opal
1.5, and will now work as intended in Opal 1.6.
