### PR TITLE
[18NL] adds check that corp has remaining tokens before blocking on token step.

### DIFF
--- a/lib/engine/game/g_18_nl/step/token.rb
+++ b/lib/engine/game/g_18_nl/step/token.rb
@@ -14,7 +14,8 @@ module Engine
               !actions.empty? ||
               @game.p2_company.owner != entity ||
               # checks to see if P2's token ability still exists. The game removes the ability after its use.
-              @game.p2_company.abilities.none? { |ability| ability.type == 'token' }
+              @game.p2_company.abilities.none? { |ability| ability.type == 'token' } ||
+              available_tokens(entity).empty?
 
             %w[pass]
           end


### PR DESCRIPTION
Fixes #9677

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Game was locking up because of an invalid past blocking step if a corp with no tokens had the P2 token ability still available, due to the way I introduced a blocking step. 

Added condition to check if corp has any remaining tokens before blocking
* **Screenshots**

* **Any Assumptions / Hacks**
