### PR TITLE
[Opal 1.6] don't use return inside of a lambda

### DIFF
--- a/assets/app/view/game/flexible_buy.rb
+++ b/assets/app/view/game/flexible_buy.rb
@@ -56,7 +56,7 @@ module View
             price = input.JS['elm'].JS['value'].to_i
             price_percent = bundle.corporation.type == :major ? 10 : 20
             share_price = (price * price_percent / bundle.percent).to_i
-            return '' unless @step.flexible_can_buy_shares?(@current_entity, bundle.shares, price)
+            next '' unless @step.flexible_can_buy_shares?(@current_entity, bundle.shares, price)
 
             buy_shares = lambda do
               process_action(

--- a/lib/engine/game/g_1822/round/stock.rb
+++ b/lib/engine/game/g_1822/round/stock.rb
@@ -29,8 +29,8 @@ module Engine
           def update_stored_winning_bids(entity)
             winning_bids = []
             check_winning = lambda { |bid_target|
-              return unless (bid = highest_bid(bid_target))
-              return unless bid.entity == entity
+              next unless (bid = highest_bid(bid_target))
+              next unless bid.entity == entity
 
               winning_bids << bid_target
             }

--- a/lib/engine/game/g_1822_africa/round/stock.rb
+++ b/lib/engine/game/g_1822_africa/round/stock.rb
@@ -15,8 +15,8 @@ module Engine
           def update_stored_winning_bids(entity)
             winning_bids = []
             check_winning = lambda { |bid_target|
-              return unless (bid = highest_bid(bid_target))
-              return unless bid.entity == entity
+              next unless (bid = highest_bid(bid_target))
+              next unless bid.entity == entity
 
               winning_bids << bid_target
             }


### PR DESCRIPTION
[opal/opal #2357](https://www.github.com/opal/opal/pull/2357) revamped how closures are tracked. As described in #9673, this is better behavior and unveiled some problems in our code, but Opal itself has a bug here (at least in 1.6.1), where a `return` inside of a lambda causes the enclosing function, instead of the lambda itself, to return. Fortunately, in a lambda, `next` behaves the same as `return`, so we can work around this issue by using `next` in our lambdas.

Fixes #9603, #9604, #9606 for Opal 1.6--progress on #9608
