### PR TITLE
[1861/1867] Show unstarted corporations on entities page

### DIFF
--- a/lib/engine/game/g_1861/game.rb
+++ b/lib/engine/game/g_1861/game.rb
@@ -184,7 +184,7 @@ module Engine
           unipoed = (@corporations + @future_corporations).reject(&:ipoed)
           minor = unipoed.select { |c| c.type == :minor }
           major = unipoed.select { |c| c.type == :major }
-          ["#{major.size} major", [@national] + minor]
+          ["#{minor.size} minor, #{major.size} major", [@national] + minor + major]
         end
 
         def init_loans

--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -563,7 +563,7 @@ module Engine
           unipoed = (@corporations + @future_corporations).reject(&:ipoed)
           minor = unipoed.select { |c| c.type == :minor }
           major = unipoed.select { |c| c.type == :major }
-          ["#{minor.size} minor, #{major.size} major", [@national]]
+          ["#{minor.size} minor, #{major.size} major", [@national] + minor + major]
         end
 
         def show_value_of_companies?(_owner)


### PR DESCRIPTION
In the section underneath the bank on the entities page, 1867 was only showing the national railway. This commits adds unstarted minor and major railways to this section. 1861 was already showing minors, majors are now added. The number of unstarted minors is added to the bank box in 1861.

Fixes #9524.

- [x] Branch is derived from the latest `master`
- ~~Add the `pins` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`