### PR TITLE
[1858] Add missing home hex markers

### DIFF
--- a/lib/engine/game/g_1858/map.rb
+++ b/lib/engine/game/g_1858/map.rb
@@ -598,6 +598,7 @@ module Engine
                     'border=type:province,edge:5',
             %w[F1] =>
                     'city=revenue:40,slots:2;' \
+                    'icon=image:1858/LG,sticky:1;' \
                     'path=a:5,b:_0,track:dual;path=a:0,b:_0,track:dual;path=a:1,b:_0,track:dual;',
             %w[F21] =>
                     'path=a:2,b:3;path=a:3,b:4',
@@ -608,7 +609,8 @@ module Engine
             %w[L17] =>
                     'town=revenue:10;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;border=edge:0',
             %w[L19] =>
-                    'town=revenue:10;path=a:2,b:_0;border=edge:1;',
+                    'town=revenue:10;path=a:2,b:_0;border=edge:1;' \
+                    'icon=image:1858/MC,sticky:1;',
           },
         }.freeze
       end


### PR DESCRIPTION
Icons are used to mark the private railway companies' home hexes. A couple of these were missing: for L&G in F1 and for M&C in L19.

Fixes #9667.

- [x] Branch is derived from the latest `master`
- ~~Add the `pins` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`