### PR TITLE
migrate_game: skip pinninng if `pin` is `nil`; validate.rb: make filename kwarg on validate_all()

### DIFF
--- a/migrate_game.rb
+++ b/migrate_game.rb
@@ -274,9 +274,13 @@ def migrate_db_actions(data, pin=nil, dry_run=false, debug=false, pry_db: false,
         puts "    Archiving #{data.id}"
         data.archive!
       else
-        puts "    Would pin #{data.id} to #{pin}"
-        data.settings['pin']=pin
-        data.save
+        if pin
+          puts "    Pinning #{data.id} to #{pin}"
+          data.settings['pin'] = pin
+          data.save
+        else
+          puts "    Skipping pin (none given)"
+        end
       end
     else
       puts "    Needs pinning #{data.id} to #{pin}"

--- a/validate.rb
+++ b/validate.rb
@@ -79,7 +79,7 @@ def run_game(game, actions = nil, strict: false)
   data
 end
 
-def validate_all(*titles, game_ids: nil, strict: false, status: %w[active finished])
+def validate_all(*titles, game_ids: nil, strict: false, status: %w[active finished], filename: 'validate.json')
   $count = 0
   $total = 0
   $total_time = 0
@@ -113,7 +113,6 @@ def validate_all(*titles, game_ids: nil, strict: false, status: %w[active finish
   puts "#{$count}/#{$total} avg #{$total_time / $total}"
   data['summary']={'failed':$count, 'total':$total, 'total_time':$total_time, 'avg_time':$total_time / $total}
 
-  filename = "validate.json"
   File.write(filename, JSON.pretty_generate(data))
   Validate.new(filename)
 end


### PR DESCRIPTION
Small changes made while I looked at #9697.

Previously, if `nil` was passed in for `pin` when calling `migrate_all()`, the game's `settings` in the DB would be updated with `pin: nil`, which is undesirable for certain calls which check whether the `pin` key exists at all, instead of checking if its value is a real pin.