### PR TITLE
[1822CA] fix big city upgrades

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1236,7 +1236,7 @@ module Engine
 
         def upgrades_to?(from, to, _special = false, selected_company: nil)
           # This is needed because the S tile upgrade removes the town in yellow
-          if self.class::UPGRADABLE_S_HEX_NAME == from.hex.name && from.color == :white
+          if self.class::UPGRADABLE_S_HEX_NAME == from.hex&.name && from.color == :white
             return self.class::UPGRADABLE_S_YELLOW_CITY_TILE == to.name
           end
 

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -228,6 +228,20 @@ module Engine
                           'The cost to upgrade an L-train to a 2-train is reduced from $80 to $70.']
         )
 
+        # the big city tiles have complex arrangements of multiple cities and
+        # multiple possible upgrade paths, the implemented upgrade logic can't
+        # handle all of them so some restrictions are hardcoded here instead of
+        # writing logic that wouldn't be very common
+        BIG_CITY_ILLEGAL_TILE_UPGRADES = {
+          'M2' => 'M6',
+          'M3' => 'M4',
+          'O2' => 'O3',
+          'O4' => 'O5',
+          'Q4' => 'Q5',
+          'T5' => 'T6',
+          'W5' => 'W6',
+        }.freeze
+
         attr_accessor :sawmill_hex, :sawmill_owner, :train_with_grain, :train_with_pullman
         attr_writer :sawmill_bonus
 
@@ -332,6 +346,7 @@ module Engine
 
         def upgrades_to?(from, to, _special = false, selected_company: nil)
           return %w[5 6 57].include?(to.name) if from.name == 'AG13' && from.color == :white
+          return false if self.class::BIG_CITY_ILLEGAL_TILE_UPGRADES[from.name] == to.name
 
           super
         end
@@ -349,7 +364,7 @@ module Engine
         end
 
         def upgrades_to_correct_label?(from, to)
-          super || (MOUNTAIN_PASS_HEXES.include?(from.hex.id) && MOUNTAIN_PASS_TILES.include?(to.name))
+          super || (MOUNTAIN_PASS_HEXES.include?(from.hex&.id) && MOUNTAIN_PASS_TILES.include?(to.name))
         end
 
         def small_mail_contract_subsidy(routes)

--- a/spec/lib/engine/tile_spec.rb
+++ b/spec/lib/engine/tile_spec.rb
@@ -54,6 +54,52 @@ EXPECTED_TILE_UPGRADES = {
     '492' => %w[],
     '611' => %w[],
   },
+  '1822CA' => {
+    'A1' => %w[A2],
+    'A2' => %w[A3],
+    'A3' => %w[],
+    'B1' => %w[B2],
+    'B2' => %w[B3],
+    'B3' => %w[],
+    'M1' => %w[M2 M3],
+    'M2' => %w[M4 M5],
+    'M3' => %w[M5 M6],
+    'M4' => %w[M7 M8],
+    'M5' => %w[M8],
+    'M6' => %w[M8],
+    'M7' => %w[],
+    'M8' => %w[],
+    'O1' => %w[O3 O4],
+    'O2' => %w[O4],
+    'O3' => %w[O5 O6],
+    'O4' => %w[O6],
+    'O5' => %w[O7 O8],
+    'O6' => %w[O8],
+    'O7' => %w[],
+    'O8' => %w[],
+    'Q1' => %w[Q3 Q4],
+    'Q2' => %w[Q3 Q4],
+    'Q3' => %w[Q5 Q6],
+    'Q4' => %w[Q6],
+    'Q5' => %w[Q7 Q8],
+    'Q6' => %w[Q8],
+    'Q7' => %w[],
+    'Q8' => %w[],
+    'T1' => %w[T2 T3],
+    'T2' => %w[T4 T5],
+    'T3' => %w[T4 T5],
+    'T4' => %w[T6 T7],
+    'T5' => %w[T7],
+    'T6' => %w[],
+    'T7' => %w[],
+    'W1' => %w[W2 W3],
+    'W2' => %w[W4 W5],
+    'W3' => %w[W5],
+    'W4' => %w[W6 W7],
+    'W5' => %w[W7],
+    'W6' => %w[],
+    'W7' => %w[],
+  },
 }.freeze
 
 module Engine
@@ -102,10 +148,10 @@ module Engine
 
           aggregate_failures 'tile upgrades' do
             upgrades.keys.each do |t|
-              tile = game.hex_by_id(t)&.tile || game.tile_by_id("#{t}-0") || Tile.for(t)
+              tile = game.tile_by_id("#{t}-0") || game.hex_by_id(t)&.tile || Tile.for(t)
 
               upgrades.keys.each do |u|
-                upgrade = game.hex_by_id(u)&.tile || game.tile_by_id("#{u}-0") || Tile.for(u)
+                upgrade = game.tile_by_id("#{u}-0") || game.hex_by_id(u)&.tile || Tile.for(u)
 
                 expected_included = upgrades[t].include?(u)
                 expected_string = "#{t} #{expected_included ? '<' : '!<'} #{u}"


### PR DESCRIPTION
- add constant specifying illegal tile upgrades which the game code would otherwise allow
- add unit tests to verify the possible upgrade paths for the big city tiles 
    - in the test, check for a tile with the given name before checking the hex; 1822CA has some overlap there, e.g., M5 and M7
    - when `upgrades_to?` is called in the test, there is no hex, so `G1822CA::Game#upgrades_to_correct_label?` and `G1822::Game#upgrades_to?` have to make sure the hex is non-nil before calling `.name` on it

#9376