### PR TITLE
Allow abilities to use on_phase and when together. Add after_phase attribute

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -26,6 +26,7 @@ These attributes may be set for all ability types
   been used at least once, but there is still `count` remaining, the ability
   gets used up and removed. Default `true`.
 - `on_phase`: The phase when this ability is active
+- `after_phase`: The ability is active for all phases after the specified phase
 - `when`: (string or array of strings) The game steps or special time descriptor
   when this ability is active. If no values are provided, this ability is
   considered to be "passive", i.e., its effect applies without the user needinng

--- a/lib/engine/ability/base.rb
+++ b/lib/engine/ability/base.rb
@@ -11,16 +11,17 @@ module Engine
 
       attr_accessor :count_this_or, :description, :desc_detail
       attr_reader :type, :owner_type, :remove, :when, :count, :count_per_or, :start_count, :passive,
-                  :on_phase, :use_across_ors
+                  :on_phase, :after_phase, :use_across_ors
 
       def initialize(type:, description: nil, desc_detail: nil, owner_type: nil, count: nil, remove: nil,
-                     use_across_ors: nil, count_per_or: nil, passive: nil, on_phase: nil, **opts)
+                     use_across_ors: nil, count_per_or: nil, passive: nil, on_phase: nil, after_phase: nil, **opts)
         @type = type&.to_sym
         @description = description&.to_s
         @desc_detail = desc_detail&.to_s
         @owner_type = owner_type&.to_sym
         @when = Array(opts.delete(:when)).map(&:to_s)
         @on_phase = on_phase
+        @after_phase = after_phase
         @count = count
         @count_per_or = count_per_or
         @count_this_or = 0

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2982,8 +2982,9 @@ module Engine
 
       def ability_right_time?(ability, time, on_phase, passive_ok, strict_time)
         return true unless @round
+        return false if ability.on_phase && !['any', ability.on_phase].include?(on_phase)
+        return false if ability.after_phase && !@phase.previous.map { |p| p['name'] }.include?(ability.after_phase)
         return true if time == 'any' || ability.when?('any')
-        return (on_phase == ability.on_phase) || (on_phase == 'any') if ability.on_phase
         return false if ability.passive && !passive_ok
         return true if ability.passive && ability.when.empty?
 

--- a/lib/engine/phase.rb
+++ b/lib/engine/phase.rb
@@ -29,6 +29,10 @@ module Engine
       @game.after_buying_train(train, source)
     end
 
+    def previous
+      @phases[0...@index]
+    end
+
     def current
       @phases[@index]
     end


### PR DESCRIPTION
If an ability uses `on_phase`, `ability_right_time?` will return before checking `when` conditions. This change will first check if it is the right phase and if it is, proceed to check the `when` condition.

The PR also includes a new attribute called `after_phase` which `ability_right_time?` will make sure the game has moved past the specified phase.