### PR TITLE
[18Tokaido] color plus name changes to match print version

### DIFF
--- a/lib/engine/game/g_18_tokaido/entities.rb
+++ b/lib/engine/game/g_18_tokaido/entities.rb
@@ -6,11 +6,11 @@ module Engine
       module Entities
         COMPANIES = [
           {
-            name: 'Kyoto Railway Co.',
+            name: 'Kyoto Railway Company',
             value: 20,
             revenue: 5,
             desc: 'No special ability. Blocks hex D8 while owned by a player.',
-            sym: 'KT',
+            sym: 'KRC',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['D8'] }],
             color: nil,
           },
@@ -93,7 +93,7 @@ module Engine
             simple_logo: '18_tokaido/YSL.alt',
             tokens: [0, 40],
             coordinates: 'I9',
-            color: '#ef2f2f',
+            color: '#d81e3e',
             text_color: 'white',
           },
           {
@@ -104,19 +104,19 @@ module Engine
             simple_logo: '18_tokaido/SRC.alt',
             tokens: [0, 40, 60],
             coordinates: 'B12',
-            color: '#ef8f2f',
-            text_color: 'black',
+            color: '#7b352a',
+            text_color: 'white',
           },
           {
             float_percent: 60,
-            sym: 'KRC',
+            sym: 'KAN',
             name: 'Kansai Railway Co.',
             logo: '18_tokaido/KRC',
             simple_logo: '18_tokaido/KRC.alt',
             tokens: [0, 40, 60],
             coordinates: 'C11',
             city: 1,
-            color: '#2f7f2f',
+            color: '#237333',
             text_color: 'white',
           },
           {
@@ -127,8 +127,8 @@ module Engine
             simple_logo: '18_tokaido/ARC.alt',
             tokens: [0, 40],
             coordinates: 'F8',
-            color: '#2f2f9f',
-            text_color: 'white',
+            color: '#FFF500',
+            text_color: 'black',
           },
           {
             float_percent: 60,
@@ -150,8 +150,8 @@ module Engine
             simple_logo: '18_tokaido/SHI.alt',
             tokens: [0, 40, 60],
             coordinates: 'J2',
-            color: '#efef4f',
-            text_color: 'black',
+            color: '#0189d1',
+            text_color: 'white',
           },
           {
             float_percent: 60,
@@ -161,8 +161,8 @@ module Engine
             simple_logo: '18_tokaido/NAN.alt',
             tokens: [0, 40, 60],
             coordinates: 'F4',
-            color: '#7f9f9f',
-            text_color: 'white',
+            color: '#a2dced',
+            text_color: 'black',
           },
         ].freeze
       end

--- a/lib/engine/game/g_18_tokaido/tiles.rb
+++ b/lib/engine/game/g_18_tokaido/tiles.rb
@@ -40,6 +40,20 @@ module Engine
           '208' => 1,
           '619' => 1,
           '622' => 1,
+          'X3' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' =>
+              'city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:_0,b:2;path=a:3,b:_1;path=a:_1,b:5;label=OO',
+          },
+          'X5' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' =>
+              'city=revenue:40;city=revenue:40;path=a:3,b:_0;path=a:_0,b:5;path=a:0,b:_1;path=a:_1,b:4;label=OO',
+          },
           'X10' =>
           {
             'count' => 1,
@@ -54,26 +68,12 @@ module Engine
             'code' =>
               'city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:_0,b:3;path=a:2,b:_1;path=a:_1,b:5;label=O',
           },
-          'X20' =>
-          {
-            'count' => 1,
-            'color' => 'green',
-            'code' =>
-              'city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:_0,b:2;path=a:3,b:_1;path=a:_1,b:5;label=OO',
-          },
-          'X21' =>
+          'X12' =>
           {
             'count' => 1,
             'color' => 'green',
             'code' =>
               'city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:_0,b:1;path=a:3,b:_1;path=a:_1,b:4;label=OO',
-          },
-          'X22' =>
-          {
-            'count' => 1,
-            'color' => 'green',
-            'code' =>
-              'city=revenue:40;city=revenue:40;path=a:3,b:_0;path=a:_0,b:5;path=a:0,b:_1;path=a:_1,b:4;label=OO',
           },
           # Brown
           '39' => 1,
@@ -86,15 +86,8 @@ module Engine
           '46' => 1,
           '47' => 2,
           '70' => 1,
+          '216' => 3,
           '611' => 3,
-          'X1' =>
-          {
-            'count' => 3,
-            'color' => 'brown',
-            'code' =>
-              'city=revenue:50,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;' \
-              'path=a:4,b:_0;label=Y',
-          },
           'X13' =>
           {
             'count' => 1,
@@ -102,7 +95,7 @@ module Engine
             'code' =>
               'city=revenue:60,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:5,b:_0;path=a:4,b:_0;label=O',
           },
-          'X23' =>
+          'X14' =>
           {
             'count' => 1,
             'color' => 'brown',
@@ -111,14 +104,14 @@ module Engine
           },
           # Gray
           '915' => 1,
-          'X2' =>
+          'X15' =>
           {
             'count' => 1,
             'color' => 'gray',
             'code' =>
             'city=revenue:60,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=Y',
           },
-          'X14' =>
+          'X16' =>
           {
             'count' => 1,
             'color' => 'gray',
@@ -126,7 +119,7 @@ module Engine
               'city=revenue:80,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;' \
               'path=a:4,b:_0;path=a:5,b:_0;label=O',
           },
-          'X24' =>
+          'X17' =>
           {
             'count' => 1,
             'color' => 'gray',

--- a/public/logos/18_tokaido/ARC.alt.svg
+++ b/public/logos/18_tokaido/ARC.alt.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#2f2f9f"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">ARC</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#FFF500"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial">ARC</text></svg>

--- a/public/logos/18_tokaido/ARC.svg
+++ b/public/logos/18_tokaido/ARC.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#2f2f9f"/><text x="4" y="5.3" text-anchor="middle" font-weight="700" font-size="3.6" textLength="6.8" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">愛知</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#FFF500"/><text x="4" y="5.3" text-anchor="middle" font-weight="700" font-size="3.6" textLength="6.8" lengthAdjust="spacingAndGlyphs" font-family="Arial">愛知</text></svg>

--- a/public/logos/18_tokaido/KRC.alt.svg
+++ b/public/logos/18_tokaido/KRC.alt.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#2f7f2f"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">KRC</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#237333"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">KAN</text></svg>

--- a/public/logos/18_tokaido/KRC.svg
+++ b/public/logos/18_tokaido/KRC.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#2f7f2f"/><text x="4" y="5.3" text-anchor="middle" font-weight="700" font-size="3.6" textLength="6.8" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">関西</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#237333"/><text x="4" y="5.3" text-anchor="middle" font-weight="700" font-size="3.6" textLength="6.8" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">関西</text></svg>

--- a/public/logos/18_tokaido/NAN.alt.svg
+++ b/public/logos/18_tokaido/NAN.alt.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#7f9f9f"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">NAN</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#a2dced"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial">NAN</text></svg>

--- a/public/logos/18_tokaido/NAN.svg
+++ b/public/logos/18_tokaido/NAN.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#7f9f9f"/><text x="4" y="5.3" text-anchor="middle" font-weight="700" font-size="3.6" textLength="6.8" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">七尾</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#a2dced"/><text x="4" y="5.3" text-anchor="middle" font-weight="700" font-size="3.6" textLength="6.8" lengthAdjust="spacingAndGlyphs" font-family="Arial">七尾</text></svg>

--- a/public/logos/18_tokaido/SHI.alt.svg
+++ b/public/logos/18_tokaido/SHI.alt.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#efef4f"/><text x="3.9" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="6.0" lengthAdjust="spacingAndGlyphs" font-family="Arial">SHI</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#0189d1"/><text x="3.9" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="6.0" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#FFF">SHI</text></svg>

--- a/public/logos/18_tokaido/SHI.svg
+++ b/public/logos/18_tokaido/SHI.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#efef4f"/><text x="4" y="5.3" text-anchor="middle" font-weight="700" font-size="3.6" textLength="6.8" lengthAdjust="spacingAndGlyphs" font-family="Arial">信濃</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#0189d1"/><text x="4" y="5.3" text-anchor="middle" font-weight="700" font-size="3.6" textLength="6.8" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#FFF">信濃</text></svg>

--- a/public/logos/18_tokaido/SRC.alt.svg
+++ b/public/logos/18_tokaido/SRC.alt.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#ef8f2f"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial">SRC</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#7b352a"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">SRC</text></svg>

--- a/public/logos/18_tokaido/SRC.svg
+++ b/public/logos/18_tokaido/SRC.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#ef8f2f"/><text x="4" y="5.3" text-anchor="middle" font-weight="700" font-size="3.6" textLength="6.8" lengthAdjust="spacingAndGlyphs" font-family="Arial">山陽</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#7b352a"/><text x="4" y="5.3" text-anchor="middle" font-weight="700" font-size="3.6" textLength="6.8" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">山陽</text></svg>

--- a/public/logos/18_tokaido/YSL.alt.svg
+++ b/public/logos/18_tokaido/YSL.alt.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#ef2f2f"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">YSL</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#d81e3e"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">YSL</text></svg>

--- a/public/logos/18_tokaido/YSL.svg
+++ b/public/logos/18_tokaido/YSL.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#ef2f2f"/><text x="4" y="5.3" text-anchor="middle" font-weight="700" font-size="3.6" textLength="6.8" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">京浜</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#d81e3e"/><text x="4" y="5.3" text-anchor="middle" font-weight="700" font-size="3.6" textLength="6.8" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">京浜</text></svg>


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

Changes to get in sync with current version of in-progress print prototype.  A couple company (three-letter) code changes to match the prototype map, some tile number changes to match prototype tile sheet, and colors now match 18Chesapeake.

All the code changes are basically cosmetic, but pretty sure the private/company three-letter code changes require a pin.
