### PR TITLE
[1822Africa] Correctly close P16

### DIFF
--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -904,7 +904,6 @@ module Engine
             ['Minor company dividend > 0', '1 →'],
             ['Each share sold (if sold by director)', '1 ←'],
             ['One or more shares sold (if sold by non-director)', '1 ←'],
-            ['Corporation sold out at end of SR', '1 →'],
           ]
         end
       end

--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -185,6 +185,8 @@ module Engine
             ['Concessions close', 'All concessions close without compensation, major companies float at 50%'],
           'full_capitalisation' =>
             ['Full capitalisation', 'Major companies receive full capitalisation when floated'],
+          'phase_revenue' =>
+            ['Phase revenue company closes', 'P16 closes if not owned by a major company'],
         }.freeze
 
         MARKET_TEXT = G1822::Game::MARKET_TEXT.merge(max_price: 'Maximum price for a minor').freeze
@@ -295,6 +297,9 @@ module Engine
             events: [
               {
                 'type' => 'full_capitalisation',
+              },
+              {
+                'type' => 'phase_revenue',
               },
             ],
           },


### PR DESCRIPTION
### Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Make P16 promptly close when Phase 6 begins, as stated in company descripton.