### PR TITLE
Fix typo in 18Dixie companies

### DIFF
--- a/lib/engine/game/g_18_dixie/companies.rb
+++ b/lib/engine/game/g_18_dixie/companies.rb
@@ -92,7 +92,7 @@ module Engine
             sym: 'P6',
             value: 140,
             revenue: 0,
-            desc: 'The purchaser of this Private Company immediately receives teh 20% president\'s certificate of the Southern '\
+            desc: 'The purchaser of this Private Company immediately receives the 20% president\'s certificate of the Southern '\
                   'Railway. The owner then immediately sets the par value for the Southern Railway, places 3 regular shares '\
                   'of the Southern Railway into the Open Market (thus it is floated and will operate with no further '\
                   'share purchases), and discards this Private Company. As long as this Private Company is in the game and '\
@@ -162,7 +162,7 @@ module Engine
             sym: 'P10',
             value: 150,
             revenue: 0,
-            desc: 'The purchaser of this Private Company immediately receives teh 20% president\'s certificate of the WRA '\
+            desc: 'The purchaser of this Private Company immediately receives the 20% president\'s certificate of the WRA '\
                   '. The owner then immediately sets the par value for the WRA, places 3 regular shares of the '\
                   'WRA into the Open Market (thus it is floated and will operate with no further share purchases), '\
                   'and discards this Private Company. As long as this Private Company is in the game and unbought, the WRA'\


### PR DESCRIPTION
Fixes minor typo in 18dixie companies

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Fixes a typo
* **Screenshots**
n/a
* **Any Assumptions / Hacks**
n/a