### PR TITLE
[1870] adds missing arguments for can_sell?

### DIFF
--- a/lib/engine/game/g_1870/step/price_protection.rb
+++ b/lib/engine/game/g_1870/step/price_protection.rb
@@ -39,7 +39,7 @@ module Engine
             @game.sell_queue.dig(0, 1)
           end
 
-          def can_sell?
+          def can_sell?(_entity, _bundle)
             false
           end
 


### PR DESCRIPTION
Fixes #9321

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
the price_protection.rb file for 1870 defined can_buy? but didn't include arguments, while the call passes two arguments. This fixes it. 

edit: not sure if pins will be required, since affected games would bounce back to a previous step when the error occurred.

* **Screenshots**

* **Any Assumptions / Hacks**
