### PR TITLE
[1847AE] fixes text of Rammelsbach private

### DIFF
--- a/lib/engine/game/g_1847_ae/entities.rb
+++ b/lib/engine/game/g_1847_ae/entities.rb
@@ -42,7 +42,7 @@ module Engine
             revenue: 30,
             min_price: 100,
             max_price: 200,
-            desc: 'Revenue increases to 50M when a tile is laid in D9. '\
+            desc: 'Revenue increases to 50M when a tile is laid in E9. '\
                   'May be sold to a corporation for 100 to 200M. '\
                   'Never closes.',
             sym: 'R',

--- a/lib/engine/game/g_18_nl/entities.rb
+++ b/lib/engine/game/g_18_nl/entities.rb
@@ -48,9 +48,9 @@ module Engine
             value: 70,
             revenue: 10,
             desc: 'A player owning this company may exchange it for a 10% share of the DV if they do not already hold 60%'\
-                  'of the DV and there is DV stock available in the Bank or the Pool. The exchange may be made during'\
-                  " the player's turn of a stock round or between the turns of other players or corporations in either "\
-                  'stock or operating rounds. This action closes the private. Blocks F9 while owned by a player.',
+                  ' of the DV and there is DV stock available in the Bank or the Pool. The exchange may be made during'\
+                  " the player's turn of a stock round or between the turns of other players or corporations in either"\
+                  ' stock or operating rounds. This action closes the private. Blocks F9 while owned by a player.',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['F9'] },
                         {
                           type: 'exchange',


### PR DESCRIPTION
Fixes #9726 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Fixes the text of the Rammelsbach private to say the revenue increases when E9 is laid, rather than the current D9. The code in the game.rb file applies the bonus properly, it was just the description text that was wrong.

I also took the opportunity to correct a missing space on a private company in 18NL.