### PR TITLE
18dixie fix b&o-like privates

### DIFF
--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -53,9 +53,8 @@ module View
 
           if @current_actions.include?('par') && @step.respond_to?(:companies_pending_par) && !@step.companies_pending_par.empty?
             return h(:div, render_company_pending_par)
-          elsif @corporation_to_par && @current_actions.include?('par')
-            return render_select_par_slot
           end
+          return render_select_par_slot if @corporation_to_par && @current_actions.include?('par')
 
           children = []
 

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -51,7 +51,11 @@ module View
             store(:corporation_to_par, nil, skip: true)
           end
 
-          return render_select_par_slot if @corporation_to_par && @current_actions.include?('par')
+          if @current_actions.include?('par') && @step.respond_to?(:companies_pending_par) && !@step.companies_pending_par.empty?
+            return h(:div, render_company_pending_par)
+          elsif @corporation_to_par && @current_actions.include?('par')
+            return render_select_par_slot
+          end
 
           children = []
 
@@ -90,6 +94,24 @@ module View
           children << h(StockMarket, game: @game, show_bank: true)
 
           h(:div, children)
+        end
+
+        def render_company_pending_par
+          children = []
+
+          company = @step.companies_pending_par.first
+          @game.abilities(company, :shares).shares&.each do |share|
+            next unless share.president
+
+            children << h(Corporation, corporation: share.corporation)
+            children << if @game.respond_to?(:par_chart)
+                          h(ParChart, corporation_to_par: share.corporation)
+                        else
+                          h(Par, corporation: share.corporation)
+                        end
+          end
+
+          children
         end
 
         def render_buttons

--- a/lib/engine/game/g_18_dixie/game.rb
+++ b/lib/engine/game/g_18_dixie/game.rb
@@ -560,6 +560,15 @@ module Engine
           after_option_choice(primary_corp, secondary_corp, merger_corp)
         end
 
+        def after_par(corporation)
+          super
+          return unless [wra, sr].find(corporation)
+
+          
+          bundle = ShareBundle.new(corporation.shares_of(corporation).slice(0,3))
+          @share_pool.buy_shares(@share_pool, bundle, exchange: :free, exchange_price: 0, allow_president_change: false)
+        end
+
         def after_option_choice(primary_corp, secondary_corp, merger_corp)
           return unless @round.pending_options.empty?
 

--- a/lib/engine/game/g_18_dixie/game.rb
+++ b/lib/engine/game/g_18_dixie/game.rb
@@ -78,6 +78,7 @@ module Engine
 
         def new_auction_round
           Engine::Round::Auction.new(self, [
+            Engine::Step::CompanyPendingPar,
             G18Dixie::Step::SelectionAuction,
           ])
         end

--- a/lib/engine/game/g_18_dixie/game.rb
+++ b/lib/engine/game/g_18_dixie/game.rb
@@ -564,8 +564,7 @@ module Engine
           super
           return unless [wra, sr].find(corporation)
 
-          
-          bundle = ShareBundle.new(corporation.shares_of(corporation).slice(0,3))
+          bundle = ShareBundle.new(corporation.shares_of(corporation).slice(0, 3))
           @share_pool.buy_shares(@share_pool, bundle, exchange: :free, exchange_price: 0, allow_president_change: false)
         end
 

--- a/lib/engine/game/g_18_dixie/game.rb
+++ b/lib/engine/game/g_18_dixie/game.rb
@@ -399,6 +399,32 @@ module Engine
           @recently_floated << minor
         end
 
+        def can_par?(corporation, parrer)
+          if corporation == sr
+            @round.companies_pending_par.index(sr_company)
+          elsif corporation == wra
+            @round.companies_pending_par.index(wra_company)
+          else
+            super
+          end
+        end
+
+        def sr_company
+          @p6 ||= company_by_id('P6')
+        end
+
+        def sr
+          @sr ||= corporation_by_id('SR')
+        end
+
+        def wra_company
+          @p10 ||= company_by_id('P10')
+        end
+
+        def wra
+          @wra ||= corporation_by_id('WRA')
+        end
+
         # ICG/SCL merger stuff
         def ic
           @ic ||= corporation_by_id('IC')

--- a/lib/engine/game/g_18_dixie/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_dixie/step/buy_sell_par_shares.rb
@@ -119,6 +119,7 @@ module Engine
 
           def process_par(action)
             return super if companies_pending_par.empty?
+
             share_price = action.share_price
             corporation = action.corporation
 

--- a/lib/engine/game/g_18_dixie/step/selection_auction.rb
+++ b/lib/engine/game/g_18_dixie/step/selection_auction.rb
@@ -115,7 +115,7 @@ module Engine
             player.spend(price, @game.bank)
             @companies.delete(company)
             @log << "#{player.name} wins the auction for #{company.name} with a bid of #{@game.format_currency(price)}"
-           @game.after_buy_company(player, company, price)
+            @game.after_buy_company(player, company, price)
           end
 
           def resolve_bids

--- a/lib/engine/game/g_18_dixie/step/selection_auction.rb
+++ b/lib/engine/game/g_18_dixie/step/selection_auction.rb
@@ -115,6 +115,7 @@ module Engine
             player.spend(price, @game.bank)
             @companies.delete(company)
             @log << "#{player.name} wins the auction for #{company.name} with a bid of #{@game.format_currency(price)}"
+           @game.after_buy_company(player, company, price)
           end
 
           def resolve_bids


### PR DESCRIPTION
Fixes P6/P10 (B&O like privates that can be bought in the stockround) for 18Dixie
I meant to work on the obsolete trains train limit here but I got side-quested with this, which I thought worked before but might not have ever worked. 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x ] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Updates the stock page to allow handing `companies_pending_par` in stock rounds and uses that in 18Dixie to get P6/P10 working
* **Screenshots**
![image](https://github.com/tobymao/18xx/assets/2993555/db0c5868-17ec-46fd-a631-d5f49d634d01)

* **Any Assumptions / Hacks**
