### PR TITLE
[1858] Move to beta

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -17,7 +17,7 @@ module View
 
     def render_notification
       message = <<~MESSAGE
-        <p>1844 is now in alpha.</p>
+        <p><a href="https://github.com/tobymao/18xx/wiki/1844">1844</a> is now in alpha. <a href="https://github.com/tobymao/18xx/wiki/1858">1858</a> is in beta.</p>
         <p>Learn how to get <a href='https://github.com/tobymao/18xx/wiki/Notifications'>notifications</a> by email, Slack, Discord, and Telegram.</p>
         <p>Please submit problem reports and make suggestions for improvements on
         <a href='https://github.com/tobymao/18xx/issues'>GitHub</a>. Join the

--- a/lib/engine/game/g_1858/meta.rb
+++ b/lib/engine/game/g_1858/meta.rb
@@ -7,7 +7,7 @@ module Engine
     module G1858
       module Meta
         include Game::Meta
-        DEV_STAGE = :alpha
+        DEV_STAGE = :beta
 
         GAME_TITLE = '1858'
         GAME_SUBTITLE = 'The Railways of Iberia'


### PR DESCRIPTION
1858 has been in alpha for three weeks with no game play bugs reported, so move to beta status.

- [x] Branch is derived from the latest `master`
- ~~Add the `pins` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`