### PR TITLE
[1844] fixes 4 train rust

### DIFF
--- a/lib/engine/game/g_1844/game.rb
+++ b/lib/engine/game/g_1844/game.rb
@@ -188,7 +188,7 @@ module Engine
             num: 6,
             distance: 4,
             price: 300,
-            rusts_on: '7',
+            rusts_on: '8E',
             variants: [
               {
                 name: '4H',


### PR DESCRIPTION
Fixes #9750 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x]Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Code was set to rust the 4 trains on '7', but they rust on the 8E, which is technically phase 7 in the rules.

No pins should be needed, games on site are all still in the opening auction.
