### PR TITLE
[18NL] adds fixture files

### DIFF
--- a/public/fixtures/18NL/135853.json
+++ b/public/fixtures/18NL/135853.json
@@ -1,0 +1,13566 @@
+{
+  "id": 135853,
+  "description": "",
+  "user": {
+    "id": 34,
+    "name": "philcampeau"
+  },
+  "players": [
+    {
+      "id": 34,
+      "name": "philcampeau"
+    },
+    {
+      "id": 690,
+      "name": "Eonthar"
+    },
+    {
+      "id": 692,
+      "name": "ynottony105"
+    }
+  ],
+  "min_players": 3,
+  "max_players": 4,
+  "title": "18NL",
+  "settings": {
+    "seed": 854078957,
+    "is_async": true,
+    "unlisted": true,
+    "auto_routing": true,
+    "player_order": null,
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "status": "finished",
+  "turn": 8,
+  "round": "Operating Round",
+  "acting": [
+    34,
+    690,
+    692
+  ],
+  "result": {
+    "34": 8571,
+    "690": 10103,
+    "692": 11547
+  },
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1695601334,
+      "company": "P4",
+      "price": 115
+    },
+    {
+      "type": "bid",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1695601362,
+      "company": "P2",
+      "price": 45
+    },
+    {
+      "type": "bid",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1695601428,
+      "company": "P3",
+      "price": 75
+    },
+    {
+      "type": "bid",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1695601441,
+      "company": "P2",
+      "price": 50
+    },
+    {
+      "type": "bid",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1695601563,
+      "company": "P3",
+      "price": 80
+    },
+    {
+      "type": "bid",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1695601680,
+      "company": "P4",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1695601755,
+      "company": "P5",
+      "price": 165
+    },
+    {
+      "type": "bid",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1695602094,
+      "company": "P5",
+      "price": 170
+    },
+    {
+      "type": "bid",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1695602115,
+      "company": "P6",
+      "price": 205
+    },
+    {
+      "type": "bid",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1695602129,
+      "company": "P1",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1695602187,
+      "company": "P2",
+      "price": 55
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1695602201
+    },
+    {
+      "type": "bid",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1695602218,
+      "company": "P3",
+      "price": 85
+    },
+    {
+      "type": "bid",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1695602258,
+      "company": "P3",
+      "price": 90
+    },
+    {
+      "type": "bid",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1695602415,
+      "company": "P3",
+      "price": 95
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1695602432
+    },
+    {
+      "type": "bid",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1695602445,
+      "company": "P4",
+      "price": 125
+    },
+    {
+      "type": "bid",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1695602584,
+      "company": "P4",
+      "price": 130
+    },
+    {
+      "type": "bid",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1695602633,
+      "company": "P4",
+      "price": 140
+    },
+    {
+      "type": "bid",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1695602655,
+      "company": "P4",
+      "price": 145
+    },
+    {
+      "type": "bid",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1695602681,
+      "company": "P4",
+      "price": 150
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1695602693
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 23,
+      "created_at": 1695602697
+    },
+    {
+      "type": "par",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 24,
+      "created_at": 1695602770,
+      "corporation": "HIS",
+      "share_price": "100,0,6"
+    },
+    {
+      "type": "par",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1695602832,
+      "corporation": "NFL",
+      "share_price": "100,0,6"
+    },
+    {
+      "type": "par",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 26,
+      "created_at": 1695603227,
+      "corporation": "NRS",
+      "share_price": "67,5,6"
+    },
+    {
+      "type": "par",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1695603776,
+      "corporation": "ZHE",
+      "share_price": "82,2,6"
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 28,
+      "created_at": 1695603785,
+      "corporation": "ZHE",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 29,
+      "created_at": 1695603870,
+      "shares": [
+        "HIS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 30,
+      "created_at": 1695603942,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695603942,
+          "shares": [
+            "ZHE_1"
+          ],
+          "percent": 10
+        }
+      ],
+      "shares": [
+        "NRS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 31,
+      "created_at": 1695603966,
+      "shares": [
+        "HIS_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 32,
+      "created_at": 1695604004,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695604004,
+          "shares": [
+            "ZHE_2"
+          ],
+          "percent": 10
+        }
+      ],
+      "shares": [
+        "HIS_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 33,
+      "created_at": 1695604045,
+      "shares": [
+        "NRS_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1695604073,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695604073,
+          "shares": [
+            "ZHE_3"
+          ],
+          "percent": 10
+        }
+      ],
+      "shares": [
+        "HIS_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1695604095,
+      "shares": [
+        "NRS_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1695604108,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695604108,
+          "shares": [
+            "ZHE_4"
+          ],
+          "percent": 10
+        }
+      ],
+      "shares": [
+        "NRS_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "shares": [
+        "HIS_5"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 37,
+      "user": 34,
+      "created_at": 1695604188
+    },
+    {
+      "type": "undo",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 38,
+      "user": 34,
+      "created_at": 1695604245
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 39,
+      "created_at": 1695604253
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 40,
+      "created_at": 1695604822
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 41,
+      "created_at": 1695604832
+    },
+    {
+      "type": "buy_train",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 42,
+      "created_at": 1695604839,
+      "train": "2-0",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 43,
+      "created_at": 1695604844
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 44,
+      "created_at": 1695604904,
+      "hex": "G4",
+      "tile": "3-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 45,
+      "created_at": 1695604905,
+      "city": "H3-0-0",
+      "slot": 0,
+      "tokener": "ZHE"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 46,
+      "created_at": 1695604908,
+      "train": "2-1",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 47,
+      "created_at": 1695604909,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 48,
+      "created_at": 1695604922
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 49,
+      "created_at": 1695605012,
+      "hex": "F7",
+      "tile": "4-0",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 50,
+      "created_at": 1695605015,
+      "train": "2-3",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 51,
+      "created_at": 1695605019
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 52,
+      "created_at": 1695605077,
+      "shares": [
+        "HIS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 53,
+      "created_at": 1695605081
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 54,
+      "created_at": 1695605132
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 55,
+      "created_at": 1695605230,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695605229
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 56,
+      "created_at": 1695605247,
+      "shares": [
+        "HIS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 57,
+      "created_at": 1695605252
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 58,
+      "created_at": 1695605279,
+      "shares": [
+        "HIS_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 59,
+      "created_at": 1695605285,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695605284
+        }
+      ]
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 60,
+      "created_at": 1695605316,
+      "shares": [
+        "HIS_1",
+        "HIS_2",
+        "HIS_5",
+        "HIS_6"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 61,
+      "created_at": 1695605329,
+      "shares": [
+        "NRS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 62,
+      "created_at": 1695605331
+    },
+    {
+      "type": "sell_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 63,
+      "created_at": 1695605361,
+      "shares": [
+        "HIS_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 64,
+      "created_at": 1695605364,
+      "shares": [
+        "NRS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 65,
+      "created_at": 1695605373,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695605372,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 66,
+      "created_at": 1695605536,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695605535
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 67,
+      "created_at": 1695605611,
+      "shares": [
+        "NRS_2",
+        "NRS_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "par",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 68,
+      "created_at": 1695605662,
+      "corporation": "AS",
+      "share_price": "71,4,6"
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 69,
+      "created_at": 1695605671,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695605670
+        }
+      ],
+      "corporation": "AS",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 70,
+      "created_at": 1695606357,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1695606357
+        },
+        {
+          "type": "program_disable",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695606357,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 71,
+      "created_at": 1695607978,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695607976
+        },
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695607976,
+          "shares": [
+            "AS_1"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695607976
+        },
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1695607976
+        },
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695607976
+        },
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695607976,
+          "shares": [
+            "AS_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695607976
+        },
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1695607976
+        },
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695607976
+        },
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695607976,
+          "shares": [
+            "AS_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695607976
+        },
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1695607976
+        },
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695607976
+        },
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695607976,
+          "shares": [
+            "AS_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695607976,
+          "reason": "AS is floated"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 72,
+      "created_at": 1695610348,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1695610348
+        },
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695610348
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 73,
+      "created_at": 1695610353,
+      "shares": [
+        "ZHE_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 74,
+      "created_at": 1695610358,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1695610359
+        },
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695610359
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 75,
+      "created_at": 1695610360
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 76,
+      "created_at": 1695610853
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 77,
+      "created_at": 1695610860,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "G2",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "G4"
+          ],
+          "revenue": 40,
+          "revenue_str": "G2-G4",
+          "nodes": [
+            "G2-1",
+            "G4-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H3",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4"
+          ],
+          "revenue": 40,
+          "revenue_str": "H3-G4",
+          "nodes": [
+            "H3-0",
+            "G4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 78,
+      "created_at": 1695610861,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 79,
+      "created_at": 1695610880
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 80,
+      "created_at": 1695610909,
+      "hex": "E16",
+      "tile": "6-0",
+      "rotation": 4
+    },
+    {
+      "type": "buy_train",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 81,
+      "created_at": 1695610914,
+      "train": "2-4",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 82,
+      "created_at": 1695610915,
+      "train": "2-5",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 83,
+      "created_at": 1695610922,
+      "train": "3-0",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 84,
+      "created_at": 1695610924
+    },
+    {
+      "type": "buy_company",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 85,
+      "created_at": 1695610930,
+      "company": "P4",
+      "price": 220
+    },
+    {
+      "type": "buy_company",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 86,
+      "created_at": 1695610934,
+      "company": "P1",
+      "price": 40
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 87,
+      "created_at": 1695610941
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 88,
+      "created_at": 1695611035,
+      "hex": "E4",
+      "tile": "6-1",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 89,
+      "created_at": 1695611045,
+      "city": "6-1-0",
+      "slot": 0,
+      "tokener": "HIS"
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 90,
+      "created_at": 1695611063,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6"
+          ],
+          "revenue": 60,
+          "revenue_str": "E4-E6",
+          "nodes": [
+            "E6-0",
+            "E4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 91,
+      "created_at": 1695611066,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 92,
+      "created_at": 1695611071,
+      "train": "3-1",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 93,
+      "created_at": 1695611074
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 94,
+      "created_at": 1695611086
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 95,
+      "created_at": 1695611103,
+      "hex": "E6",
+      "tile": "NL2-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 96,
+      "created_at": 1695611115,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6"
+          ],
+          "revenue": 70,
+          "revenue_str": "E4-E6",
+          "nodes": [
+            "E6-0",
+            "E4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 97,
+      "created_at": 1695611119,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 98,
+      "created_at": 1695611121,
+      "train": "3-2",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 99,
+      "created_at": 1695611122
+    },
+    {
+      "type": "buy_company",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 100,
+      "created_at": 1695611130,
+      "company": "P2",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 101,
+      "created_at": 1695611136
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 102,
+      "created_at": 1695611182,
+      "shares": [
+        "HIS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 103,
+      "created_at": 1695611187
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 104,
+      "created_at": 1695611487,
+      "shares": [
+        "NRS_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 105,
+      "created_at": 1695611496
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 106,
+      "created_at": 1695612088,
+      "shares": [
+        "ZHE_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 107,
+      "created_at": 1695612097,
+      "corporation": "NCS",
+      "share_price": "76,3,6"
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 108,
+      "created_at": 1695612110,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695612110
+        }
+      ],
+      "corporation": "NCS",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": true
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 109,
+      "created_at": 1695612118,
+      "corporation": "NCS",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 110,
+      "created_at": 1695612813,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1695612813
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 111,
+      "created_at": 1695613243,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695613241
+        },
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695613241,
+          "shares": [
+            "NCS_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695613241
+        },
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1695613241
+        },
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695613241
+        },
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695613241,
+          "shares": [
+            "NCS_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695613241
+        },
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1695613241
+        },
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695613241
+        },
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695613241,
+          "shares": [
+            "NCS_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695613241,
+          "reason": "NCS is floated"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 112,
+      "created_at": 1695642265,
+      "shares": [
+        "NCS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 113,
+      "created_at": 1695642279,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1695642279,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 114,
+      "created_at": 1695642294,
+      "corporation": "HIS",
+      "until_condition": 1,
+      "from_market": true,
+      "auto_pass_after": true
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 115,
+      "created_at": 1695642457,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695642456,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 116,
+      "created_at": 1695642485,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695642485
+        },
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695642485,
+          "shares": [
+            "HIS_1"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695642485,
+          "reason": "1 share(s) bought in HIS, end condition met"
+        },
+        {
+          "type": "program_share_pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695642485,
+          "unconditional": false,
+          "indefinite": false
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695642485
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 117,
+      "created_at": 1695642561,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695642560
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695642560
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 118,
+      "created_at": 1695642619,
+      "hex": "G2",
+      "tile": "NL1-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 119,
+      "created_at": 1695642639,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "H3",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4"
+          ],
+          "revenue": 40,
+          "revenue_str": "H3-G4",
+          "nodes": [
+            "H3-0",
+            "G4-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G2",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "G4"
+          ],
+          "revenue": 60,
+          "revenue_str": "G2-G4",
+          "nodes": [
+            "G2-0",
+            "G4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 120,
+      "created_at": 1695642641,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 121,
+      "created_at": 1695642657,
+      "train": "3-3",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 122,
+      "created_at": 1695642659,
+      "train": "3-4",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 123,
+      "created_at": 1695642673
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 124,
+      "created_at": 1695645578,
+      "hex": "F15",
+      "tile": "6-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 125,
+      "created_at": 1695645584
+    },
+    {
+      "type": "buy_train",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 126,
+      "created_at": 1695645597,
+      "train": "4-0",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 127,
+      "created_at": 1695645601
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 128,
+      "created_at": 1695645603
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 129,
+      "created_at": 1695649794,
+      "hex": "E4",
+      "tile": "15-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 130,
+      "created_at": 1695649804,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "E4",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "F7",
+            "E6",
+            "E4"
+          ],
+          "revenue": 90,
+          "revenue_str": "F7-E6-E4",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "E4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 131,
+      "created_at": 1695649807,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 132,
+      "created_at": 1695649810,
+      "train": "4-1",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 133,
+      "created_at": 1695649813
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 134,
+      "created_at": 1695649822
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 135,
+      "created_at": 1695649840,
+      "hex": "G8",
+      "tile": "6-1",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 136,
+      "created_at": 1695649844,
+      "city": "15-0-0",
+      "slot": 1,
+      "tokener": "NRS"
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 137,
+      "created_at": 1695649852,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "E4",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "F7",
+            "E6",
+            "E4"
+          ],
+          "revenue": 90,
+          "revenue_str": "F7-E6-E4",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "E4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 138,
+      "created_at": 1695649856,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 139,
+      "created_at": 1695649858,
+      "train": "4-2",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 140,
+      "created_at": 1695649861
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 141,
+      "created_at": 1695650414,
+      "hex": "E18",
+      "tile": "58-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 142,
+      "created_at": 1695650418
+    },
+    {
+      "type": "place_token",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 143,
+      "created_at": 1695650423,
+      "city": "6-2-0",
+      "slot": 0,
+      "tokener": "AS"
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 144,
+      "created_at": 1695650442,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13"
+            ]
+          ],
+          "hexes": [
+            "E16",
+            "F15",
+            "F13"
+          ],
+          "revenue": 60,
+          "revenue_str": "E16-F15-F13",
+          "nodes": [
+            "E16-0",
+            "F15-0",
+            "F13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 145,
+      "created_at": 1695650445,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 146,
+      "created_at": 1695650447
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 147,
+      "created_at": 1695650450
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 148,
+      "created_at": 1695650547,
+      "hex": "H3",
+      "tile": "NL3-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 149,
+      "created_at": 1695650569,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3"
+          ],
+          "revenue": 100,
+          "revenue_str": "G2-H3",
+          "nodes": [
+            "G2-0",
+            "H3-0"
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G2",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "G4",
+            "H3"
+          ],
+          "revenue": 110,
+          "revenue_str": "G2-G4-H3",
+          "nodes": [
+            "G2-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 150,
+      "created_at": 1695650573,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_company",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 151,
+      "created_at": 1695650587,
+      "company": "P3",
+      "price": 140
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 152,
+      "created_at": 1695650591
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 153,
+      "created_at": 1695659093,
+      "hex": "F3",
+      "tile": "4-1",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 154,
+      "created_at": 1695659101,
+      "city": "NL1-0-0",
+      "slot": 1,
+      "tokener": "HIS"
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 155,
+      "created_at": 1695659117,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "E4",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "F7",
+            "E6",
+            "E4"
+          ],
+          "revenue": 90,
+          "revenue_str": "F7-E6-E4",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "E4-0"
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G2",
+              "H3"
+            ],
+            [
+              "F3",
+              "G2"
+            ],
+            [
+              "E4",
+              "F3"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "F3",
+            "E4"
+          ],
+          "revenue": 140,
+          "revenue_str": "H3-G2-F3-E4",
+          "nodes": [
+            "G2-0",
+            "H3-0",
+            "F3-0",
+            "E4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 156,
+      "created_at": 1695659119,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 157,
+      "created_at": 1695659191
+    },
+    {
+      "hex": "F19",
+      "tile": "59-0",
+      "type": "lay_tile",
+      "entity": "AS",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 158,
+      "user": 34,
+      "created_at": 1695664403
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 159,
+      "user": 34,
+      "created_at": 1695664406
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "routes": [
+        {
+          "hexes": [
+            "E16",
+            "E18",
+            "F19"
+          ],
+          "nodes": [
+            "E16-0",
+            "E18-0",
+            "F19-1"
+          ],
+          "train": "3-0",
+          "revenue": 70,
+          "connections": [
+            [
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "F19"
+            ]
+          ],
+          "revenue_str": "E16-E18-F19"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 160,
+      "user": 34,
+      "created_at": 1695664411
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 161,
+      "user": 34,
+      "created_at": 1695664412
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 162,
+      "user": 34,
+      "created_at": 1695664413
+    },
+    {
+      "hex": "F15",
+      "tile": "14-0",
+      "type": "lay_tile",
+      "entity": "NCS",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 163,
+      "user": 34,
+      "created_at": 1695664420
+    },
+    {
+      "type": "undo",
+      "entity": "NCS",
+      "action_id": 162,
+      "entity_type": "corporation",
+      "id": 164,
+      "user": 34,
+      "created_at": 1695664424
+    },
+    {
+      "type": "undo",
+      "entity": "NCS",
+      "action_id": 157,
+      "entity_type": "corporation",
+      "id": 165,
+      "user": 34,
+      "created_at": 1695664425
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 166,
+      "created_at": 1695664431,
+      "hex": "E16",
+      "tile": "15-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 167,
+      "created_at": 1695664436
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 168,
+      "created_at": 1695664448,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13"
+            ]
+          ],
+          "hexes": [
+            "E16",
+            "F15",
+            "F13"
+          ],
+          "revenue": 70,
+          "revenue_str": "E16-F15-F13",
+          "nodes": [
+            "E16-0",
+            "F15-0",
+            "F13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 169,
+      "created_at": 1695664450,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 170,
+      "created_at": 1695664452
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 171,
+      "created_at": 1695664456,
+      "hex": "F15",
+      "tile": "14-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 172,
+      "created_at": 1695664459,
+      "city": "14-0-0",
+      "slot": 1,
+      "tokener": "NCS"
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 173,
+      "created_at": 1695664466,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F13",
+              "F15"
+            ],
+            [
+              "F15",
+              "E16"
+            ],
+            [
+              "E16",
+              "E18"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "F15",
+            "E16",
+            "E18"
+          ],
+          "revenue": 90,
+          "revenue_str": "F13-F15-E16-E18",
+          "nodes": [
+            "F13-0",
+            "F15-0",
+            "E16-0",
+            "E18-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 174,
+      "created_at": 1695664467,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 175,
+      "created_at": 1695664469
+    },
+    {
+      "hex": "G8",
+      "tile": "14-1",
+      "type": "lay_tile",
+      "entity": "NRS",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 176,
+      "user": 690,
+      "created_at": 1695664587
+    },
+    {
+      "type": "undo",
+      "entity": "NRS",
+      "action_id": 175,
+      "entity_type": "corporation",
+      "id": 177,
+      "user": 690,
+      "created_at": 1695665366
+    },
+    {
+      "hex": "G8",
+      "tile": "14-1",
+      "type": "lay_tile",
+      "entity": "NRS",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 178,
+      "user": 690,
+      "created_at": 1695665374
+    },
+    {
+      "type": "undo",
+      "entity": "NRS",
+      "action_id": 175,
+      "entity_type": "corporation",
+      "id": 179,
+      "user": 690,
+      "created_at": 1695665398
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 180,
+      "user": 690,
+      "created_at": 1695665419
+    },
+    {
+      "type": "undo",
+      "entity": "NRS",
+      "action_id": 175,
+      "entity_type": "corporation",
+      "id": 181,
+      "user": 690,
+      "created_at": 1695665435
+    },
+    {
+      "hex": "G8",
+      "tile": "14-1",
+      "type": "lay_tile",
+      "entity": "NRS",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 182,
+      "user": 690,
+      "created_at": 1695665440
+    },
+    {
+      "type": "undo",
+      "entity": "NRS",
+      "action_id": 175,
+      "entity_type": "corporation",
+      "id": 183,
+      "user": 690,
+      "created_at": 1695667481
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 184,
+      "created_at": 1695667488,
+      "hex": "G8",
+      "tile": "14-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 185,
+      "created_at": 1695866894,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3",
+            "G2"
+          ],
+          "revenue": 140,
+          "revenue_str": "E6-E4-F3-G2",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0",
+            "G2-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8"
+          ],
+          "revenue": 90,
+          "revenue_str": "E6-F7-G8",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 186,
+      "created_at": 1695866901,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 187,
+      "created_at": 1695866906
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 188,
+      "created_at": 1695866964,
+      "shares": [
+        "ZHE_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 189,
+      "created_at": 1695866968
+    },
+    {
+      "type": "sell_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 190,
+      "created_at": 1695871776,
+      "shares": [
+        "NRS_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 191,
+      "created_at": 1695871780,
+      "corporation": "DV",
+      "share_price": "82,2,6"
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 192,
+      "created_at": 1695871793,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695871794
+        }
+      ],
+      "corporation": "DV",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "shares": [
+        "HIS_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 193,
+      "user": 34,
+      "created_at": 1695871869
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "shares": [
+        "NRS_5"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 194,
+      "user": 34,
+      "created_at": 1695871872
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "shares": [
+        "AS_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 195,
+      "user": 34,
+      "created_at": 1695871884
+    },
+    {
+      "type": "undo",
+      "entity": 34,
+      "action_id": 192,
+      "entity_type": "player",
+      "id": 196,
+      "user": 34,
+      "created_at": 1695871895
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 197,
+      "created_at": 1695871939,
+      "shares": [
+        "NFL_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 198,
+      "created_at": 1695871941
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 199,
+      "created_at": 1695893763,
+      "shares": [
+        "NFL_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 200,
+      "created_at": 1695893772,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695893772,
+          "reason": "Eonthar bought on corporation NFL and is unsecure"
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 201,
+      "created_at": 1695904259,
+      "shares": [
+        "DV_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 202,
+      "created_at": 1695904268
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "shares": [
+        "NFL_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 203,
+      "user": 34,
+      "created_at": 1695905158
+    },
+    {
+      "type": "undo",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 204,
+      "user": 34,
+      "created_at": 1695905214
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 205,
+      "created_at": 1695905249,
+      "shares": [
+        "NFL_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 206,
+      "created_at": 1695905265,
+      "shares": [
+        "ZHE_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 207,
+      "created_at": 1695905267
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 208,
+      "created_at": 1695905782,
+      "shares": [
+        "HIS_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 209,
+      "created_at": 1695905788
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 210,
+      "created_at": 1695905963,
+      "shares": [
+        "DV_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 211,
+      "created_at": 1695905965
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 212,
+      "created_at": 1695907047,
+      "shares": [
+        "NCS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 213,
+      "created_at": 1695907051,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695907050
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 214,
+      "created_at": 1695907423,
+      "shares": [
+        "NRS_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 215,
+      "created_at": 1695907432
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 216,
+      "created_at": 1695909721,
+      "shares": [
+        "DV_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 217,
+      "created_at": 1695909730,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695909730
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 218,
+      "created_at": 1695915524,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1695915523
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 219,
+      "created_at": 1695915863,
+      "shares": [
+        "DV_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 220,
+      "created_at": 1695915864,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695915864
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1695915864
+        },
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1695915864
+        },
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1695915864
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 221,
+      "created_at": 1695915876,
+      "hex": "I4",
+      "tile": "59-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 222,
+      "created_at": 1695915883,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "G2",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "G4",
+            "H3"
+          ],
+          "revenue": 110,
+          "revenue_str": "G2-G4-H3",
+          "nodes": [
+            "G2-0",
+            "G4-0",
+            "H3-0"
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G2",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4"
+          ],
+          "revenue": 140,
+          "revenue_str": "G2-H3-I4",
+          "nodes": [
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 223,
+      "created_at": 1695915885,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 224,
+      "created_at": 1695915889
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 225,
+      "created_at": 1695915899,
+      "hex": "H9",
+      "tile": "9-0",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 226,
+      "created_at": 1695915907,
+      "train": "4-3",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 227,
+      "created_at": 1695915930
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 228,
+      "created_at": 1695918134,
+      "hex": "F19",
+      "tile": "59-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 229,
+      "created_at": 1695918152
+    },
+    {
+      "city": "59-1-1",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "AS",
+      "tokener": "AS",
+      "entity_type": "corporation",
+      "id": 230,
+      "user": 34,
+      "created_at": 1695918155
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "routes": [
+        {
+          "hexes": [
+            "E16",
+            "F15",
+            "F13"
+          ],
+          "nodes": [
+            "E16-0",
+            "F15-0",
+            "F13-0"
+          ],
+          "train": "3-0",
+          "revenue": 80,
+          "connections": [
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13"
+            ]
+          ],
+          "revenue_str": "E16-F15-F13"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 231,
+      "user": 34,
+      "created_at": 1695918168
+    },
+    {
+      "type": "undo",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 232,
+      "user": 34,
+      "created_at": 1695918172
+    },
+    {
+      "type": "undo",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 233,
+      "user": 34,
+      "created_at": 1695918180
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 234,
+      "created_at": 1695918181
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 235,
+      "created_at": 1695918184,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13"
+            ]
+          ],
+          "hexes": [
+            "E16",
+            "F15",
+            "F13"
+          ],
+          "revenue": 80,
+          "revenue_str": "E16-F15-F13",
+          "nodes": [
+            "E16-0",
+            "F15-0",
+            "F13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 236,
+      "created_at": 1695918185,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 237,
+      "created_at": 1695918187
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 238,
+      "created_at": 1695918877,
+      "hex": "F3",
+      "tile": "87-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 239,
+      "created_at": 1695918907,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3",
+            "G2"
+          ],
+          "revenue": 140,
+          "revenue_str": "E6-E4-F3-G2",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0",
+            "G2-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "G2",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4"
+          ],
+          "revenue": 140,
+          "revenue_str": "G2-H3-I4",
+          "nodes": [
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 240,
+      "created_at": 1695918909,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 241,
+      "created_at": 1695918938
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 242,
+      "created_at": 1695922550,
+      "hex": "F11",
+      "tile": "8-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 243,
+      "created_at": 1695922555
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 244,
+      "created_at": 1695922560,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F15",
+              "E16"
+            ],
+            [
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "E16",
+            "E18",
+            "F19"
+          ],
+          "revenue": 110,
+          "revenue_str": "F15-E16-E18-F19",
+          "nodes": [
+            "F15-0",
+            "E16-0",
+            "E18-0",
+            "F19-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 245,
+      "created_at": 1695922562,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 246,
+      "created_at": 1695922574
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 247,
+      "created_at": 1695925758,
+      "hex": "G4",
+      "tile": "87-1",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 248,
+      "created_at": 1695925789,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3",
+            "G2"
+          ],
+          "revenue": 140,
+          "revenue_str": "E6-E4-F3-G2",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0",
+            "G2-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8"
+          ],
+          "revenue": 90,
+          "revenue_str": "E6-F7-G8",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 249,
+      "created_at": 1695925793,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 250,
+      "created_at": 1695925795
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 251,
+      "created_at": 1695926311
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 252,
+      "created_at": 1695926314,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "G2",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "G4",
+            "H3"
+          ],
+          "revenue": 110,
+          "revenue_str": "G2-G4-H3",
+          "nodes": [
+            "G2-0",
+            "G4-0",
+            "H3-0"
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G2",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4"
+          ],
+          "revenue": 140,
+          "revenue_str": "G2-H3-I4",
+          "nodes": [
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 253,
+      "created_at": 1695926317,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 254,
+      "created_at": 1695926322
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 255,
+      "created_at": 1695929526,
+      "hex": "G10",
+      "tile": "8-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 256,
+      "created_at": 1695929528
+    },
+    {
+      "type": "place_token",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 257,
+      "created_at": 1695929530,
+      "city": "14-1-0",
+      "slot": 1,
+      "tokener": "AS"
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 258,
+      "created_at": 1695929536,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "F7",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "G8",
+            "F7",
+            "E6"
+          ],
+          "revenue": 90,
+          "revenue_str": "G8-F7-E6",
+          "nodes": [
+            "G8-0",
+            "F7-0",
+            "E6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 259,
+      "created_at": 1695929538,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 260,
+      "created_at": 1695929541
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 261,
+      "created_at": 1695929713,
+      "hex": "D7",
+      "tile": "8-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 262,
+      "created_at": 1695929719,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3",
+            "G2"
+          ],
+          "revenue": 140,
+          "revenue_str": "E6-E4-F3-G2",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0",
+            "G2-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "G2",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4"
+          ],
+          "revenue": 140,
+          "revenue_str": "G2-H3-I4",
+          "nodes": [
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 263,
+      "created_at": 1695929729,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 264,
+      "created_at": 1695929733
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 265,
+      "created_at": 1695933202,
+      "hex": "F17",
+      "tile": "8-3",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 266,
+      "created_at": 1695933204
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 267,
+      "created_at": 1695933214,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G8",
+              "G10",
+              "F11",
+              "F13"
+            ],
+            [
+              "F13",
+              "F15"
+            ],
+            [
+              "F15",
+              "E16"
+            ]
+          ],
+          "hexes": [
+            "G8",
+            "F13",
+            "F15",
+            "E16"
+          ],
+          "revenue": 110,
+          "revenue_str": "G8-F13-F15-E16",
+          "nodes": [
+            "G8-0",
+            "F13-0",
+            "F15-0",
+            "E16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 268,
+      "created_at": 1695933215,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 269,
+      "created_at": 1695933216
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 270,
+      "created_at": 1695935852,
+      "hex": "F7",
+      "tile": "88-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 271,
+      "created_at": 1695935856,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "G10",
+              "F11",
+              "F13",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8",
+            "F15"
+          ],
+          "revenue": 120,
+          "revenue_str": "E6-F7-G8-F15",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "G8-0",
+            "F15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 272,
+      "created_at": 1695935861,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 273,
+      "created_at": 1695935868
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 274,
+      "created_at": 1696077315,
+      "hex": "C6",
+      "tile": "9-1",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 275,
+      "created_at": 1696077324,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3",
+            "G2"
+          ],
+          "revenue": 140,
+          "revenue_str": "E6-E4-F3-G2",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0",
+            "G2-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8"
+          ],
+          "revenue": 90,
+          "revenue_str": "E6-F7-G8",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 276,
+      "created_at": 1696077328,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 277,
+      "created_at": 1696077334
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 278,
+      "created_at": 1696077449,
+      "shares": [
+        "ZHE_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 279,
+      "created_at": 1696077511,
+      "shares": [
+        "NRS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 280,
+      "created_at": 1696077625,
+      "corporation": "MES",
+      "share_price": "100,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 281,
+      "created_at": 1696077636
+    },
+    {
+      "type": "par",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 282,
+      "created_at": 1696078616,
+      "corporation": "NZO",
+      "share_price": "100,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 283,
+      "created_at": 1696078623
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 284,
+      "created_at": 1696078900,
+      "shares": [
+        "NFL_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 285,
+      "created_at": 1696078940
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 286,
+      "created_at": 1696081258,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696081258,
+          "shares": [
+            "MES_1"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696081258
+        }
+      ],
+      "corporation": "MES",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 287,
+      "created_at": 1696081534,
+      "shares": [
+        "NZO_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 288,
+      "created_at": 1696081553,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1696081552
+        }
+      ],
+      "corporation": "NZO",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 289,
+      "created_at": 1696082718,
+      "shares": [
+        "HIS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 290,
+      "created_at": 1696082756,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696082757,
+          "shares": [
+            "MES_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696082757
+        },
+        {
+          "type": "buy_shares",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1696082757,
+          "shares": [
+            "NZO_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1696082757
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 291,
+      "created_at": 1696082809,
+      "shares": [
+        "NCS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 292,
+      "created_at": 1696082814,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696082814,
+          "shares": [
+            "MES_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696082814
+        },
+        {
+          "type": "buy_shares",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1696082815,
+          "shares": [
+            "NZO_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1696082815
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 293,
+      "created_at": 1696082822,
+      "shares": [
+        "NRS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 294,
+      "created_at": 1696082898,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696082899,
+          "shares": [
+            "MES_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696082899,
+          "reason": "MES is floated"
+        }
+      ]
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "shares": [
+        "MES_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 295,
+      "user": 34,
+      "created_at": 1696083081
+    },
+    {
+      "type": "undo",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 296,
+      "user": 34,
+      "created_at": 1696083129
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 297,
+      "created_at": 1696083130,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1696083129,
+          "shares": [
+            "NZO_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1696083129,
+          "reason": "NZO is floated"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 298,
+      "created_at": 1696083856
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 299,
+      "created_at": 1696086322,
+      "shares": [
+        "AS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 300,
+      "created_at": 1696086330,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1696086331
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 301,
+      "created_at": 1696087025,
+      "shares": [
+        "MES_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 302,
+      "created_at": 1696087062,
+      "shares": [
+        "DV_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 303,
+      "created_at": 1696087070
+    },
+    {
+      "type": "sell_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 304,
+      "created_at": 1696088078,
+      "shares": [
+        "ZHE_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 305,
+      "created_at": 1696088088,
+      "shares": [
+        "NZO_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 306,
+      "created_at": 1696088109,
+      "shares": [
+        "NCS_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 307,
+      "created_at": 1696088118,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1696088117,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 308,
+      "created_at": 1696099566,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1696099567
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 309,
+      "created_at": 1696129089,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696129088
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 310,
+      "created_at": 1696161624,
+      "shares": [
+        "DV_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 311,
+      "created_at": 1696161627,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1696161626
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696161626
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 312,
+      "created_at": 1696161673,
+      "shares": [
+        "MES_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 313,
+      "created_at": 1696161679,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1696161679
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696161679
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 314,
+      "created_at": 1696161681
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 315,
+      "created_at": 1696250702
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 316,
+      "created_at": 1696250706,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "G2",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "G4",
+            "H3"
+          ],
+          "revenue": 110,
+          "revenue_str": "G2-G4-H3",
+          "nodes": [
+            "G2-0",
+            "G4-0",
+            "H3-0"
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G2",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4"
+          ],
+          "revenue": 140,
+          "revenue_str": "G2-H3-I4",
+          "nodes": [
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 317,
+      "created_at": 1696250715,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 318,
+      "created_at": 1696250718
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 319,
+      "created_at": 1696251290
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 320,
+      "created_at": 1696251303,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "F7",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "G8",
+            "F7",
+            "E6"
+          ],
+          "revenue": 90,
+          "revenue_str": "G8-F7-E6",
+          "nodes": [
+            "G8-0",
+            "F7-0",
+            "E6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 321,
+      "created_at": 1696251308,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 322,
+      "created_at": 1696251309
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 323,
+      "created_at": 1696251721,
+      "hex": "D5",
+      "tile": "58-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 324,
+      "created_at": 1696251732,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3",
+            "G2"
+          ],
+          "revenue": 140,
+          "revenue_str": "E6-E4-F3-G2",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0",
+            "G2-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "G2",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4"
+          ],
+          "revenue": 140,
+          "revenue_str": "G2-H3-I4",
+          "nodes": [
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 325,
+      "created_at": 1696251737,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 326,
+      "created_at": 1696251753
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 327,
+      "created_at": 1696251806,
+      "hex": "B13",
+      "tile": "7-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 328,
+      "user": 692,
+      "created_at": 1696251810
+    },
+    {
+      "type": "undo",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 329,
+      "user": 692,
+      "created_at": 1696251814
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 330,
+      "created_at": 1696251871
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 331,
+      "created_at": 1696252351,
+      "hex": "J7",
+      "tile": "57-0",
+      "rotation": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 332,
+      "created_at": 1696252388,
+      "train": "3-0",
+      "price": 249
+    },
+    {
+      "type": "buy_train",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 333,
+      "created_at": 1696252391,
+      "train": "4-4",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "buy_train",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 334,
+      "created_at": 1696252393,
+      "train": "5-0",
+      "price": 450,
+      "variant": "5"
+    },
+    {
+      "type": "discard_train",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 335,
+      "created_at": 1696252414,
+      "train": "4-4"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 336,
+      "created_at": 1696254329
+    },
+    {
+      "type": "buy_train",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 337,
+      "created_at": 1696254332,
+      "train": "5-1",
+      "price": 450,
+      "variant": "5"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 338,
+      "created_at": 1696254334,
+      "train": "5-2",
+      "price": 450,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 339,
+      "created_at": 1696260794,
+      "hex": "G18",
+      "tile": "7-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 340,
+      "created_at": 1696260803
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 341,
+      "created_at": 1696260807,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F19",
+              "G18",
+              "F17",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13"
+            ],
+            [
+              "F13",
+              "F11",
+              "G10",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "F19",
+            "F15",
+            "F13",
+            "G8"
+          ],
+          "revenue": 120,
+          "revenue_str": "F19-F15-F13-G8",
+          "nodes": [
+            "F19-0",
+            "F15-0",
+            "F13-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 342,
+      "created_at": 1696260814,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 343,
+      "created_at": 1696260816
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 344,
+      "created_at": 1696261415,
+      "hex": "G8",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 345,
+      "created_at": 1696261422,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "G10",
+              "F11",
+              "F13",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8",
+            "F15"
+          ],
+          "revenue": 130,
+          "revenue_str": "E6-F7-G8-F15",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "G8-0",
+            "F15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 346,
+      "created_at": 1696261458,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 347,
+      "created_at": 1696261482,
+      "train": "3-3",
+      "price": 439
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 348,
+      "created_at": 1696262969,
+      "hex": "E6",
+      "tile": "NL6-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 349,
+      "created_at": 1696262980,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3",
+            "G2"
+          ],
+          "revenue": 160,
+          "revenue_str": "E6-E4-F3-G2",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0",
+            "G2-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8"
+          ],
+          "revenue": 120,
+          "revenue_str": "E6-F7-G8",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 350,
+      "created_at": 1696262981,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 351,
+      "created_at": 1696263056,
+      "hex": "H3",
+      "tile": "NL5-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 352,
+      "created_at": 1696263065,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "G2",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4"
+          ],
+          "revenue": 160,
+          "revenue_str": "G2-H3-I4",
+          "nodes": [
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 353,
+      "created_at": 1696263085,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 354,
+      "created_at": 1696263087,
+      "train": "6-0",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 355,
+      "created_at": 1696263096
+    },
+    {
+      "hex": "F19",
+      "tile": "65-0",
+      "type": "lay_tile",
+      "entity": "AS",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 356,
+      "user": 34,
+      "created_at": 1696263926
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 357,
+      "user": 34,
+      "created_at": 1696263928
+    },
+    {
+      "type": "buy_train",
+      "price": 300,
+      "train": "4-4",
+      "entity": "AS",
+      "variant": "4",
+      "entity_type": "corporation",
+      "id": 358,
+      "user": 34,
+      "created_at": 1696263963
+    },
+    {
+      "type": "undo",
+      "entity": "HIS",
+      "action_id": 355,
+      "entity_type": "corporation",
+      "id": 359,
+      "user": 34,
+      "created_at": 1696263975
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 360,
+      "user": 34,
+      "created_at": 1696263976
+    },
+    {
+      "type": "undo",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 361,
+      "user": 34,
+      "created_at": 1696263980
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 362,
+      "created_at": 1696263983,
+      "hex": "F19",
+      "tile": "65-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 363,
+      "created_at": 1696263985
+    },
+    {
+      "type": "buy_train",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 364,
+      "created_at": 1696264026,
+      "train": "4-0",
+      "price": 168
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 365,
+      "created_at": 1696264033
+    },
+    {
+      "hex": "D7",
+      "tile": "16-0",
+      "type": "lay_tile",
+      "entity": "HIS",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 366,
+      "user": 690,
+      "created_at": 1696264064
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "routes": [
+        {
+          "hexes": [
+            "I4",
+            "H3",
+            "G2",
+            "G4"
+          ],
+          "nodes": [
+            "I4-0",
+            "H3-0",
+            "G2-0",
+            "G4-0"
+          ],
+          "train": "4-1",
+          "revenue": 170,
+          "connections": [
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "G4"
+            ]
+          ],
+          "revenue_str": "I4-H3-G2-G4"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 367,
+      "user": 690,
+      "created_at": 1696264078
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 368,
+      "user": 690,
+      "created_at": 1696264080
+    },
+    {
+      "type": "undo",
+      "entity": "HIS",
+      "action_id": 365,
+      "entity_type": "corporation",
+      "id": 369,
+      "user": 690,
+      "created_at": 1696264096
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 370,
+      "created_at": 1696264105,
+      "hex": "I4",
+      "tile": "64-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 371,
+      "created_at": 1696264109,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3",
+            "G2"
+          ],
+          "revenue": 160,
+          "revenue_str": "E6-E4-F3-G2",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0",
+            "G2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 372,
+      "created_at": 1696264113,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 373,
+      "created_at": 1696264141,
+      "train": "5-1",
+      "price": 454
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 374,
+      "created_at": 1696264389,
+      "hex": "F11",
+      "tile": "24-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 375,
+      "created_at": 1696264394
+    },
+    {
+      "type": "buy_train",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 376,
+      "created_at": 1696264395,
+      "train": "6-1",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 377,
+      "created_at": 1696264397
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 378,
+      "created_at": 1696264414,
+      "hex": "I10",
+      "tile": "59-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 379,
+      "created_at": 1696264432,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "H9",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8",
+            "I10"
+          ],
+          "revenue": 160,
+          "revenue_str": "E6-F7-G8-I10",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "G8-0",
+            "I10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 380,
+      "created_at": 1696264434,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 381,
+      "created_at": 1696264443
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 382,
+      "created_at": 1696264446
+    },
+    {
+      "type": "buy_train",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 383,
+      "created_at": 1696264458,
+      "train": "4-3",
+      "price": 200
+    },
+    {
+      "type": "buy_train",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 384,
+      "created_at": 1696264460,
+      "train": "D-0",
+      "price": 800,
+      "variant": "D",
+      "exchange": "4-3"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 385,
+      "created_at": 1696264493,
+      "hex": "J9",
+      "tile": "8-4",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 386,
+      "created_at": 1696264497,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "J7",
+              "J9",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "J7",
+            "I10"
+          ],
+          "revenue": 60,
+          "revenue_str": "J7-I10",
+          "nodes": [
+            "J7-0",
+            "I10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 387,
+      "created_at": 1696264498,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 388,
+      "created_at": 1696264499
+    },
+    {
+      "hex": "H13",
+      "tile": "59-0",
+      "type": "lay_tile",
+      "entity": "NZO",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "id": 389,
+      "user": 690,
+      "created_at": 1696265073
+    },
+    {
+      "city": "59-0-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "NZO",
+      "tokener": "NZO",
+      "entity_type": "corporation",
+      "id": 390,
+      "user": 690,
+      "created_at": 1696265089
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "routes": [
+        {
+          "hexes": [
+            "I14",
+            "H13"
+          ],
+          "nodes": [
+            "H13-0",
+            "I14-0"
+          ],
+          "train": "5-2",
+          "revenue": 110,
+          "connections": [
+            [
+              "H13",
+              "I14"
+            ]
+          ],
+          "revenue_str": "I14-H13"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 391,
+      "user": 690,
+      "created_at": 1696265096
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 392,
+      "user": 690,
+      "created_at": 1696265100
+    },
+    {
+      "type": "undo",
+      "entity": "NZO",
+      "action_id": 388,
+      "entity_type": "corporation",
+      "id": 393,
+      "user": 690,
+      "created_at": 1696265125
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 394,
+      "user": 690,
+      "created_at": 1696265133
+    },
+    {
+      "type": "undo",
+      "entity": "NZO",
+      "action_id": 388,
+      "entity_type": "corporation",
+      "id": 395,
+      "user": 690,
+      "created_at": 1696265168
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 396,
+      "user": 690,
+      "created_at": 1696265176
+    },
+    {
+      "type": "undo",
+      "entity": "NZO",
+      "action_id": 388,
+      "entity_type": "corporation",
+      "id": 397,
+      "user": 690,
+      "created_at": 1696265241
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 398,
+      "created_at": 1696265248,
+      "hex": "H13",
+      "tile": "59-0",
+      "rotation": 5
+    },
+    {
+      "type": "place_token",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 399,
+      "created_at": 1696265261,
+      "city": "59-0-0",
+      "slot": 0,
+      "tokener": "NZO"
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 400,
+      "created_at": 1696265268,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "H13",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13"
+          ],
+          "revenue": 110,
+          "revenue_str": "I14-H13",
+          "nodes": [
+            "H13-0",
+            "I14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 401,
+      "created_at": 1696265298,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 402,
+      "created_at": 1696265306
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 403,
+      "created_at": 1696265324,
+      "hex": "D7",
+      "tile": "16-0",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 404,
+      "created_at": 1696265340,
+      "train": "5-2",
+      "price": 238
+    },
+    {
+      "type": "sell_shares",
+      "entity": 692,
+      "shares": [
+        "NFL_3"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 405,
+      "user": 692,
+      "created_at": 1696265688
+    },
+    {
+      "type": "undo",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 406,
+      "user": 692,
+      "created_at": 1696265715
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 407,
+      "created_at": 1696265768,
+      "shares": [
+        "AS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 408,
+      "created_at": 1696265775,
+      "shares": [
+        "AS_5",
+        "AS_6"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 409,
+      "created_at": 1696265801
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 410,
+      "created_at": 1696340393,
+      "shares": [
+        "ZHE_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 411,
+      "created_at": 1696340395
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 412,
+      "created_at": 1696341259,
+      "shares": [
+        "DV_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 413,
+      "created_at": 1696341261,
+      "shares": [
+        "DV_6",
+        "DV_7"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 414,
+      "created_at": 1696341269
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 415,
+      "created_at": 1696343144,
+      "shares": [
+        "NZO_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 416,
+      "created_at": 1696343160
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 417,
+      "created_at": 1696344051,
+      "shares": [
+        "DV_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 418,
+      "created_at": 1696344158,
+      "shares": [
+        "NRS_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 419,
+      "created_at": 1696344160
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 420,
+      "created_at": 1696347670,
+      "shares": [
+        "NZO_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 421,
+      "created_at": 1696347678
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 422,
+      "created_at": 1696348104,
+      "shares": [
+        "NRS_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 423,
+      "created_at": 1696348111
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 424,
+      "created_at": 1696349041,
+      "shares": [
+        "MES_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 425,
+      "created_at": 1696349044
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 426,
+      "created_at": 1696351598,
+      "shares": [
+        "ZHE_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 427,
+      "created_at": 1696351601
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 428,
+      "created_at": 1696352173,
+      "shares": [
+        "NRS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 429,
+      "created_at": 1696352176
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 430,
+      "created_at": 1696352825,
+      "shares": [
+        "NFL_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 431,
+      "created_at": 1696352845,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696352843
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 432,
+      "created_at": 1696353261,
+      "shares": [
+        "ZHE_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 433,
+      "created_at": 1696353264
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 434,
+      "created_at": 1696353397,
+      "shares": [
+        "MES_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 435,
+      "created_at": 1696353398,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696353396
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 436,
+      "created_at": 1696358450
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 437,
+      "created_at": 1696359676,
+      "shares": [
+        "HIS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 438,
+      "created_at": 1696359677,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696359676
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 439,
+      "created_at": 1696361195
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 440,
+      "created_at": 1696361588,
+      "shares": [
+        "HIS_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 441,
+      "created_at": 1696361592,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696361591
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "shares": [
+        "ZHE_6"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 442,
+      "user": 690,
+      "created_at": 1696362900
+    },
+    {
+      "type": "undo",
+      "entity": 690,
+      "action_id": 441,
+      "entity_type": "player",
+      "id": 443,
+      "user": 690,
+      "created_at": 1696362906
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 444,
+      "created_at": 1696362907
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 445,
+      "created_at": 1696362964,
+      "shares": [
+        "NCS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 446,
+      "created_at": 1696362965,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696362965
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 447,
+      "created_at": 1696366865
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 448,
+      "created_at": 1696429522
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 449,
+      "created_at": 1696439327,
+      "hex": "F5",
+      "tile": "8-5",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 450,
+      "created_at": 1696439337,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "F3",
+              "F5",
+              "E6"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "I4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F3",
+            "G2",
+            "H3",
+            "I4"
+          ],
+          "revenue": 250,
+          "revenue_str": "E6-F3-G2-H3-I4",
+          "nodes": [
+            "F3-0",
+            "E6-0",
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 451,
+      "created_at": 1696439339,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 452,
+      "created_at": 1696439342
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 453,
+      "created_at": 1696439617,
+      "hex": "J3",
+      "tile": "9-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 454,
+      "created_at": 1696439629,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ],
+            [
+              "G2",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F3",
+            "G2",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 260,
+          "revenue_str": "E6-F3-G2-G4-H3-I4",
+          "nodes": [
+            "E6-0",
+            "F3-0",
+            "G2-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 455,
+      "created_at": 1696439631,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 456,
+      "created_at": 1696439634
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 457,
+      "created_at": 1696439679,
+      "hex": "I10",
+      "tile": "67-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 458,
+      "created_at": 1696439690,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "J7",
+              "J9",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "J7",
+            "I10"
+          ],
+          "revenue": 70,
+          "revenue_str": "J7-I10",
+          "nodes": [
+            "J7-0",
+            "I10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 459,
+      "created_at": 1696439700,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 460,
+      "created_at": 1696439702
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 461,
+      "created_at": 1696440042,
+      "hex": "H13",
+      "tile": "66-0",
+      "rotation": 4
+    },
+    {
+      "type": "buy_train",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 462,
+      "created_at": 1696440068,
+      "train": "6-2",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 463,
+      "created_at": 1696440071
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 464,
+      "created_at": 1696444192,
+      "hex": "E16",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 465,
+      "created_at": 1696444208,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F19"
+          ],
+          "revenue": 250,
+          "revenue_str": "E20-F19-E18-E16-F15-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 466,
+      "created_at": 1696444233,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 467,
+      "created_at": 1696444239
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 468,
+      "created_at": 1696444243,
+      "hex": "D15",
+      "tile": "4-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 469,
+      "created_at": 1696444248
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 470,
+      "created_at": 1696444253,
+      "shares": [
+        "HIS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 471,
+      "created_at": 1696444254,
+      "shares": [
+        "ZHE_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 472,
+      "created_at": 1696444256,
+      "shares": [
+        "NRS_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 473,
+      "created_at": 1696444258,
+      "shares": [
+        "NFL_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 474,
+      "created_at": 1696444271,
+      "shares": [
+        "MES_2",
+        "MES_3",
+        "MES_4",
+        "MES_5"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "buy_train",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 475,
+      "created_at": 1696444280,
+      "train": "D-1",
+      "price": 1100,
+      "variant": "D"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 476,
+      "created_at": 1696444355,
+      "hex": "J11",
+      "tile": "7-2",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 477,
+      "created_at": 1696444357,
+      "city": "67-0-0",
+      "slot": 0,
+      "tokener": "DV"
+    },
+    {
+      "type": "buy_train",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 478,
+      "created_at": 1696444384,
+      "train": "D-0",
+      "price": 1
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 479,
+      "created_at": 1696444388
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 480,
+      "created_at": 1696444426,
+      "hex": "C14",
+      "tile": "7-3",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 481,
+      "created_at": 1696444435
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 482,
+      "created_at": 1696449492,
+      "hex": "F5",
+      "tile": "25-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 483,
+      "created_at": 1696449505,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F3",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 210,
+          "revenue_str": "E6-F3-G4-H3-I4",
+          "nodes": [
+            "E6-0",
+            "F3-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 484,
+      "created_at": 1696449507,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 485,
+      "created_at": 1696449509
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 486,
+      "created_at": 1696450905
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 487,
+      "created_at": 1696450922,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ],
+            [
+              "G2",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F3",
+            "G2",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 260,
+          "revenue_str": "E6-F3-G2-G4-H3-I4",
+          "nodes": [
+            "E6-0",
+            "F3-0",
+            "G2-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 488,
+      "created_at": 1696450923,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 489,
+      "created_at": 1696450928
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 490,
+      "created_at": 1696450989,
+      "hex": "G6",
+      "tile": "8-6",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 491,
+      "created_at": 1696450992,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "F3",
+              "F5",
+              "E6"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "I4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F3",
+            "G2",
+            "H3",
+            "I4"
+          ],
+          "revenue": 250,
+          "revenue_str": "E6-F3-G2-H3-I4",
+          "nodes": [
+            "F3-0",
+            "E6-0",
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 492,
+      "created_at": 1696450995,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 493,
+      "created_at": 1696450999
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 494,
+      "created_at": 1696452975,
+      "hex": "C14",
+      "tile": "27-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 495,
+      "created_at": 1696452984,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F19"
+          ],
+          "revenue": 250,
+          "revenue_str": "E20-F19-E18-E16-F15-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 496,
+      "created_at": 1696452990,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 497,
+      "created_at": 1696452992
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 498,
+      "created_at": 1696455091,
+      "hex": "I12",
+      "tile": "8-7",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 499,
+      "created_at": 1696455110,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I10",
+              "J9",
+              "J7"
+            ],
+            [
+              "H13",
+              "I12",
+              "I10"
+            ],
+            [
+              "I14",
+              "H13"
+            ]
+          ],
+          "hexes": [
+            "J7",
+            "I10",
+            "H13",
+            "I14"
+          ],
+          "revenue": 190,
+          "revenue_str": "J7-I10-H13-I14",
+          "nodes": [
+            "I10-1",
+            "J7-0",
+            "H13-1",
+            "I14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 500,
+      "created_at": 1696455111,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 501,
+      "created_at": 1696455113
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 502,
+      "created_at": 1696455199,
+      "hex": "F5",
+      "tile": "46-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 503,
+      "created_at": 1696455209,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13",
+              "F11",
+              "G10",
+              "G8"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "F7",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "G8",
+            "F7",
+            "F3",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 390,
+          "revenue_str": "E20-F19-E18-E16-F15-G8-F7-F3-G4-H3-I4",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "G8-0",
+            "F7-0",
+            "F3-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 504,
+      "created_at": 1696455211,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 505,
+      "created_at": 1696455214
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 506,
+      "created_at": 1696455225,
+      "hex": "I12",
+      "tile": "24-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 507,
+      "created_at": 1696455243,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "J7",
+              "J9",
+              "I10"
+            ],
+            [
+              "I10",
+              "I12",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "J7",
+            "I10",
+            "I14"
+          ],
+          "revenue": 140,
+          "revenue_str": "J7-I10-I14",
+          "nodes": [
+            "J7-0",
+            "I10-1",
+            "I14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "undo",
+      "entity": "MES",
+      "action_id": 505,
+      "entity_type": "corporation",
+      "id": 508,
+      "user": 34,
+      "created_at": 1696455248
+    },
+    {
+      "type": "redo",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 509,
+      "user": 34,
+      "created_at": 1696455253
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 510,
+      "created_at": 1696455255,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 511,
+      "created_at": 1696455261
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 512,
+      "created_at": 1696455351,
+      "hex": "I12",
+      "tile": "47-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 513,
+      "created_at": 1696455368
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 514,
+      "created_at": 1696455388,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "I14",
+              "I12",
+              "J11",
+              "I10"
+            ],
+            [
+              "I10",
+              "H9",
+              "G8"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "F7",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "I10",
+            "G8",
+            "F7",
+            "F3",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 310,
+          "revenue_str": "I14-I10-G8-F7-F3-G4-H3-I4",
+          "nodes": [
+            "I14-0",
+            "I10-0",
+            "G8-0",
+            "F7-0",
+            "F3-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 515,
+      "created_at": 1696455389,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 516,
+      "created_at": 1696455397
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 517,
+      "created_at": 1696466422,
+      "hex": "C8",
+      "tile": "3-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 518,
+      "created_at": 1696466431,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F3",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 210,
+          "revenue_str": "E6-F3-G4-H3-I4",
+          "nodes": [
+            "E6-0",
+            "F3-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 519,
+      "created_at": 1696466433,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 520,
+      "created_at": 1696466436
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 521,
+      "created_at": 1696474121,
+      "hex": "B15",
+      "tile": "NL7-0",
+      "rotation": 5
+    },
+    {
+      "type": "sell_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 522,
+      "created_at": 1696474154,
+      "shares": [
+        "MES_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 523,
+      "created_at": 1696474167,
+      "shares": [
+        "NZO_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_train",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 524,
+      "created_at": 1696474173,
+      "train": "D-2",
+      "price": 1100,
+      "variant": "D"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 525,
+      "created_at": 1696474191,
+      "hex": "K2",
+      "tile": "9-3",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 526,
+      "created_at": 1696474205,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G2",
+            "F3",
+            "E6"
+          ],
+          "revenue": 330,
+          "revenue_str": "L1-I4-H3-G2-F3-E6",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 527,
+      "created_at": 1696474206,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 528,
+      "created_at": 1696474213
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 529,
+      "created_at": 1696487067,
+      "hex": "C6",
+      "tile": "24-2",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 530,
+      "created_at": 1696487080,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "F3",
+              "F5",
+              "E6"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "I4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F3",
+            "G2",
+            "H3",
+            "I4"
+          ],
+          "revenue": 250,
+          "revenue_str": "E6-F3-G2-H3-I4",
+          "nodes": [
+            "F3-0",
+            "E6-0",
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 531,
+      "created_at": 1696487087,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 532,
+      "created_at": 1696487088
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 533,
+      "created_at": 1696502130,
+      "hex": "G14",
+      "tile": "8-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "routes": [
+        {
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F19"
+          ],
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F19-0"
+          ],
+          "train": "6-1",
+          "revenue": 250,
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18",
+              "F19"
+            ]
+          ],
+          "revenue_str": "E20-F19-E18-E16-F15-F19"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 534,
+      "user": 34,
+      "created_at": 1696502134
+    },
+    {
+      "type": "undo",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 535,
+      "user": 34,
+      "created_at": 1696502142
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 536,
+      "created_at": 1696502146,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F19"
+          ],
+          "revenue": 250,
+          "revenue_str": "E20-F19-E18-E16-F15-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 537,
+      "created_at": 1696502147,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 538,
+      "created_at": 1696502148
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 539,
+      "created_at": 1696553877,
+      "hex": "J7",
+      "tile": "15-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 540,
+      "created_at": 1696553882,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I10",
+              "J9",
+              "J7"
+            ],
+            [
+              "H13",
+              "I12",
+              "I10"
+            ],
+            [
+              "I14",
+              "H13"
+            ]
+          ],
+          "hexes": [
+            "J7",
+            "I10",
+            "H13",
+            "I14"
+          ],
+          "revenue": 200,
+          "revenue_str": "J7-I10-H13-I14",
+          "nodes": [
+            "I10-1",
+            "J7-0",
+            "H13-1",
+            "I14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 541,
+      "created_at": 1696553886,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 542,
+      "created_at": 1696553889
+    },
+    {
+      "hex": "H15",
+      "tile": "3-0",
+      "type": "lay_tile",
+      "entity": "AS",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 543,
+      "user": 34,
+      "created_at": 1696555888
+    },
+    {
+      "type": "undo",
+      "entity": "AS",
+      "action_id": 542,
+      "entity_type": "corporation",
+      "id": 544,
+      "user": 34,
+      "created_at": 1696555920
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 545,
+      "created_at": 1696555933,
+      "hex": "F9",
+      "tile": "6-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 546,
+      "created_at": 1696555939,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "F9"
+            ],
+            [
+              "F9",
+              "F11",
+              "F13",
+              "F15"
+            ],
+            [
+              "F15",
+              "E16"
+            ],
+            [
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "F19"
+            ],
+            [
+              "F19",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G4",
+            "F3",
+            "F7",
+            "G8",
+            "F9",
+            "F15",
+            "E16",
+            "E18",
+            "F19",
+            "E20"
+          ],
+          "revenue": 490,
+          "revenue_str": "L1-I4-H3-G4-F3-F7-G8-F9-F15-E16-E18-F19-E20",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G4-0",
+            "F3-0",
+            "F7-0",
+            "G8-0",
+            "F9-0",
+            "F15-0",
+            "E16-0",
+            "E18-0",
+            "F19-1",
+            "E20-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 547,
+      "created_at": 1696555940,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 548,
+      "created_at": 1696555942
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 549,
+      "created_at": 1696570208,
+      "hex": "J11",
+      "tile": "28-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 550,
+      "user": 692,
+      "created_at": 1696570216
+    },
+    {
+      "type": "undo",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 551,
+      "user": 692,
+      "created_at": 1696570233
+    },
+    {
+      "type": "place_token",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 552,
+      "created_at": 1696570242,
+      "city": "NL5-0-0",
+      "slot": 1,
+      "tokener": "DV"
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 553,
+      "created_at": 1696570256,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "H9",
+              "I10"
+            ],
+            [
+              "I10",
+              "J11",
+              "I12",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G4",
+            "F3",
+            "F7",
+            "G8",
+            "I10",
+            "I14"
+          ],
+          "revenue": 390,
+          "revenue_str": "L1-I4-H3-G4-F3-F7-G8-I10-I14",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G4-0",
+            "F3-0",
+            "F7-0",
+            "G8-0",
+            "I10-0",
+            "I14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 554,
+      "created_at": 1696570257,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 555,
+      "created_at": 1696570270
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 556,
+      "created_at": 1696590498,
+      "hex": "C6",
+      "tile": "46-1",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 557,
+      "created_at": 1696590505,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "revenue": 190,
+          "revenue_str": "E4-E6-F3-G4-H3",
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 558,
+      "created_at": 1696590507,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 559,
+      "created_at": 1696590510
+    },
+    {
+      "hex": "J5",
+      "tile": "57-1",
+      "type": "lay_tile",
+      "entity": "MES",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 560,
+      "user": 34,
+      "created_at": 1696590714
+    },
+    {
+      "city": "67-0-1",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "MES",
+      "tokener": "MES",
+      "entity_type": "corporation",
+      "id": 561,
+      "user": 34,
+      "created_at": 1696590725
+    },
+    {
+      "type": "undo",
+      "entity": "MES",
+      "action_id": 559,
+      "entity_type": "corporation",
+      "id": 562,
+      "user": 34,
+      "created_at": 1696590736
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 563,
+      "created_at": 1696590749,
+      "hex": "J9",
+      "tile": "29-0",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 564,
+      "created_at": 1696590756,
+      "city": "67-0-1",
+      "slot": 0,
+      "tokener": "MES"
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 565,
+      "created_at": 1696590770,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "J7",
+              "J9",
+              "I10"
+            ],
+            [
+              "I10",
+              "I12",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "J7",
+            "I10",
+            "I14"
+          ],
+          "revenue": 150,
+          "revenue_str": "J7-I10-I14",
+          "nodes": [
+            "J7-0",
+            "I10-1",
+            "I14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 566,
+      "created_at": 1696590773,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 567,
+      "created_at": 1696590776
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 568,
+      "created_at": 1696595790,
+      "hex": "E14",
+      "tile": "9-4",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 569,
+      "created_at": 1696595795,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "D15"
+            ],
+            [
+              "D15",
+              "C14",
+              "B13",
+              "B15"
+            ],
+            [
+              "B15",
+              "A16"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "D15",
+            "B15",
+            "A16"
+          ],
+          "revenue": 280,
+          "revenue_str": "E20-F19-E18-E16-D15-B15-A16",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "D15-0",
+            "B15-0",
+            "A16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 570,
+      "created_at": 1696595800,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 571,
+      "created_at": 1696595804
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "shares": [
+        "HIS_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 572,
+      "user": 34,
+      "created_at": 1696596867
+    },
+    {
+      "type": "undo",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 573,
+      "user": 34,
+      "created_at": 1696596875
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 574,
+      "created_at": 1696596877,
+      "shares": [
+        "ZHE_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 575,
+      "created_at": 1696596880
+    },
+    {
+      "type": "sell_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 576,
+      "created_at": 1696597807,
+      "shares": [
+        "HIS_4",
+        "HIS_7",
+        "HIS_8",
+        "HIS_2"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 577,
+      "created_at": 1696597814,
+      "shares": [
+        "ZHE_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 578,
+      "created_at": 1696597819
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 579,
+      "created_at": 1696599662,
+      "shares": [
+        "AS_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 580,
+      "created_at": 1696599666
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 581,
+      "created_at": 1696599898,
+      "shares": [
+        "DV_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 582,
+      "created_at": 1696599900
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 583,
+      "created_at": 1696599910,
+      "corporation": "DV",
+      "until_condition": 2,
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 584,
+      "created_at": 1696600057,
+      "shares": [
+        "AS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 585,
+      "created_at": 1696600067
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 586,
+      "created_at": 1696601122,
+      "shares": [
+        "AS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 587,
+      "created_at": 1696601125,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696601125,
+          "shares": [
+            "DV_8"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696601125,
+          "reason": "2 share(s) bought in DV, end condition met"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 588,
+      "created_at": 1696604702
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 589,
+      "created_at": 1696604725,
+      "corporation": "DV",
+      "until_condition": 4,
+      "from_market": true,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 590,
+      "created_at": 1696605214,
+      "shares": [
+        "AS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 591,
+      "created_at": 1696605223
+    },
+    {
+      "type": "buy_shares",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 592,
+      "created_at": 1696608169,
+      "shares": [
+        "HIS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 593,
+      "created_at": 1696608173,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696608173,
+          "shares": [
+            "DV_7"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696608173
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 594,
+      "created_at": 1696608333,
+      "shares": [
+        "DV_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 595,
+      "created_at": 1696608347
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 596,
+      "created_at": 1696612425,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1696612426
+        },
+        {
+          "type": "program_disable",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696612426,
+          "reason": "Cannot buy DV from market"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "shares": [
+        "NFL_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 597,
+      "user": 34,
+      "created_at": 1696612771
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 598,
+      "user": 34,
+      "created_at": 1696612775
+    },
+    {
+      "type": "undo",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 599,
+      "user": 34,
+      "created_at": 1696612785
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 34,
+      "corporation": "MES",
+      "entity_type": "player",
+      "from_market": false,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 34,
+          "created_at": 1696612792,
+          "entity_type": "player"
+        }
+      ],
+      "auto_pass_after": false,
+      "until_condition": 3,
+      "id": 600,
+      "user": 34,
+      "created_at": 1696612794
+    },
+    {
+      "type": "undo",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 601,
+      "user": 34,
+      "created_at": 1696612805
+    },
+    {
+      "type": "undo",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 602,
+      "user": 34,
+      "created_at": 1696612807
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 603,
+      "created_at": 1696612814,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696612812,
+          "shares": [
+            "MES_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696612812
+        }
+      ],
+      "corporation": "MES",
+      "until_condition": 6,
+      "from_market": true,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 604,
+      "created_at": 1696612863,
+      "shares": [
+        "NFL_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 605,
+      "created_at": 1696612869,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1696612868,
+          "reason": "Eonthar bought on corporation NFL and is unsecure"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 606,
+      "created_at": 1696612940,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1696612940
+        },
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696612940,
+          "shares": [
+            "MES_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696612940
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 607,
+      "created_at": 1696613041,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1696613040
+        },
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1696613040
+        },
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696613040,
+          "shares": [
+            "MES_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696613040
+        },
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1696613040
+        },
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1696613040
+        },
+        {
+          "type": "buy_shares",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696613040,
+          "shares": [
+            "MES_5"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 34,
+          "entity_type": "player",
+          "created_at": 1696613040,
+          "reason": "6 share(s) bought in MES, end condition met"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 608,
+      "created_at": 1696614808,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1696614806
+        },
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1696614806
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 609,
+      "created_at": 1696614810,
+      "shares": [
+        "NRS_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 610,
+      "created_at": 1696614812,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1696614811
+        },
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1696614811
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 611,
+      "created_at": 1696614816,
+      "shares": [
+        "NZO_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 612,
+      "created_at": 1696614818,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 690,
+          "entity_type": "player",
+          "created_at": 1696614816
+        },
+        {
+          "type": "pass",
+          "entity": 692,
+          "entity_type": "player",
+          "created_at": 1696614816
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 613,
+      "created_at": 1696614820
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 614,
+      "user": 34,
+      "created_at": 1696614903
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 615,
+      "user": 34,
+      "created_at": 1696614906,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G2",
+            "F3",
+            "E6"
+          ],
+          "revenue": 330,
+          "revenue_str": "L1-I4-H3-G2-F3-E6",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 616,
+      "user": 34,
+      "created_at": 1696614907,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 617,
+      "user": 34,
+      "created_at": 1696614925
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 618,
+      "user": 34,
+      "created_at": 1696614930
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 619,
+      "user": 34,
+      "created_at": 1696614935,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ],
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G2",
+            "H3"
+          ],
+          "revenue": 230,
+          "revenue_str": "E4-E6-F3-G2-H3",
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G2-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 620,
+      "user": 34,
+      "created_at": 1696614937,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 621,
+      "user": 34,
+      "created_at": 1696614939
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 622,
+      "created_at": 1696614942
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 623,
+      "created_at": 1696614946,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F19"
+          ],
+          "revenue": 250,
+          "revenue_str": "E20-F19-E18-E16-F15-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 624,
+      "created_at": 1696614948,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 625,
+      "created_at": 1696614949
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 626,
+      "created_at": 1696614950
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 627,
+      "created_at": 1696614951
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 628,
+      "created_at": 1696614955,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13",
+              "F11",
+              "F9"
+            ],
+            [
+              "F9",
+              "G8"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "F7",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F9",
+            "G8",
+            "F7",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "revenue": 360,
+          "revenue_str": "E20-F19-E18-E16-F15-F9-G8-F7-F3-G4-H3",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F9-0",
+            "G8-0",
+            "F7-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 629,
+      "created_at": 1696614956,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 630,
+      "created_at": 1696614959
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 631,
+      "user": 34,
+      "created_at": 1696614966
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 632,
+      "user": 34,
+      "created_at": 1696614967
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 633,
+      "user": 34,
+      "created_at": 1696614970,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "H9",
+              "I10"
+            ],
+            [
+              "I10",
+              "J11",
+              "I12",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G4",
+            "F3",
+            "F7",
+            "G8",
+            "I10",
+            "I14"
+          ],
+          "revenue": 390,
+          "revenue_str": "L1-I4-H3-G4-F3-F7-G8-I10-I14",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G4-0",
+            "F3-0",
+            "F7-0",
+            "G8-0",
+            "I10-0",
+            "I14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 634,
+      "user": 34,
+      "created_at": 1696614972,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 635,
+      "user": 34,
+      "created_at": 1696614973
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 636,
+      "user": 34,
+      "created_at": 1696614982
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 637,
+      "user": 34,
+      "created_at": 1696614984,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "I12",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "I10"
+          ],
+          "revenue": 170,
+          "revenue_str": "I14-H13-I10",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "I10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 638,
+      "user": 34,
+      "created_at": 1696614986,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 639,
+      "user": 34,
+      "created_at": 1696614988
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 640,
+      "user": 34,
+      "created_at": 1696614991
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "routes": [
+        {
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ],
+          "train": "5-2",
+          "revenue": 190,
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "revenue_str": "E4-E6-F3-G4-H3"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 641,
+      "user": 34,
+      "created_at": 1696614993
+    },
+    {
+      "type": "undo",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 642,
+      "user": 34,
+      "created_at": 1696614998
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 643,
+      "user": 34,
+      "created_at": 1696615000,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "revenue": 190,
+          "revenue_str": "E4-E6-F3-G4-H3",
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 644,
+      "user": 34,
+      "created_at": 1696615001,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 645,
+      "user": 34,
+      "created_at": 1696615002
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 646,
+      "created_at": 1696615007,
+      "hex": "J5",
+      "tile": "57-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 647,
+      "created_at": 1696615011,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "I14",
+              "I12",
+              "I10"
+            ],
+            [
+              "I10",
+              "J9",
+              "J7"
+            ],
+            [
+              "J7",
+              "J5"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "I10",
+            "J7",
+            "J5"
+          ],
+          "revenue": 170,
+          "revenue_str": "I14-I10-J7-J5",
+          "nodes": [
+            "I14-0",
+            "I10-1",
+            "J7-0",
+            "J5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 648,
+      "created_at": 1696615012,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 649,
+      "created_at": 1696615012
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 650,
+      "user": 34,
+      "created_at": 1696615023,
+      "hex": "F17",
+      "tile": "24-1",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 651,
+      "user": 34,
+      "created_at": 1696615026,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "D15"
+            ],
+            [
+              "D15",
+              "C14",
+              "B13",
+              "B15"
+            ],
+            [
+              "B15",
+              "A16"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "D15",
+            "B15",
+            "A16"
+          ],
+          "revenue": 280,
+          "revenue_str": "E20-F19-E18-E16-D15-B15-A16",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "D15-0",
+            "B15-0",
+            "A16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 652,
+      "user": 34,
+      "created_at": 1696615027,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 653,
+      "user": 34,
+      "created_at": 1696615029
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 654,
+      "user": 34,
+      "created_at": 1696615052
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 655,
+      "user": 34,
+      "created_at": 1696615054,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G2",
+            "F3",
+            "E6"
+          ],
+          "revenue": 330,
+          "revenue_str": "L1-I4-H3-G2-F3-E6",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 656,
+      "user": 34,
+      "created_at": 1696615055,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 657,
+      "user": 34,
+      "created_at": 1696615057
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 658,
+      "user": 34,
+      "created_at": 1696615057
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 659,
+      "user": 34,
+      "created_at": 1696615058,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ],
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G2",
+            "H3"
+          ],
+          "revenue": 230,
+          "revenue_str": "E4-E6-F3-G2-H3",
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G2-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 660,
+      "user": 34,
+      "created_at": 1696615059,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 661,
+      "user": 34,
+      "created_at": 1696615060
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 662,
+      "created_at": 1696615061
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 663,
+      "created_at": 1696615062
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 664,
+      "created_at": 1696615063,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F19"
+          ],
+          "revenue": 250,
+          "revenue_str": "E20-F19-E18-E16-F15-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 665,
+      "created_at": 1696615064,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 666,
+      "created_at": 1696615065
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 667,
+      "created_at": 1696615066
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 668,
+      "created_at": 1696615067
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 669,
+      "created_at": 1696615071,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13",
+              "F11",
+              "F9"
+            ],
+            [
+              "F9",
+              "G8"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "F7",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F9",
+            "G8",
+            "F7",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "revenue": 360,
+          "revenue_str": "E20-F19-E18-E16-F15-F9-G8-F7-F3-G4-H3",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F9-0",
+            "G8-0",
+            "F7-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 670,
+      "created_at": 1696615073,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 671,
+      "created_at": 1696615075
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 672,
+      "user": 34,
+      "created_at": 1696615076
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 673,
+      "user": 34,
+      "created_at": 1696615078
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 674,
+      "user": 34,
+      "created_at": 1696615085,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "H9",
+              "I10"
+            ],
+            [
+              "I10",
+              "J11",
+              "I12",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G4",
+            "F3",
+            "F7",
+            "G8",
+            "I10",
+            "I14"
+          ],
+          "revenue": 390,
+          "revenue_str": "L1-I4-H3-G4-F3-F7-G8-I10-I14",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G4-0",
+            "F3-0",
+            "F7-0",
+            "G8-0",
+            "I10-0",
+            "I14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 675,
+      "user": 34,
+      "created_at": 1696615086,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 676,
+      "user": 34,
+      "created_at": 1696615087
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 677,
+      "user": 34,
+      "created_at": 1696615088
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 678,
+      "user": 34,
+      "created_at": 1696615089,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "I12",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "I10"
+          ],
+          "revenue": 170,
+          "revenue_str": "I14-H13-I10",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "I10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 679,
+      "user": 34,
+      "created_at": 1696615090,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 680,
+      "user": 34,
+      "created_at": 1696615091
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 681,
+      "user": 34,
+      "created_at": 1696615091
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 682,
+      "user": 34,
+      "created_at": 1696615093,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "revenue": 190,
+          "revenue_str": "E4-E6-F3-G4-H3",
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 683,
+      "user": 34,
+      "created_at": 1696615094,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 684,
+      "user": 34,
+      "created_at": 1696615095
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 685,
+      "created_at": 1696615096
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 686,
+      "created_at": 1696615097
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 687,
+      "created_at": 1696615099,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "I14",
+              "I12",
+              "I10"
+            ],
+            [
+              "I10",
+              "J9",
+              "J7"
+            ],
+            [
+              "J7",
+              "J5"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "I10",
+            "J7",
+            "J5"
+          ],
+          "revenue": 170,
+          "revenue_str": "I14-I10-J7-J5",
+          "nodes": [
+            "I14-0",
+            "I10-1",
+            "J7-0",
+            "J5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 688,
+      "created_at": 1696615100,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 689,
+      "created_at": 1696615103
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 690,
+      "user": 34,
+      "created_at": 1696615105
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 691,
+      "user": 34,
+      "created_at": 1696615106,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "D15"
+            ],
+            [
+              "D15",
+              "C14",
+              "B13",
+              "B15"
+            ],
+            [
+              "B15",
+              "A16"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "D15",
+            "B15",
+            "A16"
+          ],
+          "revenue": 280,
+          "revenue_str": "E20-F19-E18-E16-D15-B15-A16",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "D15-0",
+            "B15-0",
+            "A16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 692,
+      "user": 34,
+      "created_at": 1696615107,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 693,
+      "user": 34,
+      "created_at": 1696615108
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 694,
+      "user": 34,
+      "created_at": 1696615109
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 695,
+      "user": 34,
+      "created_at": 1696615111,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G2",
+            "F3",
+            "E6"
+          ],
+          "revenue": 330,
+          "revenue_str": "L1-I4-H3-G2-F3-E6",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 696,
+      "user": 34,
+      "created_at": 1696615112,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 697,
+      "user": 34,
+      "created_at": 1696615113
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 698,
+      "user": 34,
+      "created_at": 1696615114
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 699,
+      "user": 34,
+      "created_at": 1696615115,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ],
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G2",
+            "H3"
+          ],
+          "revenue": 230,
+          "revenue_str": "E4-E6-F3-G2-H3",
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G2-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 700,
+      "user": 34,
+      "created_at": 1696615116,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 701,
+      "user": 34,
+      "created_at": 1696615117
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 702,
+      "created_at": 1696615118
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 703,
+      "created_at": 1696615119
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 704,
+      "created_at": 1696615121,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F19"
+          ],
+          "revenue": 250,
+          "revenue_str": "E20-F19-E18-E16-F15-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 705,
+      "created_at": 1696615123,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 706,
+      "created_at": 1696615124
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 707,
+      "created_at": 1696615125
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 708,
+      "created_at": 1696615126
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 709,
+      "created_at": 1696615127,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13",
+              "F11",
+              "F9"
+            ],
+            [
+              "F9",
+              "G8"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "F7",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F9",
+            "G8",
+            "F7",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "revenue": 360,
+          "revenue_str": "E20-F19-E18-E16-F15-F9-G8-F7-F3-G4-H3",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F9-0",
+            "G8-0",
+            "F7-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 710,
+      "created_at": 1696615127,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 711,
+      "created_at": 1696615129
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 712,
+      "user": 34,
+      "created_at": 1696615129
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 713,
+      "user": 34,
+      "created_at": 1696615130,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "I12",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "I10"
+          ],
+          "revenue": 170,
+          "revenue_str": "I14-H13-I10",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "I10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 714,
+      "user": 34,
+      "created_at": 1696615131,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 715,
+      "user": 34,
+      "created_at": 1696615132
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 716,
+      "user": 34,
+      "created_at": 1696615134
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 717,
+      "user": 34,
+      "created_at": 1696615135
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 718,
+      "user": 34,
+      "created_at": 1696615136,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "H9",
+              "I10"
+            ],
+            [
+              "I10",
+              "J11",
+              "I12",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G4",
+            "F3",
+            "F7",
+            "G8",
+            "I10",
+            "I14"
+          ],
+          "revenue": 390,
+          "revenue_str": "L1-I4-H3-G4-F3-F7-G8-I10-I14",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G4-0",
+            "F3-0",
+            "F7-0",
+            "G8-0",
+            "I10-0",
+            "I14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 719,
+      "user": 34,
+      "created_at": 1696615137,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 720,
+      "user": 34,
+      "created_at": 1696615138
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 721,
+      "user": 34,
+      "created_at": 1696615139
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 722,
+      "user": 34,
+      "created_at": 1696615141,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "revenue": 190,
+          "revenue_str": "E4-E6-F3-G4-H3",
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 723,
+      "user": 34,
+      "created_at": 1696615143,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 724,
+      "user": 34,
+      "created_at": 1696615144
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 725,
+      "created_at": 1696615145
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 726,
+      "created_at": 1696615156
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 727,
+      "created_at": 1696615160,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "I14",
+              "I12",
+              "I10"
+            ],
+            [
+              "I10",
+              "J9",
+              "J7"
+            ],
+            [
+              "J7",
+              "J5"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "I10",
+            "J7",
+            "J5"
+          ],
+          "revenue": 170,
+          "revenue_str": "I14-I10-J7-J5",
+          "nodes": [
+            "I14-0",
+            "I10-1",
+            "J7-0",
+            "J5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 728,
+      "created_at": 1696615161,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 729,
+      "created_at": 1696615162
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 730,
+      "user": 34,
+      "created_at": 1696615166
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 731,
+      "user": 34,
+      "created_at": 1696615175,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "D15"
+            ],
+            [
+              "D15",
+              "C14",
+              "B13",
+              "B15"
+            ],
+            [
+              "B15",
+              "A16"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "D15",
+            "B15",
+            "A16"
+          ],
+          "revenue": 280,
+          "revenue_str": "E20-F19-E18-E16-D15-B15-A16",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "D15-0",
+            "B15-0",
+            "A16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 732,
+      "user": 34,
+      "created_at": 1696615176,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 733,
+      "user": 34,
+      "created_at": 1696615178
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 734,
+      "user": 34,
+      "created_at": 1696615246
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 735,
+      "user": 34,
+      "created_at": 1696615247
+    },
+    {
+      "type": "buy_shares",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 736,
+      "created_at": 1696615248,
+      "shares": [
+        "NZO_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 737,
+      "created_at": 1696615250
+    },
+    {
+      "type": "pass",
+      "entity": 690,
+      "entity_type": "player",
+      "id": 738,
+      "user": 34,
+      "created_at": 1696615251
+    },
+    {
+      "type": "pass",
+      "entity": 692,
+      "entity_type": "player",
+      "id": 739,
+      "user": 34,
+      "created_at": 1696615253
+    },
+    {
+      "type": "pass",
+      "entity": 34,
+      "entity_type": "player",
+      "id": 740,
+      "created_at": 1696615254
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 741,
+      "user": 34,
+      "created_at": 1696615263
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 742,
+      "user": 34,
+      "created_at": 1696615264,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G2",
+            "F3",
+            "E6"
+          ],
+          "revenue": 330,
+          "revenue_str": "L1-I4-H3-G2-F3-E6",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 743,
+      "user": 34,
+      "created_at": 1696615265,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 744,
+      "user": 34,
+      "created_at": 1696615266
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 745,
+      "user": 34,
+      "created_at": 1696615268
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 746,
+      "user": 34,
+      "created_at": 1696615269,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ],
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G2",
+            "H3"
+          ],
+          "revenue": 230,
+          "revenue_str": "E4-E6-F3-G2-H3",
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G2-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 747,
+      "user": 34,
+      "created_at": 1696615270,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 748,
+      "user": 34,
+      "created_at": 1696615271
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 749,
+      "created_at": 1696615272
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 750,
+      "created_at": 1696615273
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 751,
+      "created_at": 1696615274,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F19"
+          ],
+          "revenue": 250,
+          "revenue_str": "E20-F19-E18-E16-F15-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 752,
+      "created_at": 1696615275,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 753,
+      "created_at": 1696615276
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 754,
+      "created_at": 1696615278
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 755,
+      "created_at": 1696615279
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 756,
+      "created_at": 1696615280,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13",
+              "F11",
+              "F9"
+            ],
+            [
+              "F9",
+              "G8"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "F7",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F9",
+            "G8",
+            "F7",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "revenue": 360,
+          "revenue_str": "E20-F19-E18-E16-F15-F9-G8-F7-F3-G4-H3",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F9-0",
+            "G8-0",
+            "F7-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 757,
+      "created_at": 1696615281,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 758,
+      "created_at": 1696615282
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 759,
+      "user": 34,
+      "created_at": 1696615283
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 760,
+      "user": 34,
+      "created_at": 1696615284
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 761,
+      "user": 34,
+      "created_at": 1696615286,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "H9",
+              "I10"
+            ],
+            [
+              "I10",
+              "J11",
+              "I12",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G4",
+            "F3",
+            "F7",
+            "G8",
+            "I10",
+            "I14"
+          ],
+          "revenue": 390,
+          "revenue_str": "L1-I4-H3-G4-F3-F7-G8-I10-I14",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G4-0",
+            "F3-0",
+            "F7-0",
+            "G8-0",
+            "I10-0",
+            "I14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 762,
+      "user": 34,
+      "created_at": 1696615287,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 763,
+      "user": 34,
+      "created_at": 1696615288
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 764,
+      "user": 34,
+      "created_at": 1696615289
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 765,
+      "user": 34,
+      "created_at": 1696615290,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "I12",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "I10"
+          ],
+          "revenue": 170,
+          "revenue_str": "I14-H13-I10",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "I10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 766,
+      "user": 34,
+      "created_at": 1696615292,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 767,
+      "user": 34,
+      "created_at": 1696615335
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 768,
+      "user": 34,
+      "created_at": 1696615336
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 769,
+      "user": 34,
+      "created_at": 1696615337,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "revenue": 190,
+          "revenue_str": "E4-E6-F3-G4-H3",
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 770,
+      "user": 34,
+      "created_at": 1696615339,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 771,
+      "user": 34,
+      "created_at": 1696615341
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 772,
+      "created_at": 1696615342
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 773,
+      "created_at": 1696615343
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 774,
+      "created_at": 1696615344,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "I14",
+              "I12",
+              "I10"
+            ],
+            [
+              "I10",
+              "J9",
+              "J7"
+            ],
+            [
+              "J7",
+              "J5"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "I10",
+            "J7",
+            "J5"
+          ],
+          "revenue": 170,
+          "revenue_str": "I14-I10-J7-J5",
+          "nodes": [
+            "I14-0",
+            "I10-1",
+            "J7-0",
+            "J5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 775,
+      "created_at": 1696615345,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 776,
+      "created_at": 1696615347
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 777,
+      "user": 34,
+      "created_at": 1696615348
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 778,
+      "user": 34,
+      "created_at": 1696615350,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "D15"
+            ],
+            [
+              "D15",
+              "C14",
+              "B13",
+              "B15"
+            ],
+            [
+              "B15",
+              "A16"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "D15",
+            "B15",
+            "A16"
+          ],
+          "revenue": 280,
+          "revenue_str": "E20-F19-E18-E16-D15-B15-A16",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "D15-0",
+            "B15-0",
+            "A16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 779,
+      "user": 34,
+      "created_at": 1696615351,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 780,
+      "user": 34,
+      "created_at": 1696615352
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 781,
+      "user": 34,
+      "created_at": 1696615353
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 782,
+      "user": 34,
+      "created_at": 1696615355,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G2",
+            "F3",
+            "E6"
+          ],
+          "revenue": 330,
+          "revenue_str": "L1-I4-H3-G2-F3-E6",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 783,
+      "user": 34,
+      "created_at": 1696615356,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 784,
+      "user": 34,
+      "created_at": 1696615358
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 785,
+      "user": 34,
+      "created_at": 1696615359
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 786,
+      "user": 34,
+      "created_at": 1696615360,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ],
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G2",
+            "H3"
+          ],
+          "revenue": 230,
+          "revenue_str": "E4-E6-F3-G2-H3",
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G2-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 787,
+      "user": 34,
+      "created_at": 1696615361,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 788,
+      "user": 34,
+      "created_at": 1696615363
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 789,
+      "created_at": 1696615364
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 790,
+      "created_at": 1696615365
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 791,
+      "created_at": 1696615368,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F19"
+          ],
+          "revenue": 250,
+          "revenue_str": "E20-F19-E18-E16-F15-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 792,
+      "created_at": 1696615373,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 793,
+      "created_at": 1696615382
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 794,
+      "created_at": 1696615383
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 795,
+      "created_at": 1696615421
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 796,
+      "created_at": 1696615424,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13",
+              "F11",
+              "F9"
+            ],
+            [
+              "F9",
+              "G8"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "F7",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F9",
+            "G8",
+            "F7",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "revenue": 360,
+          "revenue_str": "E20-F19-E18-E16-F15-F9-G8-F7-F3-G4-H3",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F9-0",
+            "G8-0",
+            "F7-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 797,
+      "created_at": 1696615425,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 798,
+      "created_at": 1696615426
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 799,
+      "user": 34,
+      "created_at": 1696615427
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 800,
+      "user": 34,
+      "created_at": 1696615428
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 801,
+      "user": 34,
+      "created_at": 1696615430,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "H9",
+              "I10"
+            ],
+            [
+              "I10",
+              "J11",
+              "I12",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G4",
+            "F3",
+            "F7",
+            "G8",
+            "I10",
+            "I14"
+          ],
+          "revenue": 390,
+          "revenue_str": "L1-I4-H3-G4-F3-F7-G8-I10-I14",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G4-0",
+            "F3-0",
+            "F7-0",
+            "G8-0",
+            "I10-0",
+            "I14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 802,
+      "user": 34,
+      "created_at": 1696615431,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 803,
+      "user": 34,
+      "created_at": 1696615432
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 804,
+      "user": 34,
+      "created_at": 1696615433
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 805,
+      "user": 34,
+      "created_at": 1696615434,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "I12",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "I10"
+          ],
+          "revenue": 170,
+          "revenue_str": "I14-H13-I10",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "I10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 806,
+      "user": 34,
+      "created_at": 1696615436,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 807,
+      "user": 34,
+      "created_at": 1696615437
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 808,
+      "user": 34,
+      "created_at": 1696615438
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 809,
+      "user": 34,
+      "created_at": 1696615439,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "revenue": 190,
+          "revenue_str": "E4-E6-F3-G4-H3",
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 810,
+      "user": 34,
+      "created_at": 1696615440,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 811,
+      "user": 34,
+      "created_at": 1696615441
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 812,
+      "created_at": 1696615442
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 813,
+      "created_at": 1696615443
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 814,
+      "created_at": 1696615445,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "I14",
+              "I12",
+              "I10"
+            ],
+            [
+              "I10",
+              "J9",
+              "J7"
+            ],
+            [
+              "J7",
+              "J5"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "I10",
+            "J7",
+            "J5"
+          ],
+          "revenue": 170,
+          "revenue_str": "I14-I10-J7-J5",
+          "nodes": [
+            "I14-0",
+            "I10-1",
+            "J7-0",
+            "J5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 815,
+      "created_at": 1696615446,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 816,
+      "created_at": 1696615448
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 817,
+      "user": 34,
+      "created_at": 1696615449
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 818,
+      "user": 34,
+      "created_at": 1696615450,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "D15"
+            ],
+            [
+              "D15",
+              "C14",
+              "B13",
+              "B15"
+            ],
+            [
+              "B15",
+              "A16"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "D15",
+            "B15",
+            "A16"
+          ],
+          "revenue": 280,
+          "revenue_str": "E20-F19-E18-E16-D15-B15-A16",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "D15-0",
+            "B15-0",
+            "A16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 819,
+      "user": 34,
+      "created_at": 1696615451,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 820,
+      "user": 34,
+      "created_at": 1696615452
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 821,
+      "user": 34,
+      "created_at": 1696615462
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 822,
+      "user": 34,
+      "created_at": 1696615463,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G2",
+            "F3",
+            "E6"
+          ],
+          "revenue": 330,
+          "revenue_str": "L1-I4-H3-G2-F3-E6",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 823,
+      "user": 34,
+      "created_at": 1696615464,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 824,
+      "user": 34,
+      "created_at": 1696615468
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 825,
+      "user": 34,
+      "created_at": 1696615469
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 826,
+      "user": 34,
+      "created_at": 1696615470,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ],
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G2",
+            "H3"
+          ],
+          "revenue": 230,
+          "revenue_str": "E4-E6-F3-G2-H3",
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G2-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 827,
+      "user": 34,
+      "created_at": 1696615472,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 828,
+      "user": 34,
+      "created_at": 1696615473
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 829,
+      "created_at": 1696615474
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 830,
+      "created_at": 1696615475
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 831,
+      "created_at": 1696615476,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13",
+              "F11",
+              "F9"
+            ],
+            [
+              "F9",
+              "G8"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "F7",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F9",
+            "G8",
+            "F7",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "revenue": 360,
+          "revenue_str": "E20-F19-E18-E16-F15-F9-G8-F7-F3-G4-H3",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F9-0",
+            "G8-0",
+            "F7-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 832,
+      "created_at": 1696615477,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 833,
+      "created_at": 1696615478
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 834,
+      "created_at": 1696615479
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 835,
+      "created_at": 1696615480
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 836,
+      "created_at": 1696615483,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F15",
+            "F19"
+          ],
+          "revenue": 250,
+          "revenue_str": "E20-F19-E18-E16-F15-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 837,
+      "user": 34,
+      "created_at": 1696615488,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 838,
+      "created_at": 1696615496
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 839,
+      "user": 34,
+      "created_at": 1696615497
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 840,
+      "user": 34,
+      "created_at": 1696615498
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 841,
+      "user": 34,
+      "created_at": 1696615501,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F3"
+            ],
+            [
+              "F3",
+              "F5",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "H9",
+              "I10"
+            ],
+            [
+              "I10",
+              "J11",
+              "I12",
+              "I14"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "H3",
+            "G4",
+            "F3",
+            "F7",
+            "G8",
+            "I10",
+            "I14"
+          ],
+          "revenue": 390,
+          "revenue_str": "L1-I4-H3-G4-F3-F7-G8-I10-I14",
+          "nodes": [
+            "L1-0",
+            "I4-0",
+            "H3-0",
+            "G4-0",
+            "F3-0",
+            "F7-0",
+            "G8-0",
+            "I10-0",
+            "I14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 842,
+      "user": 34,
+      "created_at": 1696615502,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 843,
+      "user": 34,
+      "created_at": 1696615503
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 844,
+      "user": 34,
+      "created_at": 1696615504
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 845,
+      "user": 34,
+      "created_at": 1696615505,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "I12",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "I10"
+          ],
+          "revenue": 170,
+          "revenue_str": "I14-H13-I10",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "I10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 846,
+      "user": 34,
+      "created_at": 1696615506,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 847,
+      "user": 34,
+      "created_at": 1696615507
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 848,
+      "user": 34,
+      "created_at": 1696615509
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 849,
+      "user": 34,
+      "created_at": 1696615510,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "E4",
+              "E6"
+            ],
+            [
+              "E6",
+              "F5",
+              "F3"
+            ],
+            [
+              "F3",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E6",
+            "F3",
+            "G4",
+            "H3"
+          ],
+          "revenue": 190,
+          "revenue_str": "E4-E6-F3-G4-H3",
+          "nodes": [
+            "E4-0",
+            "E6-0",
+            "F3-0",
+            "G4-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 850,
+      "user": 34,
+      "created_at": 1696615511,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 851,
+      "user": 34,
+      "created_at": 1696615512
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 852,
+      "created_at": 1696615513
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 853,
+      "created_at": 1696615514
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 854,
+      "created_at": 1696615515,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "I14",
+              "I12",
+              "I10"
+            ],
+            [
+              "I10",
+              "J9",
+              "J7"
+            ],
+            [
+              "J7",
+              "J5"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "I10",
+            "J7",
+            "J5"
+          ],
+          "revenue": 170,
+          "revenue_str": "I14-I10-J7-J5",
+          "nodes": [
+            "I14-0",
+            "I10-1",
+            "J7-0",
+            "J5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 855,
+      "created_at": 1696615517,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 856,
+      "created_at": 1696615518
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 857,
+      "user": 34,
+      "created_at": 1696615519
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 858,
+      "user": 34,
+      "created_at": 1696615520,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "D15"
+            ],
+            [
+              "D15",
+              "C14",
+              "B13",
+              "B15"
+            ],
+            [
+              "B15",
+              "A16"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "D15",
+            "B15",
+            "A16"
+          ],
+          "revenue": 280,
+          "revenue_str": "E20-F19-E18-E16-D15-B15-A16",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "D15-0",
+            "B15-0",
+            "A16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 859,
+      "user": 34,
+      "created_at": 1696615521,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 860,
+      "user": 34,
+      "created_at": 1696615522
+    }
+  ],
+  "loaded": true,
+  "created_at": 1695600788,
+  "updated_at": 1696615522,
+  "finished_at": 1696615522
+}

--- a/public/fixtures/18NL/135870.json
+++ b/public/fixtures/18NL/135870.json
@@ -1,0 +1,13448 @@
+{
+  "id": 135870,
+  "description": "PDT",
+  "user": {
+    "id": 797,
+    "name": "nigelsandwich"
+  },
+  "players": [
+    {
+      "id": 797,
+      "name": "nigelsandwich"
+    },
+    {
+      "id": 9831,
+      "name": "burmer"
+    },
+    {
+      "id": 7622,
+      "name": "mb1898"
+    },
+    {
+      "id": 1947,
+      "name": "ViennaTramways"
+    }
+  ],
+  "min_players": 4,
+  "max_players": 4,
+  "title": "18NL",
+  "settings": {
+    "seed": 1116720703,
+    "is_async": true,
+    "unlisted": false,
+    "auto_routing": true,
+    "player_order": null,
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "status": "finished",
+  "turn": 8,
+  "round": "Operating Round",
+  "acting": [
+    797,
+    9831,
+    7622,
+    1947
+  ],
+  "result": {
+    "797": 9278,
+    "1947": 8444,
+    "7622": 8351,
+    "9831": 7590
+  },
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1695649518,
+      "company": "P4",
+      "price": 115
+    },
+    {
+      "type": "bid",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1695650641,
+      "company": "P5",
+      "price": 165
+    },
+    {
+      "type": "bid",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1695651388,
+      "company": "P4",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1695653368,
+      "company": "P4",
+      "price": 125
+    },
+    {
+      "type": "bid",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1695654986,
+      "company": "P2",
+      "price": 45
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1695655149
+    },
+    {
+      "type": "bid",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1695658117,
+      "company": "P3",
+      "price": 75
+    },
+    {
+      "type": "bid",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1695658150,
+      "company": "P2",
+      "price": 50
+    },
+    {
+      "type": "bid",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1695658959,
+      "company": "P1",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1695658960,
+      "company": "P2",
+      "price": 55
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1695659028
+    },
+    {
+      "type": "bid",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1695660468,
+      "company": "P4",
+      "price": 130
+    },
+    {
+      "type": "bid",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1695660889,
+      "company": "P4",
+      "price": 170
+    },
+    {
+      "type": "bid",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1695661037,
+      "company": "P4",
+      "price": 175
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1695662035
+    },
+    {
+      "type": "bid",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1695663007,
+      "company": "P4",
+      "price": 180
+    },
+    {
+      "type": "bid",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1695664582,
+      "company": "P4",
+      "price": 185
+    },
+    {
+      "type": "bid",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1695665422,
+      "company": "P4",
+      "price": 190
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 23,
+      "created_at": 1695665655
+    },
+    {
+      "type": "par",
+      "entity": 9831,
+      "corporation": "HIS",
+      "entity_type": "player",
+      "share_price": "71,4,6",
+      "id": 24,
+      "user": 9831,
+      "created_at": 1695666489
+    },
+    {
+      "type": "undo",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 25,
+      "user": 9831,
+      "created_at": 1695666507
+    },
+    {
+      "type": "par",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 26,
+      "created_at": 1695666538,
+      "corporation": "HIS",
+      "share_price": "71,4,6"
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1695666547
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 28,
+      "created_at": 1695668243
+    },
+    {
+      "type": "bid",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 29,
+      "created_at": 1695668312,
+      "company": "P6",
+      "price": 200
+    },
+    {
+      "type": "par",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 30,
+      "created_at": 1695668314,
+      "corporation": "NFL",
+      "share_price": "100,0,6"
+    },
+    {
+      "type": "par",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 31,
+      "created_at": 1695669086,
+      "corporation": "NRS",
+      "share_price": "82,2,6"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 32,
+      "created_at": 1695669169,
+      "shares": [
+        "HIS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 33,
+      "created_at": 1695671641,
+      "corporation": "NCS",
+      "share_price": "67,5,6"
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1695671653,
+      "corporation": "NCS",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1695671960,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1695671958
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1695672922,
+      "shares": [
+        "NRS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 37,
+      "created_at": 1695672928,
+      "corporation": "NRS",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 38,
+      "created_at": 1695672985,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695672979,
+          "shares": [
+            "NCS_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1695672979
+        },
+        {
+          "type": "buy_shares",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695672979,
+          "shares": [
+            "NRS_2"
+          ],
+          "percent": 10
+        }
+      ],
+      "shares": [
+        "HIS_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 39,
+      "created_at": 1695672993,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695672988,
+          "shares": [
+            "HIS_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695672988,
+          "shares": [
+            "NCS_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1695672988
+        },
+        {
+          "type": "buy_shares",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695672988,
+          "shares": [
+            "NRS_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695672988,
+          "shares": [
+            "HIS_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695672988,
+          "shares": [
+            "NCS_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1695672988
+        },
+        {
+          "type": "buy_shares",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695672988,
+          "shares": [
+            "NRS_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695672988,
+          "reason": "HIS is floated"
+        }
+      ],
+      "corporation": "HIS",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 40,
+      "created_at": 1695673209,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1695673203
+        }
+      ],
+      "shares": [
+        "NCS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 41,
+      "created_at": 1695673223,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1695673218
+        }
+      ],
+      "shares": [
+        "NRS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 42,
+      "created_at": 1695673716,
+      "hex": "F7",
+      "tile": "4-0",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 43,
+      "created_at": 1695673717,
+      "train": "2-0",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 44,
+      "created_at": 1695673720
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 45,
+      "created_at": 1695673764
+    },
+    {
+      "type": "buy_train",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 46,
+      "created_at": 1695673766,
+      "train": "2-1",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 47,
+      "created_at": 1695673780
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 48,
+      "created_at": 1695699493,
+      "hex": "F15",
+      "tile": "6-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 49,
+      "created_at": 1695699519
+    },
+    {
+      "type": "buy_train",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 50,
+      "created_at": 1695699520,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 51,
+      "created_at": 1695699541
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 52,
+      "created_at": 1695699600,
+      "shares": [
+        "NCS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 53,
+      "created_at": 1695699603,
+      "shares": [
+        "HIS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 54,
+      "created_at": 1695699607,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695699606
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 55,
+      "created_at": 1695700349,
+      "shares": [
+        "HIS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 56,
+      "created_at": 1695700350
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 57,
+      "created_at": 1695700867,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695700867
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 58,
+      "created_at": 1695701391,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695701386
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695701386
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 59,
+      "created_at": 1695702857,
+      "shares": [
+        "HIS_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "created_at": 1695702858,
+          "entity_type": "player"
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "created_at": 1695702858,
+          "entity_type": "player"
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "created_at": 1695702858,
+          "entity_type": "player"
+        }
+      ],
+      "id": 60,
+      "user": 1947,
+      "created_at": 1695702859
+    },
+    {
+      "type": "undo",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 61,
+      "user": 1947,
+      "created_at": 1695702861
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 62,
+      "created_at": 1695702863,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695702862
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695702862
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695702863
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 63,
+      "created_at": 1695702867,
+      "shares": [
+        "HIS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 64,
+      "created_at": 1695702870,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695702869
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695702869
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695702869
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 65,
+      "created_at": 1695702892,
+      "shares": [
+        "NCS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 66,
+      "created_at": 1695702894,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695702894
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695702894
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695702894
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 67,
+      "created_at": 1695702907,
+      "shares": [
+        "NRS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 68,
+      "created_at": 1695702910,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695702910
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695702910
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695702910
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 69,
+      "created_at": 1695702912
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 70,
+      "created_at": 1695705788,
+      "hex": "G8",
+      "tile": "6-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 71,
+      "created_at": 1695705790,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7"
+          ],
+          "revenue": 50,
+          "revenue_str": "E6-F7",
+          "nodes": [
+            "E6-1",
+            "F7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 72,
+      "created_at": 1695705791,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 73,
+      "created_at": 1695705793
+    },
+    {
+      "hex": "E4",
+      "tile": "6-2",
+      "type": "lay_tile",
+      "entity": "HIS",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "id": 74,
+      "user": 9831,
+      "created_at": 1695707851
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 75,
+      "user": 9831,
+      "created_at": 1695707861
+    },
+    {
+      "type": "undo",
+      "entity": "HIS",
+      "action_id": 73,
+      "entity_type": "corporation",
+      "id": 76,
+      "user": 9831,
+      "created_at": 1695707880
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 77,
+      "created_at": 1695707884,
+      "hex": "E4",
+      "tile": "6-2",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 78,
+      "created_at": 1695707887
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 79,
+      "created_at": 1695707890,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4"
+          ],
+          "revenue": 60,
+          "revenue_str": "E6-E4",
+          "nodes": [
+            "E6-0",
+            "E4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 80,
+      "created_at": 1695707895,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 81,
+      "created_at": 1695707907,
+      "train": "2-3",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 82,
+      "created_at": 1695707908
+    },
+    {
+      "hex": "E16",
+      "tile": "57-0",
+      "type": "lay_tile",
+      "entity": "NCS",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 83,
+      "user": 7622,
+      "created_at": 1695710171
+    },
+    {
+      "type": "undo",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 84,
+      "user": 7622,
+      "created_at": 1695710209
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 85,
+      "created_at": 1695710230,
+      "hex": "F11",
+      "tile": "9-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 86,
+      "created_at": 1695710256
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 87,
+      "created_at": 1695710259,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "F13",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "F15"
+          ],
+          "revenue": 40,
+          "revenue_str": "F13-F15",
+          "nodes": [
+            "F13-0",
+            "F15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 88,
+      "created_at": 1695710261,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 89,
+      "created_at": 1695710262,
+      "train": "2-4",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 90,
+      "created_at": 1695710262,
+      "train": "2-5",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 91,
+      "created_at": 1695710263,
+      "train": "3-0",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "buy_company",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 92,
+      "created_at": 1695710281,
+      "company": "P3",
+      "price": 140
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 93,
+      "created_at": 1695710331
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "shares": [
+        "NCS_6"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 94,
+      "user": 797,
+      "created_at": 1695734158
+    },
+    {
+      "type": "undo",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 95,
+      "user": 797,
+      "created_at": 1695734167
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 96,
+      "created_at": 1695734187
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 9831,
+      "indefinite": false,
+      "entity_type": "player",
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 9831,
+          "created_at": 1695734465,
+          "entity_type": "player"
+        }
+      ],
+      "unconditional": false,
+      "id": 97,
+      "user": 9831,
+      "created_at": 1695734470
+    },
+    {
+      "type": "undo",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 98,
+      "user": 9831,
+      "created_at": 1695734481
+    },
+    {
+      "type": "sell_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 99,
+      "created_at": 1695734484,
+      "shares": [
+        "HIS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 100,
+      "created_at": 1695734486,
+      "shares": [
+        "NCS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 101,
+      "created_at": 1695734492
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 102,
+      "created_at": 1695735080,
+      "shares": [
+        "NCS_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 103,
+      "created_at": 1695735097
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1947,
+      "shares": [
+        "HIS_6",
+        "HIS_7",
+        "HIS_8"
+      ],
+      "percent": 30,
+      "entity_type": "player",
+      "id": 104,
+      "user": 1947,
+      "created_at": 1695735780
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1947,
+      "shares": [
+        "NRS_6"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 105,
+      "user": 1947,
+      "created_at": 1695735791
+    },
+    {
+      "type": "undo",
+      "entity": 1947,
+      "action_id": 103,
+      "entity_type": "player",
+      "id": 106,
+      "user": 1947,
+      "created_at": 1695735806
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 107,
+      "created_at": 1695735898,
+      "shares": [
+        "HIS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 108,
+      "created_at": 1695735903
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 109,
+      "created_at": 1695741359,
+      "shares": [
+        "NCS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 110,
+      "created_at": 1695741363,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695741362
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 111,
+      "created_at": 1695744031,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695744025
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 112,
+      "created_at": 1695747898,
+      "shares": [
+        "NRS_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 113,
+      "created_at": 1695747913,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695747913
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 114,
+      "created_at": 1695749481,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695749480
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695749480
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695749480
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 115,
+      "created_at": 1695750004,
+      "hex": "E6",
+      "tile": "NL2-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 116,
+      "created_at": 1695750006
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 117,
+      "created_at": 1695750009
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 118,
+      "created_at": 1695750011,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7"
+          ],
+          "revenue": 60,
+          "revenue_str": "E6-F7",
+          "nodes": [
+            "E6-0",
+            "F7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 119,
+      "created_at": 1695750011,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 120,
+      "created_at": 1695750013,
+      "train": "3-1",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 121,
+      "created_at": 1695750015,
+      "train": "3-2",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 122,
+      "created_at": 1695750017
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 123,
+      "created_at": 1695750040
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 124,
+      "created_at": 1695750209,
+      "hex": "F3",
+      "tile": "4-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 125,
+      "created_at": 1695750215
+    },
+    {
+      "type": "place_token",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 126,
+      "created_at": 1695750219,
+      "city": "G2-0-0",
+      "slot": 0,
+      "tokener": "HIS"
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 127,
+      "created_at": 1695750261,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7"
+          ],
+          "revenue": 60,
+          "revenue_str": "E6-F7",
+          "nodes": [
+            "E6-0",
+            "F7-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4"
+          ],
+          "revenue": 70,
+          "revenue_str": "E6-E4",
+          "nodes": [
+            "E6-0",
+            "E4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 128,
+      "created_at": 1695750263,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 129,
+      "created_at": 1695750265,
+      "train": "3-3",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 130,
+      "created_at": 1695750270
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 131,
+      "created_at": 1695750273
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 132,
+      "created_at": 1695750891,
+      "hex": "F9",
+      "tile": "57-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 133,
+      "created_at": 1695750939
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 134,
+      "created_at": 1695750942
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 135,
+      "created_at": 1695750945,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "F13",
+              "F11",
+              "F9"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "F9"
+          ],
+          "revenue": 40,
+          "revenue_str": "F13-F9",
+          "nodes": [
+            "F13-0",
+            "F9-0"
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "F13",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "F15"
+          ],
+          "revenue": 40,
+          "revenue_str": "F13-F15",
+          "nodes": [
+            "F13-0",
+            "F15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 136,
+      "created_at": 1695750954,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 137,
+      "created_at": 1695750959
+    },
+    {
+      "hex": "F7",
+      "tile": "88-0",
+      "type": "lay_tile",
+      "entity": "NRS",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 138,
+      "user": 797,
+      "created_at": 1695752195
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 139,
+      "user": 797,
+      "created_at": 1695752197
+    },
+    {
+      "type": "undo",
+      "entity": "NRS",
+      "action_id": 137,
+      "entity_type": "corporation",
+      "id": 140,
+      "user": 797,
+      "created_at": 1695752208
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 141,
+      "created_at": 1695752213,
+      "hex": "G8",
+      "tile": "14-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 142,
+      "created_at": 1695752219
+    },
+    {
+      "type": "place_token",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 143,
+      "created_at": 1695752221,
+      "city": "14-0-0",
+      "slot": 1,
+      "tokener": "NRS"
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 144,
+      "created_at": 1695752231,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "G8",
+              "F7"
+            ]
+          ],
+          "hexes": [
+            "G8",
+            "F7"
+          ],
+          "revenue": 40,
+          "revenue_str": "G8-F7",
+          "nodes": [
+            "G8-0",
+            "F7-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3"
+          ],
+          "revenue": 80,
+          "revenue_str": "E6-E4-F3",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7"
+          ],
+          "revenue": 60,
+          "revenue_str": "E6-F7",
+          "nodes": [
+            "E6-0",
+            "F7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 145,
+      "created_at": 1695752233,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 146,
+      "created_at": 1695752234
+    },
+    {
+      "type": "buy_company",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 147,
+      "created_at": 1695752237,
+      "company": "P1",
+      "price": 40
+    },
+    {
+      "type": "buy_company",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 148,
+      "created_at": 1695752239,
+      "company": "P2",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 149,
+      "created_at": 1695752241
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 150,
+      "created_at": 1695752325,
+      "hex": "G2",
+      "tile": "NL1-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 151,
+      "created_at": 1695752340
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 152,
+      "created_at": 1695752372,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8"
+          ],
+          "revenue": 90,
+          "revenue_str": "E6-F7-G8",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "G8-0"
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "G2",
+              "F3"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "F3"
+          ],
+          "revenue": 60,
+          "revenue_str": "G2-F3",
+          "nodes": [
+            "G2-0",
+            "F3-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4"
+          ],
+          "revenue": 70,
+          "revenue_str": "E6-E4",
+          "nodes": [
+            "E6-0",
+            "E4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 153,
+      "created_at": 1695752393,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 154,
+      "created_at": 1695752404
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 155,
+      "created_at": 1695752409
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 156,
+      "created_at": 1695752578,
+      "hex": "F9",
+      "tile": "15-0",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 157,
+      "created_at": 1695752592,
+      "city": "15-0-0",
+      "slot": 1,
+      "tokener": "NCS"
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 158,
+      "created_at": 1695752608,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "F9",
+              "G8"
+            ],
+            [
+              "G8",
+              "F7"
+            ]
+          ],
+          "hexes": [
+            "F9",
+            "G8",
+            "F7"
+          ],
+          "revenue": 70,
+          "revenue_str": "F9-G8-F7",
+          "nodes": [
+            "F9-0",
+            "G8-0",
+            "F7-0"
+          ]
+        },
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "F13",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "F15"
+          ],
+          "revenue": 40,
+          "revenue_str": "F13-F15",
+          "nodes": [
+            "F13-0",
+            "F15-0"
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "F9",
+              "F11",
+              "F13"
+            ]
+          ],
+          "hexes": [
+            "F9",
+            "F13"
+          ],
+          "revenue": 50,
+          "revenue_str": "F9-F13",
+          "nodes": [
+            "F9-0",
+            "F13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 159,
+      "created_at": 1695752611,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 160,
+      "created_at": 1695752614
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 161,
+      "created_at": 1695753820,
+      "shares": [
+        "HIS_6",
+        "HIS_7",
+        "HIS_8"
+      ],
+      "percent": 30
+    },
+    {
+      "type": "par",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 162,
+      "created_at": 1695753905,
+      "corporation": "DV",
+      "share_price": "82,2,6"
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 163,
+      "created_at": 1695753909
+    },
+    {
+      "type": "sell_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 164,
+      "created_at": 1695755906,
+      "shares": [
+        "NCS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 165,
+      "created_at": 1695755921,
+      "shares": [
+        "NRS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 166,
+      "created_at": 1695755928,
+      "corporation": "ZHE",
+      "share_price": "76,3,6"
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 167,
+      "created_at": 1695755933
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 168,
+      "created_at": 1695755939,
+      "corporation": "ZHE",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 169,
+      "created_at": 1695757139,
+      "shares": [
+        "NCS_5",
+        "NCS_6"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "par",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 170,
+      "created_at": 1695757251,
+      "corporation": "MES",
+      "share_price": "82,2,6"
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 171,
+      "created_at": 1695757301
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 172,
+      "created_at": 1695757313,
+      "corporation": "MES",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 173,
+      "created_at": 1695801350,
+      "shares": [
+        "NCS_2",
+        "NCS_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 174,
+      "created_at": 1695801431,
+      "shares": [
+        "NRS_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 175,
+      "created_at": 1695801434,
+      "shares": [
+        "HIS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 176,
+      "created_at": 1695801441,
+      "corporation": "AS",
+      "share_price": "90,1,6"
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 177,
+      "created_at": 1695801446,
+      "corporation": "AS",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 178,
+      "created_at": 1695812411,
+      "shares": [
+        "DV_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 179,
+      "created_at": 1695812414,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695812414,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 180,
+      "created_at": 1695820813,
+      "shares": [
+        "ZHE_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 181,
+      "created_at": 1695820819,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695820819,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 182,
+      "created_at": 1695820830,
+      "corporation": "ZHE",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 183,
+      "created_at": 1695823264,
+      "shares": [
+        "MES_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 184,
+      "created_at": 1695823287,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695823287,
+          "shares": [
+            "AS_1"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695823287
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 185,
+      "created_at": 1695826144,
+      "shares": [
+        "DV_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 186,
+      "created_at": 1695826146,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695826146,
+          "shares": [
+            "ZHE_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695826146
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 187,
+      "created_at": 1695827287,
+      "shares": [
+        "MES_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 188,
+      "created_at": 1695827291,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695827291,
+          "shares": [
+            "AS_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695827291
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 189,
+      "created_at": 1695827310,
+      "shares": [
+        "DV_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 190,
+      "created_at": 1695827311,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695827311,
+          "shares": [
+            "ZHE_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695827311
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 191,
+      "created_at": 1695827315,
+      "shares": [
+        "MES_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 192,
+      "created_at": 1695827322,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695827321,
+          "shares": [
+            "AS_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695827321
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 193,
+      "created_at": 1695828825,
+      "shares": [
+        "DV_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 194,
+      "created_at": 1695828834,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695828833,
+          "shares": [
+            "ZHE_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695828833,
+          "reason": "ZHE is floated"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 195,
+      "created_at": 1695829095
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 196,
+      "created_at": 1695829101,
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 197,
+      "created_at": 1695830780,
+      "shares": [
+        "HIS_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 198,
+      "created_at": 1695830781,
+      "shares": [
+        "MES_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 199,
+      "created_at": 1695830788,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695830788
+        },
+        {
+          "type": "program_disable",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695830788,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 200,
+      "created_at": 1695834906,
+      "shares": [
+        "AS_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 201,
+      "created_at": 1695834908,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695834910
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 202,
+      "created_at": 1695835089,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1695835088
+        },
+        {
+          "type": "program_disable",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695835088,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 203,
+      "created_at": 1695835416,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695835416
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695835416
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1695835416
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 204,
+      "created_at": 1695835830,
+      "hex": "E16",
+      "tile": "6-1",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 205,
+      "created_at": 1695835833,
+      "city": "15-0-0",
+      "slot": 1,
+      "tokener": "AS"
+    },
+    {
+      "type": "buy_train",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 206,
+      "created_at": 1695835889,
+      "train": "2-2",
+      "price": 380
+    },
+    {
+      "type": "buy_train",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 207,
+      "created_at": 1695835890,
+      "train": "3-4",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "buy_train",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 208,
+      "created_at": 1695835891,
+      "train": "4-0",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 209,
+      "created_at": 1695835924,
+      "hex": "E4",
+      "tile": "15-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 210,
+      "created_at": 1695835944
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 215,
+      "created_at": 1695866701,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8"
+          ],
+          "revenue": 90,
+          "revenue_str": "E6-F7-G8",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "G8-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3"
+          ],
+          "revenue": 90,
+          "revenue_str": "E6-E4-F3",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 216,
+      "user": 797,
+      "created_at": 1695866703
+    },
+    {
+      "type": "undo",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 217,
+      "user": 797,
+      "created_at": 1695866707
+    },
+    {
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 218,
+      "user": 797,
+      "created_at": 1695866707
+    },
+    {
+      "type": "buy_train",
+      "price": 300,
+      "train": "4-1",
+      "entity": "NRS",
+      "variant": "4",
+      "entity_type": "corporation",
+      "id": 219,
+      "user": 797,
+      "created_at": 1695866708
+    },
+    {
+      "type": "undo",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 220,
+      "user": 797,
+      "created_at": 1695866711
+    },
+    {
+      "type": "undo",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 221,
+      "user": 797,
+      "created_at": 1695866713
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 222,
+      "created_at": 1695866715,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 223,
+      "created_at": 1695866721
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 224,
+      "created_at": 1695866730
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 225,
+      "created_at": 1695872906,
+      "hex": "F7",
+      "tile": "87-0",
+      "rotation": 5
+    },
+    {
+      "type": "buy_train",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 226,
+      "created_at": 1695872918,
+      "train": "4-1",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 227,
+      "created_at": 1695872920
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 228,
+      "created_at": 1695872936
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 229,
+      "created_at": 1695873096,
+      "hex": "J7",
+      "tile": "6-2",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 230,
+      "created_at": 1695873105,
+      "train": "4-2",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 231,
+      "created_at": 1695873107
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 232,
+      "created_at": 1695873110
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 233,
+      "created_at": 1695874980,
+      "hex": "H3",
+      "tile": "NL3-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 234,
+      "created_at": 1695874987
+    },
+    {
+      "type": "buy_train",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 235,
+      "created_at": 1695874988,
+      "train": "4-3",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 236,
+      "created_at": 1695874991
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 237,
+      "created_at": 1695874995
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 238,
+      "created_at": 1695875183,
+      "hex": "I4",
+      "tile": "59-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 239,
+      "created_at": 1695875196,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G2",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4"
+          ],
+          "revenue": 140,
+          "revenue_str": "G2-H3-I4",
+          "nodes": [
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 240,
+      "created_at": 1695875199,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 241,
+      "created_at": 1695875205
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 242,
+      "created_at": 1695875208
+    },
+    {
+      "hex": "E16",
+      "tile": "14-1",
+      "type": "lay_tile",
+      "entity": "NCS",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 243,
+      "user": 7622,
+      "created_at": 1695882317
+    },
+    {
+      "type": "undo",
+      "entity": "NCS",
+      "action_id": 242,
+      "entity_type": "corporation",
+      "id": 244,
+      "user": 7622,
+      "created_at": 1695882334
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 245,
+      "created_at": 1695882340,
+      "hex": "E16",
+      "tile": "14-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 246,
+      "created_at": 1695882394
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 247,
+      "created_at": 1695882396,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "G8",
+              "F9"
+            ],
+            [
+              "F9",
+              "F11",
+              "F13",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "G8",
+            "F9",
+            "F15"
+          ],
+          "revenue": 80,
+          "revenue_str": "G8-F9-F15",
+          "nodes": [
+            "G8-0",
+            "F9-0",
+            "F15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 248,
+      "created_at": 1695882397,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "price": 300,
+      "train": "4-4",
+      "entity": "NCS",
+      "variant": "4",
+      "entity_type": "corporation",
+      "id": 249,
+      "user": 7622,
+      "created_at": 1695882399
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 250,
+      "user": 7622,
+      "created_at": 1695882408
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 251,
+      "user": 7622,
+      "created_at": 1695882409
+    },
+    {
+      "type": "undo",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 252,
+      "user": 7622,
+      "created_at": 1695882438
+    },
+    {
+      "type": "undo",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 253,
+      "user": 7622,
+      "created_at": 1695882442
+    },
+    {
+      "type": "undo",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 254,
+      "user": 7622,
+      "created_at": 1695882471
+    },
+    {
+      "type": "buy_company",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 255,
+      "created_at": 1695882473,
+      "company": "P4",
+      "price": 220
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 256,
+      "created_at": 1695882486
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 257,
+      "created_at": 1695907441,
+      "hex": "G6",
+      "tile": "8-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 258,
+      "created_at": 1695907443
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 259,
+      "created_at": 1695907446,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8"
+          ],
+          "revenue": 90,
+          "revenue_str": "E6-F7-G8",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "G8-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3"
+          ],
+          "revenue": 90,
+          "revenue_str": "E6-E4-F3",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 260,
+      "created_at": 1695907451,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 261,
+      "created_at": 1695907453
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 262,
+      "created_at": 1695908173,
+      "hex": "E18",
+      "tile": "4-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 263,
+      "created_at": 1695908189,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F13",
+              "F15"
+            ],
+            [
+              "F15",
+              "E16"
+            ],
+            [
+              "E16",
+              "E18"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "F15",
+            "E16",
+            "E18"
+          ],
+          "revenue": 80,
+          "revenue_str": "F13-F15-E16-E18",
+          "nodes": [
+            "F13-0",
+            "F15-0",
+            "E16-0",
+            "E18-0"
+          ]
+        },
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "G8",
+              "F9"
+            ],
+            [
+              "F9",
+              "F11",
+              "F13"
+            ]
+          ],
+          "hexes": [
+            "G8",
+            "F9",
+            "F13"
+          ],
+          "revenue": 80,
+          "revenue_str": "G8-F9-F13",
+          "nodes": [
+            "G8-0",
+            "F9-0",
+            "F13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 264,
+      "created_at": 1695908194,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 265,
+      "created_at": 1695913165,
+      "hex": "G4",
+      "tile": "58-0",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 266,
+      "created_at": 1695913165,
+      "city": "NL3-0-0",
+      "slot": 1,
+      "tokener": "DV"
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 267,
+      "created_at": 1695913183,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "I4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4"
+          ],
+          "revenue": 140,
+          "revenue_str": "G2-H3-I4",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 268,
+      "created_at": 1695917874,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 269,
+      "created_at": 1695917875
+    },
+    {
+      "hex": "K8",
+      "tile": "9-1",
+      "type": "lay_tile",
+      "entity": "MES",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 270,
+      "user": 9831,
+      "created_at": 1695917927
+    },
+    {
+      "type": "undo",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 271,
+      "user": 9831,
+      "created_at": 1695917930
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 272,
+      "created_at": 1695917938,
+      "hex": "I6",
+      "tile": "8-1",
+      "rotation": 5
+    },
+    {
+      "type": "place_token",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 273,
+      "created_at": 1695917951,
+      "city": "59-0-1",
+      "slot": 0,
+      "tokener": "MES"
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 274,
+      "created_at": 1695917968,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "I4",
+              "I6",
+              "J7"
+            ]
+          ],
+          "hexes": [
+            "I4",
+            "J7"
+          ],
+          "revenue": 60,
+          "revenue_str": "I4-J7",
+          "nodes": [
+            "I4-1",
+            "J7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 275,
+      "created_at": 1695917970,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 276,
+      "created_at": 1695917986
+    },
+    {
+      "hex": "D7",
+      "tile": "7-0",
+      "type": "lay_tile",
+      "entity": "HIS",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 277,
+      "user": 9831,
+      "created_at": 1695918026
+    },
+    {
+      "type": "undo",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 278,
+      "user": 9831,
+      "created_at": 1695918034
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 279,
+      "created_at": 1695918067,
+      "hex": "D5",
+      "tile": "58-1",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 280,
+      "created_at": 1695918075
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 281,
+      "created_at": 1695918084,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G2",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4"
+          ],
+          "revenue": 140,
+          "revenue_str": "G2-H3-I4",
+          "nodes": [
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 282,
+      "created_at": 1695918091,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 283,
+      "created_at": 1695918095
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 285,
+      "created_at": 1695920088,
+      "hex": "F15",
+      "tile": "14-2",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 286,
+      "created_at": 1695920091
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 287,
+      "created_at": 1695920099,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "F15",
+              "F13",
+              "F11",
+              "F9"
+            ],
+            [
+              "F9",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "F9",
+            "G8"
+          ],
+          "revenue": 90,
+          "revenue_str": "F15-F9-G8",
+          "nodes": [
+            "F15-0",
+            "F9-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 288,
+      "created_at": 1695920103,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 289,
+      "created_at": 1695920131
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 290,
+      "created_at": 1695921009,
+      "hex": "G4",
+      "tile": "88-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 291,
+      "created_at": 1695921010,
+      "city": "NL3-0-0",
+      "slot": 1,
+      "tokener": "ZHE"
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 292,
+      "created_at": 1695921014,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "I4",
+            "H3",
+            "G2",
+            "G4"
+          ],
+          "revenue": 150,
+          "revenue_str": "I4-H3-G2-G4",
+          "nodes": [
+            "I4-0",
+            "H3-0",
+            "G2-0",
+            "G4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 293,
+      "created_at": 1695921016,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 294,
+      "created_at": 1695921017
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 295,
+      "created_at": 1695927216,
+      "shares": [
+        "AS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 296,
+      "created_at": 1695927218
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 297,
+      "created_at": 1695930340,
+      "shares": [
+        "AS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 298,
+      "created_at": 1695930342
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 299,
+      "created_at": 1695930700,
+      "shares": [
+        "NRS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 300,
+      "created_at": 1695930730
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 301,
+      "created_at": 1695957694,
+      "shares": [
+        "NRS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 302,
+      "created_at": 1695957698
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 303,
+      "created_at": 1695962167,
+      "shares": [
+        "MES_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 304,
+      "created_at": 1695962169
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 305,
+      "created_at": 1695991913,
+      "shares": [
+        "DV_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 306,
+      "created_at": 1695991917
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "shares": [
+        "AS_7"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 307,
+      "user": 9831,
+      "created_at": 1695991992
+    },
+    {
+      "type": "undo",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 308,
+      "user": 9831,
+      "created_at": 1695992014
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 309,
+      "created_at": 1695992030,
+      "shares": [
+        "DV_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 310,
+      "created_at": 1695992035,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695992035
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 311,
+      "created_at": 1695993743,
+      "shares": [
+        "DV_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 312,
+      "created_at": 1695993747
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 313,
+      "created_at": 1695999664
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "shares": [
+        "HIS_6"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 314,
+      "user": 797,
+      "created_at": 1695999749
+    },
+    {
+      "type": "undo",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 315,
+      "user": 797,
+      "created_at": 1695999755
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 316,
+      "created_at": 1695999757,
+      "shares": [
+        "MES_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 317,
+      "created_at": 1695999761,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1695999760
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1695999760
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 318,
+      "created_at": 1696000182,
+      "shares": [
+        "MES_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 319,
+      "created_at": 1696000185
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "created_at": 1696013093,
+          "entity_type": "player"
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "created_at": 1696013093,
+          "entity_type": "player"
+        }
+      ],
+      "id": 320,
+      "user": 1947,
+      "created_at": 1696013095
+    },
+    {
+      "type": "undo",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 321,
+      "user": 1947,
+      "created_at": 1696013100
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 322,
+      "created_at": 1696013101,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1696013100
+        },
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696013100
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696013100
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "shares": [
+        "ZHE_5"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 323,
+      "user": 7622,
+      "created_at": 1696014650
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1947,
+          "created_at": 1696014654,
+          "entity_type": "player"
+        },
+        {
+          "type": "pass",
+          "entity": 797,
+          "created_at": 1696014654,
+          "entity_type": "player"
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "created_at": 1696014654,
+          "entity_type": "player"
+        }
+      ],
+      "id": 324,
+      "user": 7622,
+      "created_at": 1696014654
+    },
+    {
+      "type": "undo",
+      "entity": 7622,
+      "action_id": 322,
+      "entity_type": "player",
+      "id": 325,
+      "user": 7622,
+      "created_at": 1696014944
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 326,
+      "created_at": 1696014956,
+      "shares": [
+        "ZHE_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 327,
+      "created_at": 1696014961,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1696014960
+        },
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696014960
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696014960
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 328,
+      "created_at": 1696014966,
+      "shares": [
+        "HIS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 329,
+      "created_at": 1696014975,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696014975
+        },
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1696014975
+        },
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696014975
+        },
+        {
+          "type": "program_disable",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696014975,
+          "reason": "mb1898 bought on corporation HIS and is unsecure"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 330,
+      "created_at": 1696015530,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696015529
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 331,
+      "created_at": 1696015901,
+      "hex": "D7",
+      "tile": "7-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 332,
+      "created_at": 1696015905
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 333,
+      "created_at": 1696015908,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8"
+          ],
+          "revenue": 90,
+          "revenue_str": "E6-F7-G8",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "G8-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3"
+          ],
+          "revenue": 90,
+          "revenue_str": "E6-E4-F3",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 334,
+      "user": 797,
+      "created_at": 1696015910
+    },
+    {
+      "type": "undo",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 335,
+      "user": 797,
+      "created_at": 1696015913
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 336,
+      "created_at": 1696015914,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 337,
+      "created_at": 1696015915
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 338,
+      "created_at": 1696062096,
+      "hex": "F17",
+      "tile": "9-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 339,
+      "created_at": 1696062105,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "E20",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "E18",
+            "E16",
+            "F15"
+          ],
+          "revenue": 80,
+          "revenue_str": "E20-E18-E16-F15",
+          "nodes": [
+            "E20-0",
+            "E18-0",
+            "E16-0",
+            "F15-0"
+          ]
+        },
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "F15",
+              "F13",
+              "F11",
+              "F9"
+            ],
+            [
+              "F9",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "F9",
+            "G8"
+          ],
+          "revenue": 90,
+          "revenue_str": "F15-F9-G8",
+          "nodes": [
+            "F15-0",
+            "F9-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 340,
+      "created_at": 1696062106,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 341,
+      "created_at": 1696065485,
+      "hex": "G6",
+      "tile": "24-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 342,
+      "created_at": 1696065496
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 343,
+      "created_at": 1696065543,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G4",
+              "G2"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "I4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 150,
+          "revenue_str": "G2-G4-H3-I4",
+          "nodes": [
+            "G4-0",
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 344,
+      "created_at": 1696065545,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 345,
+      "created_at": 1696065546
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 346,
+      "created_at": 1696069183,
+      "hex": "K8",
+      "tile": "9-2",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 347,
+      "created_at": 1696069197,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "I4",
+              "I6",
+              "J7"
+            ]
+          ],
+          "hexes": [
+            "I4",
+            "J7"
+          ],
+          "revenue": 60,
+          "revenue_str": "I4-J7",
+          "nodes": [
+            "I4-1",
+            "J7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 348,
+      "created_at": 1696069201,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 349,
+      "created_at": 1696069205
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 350,
+      "created_at": 1696069250,
+      "hex": "D7",
+      "tile": "29-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 351,
+      "created_at": 1696069297
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 352,
+      "created_at": 1696069309,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "G4"
+          ],
+          "revenue": 110,
+          "revenue_str": "H3-G2-G4",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "G4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 353,
+      "user": 9831,
+      "created_at": 1696069316
+    },
+    {
+      "type": "undo",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 354,
+      "user": 9831,
+      "created_at": 1696069332
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 355,
+      "created_at": 1696069335,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 356,
+      "created_at": 1696069337,
+      "train": "4-4",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 357,
+      "created_at": 1696069339
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 358,
+      "created_at": 1696070106,
+      "hex": "E18",
+      "tile": "87-1",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 359,
+      "created_at": 1696070113
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 360,
+      "created_at": 1696070117,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "F15",
+              "F13",
+              "F11",
+              "F9"
+            ],
+            [
+              "F9",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "F9",
+            "G8"
+          ],
+          "revenue": 90,
+          "revenue_str": "F15-F9-G8",
+          "nodes": [
+            "F15-0",
+            "F9-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 361,
+      "user": 7622,
+      "created_at": 1696070119
+    },
+    {
+      "type": "undo",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 362,
+      "user": 7622,
+      "created_at": 1696070198
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 363,
+      "created_at": 1696070201,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 364,
+      "created_at": 1696070210,
+      "train": "5-0",
+      "price": 450,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 365,
+      "created_at": 1696082173,
+      "hex": "I4",
+      "tile": "67-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 366,
+      "created_at": 1696082181,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "I4",
+            "H3",
+            "G2",
+            "G4"
+          ],
+          "revenue": 160,
+          "revenue_str": "I4-H3-G2-G4",
+          "nodes": [
+            "I4-0",
+            "H3-0",
+            "G2-0",
+            "G4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 367,
+      "created_at": 1696082182,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 368,
+      "created_at": 1696082183,
+      "train": "5-1",
+      "price": 450,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 369,
+      "created_at": 1696082193,
+      "hex": "E6",
+      "tile": "NL6-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 370,
+      "created_at": 1696082202,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8"
+          ],
+          "revenue": 110,
+          "revenue_str": "E6-F7-G8",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "G8-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3"
+          ],
+          "revenue": 110,
+          "revenue_str": "E6-E4-F3",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 371,
+      "created_at": 1696082203,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 372,
+      "created_at": 1696093137,
+      "hex": "E16",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 373,
+      "created_at": 1696093145,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13",
+              "F11",
+              "F9"
+            ],
+            [
+              "F9",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E16",
+            "F15",
+            "F9",
+            "G8"
+          ],
+          "revenue": 130,
+          "revenue_str": "E16-F15-F9-G8",
+          "nodes": [
+            "E16-0",
+            "F15-0",
+            "F9-0",
+            "G8-0"
+          ]
+        },
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "E16",
+            "E18",
+            "E20"
+          ],
+          "revenue": 120,
+          "revenue_str": "E16-E18-E20",
+          "nodes": [
+            "E16-0",
+            "E18-0",
+            "E20-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 374,
+      "created_at": 1696093150,
+      "kind": "payout"
+    },
+    {
+      "hex": "H3",
+      "tile": "NL5-0",
+      "type": "lay_tile",
+      "entity": "DV",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 375,
+      "user": 1947,
+      "created_at": 1696094387
+    },
+    {
+      "city": "67-0-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "DV",
+      "tokener": "DV",
+      "entity_type": "corporation",
+      "id": 376,
+      "user": 1947,
+      "created_at": 1696094388
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "routes": [
+        {
+          "hexes": [
+            "G2",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "nodes": [
+            "G4-0",
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ],
+          "train": "4-1",
+          "revenue": 180,
+          "connections": [
+            [
+              "G4",
+              "G2"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "I4",
+              "H3"
+            ]
+          ],
+          "revenue_str": "G2-G4-H3-I4"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 377,
+      "user": 1947,
+      "created_at": 1696094408
+    },
+    {
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 378,
+      "user": 1947,
+      "created_at": 1696094419
+    },
+    {
+      "type": "buy_train",
+      "price": 450,
+      "train": "5-2",
+      "entity": "DV",
+      "variant": "5",
+      "entity_type": "corporation",
+      "id": 379,
+      "user": 1947,
+      "created_at": 1696094422
+    },
+    {
+      "type": "undo",
+      "entity": "MES",
+      "action_id": 374,
+      "entity_type": "corporation",
+      "id": 380,
+      "user": 1947,
+      "created_at": 1696094454
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 381,
+      "created_at": 1696094457,
+      "hex": "G8",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 382,
+      "created_at": 1696094462,
+      "city": "67-0-0",
+      "slot": 0,
+      "tokener": "DV"
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 383,
+      "created_at": 1696094469,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G4",
+              "G2"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "I4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 160,
+          "revenue_str": "G2-G4-H3-I4",
+          "nodes": [
+            "G4-0",
+            "G2-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 384,
+      "created_at": 1696094472,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 385,
+      "created_at": 1696094474,
+      "train": "5-2",
+      "price": 450,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 386,
+      "created_at": 1696094772,
+      "hex": "K10",
+      "tile": "6-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 387,
+      "created_at": 1696094789
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 388,
+      "created_at": 1696094806,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "I4",
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "K6",
+              "K8",
+              "K10"
+            ]
+          ],
+          "hexes": [
+            "I4",
+            "J7",
+            "K10"
+          ],
+          "revenue": 90,
+          "revenue_str": "I4-J7-K10",
+          "nodes": [
+            "I4-1",
+            "J7-0",
+            "K10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 389,
+      "created_at": 1696094810,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 390,
+      "created_at": 1696094815
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 391,
+      "created_at": 1696094850,
+      "hex": "C6",
+      "tile": "9-3",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 392,
+      "created_at": 1696094874,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "F3"
+            ],
+            [
+              "F3",
+              "G2"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "E4",
+            "F3",
+            "G2"
+          ],
+          "revenue": 160,
+          "revenue_str": "E6-E4-F3-G2",
+          "nodes": [
+            "E6-0",
+            "E4-0",
+            "F3-0",
+            "G2-0"
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8"
+          ],
+          "revenue": 120,
+          "revenue_str": "E6-F7-G8",
+          "nodes": [
+            "E6-0",
+            "F7-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 393,
+      "created_at": 1696094876,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 394,
+      "created_at": 1696097847,
+      "hex": "F15",
+      "tile": "63-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 395,
+      "created_at": 1696097858,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "F13",
+              "F15"
+            ],
+            [
+              "F15",
+              "E16"
+            ],
+            [
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "F15",
+            "E16",
+            "E18",
+            "E20"
+          ],
+          "revenue": 180,
+          "revenue_str": "F13-F15-E16-E18-E20",
+          "nodes": [
+            "F13-0",
+            "F15-0",
+            "E16-0",
+            "E18-0",
+            "E20-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "F13",
+              "F11",
+              "F9"
+            ],
+            [
+              "F9",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "F9",
+            "G8"
+          ],
+          "revenue": 90,
+          "revenue_str": "F13-F9-G8",
+          "nodes": [
+            "F13-0",
+            "F9-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 396,
+      "created_at": 1696097881,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 397,
+      "created_at": 1696099033,
+      "hex": "H3",
+      "tile": "NL5-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 398,
+      "created_at": 1696099036,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "E4"
+            ],
+            [
+              "E4",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "F3",
+            "E4",
+            "E6"
+          ],
+          "revenue": 230,
+          "revenue_str": "H3-G2-F3-E4-E6",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E4-0",
+            "E6-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "G2",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 180,
+          "revenue_str": "G2-G4-H3-I4",
+          "nodes": [
+            "G2-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 399,
+      "created_at": 1696099037,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 400,
+      "created_at": 1696102056,
+      "shares": [
+        "AS_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 401,
+      "created_at": 1696102062,
+      "shares": [
+        "AS_5",
+        "AS_7"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 402,
+      "created_at": 1696102064
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "shares": [
+        "NRS_7"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 403,
+      "user": 797,
+      "created_at": 1696103855
+    },
+    {
+      "type": "undo",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 404,
+      "user": 797,
+      "created_at": 1696103862
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 405,
+      "created_at": 1696103873,
+      "shares": [
+        "MES_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 406,
+      "created_at": 1696103874,
+      "shares": [
+        "MES_6",
+        "MES_8"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 407,
+      "created_at": 1696103904
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 408,
+      "created_at": 1696106642,
+      "shares": [
+        "NFL_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 409,
+      "created_at": 1696106647
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 410,
+      "created_at": 1696143701,
+      "shares": [
+        "MES_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 411,
+      "created_at": 1696143724,
+      "shares": [
+        "MES_7",
+        "MES_6"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 412,
+      "created_at": 1696143757
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 413,
+      "created_at": 1696146081,
+      "shares": [
+        "ZHE_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 414,
+      "created_at": 1696146084
+    },
+    {
+      "type": "par",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 415,
+      "created_at": 1696170480,
+      "corporation": "NZO",
+      "share_price": "90,1,6"
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 416,
+      "created_at": 1696170487
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 417,
+      "created_at": 1696170494,
+      "corporation": "NZO",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 418,
+      "created_at": 1696170546,
+      "shares": [
+        "NFL_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 419,
+      "created_at": 1696170567
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 420,
+      "created_at": 1696177304,
+      "shares": [
+        "DV_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 421,
+      "created_at": 1696177307
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 422,
+      "created_at": 1696177402,
+      "corporation": "NZO",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 423,
+      "created_at": 1696177493,
+      "shares": [
+        "NFL_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 424,
+      "created_at": 1696177495,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696177494,
+          "shares": [
+            "NZO_1"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696177494
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 425,
+      "created_at": 1696178038,
+      "shares": [
+        "ZHE_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 426,
+      "created_at": 1696178048,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696178047
+        },
+        {
+          "type": "buy_shares",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696178047,
+          "shares": [
+            "NZO_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696178047
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 427,
+      "created_at": 1696185996,
+      "shares": [
+        "NFL_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 428,
+      "created_at": 1696185998,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696185998,
+          "shares": [
+            "NZO_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696185998
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696185998
+        },
+        {
+          "type": "buy_shares",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696185998,
+          "shares": [
+            "NZO_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696185998,
+          "reason": "NZO is floated"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 429,
+      "created_at": 1696222898
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 430,
+      "created_at": 1696227301,
+      "shares": [
+        "NFL_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 431,
+      "created_at": 1696227302,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696227301,
+          "reason": "NZO is floated"
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 432,
+      "created_at": 1696254718,
+      "shares": [
+        "NZO_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 433,
+      "created_at": 1696254721,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696254721
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 434,
+      "created_at": 1696259606,
+      "shares": [
+        "NZO_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 435,
+      "created_at": 1696259608,
+      "shares": [
+        "NZO_2",
+        "NZO_4",
+        "NZO_6"
+      ],
+      "percent": 30
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 436,
+      "created_at": 1696259611
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 437,
+      "created_at": 1696262218
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 438,
+      "created_at": 1696262375,
+      "shares": [
+        "NCS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 439,
+      "created_at": 1696262390,
+      "shares": [
+        "AS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 440,
+      "created_at": 1696262402,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696262400,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "sell_shares",
+      "entity": 9831,
+      "shares": [
+        "NFL_1",
+        "NFL_2"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 441,
+      "user": 9831,
+      "created_at": 1696262439
+    },
+    {
+      "type": "undo",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 442,
+      "user": 9831,
+      "created_at": 1696262457
+    },
+    {
+      "type": "sell_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 443,
+      "created_at": 1696262478,
+      "shares": [
+        "NRS_5",
+        "NRS_8"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 444,
+      "created_at": 1696262488,
+      "shares": [
+        "ZHE_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 445,
+      "created_at": 1696262499
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 446,
+      "created_at": 1696266201,
+      "shares": [
+        "NCS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 447,
+      "created_at": 1696266204
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 448,
+      "created_at": 1696271235,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1696271234
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 449,
+      "created_at": 1696271801,
+      "shares": [
+        "NCS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 450,
+      "created_at": 1696271818,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696271816
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 451,
+      "created_at": 1696271876,
+      "shares": [
+        "NCS_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 452,
+      "created_at": 1696271947
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 453,
+      "created_at": 1696323359,
+      "shares": [
+        "NCS_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 454,
+      "created_at": 1696323390,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696323390
+        },
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1696323390
+        },
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696323390
+        }
+      ],
+      "corporation": "NFL",
+      "until_condition": 2,
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 455,
+      "created_at": 1696338299,
+      "shares": [
+        "HIS_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 456,
+      "created_at": 1696338302,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696338301
+        },
+        {
+          "type": "buy_shares",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696338301,
+          "shares": [
+            "NFL_6"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696338301
+        },
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1696338301
+        },
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696338301
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696338301
+        },
+        {
+          "type": "buy_shares",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696338301,
+          "shares": [
+            "NFL_7"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696338301,
+          "reason": "2 share(s) bought in NFL, end condition met"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 457,
+      "created_at": 1696340306,
+      "shares": [
+        "NFL_6",
+        "NFL_7"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 458,
+      "created_at": 1696340377,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696340376
+        },
+        {
+          "type": "program_disable",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1696340376,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 459,
+      "created_at": 1696341387,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1947,
+          "entity_type": "player",
+          "created_at": 1696341385
+        },
+        {
+          "type": "program_disable",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696341385,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 460,
+      "created_at": 1696345267,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696345266
+        },
+        {
+          "type": "program_disable",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696345266,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 461,
+      "created_at": 1696345709,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696345708
+        },
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696345708
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 462,
+      "created_at": 1696360590,
+      "hex": "J5",
+      "tile": "6-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 463,
+      "created_at": 1696360604,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "I4",
+              "J5"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4",
+            "J5"
+          ],
+          "revenue": 190,
+          "revenue_str": "G2-H3-I4-J5",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "I4-0",
+            "J5-0"
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "G8",
+              "G6",
+              "G4"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "E6",
+              "F7"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4",
+            "G8",
+            "F7",
+            "E6"
+          ],
+          "revenue": 200,
+          "revenue_str": "H3-G4-G8-F7-E6",
+          "nodes": [
+            "G4-0",
+            "H3-0",
+            "G8-0",
+            "F7-0",
+            "E6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 464,
+      "created_at": 1696360605,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 465,
+      "created_at": 1696387579,
+      "hex": "F19",
+      "tile": "59-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 466,
+      "created_at": 1696387609,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F19",
+              "F17",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13",
+              "F11",
+              "F9"
+            ],
+            [
+              "F9",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "F19",
+            "F15",
+            "F9",
+            "G8"
+          ],
+          "revenue": 150,
+          "revenue_str": "F19-F15-F9-G8",
+          "nodes": [
+            "F19-0",
+            "F15-0",
+            "F9-0",
+            "G8-0"
+          ]
+        },
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "E16",
+            "E18",
+            "E20"
+          ],
+          "revenue": 120,
+          "revenue_str": "E16-E18-E20",
+          "nodes": [
+            "E16-0",
+            "E18-0",
+            "E20-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 467,
+      "created_at": 1696387666,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 468,
+      "created_at": 1696392163,
+      "hex": "B15",
+      "tile": "NL7-0",
+      "rotation": 5
+    },
+    {
+      "type": "buy_train",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 469,
+      "created_at": 1696392179,
+      "train": "6-0",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 470,
+      "created_at": 1696392187
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 471,
+      "created_at": 1696393328,
+      "hex": "G6",
+      "tile": "46-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 472,
+      "created_at": 1696393333,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "E4"
+            ],
+            [
+              "E4",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "F3",
+            "E4",
+            "E6"
+          ],
+          "revenue": 230,
+          "revenue_str": "H3-G2-F3-E4-E6",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E4-0",
+            "E6-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "G2",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 180,
+          "revenue_str": "G2-G4-H3-I4",
+          "nodes": [
+            "G2-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 473,
+      "created_at": 1696393334,
+      "kind": "payout"
+    },
+    {
+      "hex": "F5",
+      "tile": "9-4",
+      "type": "lay_tile",
+      "entity": "HIS",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 474,
+      "user": 9831,
+      "created_at": 1696393418
+    },
+    {
+      "type": "undo",
+      "entity": "HIS",
+      "action_id": 473,
+      "entity_type": "corporation",
+      "id": 475,
+      "user": 9831,
+      "created_at": 1696393439
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 476,
+      "created_at": 1696393497,
+      "hex": "D7",
+      "tile": "43-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 477,
+      "created_at": 1696393500
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 478,
+      "created_at": 1696393514,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "G4"
+            ],
+            [
+              "G4",
+              "G6",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "G4",
+            "G8"
+          ],
+          "revenue": 170,
+          "revenue_str": "H3-G2-G4-G8",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "G4-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 479,
+      "created_at": 1696393520,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 480,
+      "created_at": 1696393526
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 481,
+      "created_at": 1696393567,
+      "hex": "G10",
+      "tile": "9-4",
+      "rotation": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 482,
+      "created_at": 1696393571,
+      "train": "6-1",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 483,
+      "created_at": 1696405793,
+      "hex": "F19",
+      "tile": "66-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 484,
+      "user": 7622,
+      "created_at": 1696405800
+    },
+    {
+      "type": "undo",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 485,
+      "user": 7622,
+      "created_at": 1696405829
+    },
+    {
+      "type": "place_token",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 486,
+      "created_at": 1696405831,
+      "city": "63-0-0",
+      "slot": 1,
+      "tokener": "NCS"
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 487,
+      "created_at": 1696405892,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E20",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F17",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "E18",
+            "E16",
+            "F15",
+            "F19"
+          ],
+          "revenue": 210,
+          "revenue_str": "E20-E18-E16-F15-F19",
+          "nodes": [
+            "E20-0",
+            "E18-0",
+            "E16-0",
+            "F15-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 488,
+      "created_at": 1696405893,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 489,
+      "created_at": 1696405925
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 490,
+      "created_at": 1696425986,
+      "hex": "H13",
+      "tile": "59-0",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 491,
+      "created_at": 1696425998,
+      "city": "59-0-0",
+      "slot": 0,
+      "tokener": "NZO"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 492,
+      "created_at": 1696426002,
+      "train": "6-2",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 493,
+      "created_at": 1696426003
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 494,
+      "created_at": 1696426341,
+      "hex": "J7",
+      "tile": "14-1",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 495,
+      "created_at": 1696426368
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 496,
+      "created_at": 1696426373,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "I4",
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "K6",
+              "K8",
+              "K10"
+            ]
+          ],
+          "hexes": [
+            "I4",
+            "J7",
+            "K10"
+          ],
+          "revenue": 100,
+          "revenue_str": "I4-J7-K10",
+          "nodes": [
+            "I4-1",
+            "J7-0",
+            "K10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 497,
+      "created_at": 1696426376,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 498,
+      "created_at": 1696426381
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 499,
+      "created_at": 1696431007,
+      "hex": "G12",
+      "tile": "9-5",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 500,
+      "created_at": 1696431024,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "I4",
+              "J5"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4",
+            "J5"
+          ],
+          "revenue": 190,
+          "revenue_str": "G2-H3-I4-J5",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "I4-0",
+            "J5-0"
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "G8",
+              "G6",
+              "G4"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "E6",
+              "F7"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4",
+            "G8",
+            "F7",
+            "E6"
+          ],
+          "revenue": 200,
+          "revenue_str": "H3-G4-G8-F7-E6",
+          "nodes": [
+            "G4-0",
+            "H3-0",
+            "G8-0",
+            "F7-0",
+            "E6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 501,
+      "created_at": 1696431025,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 502,
+      "created_at": 1696437291,
+      "hex": "G10",
+      "tile": "19-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 503,
+      "created_at": 1696437301,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "E16",
+              "E18"
+            ],
+            [
+              "E18",
+              "F19"
+            ],
+            [
+              "F19",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "E16",
+            "E18",
+            "F19",
+            "E20"
+          ],
+          "revenue": 170,
+          "revenue_str": "E16-E18-F19-E20",
+          "nodes": [
+            "E16-0",
+            "E18-0",
+            "F19-1",
+            "E20-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 504,
+      "created_at": 1696437304,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 505,
+      "created_at": 1696437422
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 506,
+      "created_at": 1696438466
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 507,
+      "created_at": 1696438473
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 508,
+      "created_at": 1696438478,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "G4"
+            ],
+            [
+              "G4",
+              "G6",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "G4",
+            "G8"
+          ],
+          "revenue": 170,
+          "revenue_str": "H3-G2-G4-G8",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "G4-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 509,
+      "created_at": 1696438483,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 510,
+      "created_at": 1696438488
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 511,
+      "created_at": 1696438769,
+      "hex": "C8",
+      "tile": "3-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 512,
+      "created_at": 1696438772,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "E4"
+            ],
+            [
+              "E4",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "F3",
+            "E4",
+            "E6"
+          ],
+          "revenue": 230,
+          "revenue_str": "H3-G2-F3-E4-E6",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E4-0",
+            "E6-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "G2",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 180,
+          "revenue_str": "G2-G4-H3-I4",
+          "nodes": [
+            "G2-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 513,
+      "created_at": 1696438774,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 514,
+      "created_at": 1696439505,
+      "hex": "F17",
+      "tile": "23-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 515,
+      "created_at": 1696439510
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 516,
+      "created_at": 1696439523,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F17",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F19"
+          ],
+          "revenue": 220,
+          "revenue_str": "E20-F19-E18-E16-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 517,
+      "created_at": 1696439528,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 518,
+      "created_at": 1696439590
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 519,
+      "created_at": 1696441328,
+      "hex": "B13",
+      "tile": "7-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 520,
+      "created_at": 1696441336,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "A16",
+              "B15"
+            ]
+          ],
+          "hexes": [
+            "B15",
+            "A16"
+          ],
+          "revenue": 100,
+          "revenue_str": "B15-A16",
+          "nodes": [
+            "A16-0",
+            "B15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 521,
+      "created_at": 1696441337,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 522,
+      "created_at": 1696441348
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 523,
+      "created_at": 1696453637,
+      "hex": "G12",
+      "tile": "23-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 524,
+      "created_at": 1696453642,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "G6",
+              "G8"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "F7",
+              "E6"
+            ],
+            [
+              "E6",
+              "E4"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4",
+            "G8",
+            "F7",
+            "E6",
+            "E4"
+          ],
+          "revenue": 230,
+          "revenue_str": "H3-G4-G8-F7-E6-E4",
+          "nodes": [
+            "H3-0",
+            "G4-0",
+            "G8-0",
+            "F7-0",
+            "E6-0",
+            "E4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 525,
+      "created_at": 1696453643,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 526,
+      "created_at": 1696453646
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 527,
+      "created_at": 1696453678,
+      "hex": "J11",
+      "tile": "8-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 528,
+      "created_at": 1696453707
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 529,
+      "created_at": 1696453718,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "I4",
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "K6",
+              "K8",
+              "K10"
+            ]
+          ],
+          "hexes": [
+            "I4",
+            "J7",
+            "K10"
+          ],
+          "revenue": 100,
+          "revenue_str": "I4-J7-K10",
+          "nodes": [
+            "I4-1",
+            "J7-0",
+            "K10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 530,
+      "created_at": 1696453720,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 531,
+      "created_at": 1696453724
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 532,
+      "created_at": 1696453926,
+      "hex": "H13",
+      "tile": "68-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 533,
+      "created_at": 1696453934,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "G12",
+              "G10",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "G8"
+          ],
+          "revenue": 160,
+          "revenue_str": "I14-H13-G8",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 534,
+      "created_at": 1696453935,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 535,
+      "created_at": 1696453939
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 536,
+      "created_at": 1696482361,
+      "hex": "G14",
+      "tile": "8-3",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "routes": [
+        {
+          "hexes": [
+            "F21",
+            "F19",
+            "F15",
+            "G8"
+          ],
+          "nodes": [
+            "F19-0",
+            "F21-0",
+            "F15-0",
+            "G8-0"
+          ],
+          "train": "4-1",
+          "revenue": 170,
+          "connections": [
+            [
+              "F19",
+              "F21"
+            ],
+            [
+              "F15",
+              "F17",
+              "F19"
+            ],
+            [
+              "G8",
+              "G10",
+              "G12",
+              "G14",
+              "F15"
+            ]
+          ],
+          "revenue_str": "F21-F19-F15-G8"
+        },
+        {
+          "hexes": [
+            "H3",
+            "G4",
+            "G8",
+            "F7",
+            "E6"
+          ],
+          "nodes": [
+            "G4-0",
+            "H3-0",
+            "G8-0",
+            "F7-0",
+            "E6-0"
+          ],
+          "train": "5-2",
+          "revenue": 200,
+          "connections": [
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "G8",
+              "G6",
+              "G4"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "E6",
+              "F7"
+            ]
+          ],
+          "revenue_str": "H3-G4-G8-F7-E6"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 537,
+      "user": 1947,
+      "created_at": 1696482405
+    },
+    {
+      "type": "undo",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 538,
+      "user": 1947,
+      "created_at": 1696482415
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 539,
+      "created_at": 1696482425,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "I4",
+              "J5"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4",
+            "J5"
+          ],
+          "revenue": 190,
+          "revenue_str": "G2-H3-I4-J5",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "I4-0",
+            "J5-0"
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "G8",
+              "G6",
+              "G4"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "E6",
+              "F7"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4",
+            "G8",
+            "F7",
+            "E6"
+          ],
+          "revenue": 200,
+          "revenue_str": "H3-G4-G8-F7-E6",
+          "nodes": [
+            "G4-0",
+            "H3-0",
+            "G8-0",
+            "F7-0",
+            "E6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 540,
+      "created_at": 1696482427,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 541,
+      "created_at": 1696488329,
+      "hex": "G16",
+      "tile": "8-4",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 542,
+      "created_at": 1696488331
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 543,
+      "created_at": 1696488334,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F19",
+              "F17",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "G14",
+              "G12",
+              "G10",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "F19",
+            "E16",
+            "F15",
+            "G8"
+          ],
+          "revenue": 170,
+          "revenue_str": "F19-E16-F15-G8",
+          "nodes": [
+            "F19-0",
+            "E16-0",
+            "F15-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 544,
+      "created_at": 1696488334,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 545,
+      "created_at": 1696488528
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 546,
+      "created_at": 1696513353,
+      "hex": "F5",
+      "tile": "9-6",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 547,
+      "created_at": 1696513384
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 548,
+      "created_at": 1696513396,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2"
+            ],
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "G2",
+            "H3"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-G2-H3",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "G2-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 549,
+      "created_at": 1696513401,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 550,
+      "created_at": 1696513405
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 551,
+      "created_at": 1696514012,
+      "hex": "F5",
+      "tile": "23-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 552,
+      "created_at": 1696514022,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "E4"
+            ],
+            [
+              "E4",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "F3",
+            "E4",
+            "E6"
+          ],
+          "revenue": 230,
+          "revenue_str": "H3-G2-F3-E4-E6",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E4-0",
+            "E6-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-H3-I4",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 553,
+      "created_at": 1696514022,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 554,
+      "created_at": 1696520858,
+      "hex": "H15",
+      "tile": "4-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 555,
+      "created_at": 1696520861
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 556,
+      "created_at": 1696520871,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F17",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F19"
+          ],
+          "revenue": 220,
+          "revenue_str": "E20-F19-E18-E16-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 557,
+      "created_at": 1696522503,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 558,
+      "created_at": 1696522506
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 559,
+      "created_at": 1696526732,
+      "hex": "C14",
+      "tile": "8-5",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 560,
+      "created_at": 1696526735,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "A16",
+              "B15"
+            ]
+          ],
+          "hexes": [
+            "A16",
+            "B15"
+          ],
+          "revenue": 100,
+          "revenue_str": "A16-B15",
+          "nodes": [
+            "A16-0",
+            "B15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 561,
+      "created_at": 1696526736,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 562,
+      "created_at": 1696526737
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 563,
+      "created_at": 1696527576,
+      "hex": "G12",
+      "tile": "41-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 564,
+      "created_at": 1696527587,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "G10",
+              "G12",
+              "H13"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4",
+            "E6",
+            "F7",
+            "G8",
+            "H13"
+          ],
+          "revenue": 250,
+          "revenue_str": "H3-G4-E6-F7-G8-H13",
+          "nodes": [
+            "H3-0",
+            "G4-0",
+            "E6-0",
+            "F7-0",
+            "G8-0",
+            "H13-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 565,
+      "created_at": 1696527588,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 566,
+      "created_at": 1696527590
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 567,
+      "created_at": 1696527995,
+      "hex": "I10",
+      "tile": "59-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 568,
+      "created_at": 1696528012
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 569,
+      "created_at": 1696528020,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "I4",
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "K6",
+              "K8",
+              "K10"
+            ],
+            [
+              "K10",
+              "J11",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "I4",
+            "J7",
+            "K10",
+            "I10"
+          ],
+          "revenue": 140,
+          "revenue_str": "I4-J7-K10-I10",
+          "nodes": [
+            "I4-1",
+            "J7-0",
+            "K10-0",
+            "I10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 570,
+      "created_at": 1696528023,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 571,
+      "created_at": 1696528029
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 572,
+      "created_at": 1696528252,
+      "hex": "G10",
+      "tile": "46-1",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 573,
+      "created_at": 1696528255,
+      "city": "66-0-0",
+      "slot": 0,
+      "tokener": "NZO"
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 574,
+      "created_at": 1696528262,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "G12",
+              "G14",
+              "F15"
+            ],
+            [
+              "F15",
+              "F17",
+              "F19"
+            ],
+            [
+              "F19",
+              "F21"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "F15",
+            "F19",
+            "F21"
+          ],
+          "revenue": 250,
+          "revenue_str": "I14-H13-F15-F19-F21",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "F15-0",
+            "F19-0",
+            "F21-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 575,
+      "created_at": 1696528264,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 576,
+      "created_at": 1696528268
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 577,
+      "created_at": 1696536586,
+      "shares": [
+        "NZO_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 578,
+      "created_at": 1696536588
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 579,
+      "created_at": 1696536750,
+      "shares": [
+        "NZO_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 580,
+      "created_at": 1696536755
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 581,
+      "created_at": 1696538869,
+      "shares": [
+        "NZO_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 582,
+      "created_at": 1696538880
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "shares": [
+        "NRS_7"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 583,
+      "user": 7622,
+      "created_at": 1696583632
+    },
+    {
+      "type": "undo",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 584,
+      "user": 7622,
+      "created_at": 1696583645
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 585,
+      "created_at": 1696583646,
+      "shares": [
+        "NZO_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 586,
+      "created_at": 1696583649
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 587,
+      "created_at": 1696584426,
+      "shares": [
+        "AS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 588,
+      "created_at": 1696584428
+    },
+    {
+      "type": "buy_shares",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 589,
+      "created_at": 1696600114,
+      "shares": [
+        "NRS_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 590,
+      "created_at": 1696600133,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696600132
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 591,
+      "created_at": 1696600524,
+      "shares": [
+        "NRS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 592,
+      "created_at": 1696600542
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 593,
+      "created_at": 1696604360,
+      "shares": [
+        "NZO_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 594,
+      "created_at": 1696604363
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "shares": [
+        "AS_5"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 595,
+      "user": 1947,
+      "created_at": 1696606781
+    },
+    {
+      "type": "undo",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 596,
+      "user": 1947,
+      "created_at": 1696606788
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 597,
+      "created_at": 1696606802,
+      "shares": [
+        "MES_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 598,
+      "created_at": 1696606805,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696606803
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 599,
+      "created_at": 1696607979,
+      "shares": [
+        "NRS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 600,
+      "created_at": 1696607984,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696607983
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 601,
+      "created_at": 1696608396,
+      "shares": [
+        "NFL_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 602,
+      "created_at": 1696608398
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 603,
+      "created_at": 1696616316,
+      "shares": [
+        "HIS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 604,
+      "created_at": 1696616321,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696616319
+        },
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696616319
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 605,
+      "created_at": 1696617337,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696617334
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 606,
+      "created_at": 1696620600
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 607,
+      "created_at": 1696620616,
+      "hex": "E14",
+      "tile": "9-4",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 608,
+      "created_at": 1696620647,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "I4",
+              "J5"
+            ]
+          ],
+          "hexes": [
+            "G2",
+            "H3",
+            "I4",
+            "J5"
+          ],
+          "revenue": 190,
+          "revenue_str": "G2-H3-I4-J5",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "I4-0",
+            "J5-0"
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "G8",
+              "G6",
+              "G4"
+            ],
+            [
+              "G8",
+              "G10",
+              "G12",
+              "G14",
+              "F15"
+            ],
+            [
+              "F15",
+              "F17",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4",
+            "G8",
+            "F15",
+            "F19"
+          ],
+          "revenue": 210,
+          "revenue_str": "H3-G4-G8-F15-F19",
+          "nodes": [
+            "G4-0",
+            "H3-0",
+            "G8-0",
+            "F15-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 609,
+      "created_at": 1696620649,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 610,
+      "created_at": 1696621675,
+      "hex": "F5",
+      "tile": "45-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 611,
+      "created_at": 1696621681,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "E4"
+            ],
+            [
+              "E4",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "F3",
+            "E4",
+            "E6"
+          ],
+          "revenue": 230,
+          "revenue_str": "H3-G2-F3-E4-E6",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E4-0",
+            "E6-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-H3-I4",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 612,
+      "created_at": 1696621682,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 613,
+      "created_at": 1696667078,
+      "hex": "H15",
+      "tile": "88-1",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 614,
+      "created_at": 1696667095,
+      "city": "63-2-0",
+      "slot": 0,
+      "tokener": "AS"
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 615,
+      "created_at": 1696667099,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F19",
+              "F17",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "G14",
+              "G12",
+              "H13"
+            ]
+          ],
+          "hexes": [
+            "F19",
+            "E16",
+            "F15",
+            "H13"
+          ],
+          "revenue": 180,
+          "revenue_str": "F19-E16-F15-H13",
+          "nodes": [
+            "F19-0",
+            "E16-0",
+            "F15-0",
+            "H13-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 616,
+      "created_at": 1696667100,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 617,
+      "created_at": 1696667112
+    },
+    {
+      "type": "lay_tile",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 618,
+      "created_at": 1696689271,
+      "hex": "C6",
+      "tile": "24-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 619,
+      "created_at": 1696689275
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 620,
+      "created_at": 1696689289,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2"
+            ],
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "G2",
+            "H3"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-G2-H3",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "G2-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 621,
+      "created_at": 1696689306,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 622,
+      "created_at": 1696689308
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 623,
+      "created_at": 1696705514,
+      "hex": "H9",
+      "tile": "8-6",
+      "rotation": 3
+    },
+    {
+      "type": "place_token",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 624,
+      "created_at": 1696705516,
+      "city": "63-2-0",
+      "slot": 1,
+      "tokener": "NCS"
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 625,
+      "created_at": 1696705522,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F17",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F19"
+          ],
+          "revenue": 220,
+          "revenue_str": "E20-F19-E18-E16-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 626,
+      "created_at": 1696705524,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 627,
+      "created_at": 1696705525
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 628,
+      "created_at": 1696710336,
+      "hex": "G14",
+      "tile": "24-2",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 629,
+      "created_at": 1696710345,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "G10",
+              "G12",
+              "H13"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4",
+            "E6",
+            "F7",
+            "G8",
+            "H13"
+          ],
+          "revenue": 250,
+          "revenue_str": "H3-G4-E6-F7-G8-H13",
+          "nodes": [
+            "H3-0",
+            "G4-0",
+            "E6-0",
+            "F7-0",
+            "G8-0",
+            "H13-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 630,
+      "created_at": 1696710346,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 631,
+      "created_at": 1696710349
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 632,
+      "created_at": 1696710982,
+      "hex": "J3",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 633,
+      "created_at": 1696710998
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 634,
+      "created_at": 1696711002,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "I4",
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "K6",
+              "K8",
+              "K10"
+            ],
+            [
+              "K10",
+              "J11",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "I4",
+            "J7",
+            "K10",
+            "I10"
+          ],
+          "revenue": 140,
+          "revenue_str": "I4-J7-K10-I10",
+          "nodes": [
+            "I4-1",
+            "J7-0",
+            "K10-0",
+            "I10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 635,
+      "created_at": 1696711004,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 636,
+      "created_at": 1696711005
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 637,
+      "created_at": 1696742623,
+      "hex": "D13",
+      "tile": "8-7",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 638,
+      "created_at": 1696742626,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "A16",
+              "B15"
+            ],
+            [
+              "B15",
+              "B13",
+              "C14",
+              "D13",
+              "E14",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "A16",
+            "B15",
+            "F15"
+          ],
+          "revenue": 140,
+          "revenue_str": "A16-B15-F15",
+          "nodes": [
+            "A16-0",
+            "B15-0",
+            "F15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 639,
+      "created_at": 1696742627,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 640,
+      "created_at": 1696742629
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 641,
+      "created_at": 1696743041,
+      "hex": "G16",
+      "tile": "16-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 642,
+      "created_at": 1696743057,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "G12",
+              "G10",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "G8"
+          ],
+          "revenue": 160,
+          "revenue_str": "I14-H13-G8",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 643,
+      "created_at": 1696743058,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 644,
+      "created_at": 1696743061
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 645,
+      "user": 1947,
+      "created_at": 1696743738
+    },
+    {
+      "type": "undo",
+      "entity": "DV",
+      "action_id": 644,
+      "entity_type": "corporation",
+      "id": 646,
+      "user": 1947,
+      "created_at": 1696745752
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 647,
+      "created_at": 1696745757
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 648,
+      "created_at": 1696745779,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "I4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-H3-I4",
+          "nodes": [
+            "G4-0",
+            "E6-0",
+            "H3-0",
+            "I4-0"
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "F7",
+              "E6"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "G4",
+              "G6",
+              "G8"
+            ],
+            [
+              "G2",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8",
+            "G4",
+            "G2"
+          ],
+          "revenue": 180,
+          "revenue_str": "E6-F7-G8-G4-G2",
+          "nodes": [
+            "F7-0",
+            "E6-0",
+            "G8-0",
+            "G4-0",
+            "G2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 649,
+      "created_at": 1696745781,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 650,
+      "created_at": 1696775047
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 651,
+      "created_at": 1696775052,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "E4"
+            ],
+            [
+              "E4",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "F3",
+            "E4",
+            "E6"
+          ],
+          "revenue": 230,
+          "revenue_str": "H3-G2-F3-E4-E6",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E4-0",
+            "E6-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-H3-I4",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 652,
+      "created_at": 1696775053,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 653,
+      "created_at": 1696776245,
+      "hex": "I10",
+      "tile": "64-0",
+      "rotation": 5
+    },
+    {
+      "type": "undo",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 654,
+      "user": 7622,
+      "created_at": 1696776258
+    },
+    {
+      "type": "redo",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 655,
+      "user": 7622,
+      "created_at": 1696776267
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 656,
+      "created_at": 1696776297
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 657,
+      "created_at": 1696776302,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F19",
+              "F17",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "E14",
+              "D13",
+              "C14",
+              "B13",
+              "B15"
+            ]
+          ],
+          "hexes": [
+            "F19",
+            "E16",
+            "F15",
+            "B15"
+          ],
+          "revenue": 180,
+          "revenue_str": "F19-E16-F15-B15",
+          "nodes": [
+            "F19-0",
+            "E16-0",
+            "F15-0",
+            "B15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 658,
+      "created_at": 1696776309,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 659,
+      "created_at": 1696776333
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 660,
+      "created_at": 1696777627
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 661,
+      "created_at": 1696777636
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 662,
+      "created_at": 1696777640,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2"
+            ],
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "G2",
+            "H3"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-G2-H3",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "G2-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 663,
+      "created_at": 1696777660,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 664,
+      "created_at": 1696777663
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 665,
+      "created_at": 1696779880,
+      "hex": "H9",
+      "tile": "24-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 666,
+      "created_at": 1696779886,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F17",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F19"
+          ],
+          "revenue": 220,
+          "revenue_str": "E20-F19-E18-E16-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 667,
+      "created_at": 1696779888,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 668,
+      "created_at": 1696779890
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 669,
+      "created_at": 1696780153,
+      "hex": "F17",
+      "tile": "45-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 670,
+      "created_at": 1696780165,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "G10",
+              "G12",
+              "H13"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4",
+            "E6",
+            "F7",
+            "G8",
+            "H13"
+          ],
+          "revenue": 250,
+          "revenue_str": "H3-G4-E6-F7-G8-H13",
+          "nodes": [
+            "H3-0",
+            "G4-0",
+            "E6-0",
+            "F7-0",
+            "G8-0",
+            "H13-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 671,
+      "created_at": 1696780166,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 672,
+      "created_at": 1696780167
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 673,
+      "created_at": 1696780722,
+      "hex": "K2",
+      "tile": "9-5",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 674,
+      "created_at": 1696780727
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 675,
+      "created_at": 1696780733,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "K6",
+              "K8",
+              "K10"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "J7",
+            "K10"
+          ],
+          "revenue": 180,
+          "revenue_str": "L1-I4-J7-K10",
+          "nodes": [
+            "L1-0",
+            "I4-1",
+            "J7-0",
+            "K10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 676,
+      "created_at": 1696780734,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 677,
+      "created_at": 1696780735
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 678,
+      "created_at": 1696796987,
+      "hex": "D13",
+      "tile": "29-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 679,
+      "created_at": 1696796990,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "A16",
+              "B15"
+            ],
+            [
+              "B15",
+              "B13",
+              "C14",
+              "D13",
+              "E14",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "A16",
+            "B15",
+            "F15"
+          ],
+          "revenue": 140,
+          "revenue_str": "A16-B15-F15",
+          "nodes": [
+            "A16-0",
+            "B15-0",
+            "F15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 680,
+      "created_at": 1696796991,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 681,
+      "created_at": 1696797003
+    },
+    {
+      "hex": "G16",
+      "tile": "43-1",
+      "type": "lay_tile",
+      "entity": "NZO",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 682,
+      "user": 797,
+      "created_at": 1696799848
+    },
+    {
+      "type": "undo",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 683,
+      "user": 797,
+      "created_at": 1696799855
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 684,
+      "created_at": 1696799861,
+      "hex": "G16",
+      "tile": "70-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 685,
+      "created_at": 1696799871,
+      "city": "64-0-1",
+      "slot": 0,
+      "tokener": "NZO"
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 686,
+      "created_at": 1696799875,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "G12",
+              "G14",
+              "G16",
+              "H15"
+            ],
+            [
+              "H15",
+              "H13"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "H15",
+            "H13"
+          ],
+          "revenue": 180,
+          "revenue_str": "I14-H13-H15-H13",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "H15-0",
+            "H13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 687,
+      "created_at": 1696799876,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 688,
+      "created_at": 1696799877
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 689,
+      "created_at": 1696833054
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 690,
+      "created_at": 1696833094,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "I4",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-H3-I4",
+          "nodes": [
+            "G4-0",
+            "E6-0",
+            "H3-0",
+            "I4-0"
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "F7",
+              "E6"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "G4",
+              "G6",
+              "G8"
+            ],
+            [
+              "G2",
+              "G4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8",
+            "G4",
+            "G2"
+          ],
+          "revenue": 180,
+          "revenue_str": "E6-F7-G8-G4-G2",
+          "nodes": [
+            "F7-0",
+            "E6-0",
+            "G8-0",
+            "G4-0",
+            "G2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 691,
+      "user": 1947,
+      "created_at": 1696833095
+    },
+    {
+      "type": "undo",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 692,
+      "user": 1947,
+      "created_at": 1696833100
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 693,
+      "created_at": 1696833114,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 694,
+      "created_at": 1696860132
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 695,
+      "created_at": 1696860134,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "E4"
+            ],
+            [
+              "E4",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "F3",
+            "E4",
+            "E6"
+          ],
+          "revenue": 230,
+          "revenue_str": "H3-G2-F3-E4-E6",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E4-0",
+            "E6-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-H3-I4",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 696,
+      "created_at": 1696860135,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 697,
+      "created_at": 1696860905
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 698,
+      "created_at": 1696860907
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 699,
+      "created_at": 1696860919,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F19",
+              "F17",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "E14",
+              "D13",
+              "C14",
+              "B13",
+              "B15"
+            ]
+          ],
+          "hexes": [
+            "F19",
+            "E16",
+            "F15",
+            "B15"
+          ],
+          "revenue": 180,
+          "revenue_str": "F19-E16-F15-B15",
+          "nodes": [
+            "F19-0",
+            "E16-0",
+            "F15-0",
+            "B15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 700,
+      "created_at": 1696860921,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 701,
+      "created_at": 1696860952
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 702,
+      "created_at": 1696861230
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 703,
+      "created_at": 1696861239
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 704,
+      "created_at": 1696861245,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2"
+            ],
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "G2",
+            "H3"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-G2-H3",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "G2-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 705,
+      "created_at": 1696861246,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 706,
+      "created_at": 1696861256
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 707,
+      "created_at": 1696861397,
+      "hex": "D17",
+      "tile": "9-6",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 708,
+      "created_at": 1696861404,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F17",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F19"
+          ],
+          "revenue": 220,
+          "revenue_str": "E20-F19-E18-E16-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 709,
+      "created_at": 1696861407,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 710,
+      "created_at": 1696861408
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 713,
+      "created_at": 1696861777
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 714,
+      "created_at": 1696861780,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "G10",
+              "G12",
+              "H13"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4",
+            "E6",
+            "F7",
+            "G8",
+            "H13"
+          ],
+          "revenue": 250,
+          "revenue_str": "H3-G4-E6-F7-G8-H13",
+          "nodes": [
+            "H3-0",
+            "G4-0",
+            "E6-0",
+            "F7-0",
+            "G8-0",
+            "H13-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 715,
+      "created_at": 1696861781,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 716,
+      "created_at": 1696861782
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 717,
+      "created_at": 1696870058,
+      "hex": "D15",
+      "tile": "4-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 718,
+      "created_at": 1696870064,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "A16",
+              "B15"
+            ],
+            [
+              "B15",
+              "B13",
+              "C14",
+              "D13",
+              "E14",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "A16",
+            "B15",
+            "F15"
+          ],
+          "revenue": 140,
+          "revenue_str": "A16-B15-F15",
+          "nodes": [
+            "A16-0",
+            "B15-0",
+            "F15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 719,
+      "created_at": 1696870066,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 720,
+      "created_at": 1696870069
+    },
+    {
+      "hex": "K8",
+      "tile": "26-0",
+      "type": "lay_tile",
+      "entity": "MES",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "id": 721,
+      "user": 9831,
+      "created_at": 1696870332
+    },
+    {
+      "type": "undo",
+      "entity": "MES",
+      "action_id": 720,
+      "entity_type": "corporation",
+      "id": 722,
+      "user": 9831,
+      "created_at": 1696870352
+    },
+    {
+      "hex": "I8",
+      "tile": "9-3",
+      "type": "lay_tile",
+      "entity": "MES",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 723,
+      "user": 9831,
+      "created_at": 1696870366
+    },
+    {
+      "type": "undo",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 724,
+      "user": 9831,
+      "created_at": 1696870378
+    },
+    {
+      "hex": "I8",
+      "tile": "8-0",
+      "type": "lay_tile",
+      "entity": "MES",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "id": 725,
+      "user": 9831,
+      "created_at": 1696870385
+    },
+    {
+      "city": "64-0-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "MES",
+      "tokener": "MES",
+      "entity_type": "corporation",
+      "id": 726,
+      "user": 9831,
+      "created_at": 1696870387
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "routes": [
+        {
+          "hexes": [
+            "I10",
+            "J7",
+            "I4",
+            "L1"
+          ],
+          "nodes": [
+            "I10-0",
+            "J7-0",
+            "I4-1",
+            "L1-0"
+          ],
+          "train": "4-2",
+          "revenue": 210,
+          "connections": [
+            [
+              "I10",
+              "I8",
+              "J7"
+            ],
+            [
+              "J7",
+              "I6",
+              "I4"
+            ],
+            [
+              "I4",
+              "J3",
+              "K2",
+              "L1"
+            ]
+          ],
+          "revenue_str": "I10-J7-I4-L1"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 727,
+      "user": 9831,
+      "created_at": 1696870392
+    },
+    {
+      "type": "undo",
+      "entity": "MES",
+      "action_id": 720,
+      "entity_type": "corporation",
+      "id": 728,
+      "user": 9831,
+      "created_at": 1696870409
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 729,
+      "created_at": 1696870413,
+      "hex": "I8",
+      "tile": "9-3",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 730,
+      "created_at": 1696870420
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 731,
+      "created_at": 1696870440,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "I8",
+              "H9",
+              "G10",
+              "G12",
+              "H13"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "J7",
+            "H13"
+          ],
+          "revenue": 210,
+          "revenue_str": "L1-I4-J7-H13",
+          "nodes": [
+            "L1-0",
+            "I4-1",
+            "J7-0",
+            "H13-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 732,
+      "created_at": 1696870456,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 733,
+      "created_at": 1696870461
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 734,
+      "created_at": 1696871178,
+      "hex": "K10",
+      "tile": "14-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 735,
+      "created_at": 1696871191,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "G12",
+              "G10",
+              "H9",
+              "I8",
+              "J7"
+            ],
+            [
+              "J7",
+              "K6",
+              "K8",
+              "K10"
+            ],
+            [
+              "K10",
+              "J11",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "J7",
+            "K10",
+            "I10"
+          ],
+          "revenue": 230,
+          "revenue_str": "I14-H13-J7-K10-I10",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "J7-0",
+            "K10-0",
+            "I10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 736,
+      "created_at": 1696871191,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 737,
+      "created_at": 1696871194
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 738,
+      "created_at": 1696871223,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696871222
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 739,
+      "created_at": 1696871542,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696871540
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 740,
+      "created_at": 1696873147,
+      "shares": [
+        "NFL_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 741,
+      "created_at": 1696873155,
+      "shares": [
+        "HIS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 742,
+      "created_at": 1696873168
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 743,
+      "created_at": 1696876688,
+      "shares": [
+        "NZO_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 744,
+      "created_at": 1696876700,
+      "shares": [
+        "HIS_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 745,
+      "created_at": 1696876702,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696876701,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 797,
+      "entity_type": "player",
+      "id": 746,
+      "created_at": 1696876813,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 797,
+          "entity_type": "player",
+          "created_at": 1696876813
+        },
+        {
+          "type": "program_disable",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696876813,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 9831,
+      "entity_type": "player",
+      "id": 747,
+      "created_at": 1696876840,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 9831,
+          "entity_type": "player",
+          "created_at": 1696876839
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 7622,
+      "entity_type": "player",
+      "id": 748,
+      "created_at": 1696879928,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 7622,
+          "entity_type": "player",
+          "created_at": 1696879927
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 1947,
+      "entity_type": "player",
+      "id": 749,
+      "created_at": 1696881018
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 750,
+      "created_at": 1696881056
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 751,
+      "created_at": 1696881104,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "F7",
+              "E6"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "H13",
+              "G12",
+              "G10",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8",
+            "H13"
+          ],
+          "revenue": 170,
+          "revenue_str": "E6-F7-G8-H13",
+          "nodes": [
+            "F7-0",
+            "E6-0",
+            "G8-0",
+            "H13-1"
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "J5",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "H3",
+            "I4",
+            "J5"
+          ],
+          "revenue": 220,
+          "revenue_str": "E6-G4-H3-I4-J5",
+          "nodes": [
+            "G4-0",
+            "E6-0",
+            "H3-0",
+            "I4-0",
+            "J5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 752,
+      "created_at": 1696881105,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 753,
+      "created_at": 1696883250
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 754,
+      "created_at": 1696883252,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "E4"
+            ],
+            [
+              "E4",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "F3",
+            "E4",
+            "E6"
+          ],
+          "revenue": 230,
+          "revenue_str": "H3-G2-F3-E4-E6",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E4-0",
+            "E6-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-H3-I4",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 755,
+      "created_at": 1696883253,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 756,
+      "created_at": 1696883276
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 757,
+      "created_at": 1696883280
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 758,
+      "created_at": 1696883285,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2"
+            ],
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "G2",
+            "H3"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-G2-H3",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "G2-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 759,
+      "created_at": 1696883290,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 760,
+      "created_at": 1696883291
+    },
+    {
+      "hex": "I8",
+      "tile": "27-0",
+      "type": "lay_tile",
+      "entity": "NCS",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 761,
+      "user": 7622,
+      "created_at": 1696912295
+    },
+    {
+      "type": "undo",
+      "entity": "NCS",
+      "action_id": 760,
+      "entity_type": "corporation",
+      "id": 762,
+      "user": 7622,
+      "created_at": 1696912338
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 763,
+      "created_at": 1696912378,
+      "hex": "I8",
+      "tile": "26-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 764,
+      "created_at": 1696912385,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F17",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F19"
+          ],
+          "revenue": 220,
+          "revenue_str": "E20-F19-E18-E16-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 765,
+      "created_at": 1696912387,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 766,
+      "created_at": 1696912389
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 767,
+      "user": 7622,
+      "created_at": 1696912396
+    },
+    {
+      "type": "undo",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 768,
+      "user": 7622,
+      "created_at": 1696912403
+    },
+    {
+      "type": "lay_tile",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 769,
+      "created_at": 1696912419,
+      "hex": "D17",
+      "tile": "20-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 770,
+      "created_at": 1696912427
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 771,
+      "created_at": 1696912451,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F19",
+              "F17",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "E14",
+              "D13",
+              "C14",
+              "B13",
+              "B15"
+            ]
+          ],
+          "hexes": [
+            "F19",
+            "E16",
+            "F15",
+            "B15"
+          ],
+          "revenue": 180,
+          "revenue_str": "F19-E16-F15-B15",
+          "nodes": [
+            "F19-0",
+            "E16-0",
+            "F15-0",
+            "B15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 772,
+      "created_at": 1696912452,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 773,
+      "created_at": 1696912470
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 774,
+      "created_at": 1696912795,
+      "hex": "H9",
+      "tile": "47-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 775,
+      "created_at": 1696912809,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "H9",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4",
+            "E6",
+            "F7",
+            "G8",
+            "I10"
+          ],
+          "revenue": 250,
+          "revenue_str": "H3-G4-E6-F7-G8-I10",
+          "nodes": [
+            "H3-0",
+            "G4-0",
+            "E6-0",
+            "F7-0",
+            "G8-0",
+            "I10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 776,
+      "created_at": 1696912812,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 777,
+      "created_at": 1696912813
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 778,
+      "created_at": 1696913784,
+      "hex": "I6",
+      "tile": "23-1",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 779,
+      "created_at": 1696913814,
+      "city": "64-0-0",
+      "slot": 0,
+      "tokener": "MES"
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 780,
+      "created_at": 1696913818,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "I8",
+              "H9",
+              "G10",
+              "G12",
+              "H13"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "J7",
+            "H13"
+          ],
+          "revenue": 210,
+          "revenue_str": "L1-I4-J7-H13",
+          "nodes": [
+            "L1-0",
+            "I4-1",
+            "J7-0",
+            "H13-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 781,
+      "created_at": 1696913820,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 782,
+      "created_at": 1696913822
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 783,
+      "created_at": 1696924114
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 784,
+      "created_at": 1696924116,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "A16",
+              "B15"
+            ],
+            [
+              "B15",
+              "B13",
+              "C14",
+              "D13",
+              "E14",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "A16",
+            "B15",
+            "F15"
+          ],
+          "revenue": 140,
+          "revenue_str": "A16-B15-F15",
+          "nodes": [
+            "A16-0",
+            "B15-0",
+            "F15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 785,
+      "created_at": 1696924117,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 786,
+      "created_at": 1696924118
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 787,
+      "created_at": 1696947792,
+      "hex": "L11",
+      "tile": "8-0",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 788,
+      "created_at": 1696947797,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "G12",
+              "G10",
+              "H9",
+              "I8",
+              "J7"
+            ],
+            [
+              "J7",
+              "K6",
+              "K8",
+              "K10"
+            ],
+            [
+              "K10",
+              "L9",
+              "L11",
+              "M12"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "J7",
+            "K10",
+            "M12"
+          ],
+          "revenue": 240,
+          "revenue_str": "I14-H13-J7-K10-M12",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "J7-0",
+            "K10-0",
+            "M12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 789,
+      "created_at": 1696947799,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 790,
+      "created_at": 1696947800
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 791,
+      "created_at": 1696952484
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 792,
+      "created_at": 1696952495,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "F7",
+              "E6"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "H13",
+              "G12",
+              "G10",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8",
+            "H13"
+          ],
+          "revenue": 170,
+          "revenue_str": "E6-F7-G8-H13",
+          "nodes": [
+            "F7-0",
+            "E6-0",
+            "G8-0",
+            "H13-1"
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "J5",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "H3",
+            "I4",
+            "J5"
+          ],
+          "revenue": 220,
+          "revenue_str": "E6-G4-H3-I4-J5",
+          "nodes": [
+            "G4-0",
+            "E6-0",
+            "H3-0",
+            "I4-0",
+            "J5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 793,
+      "created_at": 1696952497,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 794,
+      "created_at": 1696959060
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 795,
+      "created_at": 1696959062,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "E4"
+            ],
+            [
+              "E4",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "F3",
+            "E4",
+            "E6"
+          ],
+          "revenue": 230,
+          "revenue_str": "H3-G2-F3-E4-E6",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E4-0",
+            "E6-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-H3-I4",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 796,
+      "created_at": 1696959065,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 797,
+      "created_at": 1696959949
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 798,
+      "created_at": 1696959952
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 799,
+      "created_at": 1696959955,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2"
+            ],
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "G2",
+            "H3"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-G2-H3",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "G2-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 800,
+      "created_at": 1696959956,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 801,
+      "created_at": 1696959961
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 802,
+      "created_at": 1696961380
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 803,
+      "created_at": 1696961391,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F17",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F19"
+          ],
+          "revenue": 220,
+          "revenue_str": "E20-F19-E18-E16-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 804,
+      "created_at": 1696961392,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 805,
+      "created_at": 1696961395
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 806,
+      "created_at": 1696961396
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 807,
+      "created_at": 1696961398
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 808,
+      "created_at": 1696961406,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F19",
+              "F17",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "E14",
+              "D13",
+              "C14",
+              "B13",
+              "B15"
+            ]
+          ],
+          "hexes": [
+            "F19",
+            "E16",
+            "F15",
+            "B15"
+          ],
+          "revenue": 180,
+          "revenue_str": "F19-E16-F15-B15",
+          "nodes": [
+            "F19-0",
+            "E16-0",
+            "F15-0",
+            "B15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 809,
+      "created_at": 1696961408,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 810,
+      "created_at": 1696961409
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 811,
+      "created_at": 1696963863
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 812,
+      "created_at": 1696963867,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "H9",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4",
+            "E6",
+            "F7",
+            "G8",
+            "I10"
+          ],
+          "revenue": 250,
+          "revenue_str": "H3-G4-E6-F7-G8-I10",
+          "nodes": [
+            "H3-0",
+            "G4-0",
+            "E6-0",
+            "F7-0",
+            "G8-0",
+            "I10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 813,
+      "created_at": 1696963868,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 814,
+      "created_at": 1696963870
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 815,
+      "created_at": 1696964846,
+      "hex": "I8",
+      "tile": "44-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 816,
+      "created_at": 1696964852,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "I8",
+              "H9",
+              "G10",
+              "G12",
+              "H13"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "J7",
+            "H13"
+          ],
+          "revenue": 210,
+          "revenue_str": "L1-I4-J7-H13",
+          "nodes": [
+            "L1-0",
+            "I4-1",
+            "J7-0",
+            "H13-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 817,
+      "created_at": 1696964853,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 818,
+      "created_at": 1696964854
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 819,
+      "created_at": 1696965247
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 820,
+      "created_at": 1696965248,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "A16",
+              "B15"
+            ],
+            [
+              "B15",
+              "B13",
+              "C14",
+              "D13",
+              "E14",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "A16",
+            "B15",
+            "F15"
+          ],
+          "revenue": 140,
+          "revenue_str": "A16-B15-F15",
+          "nodes": [
+            "A16-0",
+            "B15-0",
+            "F15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 821,
+      "created_at": 1696965250,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 822,
+      "created_at": 1696965251
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 823,
+      "user": 797,
+      "created_at": 1696966263
+    },
+    {
+      "type": "undo",
+      "entity": "NZO",
+      "action_id": 822,
+      "entity_type": "corporation",
+      "id": 824,
+      "user": 797,
+      "created_at": 1696966272
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 825,
+      "created_at": 1696966309,
+      "hex": "K8",
+      "tile": "23-2",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 826,
+      "created_at": 1696966315,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "G12",
+              "G10",
+              "H9",
+              "I8",
+              "J7"
+            ],
+            [
+              "J7",
+              "K6",
+              "K8",
+              "K10"
+            ],
+            [
+              "K10",
+              "L9",
+              "L11",
+              "M12"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "J7",
+            "K10",
+            "M12"
+          ],
+          "revenue": 240,
+          "revenue_str": "I14-H13-J7-K10-M12",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "J7-0",
+            "K10-0",
+            "M12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 827,
+      "created_at": 1696966316,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 828,
+      "created_at": 1696966317
+    },
+    {
+      "type": "pass",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 829,
+      "created_at": 1696966368
+    },
+    {
+      "type": "run_routes",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 830,
+      "created_at": 1696966383,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "F7",
+              "E6"
+            ],
+            [
+              "G8",
+              "F7"
+            ],
+            [
+              "H13",
+              "G12",
+              "G10",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "F7",
+            "G8",
+            "H13"
+          ],
+          "revenue": 170,
+          "revenue_str": "E6-F7-G8-H13",
+          "nodes": [
+            "F7-0",
+            "E6-0",
+            "G8-0",
+            "H13-1"
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "I4",
+              "H3"
+            ],
+            [
+              "J5",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "H3",
+            "I4",
+            "J5"
+          ],
+          "revenue": 220,
+          "revenue_str": "E6-G4-H3-I4-J5",
+          "nodes": [
+            "G4-0",
+            "E6-0",
+            "H3-0",
+            "I4-0",
+            "J5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DV",
+      "entity_type": "corporation",
+      "id": 831,
+      "created_at": 1696966395,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 832,
+      "created_at": 1696966953
+    },
+    {
+      "type": "run_routes",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 833,
+      "created_at": 1696966956,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H3",
+              "G2"
+            ],
+            [
+              "G2",
+              "F3"
+            ],
+            [
+              "F3",
+              "E4"
+            ],
+            [
+              "E4",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G2",
+            "F3",
+            "E4",
+            "E6"
+          ],
+          "revenue": 230,
+          "revenue_str": "H3-G2-F3-E4-E6",
+          "nodes": [
+            "H3-0",
+            "G2-0",
+            "F3-0",
+            "E4-0",
+            "E6-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "H3"
+            ],
+            [
+              "H3",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "H3",
+            "I4"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-H3-I4",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "H3-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ZHE",
+      "entity_type": "corporation",
+      "id": 834,
+      "created_at": 1696966958,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 835,
+      "created_at": 1696967304
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 836,
+      "created_at": 1696967305
+    },
+    {
+      "type": "run_routes",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 837,
+      "created_at": 1696967309,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "E6",
+              "F5",
+              "G4"
+            ],
+            [
+              "G4",
+              "G2"
+            ],
+            [
+              "G2",
+              "H3"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "G4",
+            "G2",
+            "H3"
+          ],
+          "revenue": 200,
+          "revenue_str": "E6-G4-G2-H3",
+          "nodes": [
+            "E6-0",
+            "G4-0",
+            "G2-0",
+            "H3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 838,
+      "created_at": 1696967310,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "HIS",
+      "entity_type": "corporation",
+      "id": 839,
+      "created_at": 1696967311
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 840,
+      "created_at": 1696991363
+    },
+    {
+      "type": "run_routes",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 841,
+      "created_at": 1696991385,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ],
+            [
+              "F19",
+              "E18"
+            ],
+            [
+              "E18",
+              "E16"
+            ],
+            [
+              "E16",
+              "F17",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19",
+            "E18",
+            "E16",
+            "F19"
+          ],
+          "revenue": 220,
+          "revenue_str": "E20-F19-E18-E16-F19",
+          "nodes": [
+            "E20-0",
+            "F19-1",
+            "E18-0",
+            "E16-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 842,
+      "created_at": 1696991388,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NCS",
+      "entity_type": "corporation",
+      "id": 843,
+      "created_at": 1696991390
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 844,
+      "created_at": 1696991393
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 845,
+      "created_at": 1696991395
+    },
+    {
+      "type": "run_routes",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 846,
+      "created_at": 1696991398,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "F19",
+              "F17",
+              "E16"
+            ],
+            [
+              "E16",
+              "F15"
+            ],
+            [
+              "F15",
+              "E14",
+              "D13",
+              "C14",
+              "B13",
+              "B15"
+            ]
+          ],
+          "hexes": [
+            "F19",
+            "E16",
+            "F15",
+            "B15"
+          ],
+          "revenue": 180,
+          "revenue_str": "F19-E16-F15-B15",
+          "nodes": [
+            "F19-0",
+            "E16-0",
+            "F15-0",
+            "B15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 847,
+      "created_at": 1696991399,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "AS",
+      "entity_type": "corporation",
+      "id": 848,
+      "created_at": 1696991403
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 849,
+      "created_at": 1696991483
+    },
+    {
+      "type": "run_routes",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 850,
+      "created_at": 1696991487,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "H3",
+              "G4"
+            ],
+            [
+              "G4",
+              "F5",
+              "E6"
+            ],
+            [
+              "E6",
+              "F7"
+            ],
+            [
+              "F7",
+              "G8"
+            ],
+            [
+              "G8",
+              "H9",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "H3",
+            "G4",
+            "E6",
+            "F7",
+            "G8",
+            "I10"
+          ],
+          "revenue": 250,
+          "revenue_str": "H3-G4-E6-F7-G8-I10",
+          "nodes": [
+            "H3-0",
+            "G4-0",
+            "E6-0",
+            "F7-0",
+            "G8-0",
+            "I10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 851,
+      "created_at": 1696991488,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NRS",
+      "entity_type": "corporation",
+      "id": 852,
+      "created_at": 1696991489
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 853,
+      "created_at": 1696994122
+    },
+    {
+      "type": "run_routes",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 854,
+      "created_at": 1696994125,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "L1",
+              "K2",
+              "J3",
+              "I4"
+            ],
+            [
+              "I4",
+              "I6",
+              "J7"
+            ],
+            [
+              "J7",
+              "I8",
+              "H9",
+              "G10",
+              "G12",
+              "H13"
+            ]
+          ],
+          "hexes": [
+            "L1",
+            "I4",
+            "J7",
+            "H13"
+          ],
+          "revenue": 210,
+          "revenue_str": "L1-I4-J7-H13",
+          "nodes": [
+            "L1-0",
+            "I4-1",
+            "J7-0",
+            "H13-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 855,
+      "created_at": 1696994127,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MES",
+      "entity_type": "corporation",
+      "id": 856,
+      "created_at": 1696994145
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 857,
+      "created_at": 1696996375
+    },
+    {
+      "type": "run_routes",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 858,
+      "created_at": 1696996376,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "A16",
+              "B15"
+            ],
+            [
+              "B15",
+              "B13",
+              "C14",
+              "D13",
+              "E14",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "A16",
+            "B15",
+            "F15"
+          ],
+          "revenue": 140,
+          "revenue_str": "A16-B15-F15",
+          "nodes": [
+            "A16-0",
+            "B15-0",
+            "F15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 859,
+      "created_at": 1696996378,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NFL",
+      "entity_type": "corporation",
+      "id": 860,
+      "created_at": 1696996379
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 861,
+      "created_at": 1696996837
+    },
+    {
+      "type": "run_routes",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 862,
+      "created_at": 1696996840,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ],
+            [
+              "H13",
+              "G12",
+              "G10",
+              "H9",
+              "I8",
+              "J7"
+            ],
+            [
+              "J7",
+              "K6",
+              "K8",
+              "K10"
+            ],
+            [
+              "K10",
+              "L9",
+              "L11",
+              "M12"
+            ]
+          ],
+          "hexes": [
+            "I14",
+            "H13",
+            "J7",
+            "K10",
+            "M12"
+          ],
+          "revenue": 240,
+          "revenue_str": "I14-H13-J7-K10-M12",
+          "nodes": [
+            "I14-0",
+            "H13-1",
+            "J7-0",
+            "K10-0",
+            "M12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 863,
+      "created_at": 1696996841,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NZO",
+      "entity_type": "corporation",
+      "id": 864,
+      "created_at": 1696996842
+    }
+  ],
+  "loaded": true,
+  "created_at": 1695611709,
+  "updated_at": 1697051214,
+  "finished_at": 1697051214
+}


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Adds two fixture files for 18NL

