### PR TITLE
[1880] show simple logos for FIs on player cards

### DIFF
--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -249,7 +249,7 @@ module View
         minor_logos = minors.map do |minor|
           logo_props = {
             attrs: {
-              src: minor.logo,
+              src: setting_for(:simple_logos, @game) ? minor.simple_logo : minor.logo,
             },
             style: {
               paddingRight: '1px',


### PR DESCRIPTION
Fixes #9753

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Uses the minor's simple_logo preference 

Likely affects other games besides '80 which have similar mechanics

* **Screenshots**

![Screenshot 2023-10-12 9 16 35 PM](https://github.com/tobymao/18xx/assets/1711810/2e0047a3-5f32-427e-9c97-8199bb991968)


* **Any Assumptions / Hacks**
