### PR TITLE
[1822 family] never let minors use a private to lay brown or gray tiles

### DIFF
--- a/lib/engine/game/g_1822/step/special_track.rb
+++ b/lib/engine/game/g_1822/step/special_track.rb
@@ -38,6 +38,11 @@ module Engine
                       else
                         @game.current_entity
                       end
+
+            if spender.type == :minor && %i[brown gray].include?(action.tile.color)
+              raise GameError, 'Minor cannot upgrade past green'
+            end
+
             @in_process = true
 
             minor_single_use = false
@@ -207,6 +212,8 @@ module Engine
           end
 
           def potential_tiles_for_entity(entity, hex, tile_ability)
+            return [] if entity.owner.type == :minor && %i[green brown gray].include?(hex.tile.color)
+
             advanced_tile_lay = @game.can_upgrade_one_phase_ahead?(entity)
             return [] if advanced_tile_lay && entity.owner.type == :minor && hex.tile.color != :yellow
 


### PR DESCRIPTION
Fixes issue in 1822CA with the "major city upgrade" privates being usable by minors to upgrade Montreal/etc. to brown and gray. #9376

Now includes actual validation, so pins will be needed for #9196 and #9669