### PR TITLE
[1868WY] fix LHP assignment when phase 5 is triggered by export

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -703,6 +703,13 @@ module View
       end
 
       def can_assign_corporation?
+        # reset selected_company if cleared during an undo action
+        @selected_company ||=
+          begin
+            step = @game.round.active_step
+            (step.respond_to?(:selected_company) && step.selected_company) || nil
+          end
+
         @selected_corporation && @game.abilities(@selected_company, :assign_corporation)
       end
     end

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -35,7 +35,7 @@ module View
           @auctioning_corporation = @step.auctioning_corporation if @step.respond_to?(:auctioning_corporation)
           @selected_corporation ||= @auctioning_corporation
           @auctioning_company = @step.auctioning_company if @step.respond_to?(:auctioning_company)
-          @selected_company ||= @auctioning_company
+          @selected_company ||= (@step.respond_to?(:selected_company) && @step.selected_company) || @auctioning_company
           @mergeable_entity = @step.mergeable_entity if @step.respond_to?(:mergeable_entity)
           @price_protection = @step.price_protection if @step.respond_to?(:price_protection)
           @selected_corporation ||= @price_protection&.corporation
@@ -199,7 +199,8 @@ module View
             children = []
             children.concat(render_subsidiaries)
             input = render_input(corporation) if @game.corporation_available?(corporation)
-            children << h(Corporation, corporation: corporation, interactive: input || merging)
+            children << h(Corporation, corporation: corporation, interactive: input || merging,
+                                       selected_company: @selected_company)
             children << input if input && @selected_corporation == corporation
             h(:div, props, children)
           end.compact

--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -4,6 +4,7 @@ require_relative 'abilities'
 require_relative 'entity'
 require_relative 'ownable'
 require_relative 'passer'
+require_relative 'share_holder'
 
 module Engine
   class Company
@@ -11,6 +12,7 @@ module Engine
     include Entity
     include Ownable
     include Passer
+    include ShareHolder
 
     attr_accessor :name, :desc, :min_price, :revenue, :discount, :value
     attr_reader :sym, :min_auction_price, :treasury, :interval, :color, :text_color, :type, :auction_row

--- a/lib/engine/game/g_1868_wy/step/assign.rb
+++ b/lib/engine/game/g_1868_wy/step/assign.rb
@@ -19,7 +19,9 @@ module Engine
           def help
             case current_entity
             when @game.lhp_private
-              "#{@game.lhp_private.name} is closing. You may assign the 2+1 train to a Railroad Company for no compensation."
+              "#{@game.lhp_private.name} is closing. "\
+              "#{@game.lhp_private.owner.name} may assign the 2+1 train "\
+              'to a Railroad Company for no compensation.'
             end
           end
 
@@ -96,6 +98,18 @@ module Engine
             else
               available
             end
+          end
+
+          def available_subsidiaries
+            []
+          end
+
+          def ipo_type
+            :par
+          end
+
+          def selected_company
+            current_entity == @game.lhp_private ? @game.lhp_private : nil
           end
         end
       end


### PR DESCRIPTION
Export means the assignment happens in a stock round instead of an operating round. The Assign step has a couple of methods implemented so it can render without error in the stock round, and a newly created `selected_company` method so the LHP is automatically selected without the player choosing it.

Because the LHP is the active entity, it needs methods from the `ShareHolder` module which are called on the entities when rendering a stock round.

Fixes #9714


### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

* **Screenshots**

* **Any Assumptions / Hacks**

Adding the `ShareHolder` module to companies feels like a hack, and there is some finickiness with how the new `selected_company` method is called.
