### PR TITLE
[1868WY] fix LHP assignment when phase 5 is triggered by export

### DIFF
--- a/lib/engine/game/g_1868_wy/round/bust.rb
+++ b/lib/engine/game/g_1868_wy/round/bust.rb
@@ -16,7 +16,10 @@ module Engine
           end
 
           def select_entities
-            @game.abilities(@game.no_bust, :assign_hexes) ? [@game.no_bust] : []
+            entities = []
+            entities << @game.lhp_private if @game.lhp_train_pending?
+            entities << @game.no_bust if @game.abilities(@game.no_bust, :assign_hexes)
+            entities
           end
 
           def start_operating


### PR DESCRIPTION
Adds LHP to BUST round entities; train export happens after an OR set but before a BUST round.

Much nicer than the attempt to handle this in the SR (#9785)

Fixes #9714


