### PR TITLE
enforce  token abilities w/ limited hexes

### DIFF
--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -48,18 +48,15 @@ module Engine
         hex = city.hex
         extra_action ||= special_ability.extra_action if %i[teleport token].include?(special_ability&.type)
 
+        check_connected(entity, city, hex) if connected
         unless @game.loading
-
-          check_connected(entity, city, hex) if connected
-
           if special_ability&.type == :token && special_ability.city && special_ability.city != city.index
             raise GameError, "#{special_ability.owner.name} can only place token on #{hex.name} city "\
                              "#{special_ability.city}, not on city #{city.index}"
           end
 
-          if special_ability&.type == :token && !special_ability&.hexes&.empty? && !special_ability.hexes.include?(hex.id)
-            raise GameError, "#{special_ability.owner.name} can only place token on #{special_ability.hexes} hexes"\
-                             ", not on #{hex.id}"
+          if special_ability&.type == :token && !@round.active_step.available_hex(special_ability.owner, hex)
+            raise GameError, "#{special_ability.owner.name} cannot place token on hex #{hex.id}"
           end
 
           if special_ability&.type == :teleport &&


### PR DESCRIPTION
Fixes #9782
<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
It doesn't look like we were checking when tokens were placed via ability

* **Screenshots**

Expected error thrown when wrong hex is chosen

![Screenshot 2023-10-15 11 22 24 PM](https://github.com/tobymao/18xx/assets/1711810/84cdd7f0-b5d8-4b64-ada1-22d467827487)


Still works if correct hex

![Screenshot 2023-10-15 11 22 46 PM](https://github.com/tobymao/18xx/assets/1711810/65a5bc9b-2eb3-4f80-8975-1ac7c10dfc42)

* **Any Assumptions / Hacks**
