### PR TITLE
18ZOO - Update 2D StockMarket to show bigger cells when there is any user_info in any cell

### DIFF
--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -64,13 +64,17 @@ module View
         textAlign: 'center',
       }.freeze
 
-      PRICE_STYLE_INFO = {
+      PRICE_STYLE_1D_INFO = {
         fontSize: '80%',
         textAlign: 'center',
         position: 'absolute',
         bottom: "#{PAD}px",
         width: "#{WIDTH_TOTAL - (2 * PAD) - (2 * BORDER)}px",
       }.freeze
+
+      PRICE_STYLE_2D_INFO = PRICE_STYLE_1D_INFO.merge({
+        width: "#{WIDTH_TOTAL + PRICE_HEIGHT - (2 * PAD) - (2 * BORDER)}px",
+      }).freeze
 
       def box_style_1d
         {
@@ -234,7 +238,7 @@ module View
 
           cell_elements = [h(:div, { style: PRICE_STYLE_1D }, price.price),
                            h(:div, { style: TOKEN_STYLE_1D }, tokens)]
-          cell_elements << h(:div, { style: PRICE_STYLE_INFO }, price.info) if price.info
+          cell_elements << h(:div, { style: PRICE_STYLE_1D_INFO }, price.info) if price.info
 
           element = h(:div, { style: cell_style(box_style, price.types) }, cell_elements)
           if idx.even?
@@ -253,6 +257,8 @@ module View
       end
 
       def grid_2d
+        has_price_info = @game.stock_market.market.any? { |row| row.any?(&:info) }
+
         # Need to peek at row below to know if sitting on ledge.
         @game.stock_market.market.push([]).each_cons(2).each_with_index.map do |rows, row_i|
           row_prices, next_row = rows
@@ -280,10 +286,14 @@ module View
 
               first_price = false
 
-              h(:div, { style: cell_style(@box_style_2d, price.types) }, [
+              h(:div, { style: cell_style(has_price_info ? @box_style_2d_with_info : @box_style_2d, price.types) }, [
                 h('div.xsmall_font', price.price),
                 h(:div, tokens),
-                h(:div, { style: { color: '#00000060', position: 'absolute', 'font-size': '170%' }.merge(align) }, arrow),
+                if price.info
+                  h(:div, { style: PRICE_STYLE_2D_INFO }, price.info)
+                else
+                  h(:div, { style: { color: '#00000060', position: 'absolute', 'font-size': '170%' }.merge(align) }, arrow)
+                end,
               ])
             else
               h(:div, { style: @space_style_2d }, '')
@@ -315,6 +325,11 @@ module View
         @box_style_2d = @space_style_2d.merge(
           border: "solid #{BORDER}px rgba(0,0,0,0.2)",
           color: color_for(:font2),
+        )
+
+        @box_style_2d_with_info = @box_style_2d.merge(
+          height: "#{HEIGHT_TOTAL + PRICE_HEIGHT - (2 * PAD) - (2 * BORDER)}px",
+          width: "#{WIDTH_TOTAL + PRICE_HEIGHT - (2 * PAD) - (2 * BORDER)}px",
         )
 
         grid = if @game.stock_market.one_d?

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -73,8 +73,8 @@ module View
       }.freeze
 
       PRICE_STYLE_2D_INFO = PRICE_STYLE_1D_INFO.merge({
-        width: "#{WIDTH_TOTAL + PRICE_HEIGHT - (2 * PAD) - (2 * BORDER)}px",
-      }).freeze
+                                                        width: "#{WIDTH_TOTAL + PRICE_HEIGHT - (2 * PAD) - (2 * BORDER)}px",
+                                                      }).freeze
 
       def box_style_1d
         {

--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -25,12 +25,56 @@ module Engine
         MUST_SELL_IN_BLOCKS = true
 
         MARKET = [
-          %w[7 8 9 10s 11s 12s 13s 14s 15s 16 20 24e],
-          %w[6 7x 8 9z 10 11 12w 13 14],
-          %w[5 6x 7 8 9 10 11],
-          %w[4 5x 6 7 8],
-          %w[3 4 5],
-          %w[2 3],
+          [
+            { price: 7, info: '100        1' },
+            { price: 8, info: '150        2' },
+            { price: 9, info: '150        2' },
+            { price: 10, info: '200    2+1', types: [:safe_par] },
+            { price: 11, info: '200    2+2', types: [:safe_par] },
+            { price: 12, info: '250    3+2', types: [:safe_par] },
+            { price: 13, info: '250    3+2', types: [:safe_par] },
+            { price: 14, info: '300    3+2', types: [:safe_par] },
+            { price: 15, info: '350    3+3', types: [:safe_par] },
+            { price: 16, info: '400        4' },
+            { price: 20, info: '450        5' },
+            { price: 24, info: 'END       6', types: [:endgame] },
+          ],
+          [
+            { price: 6, info: '100        1' },
+            { price: 7, info: '100        1', types: [:par_1] },
+            { price: 8, info: '150        2' },
+            { price: 9, info: '150        2', types: [:par_2] },
+            { price: 10, info: '200        2' },
+            { price: 11, info: '200        2' },
+            { price: 12, info: '250        3', types: [:par_3] },
+            { price: 13, info: '250        3' },
+            { price: 14, info: '300        3' },
+          ],
+          [
+            { price: 5, info: '80          1' },
+            { price: 6, info: '100        1', types: [:par_1] },
+            { price: 7, info: '100        2' },
+            { price: 8, info: '150        2' },
+            { price: 9, info: '150        2' },
+            { price: 10, info: '200        2' },
+            { price: 11, info: '200        2' },
+          ],
+          [
+            { price: 4, info: '50        1' },
+            { price: 5, info: '80        1', types: [:par_1] },
+            { price: 6, info: '100        1' },
+            { price: 7, info: '100        2' },
+            { price: 8, info: '150        2' },
+          ],
+          [
+            { price: 3, info: '40        0' },
+            { price: 4, info: '50        1' },
+            { price: 5, info: '80        1' },
+          ],
+          [
+            { price: 2, info: '30        0' },
+            { price: 3, info: '40        0' },
+          ],
         ].freeze
 
         PHASES = [

--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -60,20 +60,20 @@ module Engine
             { price: 11, info: '200        2' },
           ],
           [
-            { price: 4, info: '50        1' },
-            { price: 5, info: '80        1', types: [:par_1] },
+            { price: 4, info: '50          1' },
+            { price: 5, info: '80          1', types: [:par_1] },
             { price: 6, info: '100        1' },
             { price: 7, info: '100        2' },
             { price: 8, info: '150        2' },
           ],
           [
-            { price: 3, info: '40        0' },
-            { price: 4, info: '50        1' },
-            { price: 5, info: '80        1' },
+            { price: 3, info: '40          0' },
+            { price: 4, info: '50          1' },
+            { price: 5, info: '80          1' },
           ],
           [
-            { price: 2, info: '30        0' },
-            { price: 3, info: '40        0' },
+            { price: 2, info: '30          0' },
+            { price: 3, info: '40          0' },
           ],
         ].freeze
 


### PR DESCRIPTION
Fixes #9693 

In https://github.com/tobymao/18xx/pull/9731 I changed a style shared, in this case I renamed it to be specific to own flow, and created a new property, specific for 2D with user info (and the only market with that configuration is 18ZOO)

### Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
As requested inside the issue, the stock market was updated to support the info, but only for the 2d grid

* **Screenshots**
![](https://user-images.githubusercontent.com/147172862/273274220-b55afd3e-7248-4515-8c9d-86634f585b5d.png)

* **Any Assumptions / Hacks**
Right now no game is using the user info inside the market; maybe in the future the size of the market could be related to the specific game, instead of just 2 values (with user info / without user info)