### PR TITLE
[1822Africa] Change P5 from Pullman to Add Town

### DIFF
--- a/lib/engine/game/g_1822_africa/entities.rb
+++ b/lib/engine/game/g_1822_africa/entities.rb
@@ -44,14 +44,29 @@ module Engine
             color: nil,
           },
           {
-            name: 'P5 (Pullman)',
+            name: 'P5 (Add Town)',
             sym: 'P5',
-            desc: 'MAJOR/MINOR, Phase 3. A "Pullman" carriage that can be added to another train owned by the company.'\
-                  ' It converts the train into a + train. Does not count against train limit and does not count '\
-                  'as a train for the purposes of train ownership. Can’t be sold to another company.',
+            desc: 'MAJOR/MINOR, Phase 2. Add Small Station. Allows the owning company to place a yellow track tile '\
+                  'with a small station directly on an undeveloped plain hex or upgrade a plain tile of one colour '\
+                  'to a small station tile of the next colour. This closes the company and counts as the company’s '\
+                  'normal track laying step. All other normal track laying restrictions apply. Once acquired, the '\
+                  'private company pays its revenue to the owning company until the power is exercised and the '\
+                  'company is closed.',
             value: 0,
             revenue: 10,
-            abilities: [],
+            abilities: [
+              {
+                type: 'tile_lay',
+                owner_type: 'corporation',
+                when: %w[track special_track],
+                count: 1,
+                reachable: true,
+                closed_when_used_up: true,
+                hexes: [],
+                tiles: %w[3 4 58 141 142 143 144],
+                combo_entities: %w[P7 P11],
+              },
+            ],
             color: nil,
           },
           {

--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -67,13 +67,14 @@ module Engine
         EXTRA_TRAINS = %w[2P P+ LP S].freeze
         EXTRA_TRAIN_PERMANENTS = %w[2P LP].freeze
 
-        PRIVATE_TRAINS = %w[P1 P2 P3 P4 P5 P18].freeze
+        PRIVATE_TRAINS = %w[P1 P2 P3 P4 P18].freeze
         PRIVATE_MAIL_CONTRACTS = [].freeze # Stub
         PRIVATE_PHASE_REVENUE = %w[P16].freeze
         PRIVATE_REMOVE_REVENUE = %w[P13].freeze
 
         COMPANY_10X_REVENUE = 'P16'
         COMPANY_REMOVE_TOWN = 'P9'
+        COMPANY_ADD_TOWN = 'P5'
         COMPANY_EXTRA_TILE_LAYS = %w[P7 P8 P12].freeze
         COMPANY_TOKEN_SWAP = 'P13'
         COMPANY_RECYCLED_TRAIN = 'P6'
@@ -126,7 +127,7 @@ module Engine
           'P2' => { acquire: %i[major], phase: 2 },
           'P3' => { acquire: %i[major], phase: 2 },
           'P4' => { acquire: %i[major minor], phase: 3 },
-          'P5' => { acquire: %i[major minor], phase: 3 },
+          'P5' => { acquire: %i[major minor], phase: 2 },
           'P6' => { acquire: %i[major minor], phase: 3 },
           'P7' => { acquire: %i[major minor], phase: 3 },
           'P8' => { acquire: %i[major minor], phase: 1 },
@@ -147,7 +148,7 @@ module Engine
           'P2' => 'P2 (Permanent 2-train)',
           'P3' => 'P3 (Permanent 2-train)',
           'P4' => 'P4 (Pullman)',
-          'P5' => 'P5 (Pullman)',
+          'P5' => 'P5 (Add Town)',
           'P6' => 'P6 (Recycled train)',
           'P7' => 'P7 (Extra tile)',
           'P8' => 'P8 (Reserve Three Tiles)',
@@ -353,7 +354,7 @@ module Engine
                 'visit' => 99,
               },
             ],
-            num: 2,
+            num: 1,
             price: 0,
           },
           {
@@ -441,7 +442,6 @@ module Engine
           @company_trains['P2'] = find_and_remove_train_by_id('2P-0', buyable: false)
           @company_trains['P3'] = find_and_remove_train_by_id('2P-1', buyable: false)
           @company_trains['P4'] = find_and_remove_train_by_id('P+-0', buyable: false)
-          @company_trains['P5'] = find_and_remove_train_by_id('P+-1', buyable: false)
           @company_trains['P18'] = find_and_remove_train_by_id('S-0', buyable: false)
 
           @recycled_trains = [
@@ -523,7 +523,7 @@ module Engine
             G1822::Step::DiscardTrain,
             G1822::Step::SpecialChoose,
             G1822Africa::Step::LayGameReserve,
-            G1822::Step::SpecialTrack,
+            G1822Africa::Step::SpecialTrack,
             G1822Africa::Step::SpecialToken,
             G1822Africa::Step::Assign,
             G1822::Step::Track,
@@ -612,6 +612,10 @@ module Engine
 
         def must_remove_town?(entity)
           entity.id == self.class::COMPANY_REMOVE_TOWN
+        end
+
+        def must_add_town?(entity)
+          entity.id == self.class::COMPANY_ADD_TOWN
         end
 
         def train_help(entity, runnable_trains, _routes)
@@ -715,6 +719,11 @@ module Engine
         def upgrades_to?(from, to, special = false, selected_company: nil)
           return true if special && tile_game_reserve?(to)
           return false if from.color == :yellow && plantation_assigned?(from.hex)
+
+          # Special case for P5 where we add a town to a tile
+          if self.class::TRACK_PLAIN.include?(from.name) && self.class::TRACK_TOWN.include?(to.name)
+            return Engine::Tile::COLORS.index(to.color) == (Engine::Tile::COLORS.index(from.color) + 1)
+          end
 
           result = super
 

--- a/lib/engine/game/g_1822_africa/step/special_track.rb
+++ b/lib/engine/game/g_1822_africa/step/special_track.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1822/step/special_track'
+
+module Engine
+  module Game
+    module G1822Africa
+      module Step
+        class SpecialTrack < G1822::Step::SpecialTrack
+          def available_hex(entity_or_entities, hex)
+            entities = Array(entity_or_entities)
+
+            # check for P5 (Add Town)
+            return nil if entities.any? { |e| @game.must_add_town?(e) } && (!hex.tile.towns.empty? || !hex.tile.cities.empty?)
+
+            super
+          end
+
+          def legal_tile_rotation?(entity_or_entities, hex, tile)
+            entities = Array(entity_or_entities)
+            entity, *_combo_entities = entities
+
+            # check for P5 (Add Town)
+            return legal_tile_rotation_remove_town?(entity.owner, hex, tile) if entities.any? { |e| @game.must_add_town?(e) }
+
+            super
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
P5 (Pullman) is replaced with P5 (Add Town) which works like P9 (Remove Town), but in reverse.