### PR TITLE
[1822Africa] Allow Pullman trains to visit stops with 0 visit cost

### DIFF
--- a/lib/engine/game/g_1822/step/route.rb
+++ b/lib/engine/game/g_1822/step/route.rb
@@ -32,7 +32,7 @@ module Engine
             @pullman_train.distance = [
               {
                 'nodes' => %w[city offboard],
-                'pay' => distance,
+                'pay' => 99,
                 'visit' => distance,
               },
               {


### PR DESCRIPTION
Fixes #9724

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Fixed in base 1822 because it may affect other versions too.