### PR TITLE
[multiple] clarifies text for teleport abilities

### DIFF
--- a/lib/engine/game/g_1830/entities.rb
+++ b/lib/engine/game/g_1830/entities.rb
@@ -40,8 +40,8 @@ module Engine
             revenue: 15,
             desc: 'A corporation owning the DH may place a tile and station token in the DH hex F16 for only the $120'\
                   " cost of the mountain. The station does not have to be connected to the remainder of the corporation's"\
-                  " route. The tile laid is the owning corporation's"\
-                  ' one tile placement for the turn. Blocks F16 while owned by a player.',
+                  " route. The tile laid is the owning corporation's one tile placement for the turn. The hex must be empty"\
+                  ' to use this ability. Blocks F16 while owned by a player.',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['F16'] },
                         {
                           type: 'teleport',

--- a/lib/engine/game/g_1836_jr30/entities.rb
+++ b/lib/engine/game/g_1836_jr30/entities.rb
@@ -37,8 +37,8 @@ module Engine
             revenue: 15,
             desc: 'Owning corporation may place a tile and station token in the CdH hex J8 for only the F60 cost of'\
                   ' the mountain. The track is not required to be connected to existing track of this corporation (or any'\
-                  " corporation), and can be used as a teleport. This counts as the corporation's track lay for that turn."\
-                  ' Blocks hex J8 while owned by player.',
+                  ' corporation), and can be used as a teleport. The hex must be empty to use this ability. This counts as '\
+                  " the corporation's track lay for that turn. Blocks hex J8 while owned by player.",
             sym: 'CdH',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['J8'] },
                         {

--- a/lib/engine/game/g_1836_jr56/entities.rb
+++ b/lib/engine/game/g_1836_jr56/entities.rb
@@ -39,8 +39,8 @@ module Engine
             revenue: 10,
             desc: 'Owning corporation may place a tile and station token in the CdH hex J8 for only the F60 cost of'\
                   ' the mountain. The track is not required to be connected to existing track of this corporation (or any'\
-                  " corporation), and can be used as a teleport. This counts as the corporation's track lay for that turn."\
-                  ' Blocks hex J8 while owned by player.',
+                  ' corporation), and can be used as a teleport. The hex must be empty to use this ability. This counts as'\
+                  " the corporation's track lay for that turn. Blocks hex J8 while owned by player.",
             sym: 'CdH',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['J8'] },
                         {


### PR DESCRIPTION
Fixes #[9818]

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Added a sentence explaining that the teleport ability in 1830 and both variants of 1836jr require that the teleport hex be empty in order to use the private ability, as I've seen the question come up more than once. 


