### PR TITLE
generalize values used for variable dividends

### DIFF
--- a/lib/engine/game/g_1840/step/dividend.rb
+++ b/lib/engine/game/g_1840/step/dividend.rb
@@ -181,10 +181,6 @@ module Engine
             @game.price_movement_chart
           end
 
-          def variable_share_multiplier(_corporation)
-            1
-          end
-
           def variable_input_step
             10
           end

--- a/lib/engine/game/g_18_mag/step/dividend.rb
+++ b/lib/engine/game/g_18_mag/step/dividend.rb
@@ -212,10 +212,6 @@ module Engine
           def variable_share_multiplier(corporation)
             corporation.total_shares
           end
-
-          def variable_input_step
-            1
-          end
         end
       end
     end

--- a/lib/engine/game/g_rolling_stock/step/dividend.rb
+++ b/lib/engine/game/g_rolling_stock/step/dividend.rb
@@ -76,14 +76,6 @@ module Engine
             @game.max_dividend_per_share(current_entity)
           end
 
-          def variable_share_multiplier(_corporation)
-            1
-          end
-
-          def variable_input_step
-            1
-          end
-
           def chart
             @game.dividend_chart(current_entity)
           end

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -48,6 +48,18 @@ module Engine
         end
       end
 
+      def variable_share_multiplier(_corporation)
+        1
+      end
+
+      def variable_input_step
+        1
+      end
+
+      def variable_max
+        1
+      end
+
       def process_dividend(action)
         entity = action.entity
         revenue = total_revenue

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -49,14 +49,18 @@ module Engine
       end
 
       def variable_share_multiplier(_corporation)
+        # For variable dividends, multiplier on chosen dividend
+        # (used for games where player chooses an amount per share to pay out rather than a flat dividend amount)
         1
       end
 
       def variable_input_step
+        # For variable dividends, allowed dividend modulo (e.g. 5, 10)
         1
       end
 
       def variable_max
+        # For variable dividends, maximum dividend allowed to be paid out
         1
       end
 


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Currently, if one creates a game with a "variable" dividend payout method and a custom 'dividend step', one must also define a specific set of methods in the custom step or the custom step will error out.

This attempts to shave off those rough edges by adding default methods in `step/dividend base`, which are called [from view/dividend](https://github.com/tobymao/18xx/blob/master/assets/app/view/game/dividend.rb#L147) to render the variable payout UI. 

I tried to set sane defaults here, LMK if these need tweaked

This also removes the relevant custom method definitions in 1840 and Rolling Stock which can just use those defaults

* **Screenshots**

* **Any Assumptions / Hacks**
