### PR TITLE
[1847 AE] Must sell shares in blocks

### DIFF
--- a/lib/engine/game/g_1847_ae/game.rb
+++ b/lib/engine/game/g_1847_ae/game.rb
@@ -503,7 +503,8 @@ module Engine
           # May sell president share only if someone else can become new president
           if corporation.owner == share_holder
             sh_values = corporation.share_holders.values
-            if sh_values.size < 2
+            if sh_values.size == 1
+              # No one else owns shares of the corporation
               bundles.reject!(&:presidents_share)
             else
               sh_values.sort!.reverse!

--- a/lib/engine/game/g_1847_ae/game.rb
+++ b/lib/engine/game/g_1847_ae/game.rb
@@ -26,6 +26,7 @@ module Engine
         SELL_MOVEMENT = :down_block
         TILE_RESERVATION_BLOCKS_OTHERS = :always
         CAPITALIZATION = :incremental
+        MUST_SELL_IN_BLOCKS = true
 
         BANK_CASH = 8_000
         CURRENCY_FORMAT_STR = '%sM'


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Add the missing "MUST_SELL_IN_BLOCKS" setting.
