### PR TITLE
1841: prohibit x-corp EMR buy; prohibit selling last non-pass placed token

### DIFF
--- a/lib/engine/game/g_1841/step/buy_token.rb
+++ b/lib/engine/game/g_1841/step/buy_token.rb
@@ -84,7 +84,7 @@ module Engine
               token.used &&
               city &&
               can_token_city?(entity, city) &&
-              other_corporation.placed_tokens.size > 1 &&
+              other_corporation.placed_tokens.count { |t| !t.city.pass? } > 1 &&
               @game.token_graph_for_entity(entity).connected_nodes(entity)[city]
           end
 

--- a/lib/engine/game/g_1841/step/buy_token.rb
+++ b/lib/engine/game/g_1841/step/buy_token.rb
@@ -84,7 +84,7 @@ module Engine
               token.used &&
               city &&
               can_token_city?(entity, city) &&
-              other_corporation.placed_tokens.count { |t| !t.city.pass? } > 1 &&
+              (city.pass? || other_corporation.placed_tokens.count { |t| !t.city.pass? } > 1) &&
               @game.token_graph_for_entity(entity).connected_nodes(entity)[city]
           end
 

--- a/lib/engine/game/g_1841/step/buy_train.rb
+++ b/lib/engine/game/g_1841/step/buy_train.rb
@@ -75,6 +75,10 @@ module Engine
             price = action.price
             player = entity.player
 
+            if entity.cash < price && action.train.owner != @game.depot
+              raise GameError, "#{entity.name} has insufficient cash to buy this train"
+            end
+
             if @emr_triggered && action.train.owner != @game.depot
               raise GameError, 'Must purchase first train from depot after EMR'
             end


### PR DESCRIPTION
Fixes #9832 
Fixes #9834 

The first fix will need to archive '41 games that broke the rules.