### PR TITLE
1822Africa - Remove sold out increase

### DIFF
--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -49,7 +49,6 @@ module Engine
 
         MUST_SELL_IN_BLOCKS = true
         SELL_MOVEMENT = :left_per_10_if_pres_else_left_one
-        SOLD_OUT_INCREASE = false
 
         GAME_END_CHECK = { stock_market: :current_or, custom: :full_or }.freeze
         GAME_END_REASONS_TEXT = Base::GAME_END_REASONS_TEXT.merge(

--- a/lib/engine/game/g_1822_africa/round/stock.rb
+++ b/lib/engine/game/g_1822_africa/round/stock.rb
@@ -76,17 +76,6 @@ module Engine
 
             # Increase player loans with 50% interest in SR x.2
             @game.add_interest_player_loans! if round_num == 2
-
-            # Move sold out corps stock value right
-            corporations_to_move_price.sort.each do |corp|
-              next unless corp.share_price
-
-              old_price = corp.share_price
-
-              sold_out_stock_movement(corp) if sold_out?(corp)
-
-              @game.log_share_price(corp, old_price)
-            end
           end
 
           def clear_bidboxes(bidbox_items)


### PR DESCRIPTION
Fixes #9837

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

1822Africa has a custom `finish_round` function for stock round and sold out increase was called unconditionally.