### PR TITLE
[1844] fixes placement of Appelzell name on map

### DIFF
--- a/lib/engine/game/g_1844/map.rb
+++ b/lib/engine/game/g_1844/map.rb
@@ -172,7 +172,7 @@ module Engine
           'D17' => 'Baden',
           'D19' => 'Zurich',
           'D21' => 'Rapperswil',
-          'D23' => 'Appelzell',
+          'D25' => 'Appelzell',
           'E8' => 'Biel',
           'E10' => 'Solothurn',
           'E18' => 'Zug',


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
"appelzell was labelling an empty hex instead of the correct city location (neighbouring hex)

* **Screenshots**

![image](https://github.com/tobymao/18xx/assets/26125362/2990e19a-f005-404a-9d60-ffedf25903eb)

