### PR TITLE
Add z-index to radial selector to ensure that all tiles appear on top.

### DIFF
--- a/assets/app/lib/radial_selector.rb
+++ b/assets/app/lib/radial_selector.rb
@@ -28,6 +28,8 @@ module Lib
         height: "#{size}px",
         filter: "drop-shadow(#{DROP_SHADOW_SIZE}px #{DROP_SHADOW_SIZE}px 2px #555)",
         pointerEvents: 'auto',
+        # set z-index to ensure that these tiles appear at the topmost level.
+        'z-index': '1',
       }
     end
   end


### PR DESCRIPTION
Fixes #9855

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Add a new z-index value to the radial selector.  This issue was introduced in https://github.com/tobymao/18xx/commit/9c0e13167f619f6c699e2e80a5a02ebb4b3d1204, specifically with adding `position: relative` in [this line](https://github.com/tobymao/18xx/blame/bb32b0318896fd2e63e72529ee47159b6484c47a/assets/app/view/tiles.rb#L62).  I don't know why this causes this problem specifically.  Alternatively, this `position:relative` could be reverted, but that causes issues in the tiles/test page that was added in that commit.  This seemed like the easier option.

    I could not recreate the second portion of that issue for upgrades not appearing.

* **Screenshots**

| Old | New |
| :---:        |   :---: |
| ![old](https://github.com/tobymao/18xx/assets/5263073/0c3dfbb0-54fc-45b9-878a-3f62d3661bf3) | ![new](https://github.com/tobymao/18xx/assets/5263073/177078c1-dcc1-43aa-b09d-a80f1b59ee7f) |


* **Any Assumptions / Hacks**
I checked for other instances of z-index but could not find any.  If something else with z-index was introduced, it could overlap on top of this.