### PR TITLE
[1850] fixes Western Land Grant closing, and typos

### DIFF
--- a/lib/engine/game/g_1850/entities.rb
+++ b/lib/engine/game/g_1850/entities.rb
@@ -128,6 +128,7 @@ module Engine
             when: 'track',
             hexes: [],
             tiles: %w[1 2 3 4 5 6 7 8 9 55 56 57 58 69],
+            closed_when_used_up: true,
           }],
           color: nil,
         },

--- a/lib/engine/game/g_1850/entities.rb
+++ b/lib/engine/game/g_1850/entities.rb
@@ -115,8 +115,8 @@ module Engine
           desc: 'The corporation owning the Western Land Grant is allowed extra construction of yellow track. During'\
                 ' the track laying phase, the owning corporation is allowed to lay a second tile which must be yellow. The'\
                 ' owning corporation may do this up to three times. Two of these track lays must be used west of the'\
-                ' Mississippi river, one may be used anywhere on the map. If none of the track lays have been used, this'\
-                ' company survives until phase six as a non-revenue company.',
+                ' Mississippi river, one may be used anywhere on the map. This company closes when all three track lays'\
+                ' have been used; otherwise it survives until phase six as a non-revenue paying company.',
           sym: 'WLG',
           abilities: [{
             type: 'tile_lay',

--- a/lib/engine/game/g_1850/game.rb
+++ b/lib/engine/game/g_1850/game.rb
@@ -262,8 +262,9 @@ module Engine
           @log << '-- Event: Private companies close --'
           @companies.each do |company|
             if company == gbc_company ||
-              (company == wlg_company && wlg_company.abilities&.first) ||
+              company == wlg_company ||
               (company == cm_company && cm_company.abilities&.first)
+
               company.revenue = 0
               next
             end

--- a/lib/engine/game/g_1850/game.rb
+++ b/lib/engine/game/g_1850/game.rb
@@ -14,7 +14,7 @@ module Engine
         include G1850::Entities
         include G1850::Map
 
-        attr_accessor :sell_queue, :connection_run, :reissued, :mesabi_token_counter, :mesabi_compnay_sold_or_closed
+        attr_accessor :sell_queue, :connection_run, :reissued, :mesabi_token_counter, :mesabi_company_sold_or_closed
 
         CORPORATION_CLASS = G1850::Corporation
         COMPANY_CLASS = G1850::Company
@@ -243,7 +243,7 @@ module Engine
         end
 
         def wlg_company
-          @wlg_compnay ||= company_by_id('WLG')
+          @wlg_company ||= company_by_id('WLG')
         end
 
         def gbc_company
@@ -262,7 +262,7 @@ module Engine
           @log << '-- Event: Private companies close --'
           @companies.each do |company|
             if company == gbc_company ||
-              (company == wlg_company && wlg_company.abilities&.first&.count == 3) ||
+              (company == wlg_company && wlg_company.abilities&.first) ||
               (company == cm_company && cm_company.abilities&.first)
               company.revenue = 0
               next
@@ -270,7 +270,7 @@ module Engine
 
             company.close!
           end
-          @mesabi_compnay_sold_or_closed = true
+          @mesabi_company_sold_or_closed = true
         end
 
         def event_close_remaining_companies!
@@ -296,7 +296,7 @@ module Engine
 
           buyer.mesabi_token = true
           @mesabi_token_counter -= 1
-          @mesabi_compnay_sold_or_closed = true
+          @mesabi_company_sold_or_closed = true
           log << "#{buyer.name} receives Mesabi token. #{@mesabi_token_counter} Mesabi tokens left in the game."
           log << '-- Corporations can now buy Mesabi tokens --'
         end

--- a/lib/engine/game/g_1850/step/track.rb
+++ b/lib/engine/game/g_1850/step/track.rb
@@ -82,7 +82,7 @@ module Engine
           def can_buy_mesabi_token?(entity)
             entity.corporation? &&
             !entity.mesabi_token &&
-            @game.mesabi_compnay_sold_or_closed &&
+            @game.mesabi_company_sold_or_closed &&
             @game.mesabi_token_counter.positive? &&
             entity.cash >= 80 &&
             hex_neighbors(entity, @game.mesabi_hex) &&


### PR DESCRIPTION

Fixes #9863

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Private was closing if any of the 3 tile lays had been used. Should only close if all 3 have been used. I updated the text on the private to match the text on the physical card, which also meant updating the abilities of the private to close immediately once all 3 tile lays have been used, which also allowed the method in game.rb to be simplified for WLG, since it only needs to check that it is still open. 

Also fixed several instances in the code where "company" was misspelled as "compnay"
