### PR TITLE
[18EU] moved back to beta

### DIFF
--- a/lib/engine/game/g_18_eu/meta.rb
+++ b/lib/engine/game/g_18_eu/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :production
+        DEV_STAGE = :beta
 
         GAME_DESIGNER = 'David Hecht'
         GAME_IMPLEMENTER = 'R. Ryan Driskel'


### PR DESCRIPTION
Fixes #9862 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Moves 18EU back to beta. From the Issue report: 
"There are currently 16 open bugs for 18EU. 11 of them are to do with the final exchange round. Several of these prevent the game from proceeding. The oldest of these reports is over a year old."

