### PR TITLE
[18Tokaido] Make sure initial round is finished properly

### DIFF
--- a/lib/engine/game/g_18_tokaido/game.rb
+++ b/lib/engine/game/g_18_tokaido/game.rb
@@ -299,8 +299,12 @@ module Engine
               reorder_players
               new_stock_round
             when Engine::Round::Auction
+              init_round_finished
               new_stock_round
             when Engine::Round::Stock
+              # If the initial round is a normal stock round,
+              # ensure that companies are closed properly if unclaimed.
+              init_round_finished unless @draft_finished
               @operating_rounds = @phase.operating_rounds
               @need_last_stock_round = false
               reorder_players


### PR DESCRIPTION
Any private companies remaining after the initial round should be closed via init_round_finished.  I verified the fix by taking the [given game](https://18xx.games/game/138956), undo all the way to the beginning, then redo all the way and I was able to proceed.

Fixes #9839

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
I added a big description in the issue, but the basic issue is that a private company ended up in the Bank by accident, and when private companies were paid out at the beginning of the operating round, there was sorting code that tried to compare a corporation to the bank.

* **Screenshots**

* **Any Assumptions / Hacks**
