### PR TITLE
[18NY] Use Operating Round base class for Capitalization Round.

### DIFF
--- a/lib/engine/game/g_18_ny/round/capitalization.rb
+++ b/lib/engine/game/g_18_ny/round/capitalization.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require_relative 'operating'
+require_relative '../../../round/operating'
 
 module Engine
   module Game
     module G18NY
       module Round
-        class Capitalization < Operating
+        class Capitalization < Engine::Round::Operating
           def name
             'Capitalization Round'
           end


### PR DESCRIPTION
18NY Operating Round class has special handling for auto actions. Don't inherit from it for the Capitalization Round.