### PR TITLE
[1848] Fix timing issue with calling actions and blocks?

### DIFF
--- a/lib/engine/game/g_1848/step/check_com_formation.rb
+++ b/lib/engine/game/g_1848/step/check_com_formation.rb
@@ -11,14 +11,10 @@ module Engine
 
           def actions(entity)
             return [] unless entity == current_entity
-
-            @connected = false
-
             return [] if @game.sydney_adelaide_connected
             return ACTIONS if @game.loading
             return [] unless @game.check_for_sydney_adelaide_connection
 
-            @connected = true
             ACTIONS
           end
 
@@ -26,12 +22,16 @@ module Engine
             'COM Sydney Adelaide Check'
           end
 
+          def active?
+            !@game.sydney_adelaide_connected
+          end
+
           def blocks?
-            @connected
+            @game.check_for_sydney_adelaide_connection
           end
 
           def auto_actions(entity)
-            return [] unless @connected
+            return [] unless @game.check_for_sydney_adelaide_connection
 
             [Engine::Action::DestinationConnection.new(entity)]
           end


### PR DESCRIPTION
Fixes #9847

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

    This issue was introduced in 6e628bec64f5bf0d6e5742a294b63ec40f3f1c53.  This commit reversed the order that `actions` and `blocking?` are evaluated in.  In the existing code for 1848, this order mattered, because `actions` had a side-effect to set `@connected` to true, which was then used in `blocks?`.

    When this order was reversed, `blocks?` will always return false, and `actions` will be short-circuited out of that check, never being evaluated.

    This change removes `@connected` and calls the actual connection check at each point to remove any ordering problems when things are called.  This change also deactivates the step once the connection is made.

* **Screenshots**

* **Any Assumptions / Hacks**
