### PR TITLE
[1880] skip P5 assignment if corp already has D

### DIFF
--- a/lib/engine/game/g_1880/step/assign.rb
+++ b/lib/engine/game/g_1880/step/assign.rb
@@ -9,13 +9,11 @@ module Engine
         class Assign < Engine::Step::Assign
           ACTIONS_WITH_PASS = %w[assign pass].freeze
           def actions(entity)
-            return [] if entity.player?
+            return [] if entity.player? || current_entity.minor?
             return [] unless @game.abilities(entity, :assign_corporation)
-            return [] if current_entity.minor? ||
-                        (entity == @game.p5 && current_entity.corporation? && current_entity.building_permits&.include?('D'))
 
             return ACTIONS if @game.forced_exchange_rocket? && entity == @game.rocket
-            return ACTIONS_WITH_PASS if p5_block? && current_entity.owner == @game.p5.owner
+            return ACTIONS_WITH_PASS if p5_block?
 
             super
           end
@@ -40,14 +38,13 @@ module Engine
           end
 
           def description
-            @game.forced_exchange_rocket? ? 'Forced Rocket exchange' : 'Assign'
+            @game.forced_exchange_rocket? ? 'Forced Exchange for Rocket of China' : 'Assign Jeme Tien Yow Engineer Office'
           end
 
           def help
             return super unless @game.forced_exchange_rocket?
 
-            'Rocket of China is still open at phase B3. Owner must trade the rocket of china,'\
-              ' pick one of the corporation to gain a 4 train'
+            'Owner of Rocket of China must choose one of their corporations to receive the next 4 train from the depot at no cost'
           end
 
           def blocks?
@@ -55,22 +52,24 @@ module Engine
           end
 
           def p5_block?
-            @game.phase.name[0] == 'D' && !@game.p5.all_abilities.empty?
+            @game.phase.name[0] == 'D' && !@game.p5.all_abilities.empty? && current_entity.corporation? \
+            && current_entity.owner == @game.p5.owner && !current_entity.building_permits&.include?('D')
           end
 
           def process_assign(action)
             return process_assign_rocket(action) if @game.forced_exchange_rocket?
+            raise GameError, "#{current_entity.id} already has a D permit" if current_entity.building_permits&.include?('D')
 
             super
             corporation = action.target
-            @game.log << "#{corporation.name} recieves a D building permit"
+            @game.log << "#{corporation.name} receives a D building permit"
             corporation.building_permits += 'D'
           end
 
           def process_assign_rocket(action)
             buying_corp = action.target
             train = @game.rocket_train || @game.depot.upcoming.first
-            @log << "#{buying_corp.name} exchanges the #{@game.rocket.name} for a #{train.name} train"
+            @log << "#{buying_corp.name} exchanges #{@game.rocket.name} for a free #{train.name} train"
 
             @game.rocket.close!
             @game.buy_train(buying_corp, train, :free)


### PR DESCRIPTION
Fixes #9791

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

I believe this will require pins, since players could have inserted a 'pass' action for an "Assignment" step which is now skipped

* **Explanation of Change**

Skips the 'P5 assignment step' when the active corp already has a D permit

Adds an error case if the player tries to assign P5 to a corp that already has a D permit

Also made some "happy to glad" changes to the verbiage

* **Screenshots**

The below cases assume that a corp is operating whose president owns the P5

To address the specific case in the issue: in D phase, the Assign step will NOT block (be skipped) if active corp already has a D permit

![image](https://github.com/tobymao/18xx/assets/1711810/9fb38c56-db18-40d2-9759-db931e610467)

in D phase, an Assign step will block if P5 can be used if active corp does not have a D permit
![image](https://github.com/tobymao/18xx/assets/1711810/1b6d1386-8fe1-46a5-8b3d-b06bfb0bf741)

P5 cannot be used if corp already has a D permit
![image](https://github.com/tobymao/18xx/assets/1711810/572c2da8-0d01-490a-a93b-4d3fb82355ef)

P5 can still be used earlier in the game
![image](https://github.com/tobymao/18xx/assets/1711810/448615f7-65d5-4eb3-98fb-94af542fe487)


* **Any Assumptions / Hacks**
