### PR TITLE
[rolling stock] fix broken dividend step

### DIFF
--- a/lib/engine/game/g_rolling_stock/step/dividend.rb
+++ b/lib/engine/game/g_rolling_stock/step/dividend.rb
@@ -76,6 +76,14 @@ module Engine
             @game.max_dividend_per_share(current_entity)
           end
 
+          def variable_share_multiplier(_corporation)
+            1
+          end
+
+          def variable_input_step
+            1
+          end
+
           def chart
             @game.dividend_chart(current_entity)
           end

--- a/public/fixtures/RollingStockStars/dividend.json
+++ b/public/fixtures/RollingStockStars/dividend.json
@@ -1,0 +1,1725 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1698181631,
+      "company": "MHE",
+      "price": 11
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1698183714
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1698205869
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1698214572
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 5,
+      "user": 545,
+      "created_at": 1698247607
+    },
+    {
+      "type": "undo",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 6,
+      "user": 545,
+      "created_at": 1698247609
+    },
+    {
+      "type": "bid",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1698247628,
+      "company": "AKE",
+      "price": 8
+    },
+    {
+      "type": "bid",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1698372220,
+      "company": "AKE",
+      "price": 9
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1698393260
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1698407946
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1698419240
+    },
+    {
+      "type": "bid",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1698442700,
+      "company": "BPM",
+      "price": 9
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1698446968
+    },
+    {
+      "type": "bid",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1698478855,
+      "company": "BPM",
+      "price": 10
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1698508831
+    },
+    {
+      "type": "bid",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1698553725,
+      "company": "BPM",
+      "price": 11
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1698564312
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1698575889
+    },
+    {
+      "type": "bid",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1698577576,
+      "company": "BME",
+      "price": 3
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1698590942
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1698608098
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1698609228,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3669,
+          "entity_type": "player",
+          "created_at": 1698609228
+        },
+        {
+          "type": "pass",
+          "entity": 6408,
+          "entity_type": "player",
+          "created_at": 1698609228
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "MHE",
+      "entity_type": "company",
+      "id": 23,
+      "created_at": 1698609384
+    },
+    {
+      "type": "par",
+      "entity": "BPM",
+      "corporation": "VM",
+      "entity_type": "company",
+      "share_price": "10,0,6",
+      "id": 24,
+      "user": 6408,
+      "created_at": 1698632468
+    },
+    {
+      "type": "undo",
+      "entity": "AKE",
+      "entity_type": "company",
+      "id": 25,
+      "user": 6408,
+      "created_at": 1698632480
+    },
+    {
+      "type": "par",
+      "entity": "BPM",
+      "entity_type": "company",
+      "id": 26,
+      "created_at": 1698632497,
+      "corporation": "VM",
+      "share_price": "10,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": "AKE",
+      "entity_type": "company",
+      "id": 27,
+      "created_at": 1698632570
+    },
+    {
+      "type": "par",
+      "entity": "BME",
+      "entity_type": "company",
+      "id": 28,
+      "created_at": 1698649312,
+      "corporation": "SI",
+      "share_price": "12,0,8"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 29,
+      "created_at": 1698678268,
+      "shares": [
+        "SI_1"
+      ],
+      "percent": 10,
+      "share_price": 13
+    },
+    {
+      "type": "bid",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 30,
+      "created_at": 1698686338,
+      "company": "WT",
+      "price": 11
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 31,
+      "created_at": 1698689460
+    },
+    {
+      "type": "bid",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 32,
+      "created_at": 1698689594,
+      "company": "KME",
+      "price": 7
+    },
+    {
+      "type": "undo",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 33,
+      "user": 3669,
+      "created_at": 1698689627
+    },
+    {
+      "type": "redo",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 34,
+      "user": 3669,
+      "created_at": 1698689712
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1698689787
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1698689813
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 37,
+      "created_at": 1698703802
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 38,
+      "created_at": 1698708007,
+      "shares": [
+        "VM_1"
+      ],
+      "percent": 10,
+      "share_price": 11
+    },
+    {
+      "type": "bid",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 39,
+      "created_at": 1698709708,
+      "company": "SX",
+      "price": 16
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 40,
+      "created_at": 1698748762
+    },
+    {
+      "type": "bid",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 41,
+      "created_at": 1698748786,
+      "company": "BY",
+      "price": 12
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 42,
+      "created_at": 1698748867
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 43,
+      "created_at": 1698754864
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 44,
+      "created_at": 1698764343
+    },
+    {
+      "type": "offer",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 45,
+      "created_at": 1698766669,
+      "corporation": "SI",
+      "company": "KME",
+      "price": 7
+    },
+    {
+      "type": "offer",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 46,
+      "created_at": 1698766677,
+      "corporation": "SI",
+      "company": "MHE",
+      "price": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 47,
+      "created_at": 1698766706
+    },
+    {
+      "type": "offer",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 48,
+      "created_at": 1698768427,
+      "corporation": "VM",
+      "company": "AKE",
+      "price": 8
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 49,
+      "created_at": 1698769168,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 10481,
+          "entity_type": "player",
+          "created_at": 1698769168
+        },
+        {
+          "type": "pass",
+          "entity": 545,
+          "entity_type": "player",
+          "created_at": 1698769168
+        },
+        {
+          "type": "pass",
+          "entity": 3669,
+          "entity_type": "player",
+          "created_at": 1698769168
+        },
+        {
+          "type": "pass",
+          "entity": 6408,
+          "entity_type": "player",
+          "created_at": 1698769168
+        }
+      ]
+    },
+    {
+      "kind": "variable",
+      "type": "dividend",
+      "amount": 4,
+      "entity": "SI",
+      "entity_type": "corporation",
+      "id": 50,
+      "user": 3669,
+      "created_at": 1698771918
+    },
+    {
+      "type": "undo",
+      "entity": "VM",
+      "entity_type": "corporation",
+      "id": 51,
+      "user": 3669,
+      "created_at": 1698771927
+    },
+    {
+      "type": "dividend",
+      "entity": "SI",
+      "entity_type": "corporation",
+      "id": 52,
+      "created_at": 1698771960,
+      "kind": "variable",
+      "amount": 1
+    },
+    {
+      "type": "dividend",
+      "entity": "VM",
+      "entity_type": "corporation",
+      "id": 53,
+      "created_at": 1698771990,
+      "kind": "variable",
+      "amount": 3
+    },
+    {
+      "type": "sell_shares",
+      "entity": "SI",
+      "entity_type": "corporation",
+      "id": 54,
+      "created_at": 1698772057,
+      "shares": [
+        "SI_2"
+      ],
+      "percent": 10,
+      "share_price": 14
+    },
+    {
+      "type": "pass",
+      "entity": "VM",
+      "entity_type": "corporation",
+      "id": 55,
+      "created_at": 1698772192
+    },
+    {
+      "type": "par",
+      "entity": "SX",
+      "entity_type": "company",
+      "id": 56,
+      "created_at": 1698773363,
+      "corporation": "SM",
+      "share_price": "16,0,11"
+    },
+    {
+      "type": "par",
+      "entity": "BY",
+      "corporation": "PR",
+      "entity_type": "company",
+      "share_price": "12,0,8",
+      "id": 57,
+      "user": 10481,
+      "created_at": 1698776612
+    },
+    {
+      "type": "undo",
+      "entity": "WT",
+      "entity_type": "company",
+      "id": 58,
+      "user": 10481,
+      "created_at": 1698776646
+    },
+    {
+      "type": "par",
+      "entity": "BY",
+      "corporation": "PR",
+      "entity_type": "company",
+      "share_price": "18,0,12",
+      "id": 59,
+      "user": 10481,
+      "created_at": 1698776678
+    },
+    {
+      "type": "undo",
+      "entity": "WT",
+      "entity_type": "company",
+      "id": 60,
+      "user": 10481,
+      "created_at": 1698776701
+    },
+    {
+      "type": "par",
+      "entity": "BY",
+      "entity_type": "company",
+      "id": 61,
+      "created_at": 1698776713,
+      "corporation": "PR",
+      "share_price": "10,0,6"
+    },
+    {
+      "type": "par",
+      "entity": "WT",
+      "entity_type": "company",
+      "id": 62,
+      "created_at": 1698776770,
+      "corporation": "DA",
+      "share_price": "12,0,8"
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 63,
+      "created_at": 1698776787
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 64,
+      "created_at": 1698783801
+    },
+    {
+      "type": "bid",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 66,
+      "created_at": 1698791527,
+      "company": "OL",
+      "price": 15
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 68,
+      "created_at": 1698794970
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 69,
+      "created_at": 1698828277
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 70,
+      "created_at": 1698847131
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 71,
+      "created_at": 1698847252
+    },
+    {
+      "type": "offer",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 72,
+      "created_at": 1698847262,
+      "corporation": "SI",
+      "company": "OL",
+      "price": 20
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 73,
+      "created_at": 1698847428
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 74,
+      "created_at": 1698847520
+    },
+    {
+      "type": "offer",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 75,
+      "created_at": 1698855274,
+      "corporation": "PR",
+      "company": "HE",
+      "price": 18
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 76,
+      "created_at": 1698856078
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 79,
+      "created_at": 1698871058,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 10481,
+          "entity_type": "player",
+          "created_at": 1698871057
+        },
+        {
+          "type": "pass",
+          "entity": 3669,
+          "entity_type": "player",
+          "created_at": 1698871057
+        },
+        {
+          "type": "pass",
+          "entity": 6408,
+          "entity_type": "player",
+          "created_at": 1698871057
+        },
+        {
+          "type": "pass",
+          "entity": 545,
+          "entity_type": "player",
+          "created_at": 1698871057
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SM",
+      "entity_type": "corporation",
+      "id": 80,
+      "created_at": 1698877798,
+      "kind": "variable",
+      "amount": 4
+    },
+    {
+      "type": "dividend",
+      "entity": "SI",
+      "entity_type": "corporation",
+      "id": 81,
+      "created_at": 1698901183,
+      "kind": "variable",
+      "amount": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DA",
+      "entity_type": "corporation",
+      "id": 82,
+      "created_at": 1698909215,
+      "kind": "variable",
+      "amount": 2
+    },
+    {
+      "type": "dividend",
+      "entity": "VM",
+      "entity_type": "corporation",
+      "id": 83,
+      "created_at": 1698930452,
+      "kind": "variable",
+      "amount": 3
+    },
+    {
+      "type": "dividend",
+      "entity": "PR",
+      "entity_type": "corporation",
+      "id": 84,
+      "created_at": 1698938193,
+      "kind": "variable",
+      "amount": 0
+    },
+    {
+      "type": "sell_shares",
+      "entity": "SI",
+      "entity_type": "corporation",
+      "id": 85,
+      "created_at": 1698938442,
+      "shares": [
+        "SI_3"
+      ],
+      "percent": 10,
+      "share_price": 14
+    },
+    {
+      "type": "sell_shares",
+      "entity": "SM",
+      "entity_type": "corporation",
+      "id": 86,
+      "created_at": 1698939307,
+      "shares": [
+        "SM_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": "DA",
+      "entity_type": "corporation",
+      "id": 87,
+      "created_at": 1698944656,
+      "shares": [
+        "DA_2"
+      ],
+      "percent": 10,
+      "share_price": 10
+    },
+    {
+      "type": "pass",
+      "entity": "PR",
+      "entity_type": "corporation",
+      "id": 88,
+      "created_at": 1698944666
+    },
+    {
+      "type": "pass",
+      "entity": "VM",
+      "entity_type": "corporation",
+      "id": 89,
+      "created_at": 1698949634
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 90,
+      "created_at": 1698949680,
+      "shares": [
+        "SI_2"
+      ],
+      "percent": 10,
+      "share_price": 18
+    },
+    {
+      "type": "sell_shares",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 92,
+      "created_at": 1698951776,
+      "shares": [
+        "SI_1"
+      ],
+      "percent": 10,
+      "share_price": 14
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 95,
+      "created_at": 1698952567
+    },
+    {
+      "type": "bid",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 96,
+      "created_at": 1698953853,
+      "company": "DSB",
+      "price": 20
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 97,
+      "created_at": 1698962846
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 98,
+      "created_at": 1698978179
+    },
+    {
+      "type": "bid",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 99,
+      "created_at": 1698980461,
+      "company": "NS",
+      "price": 22
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 101,
+      "created_at": 1699000681
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 102,
+      "created_at": 1699001835
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 103,
+      "created_at": 1699016385,
+      "shares": [
+        "VM_1"
+      ],
+      "percent": 10,
+      "share_price": 9
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 104,
+      "created_at": 1699023290
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 105,
+      "created_at": 1699024690
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 106,
+      "created_at": 1699024867
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 107,
+      "created_at": 1699035990,
+      "shares": [
+        "SI_2"
+      ],
+      "percent": 10,
+      "share_price": 13
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 108,
+      "created_at": 1699036100
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 109,
+      "created_at": 1699046008
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 110,
+      "created_at": 1699046135
+    },
+    {
+      "type": "program_close_pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 111,
+      "created_at": 1699046607,
+      "unconditional": false
+    },
+    {
+      "type": "program_disable",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 112,
+      "created_at": 1699046611,
+      "reason": "user",
+      "original_type": "program_close_pass"
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 113,
+      "created_at": 1699046612,
+      "unconditional": true,
+      "indefinite": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 114,
+      "created_at": 1699063604,
+      "shares": [
+        "VM_0"
+      ],
+      "percent": 10,
+      "share_price": 8
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 115,
+      "created_at": 1699063714
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 116,
+      "created_at": 1699091887,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3669,
+          "entity_type": "player",
+          "created_at": 1699091884
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 117,
+      "created_at": 1699109456,
+      "shares": [
+        "DA_1"
+      ],
+      "percent": 10,
+      "share_price": 11
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 118,
+      "created_at": 1699113166
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 119,
+      "created_at": 1699139685,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3669,
+          "entity_type": "player",
+          "created_at": 1699139683
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 120,
+      "created_at": 1699163624,
+      "shares": [
+        "DA_2"
+      ],
+      "percent": 10,
+      "share_price": 14
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 121,
+      "created_at": 1699164175
+    },
+    {
+      "type": "sell_shares",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 122,
+      "created_at": 1699183220,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3669,
+          "entity_type": "player",
+          "created_at": 1699183218
+        }
+      ],
+      "shares": [
+        "DA_1"
+      ],
+      "percent": 10,
+      "share_price": 11
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 123,
+      "created_at": 1699194501
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 124,
+      "created_at": 1699195501
+    },
+    {
+      "type": "buy_shares",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 125,
+      "created_at": 1699197010,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3669,
+          "entity_type": "player",
+          "created_at": 1699197007
+        }
+      ],
+      "shares": [
+        "PR_2"
+      ],
+      "percent": 10,
+      "share_price": 14
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 126,
+      "created_at": 1699228874
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 127,
+      "created_at": 1699231315
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 128,
+      "created_at": 1699263259
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 129,
+      "created_at": 1699263278
+    },
+    {
+      "type": "offer",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 130,
+      "created_at": 1699264254,
+      "corporation": "SI",
+      "company": "DSB",
+      "price": 26
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 131,
+      "created_at": 1699264266
+    },
+    {
+      "type": "offer",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 132,
+      "created_at": 1699284482,
+      "corporation": "SM",
+      "company": "NS",
+      "price": 27
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 133,
+      "created_at": 1699284516
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 134,
+      "created_at": 1699324384,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 10481,
+          "entity_type": "player",
+          "created_at": 1699324384
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 135,
+      "user": 6408,
+      "created_at": 1699324394
+    },
+    {
+      "type": "undo",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 136,
+      "user": 6408,
+      "created_at": 1699324400
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 137,
+      "created_at": 1699324425
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 138,
+      "created_at": 1699333139,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 545,
+          "entity_type": "player",
+          "created_at": 1699333138
+        }
+      ]
+    },
+    {
+      "kind": "variable",
+      "type": "dividend",
+      "amount": 0,
+      "entity": "SM",
+      "entity_type": "corporation",
+      "id": 139,
+      "user": 545,
+      "created_at": 1699335914
+    },
+    {
+      "type": "undo",
+      "entity": "PR",
+      "entity_type": "corporation",
+      "id": 140,
+      "user": 545,
+      "created_at": 1699335919
+    },
+    {
+      "type": "dividend",
+      "entity": "SM",
+      "entity_type": "corporation",
+      "id": 141,
+      "created_at": 1699335989,
+      "kind": "variable",
+      "amount": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PR",
+      "entity_type": "corporation",
+      "id": 142,
+      "created_at": 1699344529,
+      "kind": "variable",
+      "amount": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SI",
+      "entity_type": "corporation",
+      "id": 143,
+      "created_at": 1699346428,
+      "kind": "variable",
+      "amount": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DA",
+      "entity_type": "corporation",
+      "id": 144,
+      "created_at": 1699365953,
+      "kind": "variable",
+      "amount": 3
+    },
+    {
+      "type": "pass",
+      "entity": "PR",
+      "entity_type": "corporation",
+      "id": 145,
+      "created_at": 1699370767
+    },
+    {
+      "type": "sell_shares",
+      "entity": "SM",
+      "entity_type": "corporation",
+      "id": 146,
+      "created_at": 1699371250,
+      "shares": [
+        "SM_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "DA",
+      "entity_type": "corporation",
+      "id": 147,
+      "created_at": 1699371845
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 148,
+      "created_at": 1699371862
+    },
+    {
+      "type": "bid",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 149,
+      "created_at": 1699372291,
+      "company": "DR",
+      "price": 29
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 150,
+      "created_at": 1699372620
+    },
+    {
+      "type": "bid",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 151,
+      "created_at": 1699373037,
+      "company": "KK",
+      "price": 21
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 152,
+      "created_at": 1699375131
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 153,
+      "created_at": 1699377299
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 154,
+      "created_at": 1699382337
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 155,
+      "created_at": 1699389524
+    },
+    {
+      "type": "offer",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 156,
+      "created_at": 1699389629,
+      "corporation": "SM",
+      "company": "KK",
+      "price": 24
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 157,
+      "created_at": 1699389704
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 158,
+      "created_at": 1699393969
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 159,
+      "created_at": 1699396142
+    },
+    {
+      "type": "offer",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 160,
+      "created_at": 1699433005,
+      "corporation": "PR",
+      "company": "PR",
+      "price": 25
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 161,
+      "created_at": 1699433017
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 162,
+      "created_at": 1699433162
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 163,
+      "created_at": 1699433240,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 6408,
+          "entity_type": "player",
+          "created_at": 1699433239
+        },
+        {
+          "type": "pass",
+          "entity": 545,
+          "entity_type": "player",
+          "created_at": 1699433239
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SI",
+      "entity_type": "corporation",
+      "id": 164,
+      "created_at": 1699433455,
+      "kind": "variable",
+      "amount": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PR",
+      "entity_type": "corporation",
+      "id": 165,
+      "created_at": 1699433800,
+      "kind": "variable",
+      "amount": 2
+    },
+    {
+      "type": "dividend",
+      "entity": "SM",
+      "entity_type": "corporation",
+      "id": 166,
+      "created_at": 1699458487,
+      "kind": "variable",
+      "amount": 2
+    },
+    {
+      "type": "dividend",
+      "entity": "DA",
+      "entity_type": "corporation",
+      "id": 167,
+      "created_at": 1699480875,
+      "kind": "variable",
+      "amount": 4
+    },
+    {
+      "type": "sell_shares",
+      "entity": "SM",
+      "entity_type": "corporation",
+      "id": 168,
+      "created_at": 1699490425,
+      "shares": [
+        "SM_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "PR",
+      "entity_type": "corporation",
+      "id": 169,
+      "created_at": 1699493857
+    },
+    {
+      "type": "pass",
+      "entity": "DA",
+      "entity_type": "corporation",
+      "id": 170,
+      "created_at": 1699556465
+    },
+    {
+      "type": "pass",
+      "entity": "DR",
+      "entity_type": "company",
+      "id": 171,
+      "created_at": 1699557529
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 172,
+      "user": 6408,
+      "created_at": 1699588323
+    },
+    {
+      "type": "undo",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 173,
+      "user": 6408,
+      "created_at": 1699588328
+    },
+    {
+      "type": "sell_shares",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 174,
+      "created_at": 1699588344,
+      "shares": [
+        "DA_2"
+      ],
+      "percent": 10,
+      "share_price": 10
+    },
+    {
+      "type": "bid",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 175,
+      "created_at": 1699591257,
+      "company": "RENFE",
+      "price": 33
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 176,
+      "created_at": 1699628252
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 177,
+      "created_at": 1699630356
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6408,
+      "shares": [
+        "SI_3"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "share_price": 27,
+      "id": 178,
+      "user": 6408,
+      "created_at": 1699632462
+    },
+    {
+      "type": "undo",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 179,
+      "user": 6408,
+      "created_at": 1699632471
+    },
+    {
+      "type": "buy_shares",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 180,
+      "created_at": 1699632476,
+      "shares": [
+        "SM_1"
+      ],
+      "percent": 10,
+      "share_price": 22
+    },
+    {
+      "type": "undo",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 181,
+      "user": 545,
+      "created_at": 1699632479
+    },
+    {
+      "type": "redo",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 182,
+      "user": 545,
+      "created_at": 1699632484
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 183,
+      "created_at": 1699632567
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 184,
+      "created_at": 1699632796
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 185,
+      "created_at": 1699633675
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 186,
+      "created_at": 1699722801
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 187,
+      "created_at": 1699722815
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 188,
+      "created_at": 1699722816
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 189,
+      "created_at": 1699722816
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 190,
+      "created_at": 1699722817
+    },
+    {
+      "type": "pass",
+      "entity": 3669,
+      "entity_type": "player",
+      "id": 191,
+      "created_at": 1699722818
+    },
+    {
+      "type": "pass",
+      "entity": 10481,
+      "entity_type": "player",
+      "id": 192,
+      "created_at": 1699722820
+    },
+    {
+      "type": "pass",
+      "entity": 545,
+      "entity_type": "player",
+      "id": 193,
+      "created_at": 1699722820
+    },
+    {
+      "type": "pass",
+      "entity": 6408,
+      "entity_type": "player",
+      "id": 194,
+      "created_at": 1699739133
+    },
+    {
+      "type": "end_game",
+      "entity": "SI",
+      "entity_type": "corporation",
+      "id": 195,
+      "created_at": 1699740037
+    }
+  ],
+  "id": "hs_bgcavcet_138858",
+  "players": [
+    {
+      "id": 3669,
+      "name": "DSteiner"
+    },
+    {
+      "id": 545,
+      "name": "SamK"
+    },
+    {
+      "id": 6408,
+      "name": "debellefeuille"
+    },
+    {
+      "id": 10481,
+      "name": "beardurham"
+    }
+  ],
+  "title": "Rolling Stock Stars",
+  "description": "Cloned from game 138858",
+  "min_players": 4,
+  "max_players": 4,
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "settings": {
+    "seed": 1865480081,
+    "is_async": true,
+    "unlisted": false,
+    "auto_routing": null,
+    "player_order": null,
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "turn": 6,
+  "round": "Dividends",
+  "acting": [
+    3669
+  ],
+  "result": {"10481":63.0, "3669":64.0, "545":62.0, "6408":41.0},
+  "loaded": true,
+  "created_at": "2023-11-11",
+  "updated_at": 1699740037,
+  "finished_at": null,
+  "mode": "hotseat",
+  "manually_ended": true
+}


### PR DESCRIPTION
Fixes #9888

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Rolling stock's dividend step used to inherit from base.rb instead of base/dividend.rb, for some reason

Also adds a test file

* **Screenshots**

* **Any Assumptions / Hacks**
