### PR TITLE
don't override dividend history when skipping dividend step

### DIFF
--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -34,9 +34,6 @@ module Engine
 
       def skip!
         process_dividend(Action::Dividend.new(current_entity, kind: 'withhold'))
-
-        current_entity.operating_history[[@game.turn, @round.round_num]] =
-          OperatingInfo.new([], @game.actions.last, 0, @round.laid_hexes)
       end
 
       def dividend_options(entity)

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -33,7 +33,10 @@ module Engine
       end
 
       def skip!
-        process_dividend(Action::Dividend.new(current_entity, kind: 'withhold'))
+        # insert a dummy action so the operating history has something to link to
+        action = Action::Dividend.new(current_entity, kind: 'withhold')
+        action.id = @game.actions.last.id if @game.actions.last
+        process_dividend(action)
       end
 
       def dividend_options(entity)


### PR DESCRIPTION
Fixes #9882

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

The base dividend `skip!` function was overriding corp operating history to insert a zero payout 'withhold'

I wanted to double-check that in such cases we were still outputting corp operation history, so I checked and every game that overrides `process_dividend()` will still output corp operating history - either implementing a game-specific operating history (i.e. games with "psuedo-corps" like Bank of England) or calling `super`

* **Screenshots**

![Screenshot 2023-11-11 5 14 46 PM](https://github.com/tobymao/18xx/assets/1711810/0491f6aa-5dd4-464d-b982-60134b128483)


* **Any Assumptions / Hacks**
