### PR TITLE
[1848] output BoE revenue history

### DIFF
--- a/lib/engine/game/g_1848/step/dividend.rb
+++ b/lib/engine/game/g_1848/step/dividend.rb
@@ -38,6 +38,12 @@ module Engine
             revenue = calculate_boe_revenue
             payout = send(:payout, entity, revenue)
             payout_shares(entity, revenue) if payout[:per_share].positive?
+            entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
+          [],
+          action,
+          revenue,
+          @round.laid_hexes
+        )
             pass!
           end
 

--- a/lib/engine/game/g_1848/step/dividend.rb
+++ b/lib/engine/game/g_1848/step/dividend.rb
@@ -38,6 +38,7 @@ module Engine
             revenue = calculate_boe_revenue
             payout = send(:payout, entity, revenue)
             payout_shares(entity, revenue) if payout[:per_share].positive?
+            action.id = @game.actions.last.id
             entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
           [],
           action,


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Output revenue history for BoE

* **Screenshots**

before:
![Screenshot 2023-11-11 5 20 28 PM](https://github.com/tobymao/18xx/assets/1711810/563c527d-8848-4c23-a1ea-6ef1cacc6529)


after:
![Screenshot 2023-11-11 5 05 11 PM](https://github.com/tobymao/18xx/assets/1711810/024f0035-900a-4f22-84e1-6dd160fa6792)



* **Any Assumptions / Hacks**
