### PR TITLE
18 tokaido fix sort key issue

### DIFF
--- a/lib/engine/game/g_18_tokaido/game.rb
+++ b/lib/engine/game/g_18_tokaido/game.rb
@@ -299,12 +299,8 @@ module Engine
               reorder_players
               new_stock_round
             when Engine::Round::Auction
-              init_round_finished
               new_stock_round
             when Engine::Round::Stock
-              # If the initial round is a normal stock round,
-              # ensure that companies are closed properly if unclaimed.
-              init_round_finished unless @draft_finished
               @operating_rounds = @phase.operating_rounds
               @need_last_stock_round = false
               reorder_players

--- a/lib/engine/game/g_18_tokaido/game.rb
+++ b/lib/engine/game/g_18_tokaido/game.rb
@@ -400,7 +400,7 @@ module Engine
 
         def payout_companies(ignore: [])
           companies = @companies.select do |c|
-            c.owner && !c.owner.is_a?(Engine::Bank) && c.revenue.positive? && !ignore.include?(c.id)
+            c.owner && c.owner != bank && c.revenue.positive? && !ignore.include?(c.id)
           end
 
           companies.sort_by! do |company|
@@ -413,8 +413,6 @@ module Engine
 
           companies.each do |company|
             owner = company.owner
-            next if owner == bank
-
             revenue = company.revenue
             @bank.spend(revenue, owner)
             @log << "#{owner.name} collects #{format_currency(revenue)} from #{company.name}"


### PR DESCRIPTION
Fixes #9902, backs out the breaking change for #9839 and fixes that underlying issue.

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

There's a sort in `payout_companies` that breaks when both the bank and corporations own anything (works fine if it's only one or the other).  @andrewzwicky tracked that down, but his change both broke a bunch of existing games where the corporations weren't already removed, and also...  They're not supposed to be removed.  So I backed out that change and fixed the actual sort issue.

TBH, I think the version of `payout_companies` I put in my game object could go in the main engine (whether you filter out the bank owned companies or short-circuit the payout loop, the result is the same), but in the interests of not potentially breaking anything else, I just did the minimal thing.
