### PR TITLE
[improvement] Adds the development status to game cards on homepage

### DIFF
--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -122,9 +122,22 @@ module View
         },
       }
 
+      dev_status = game.meta::DEV_STAGE
+      prototype_status = game.meta::PROTOTYPE
+
+      game_status = if dev_status != :production && prototype_status
+                      " (#{dev_status} prototype)"
+                    elsif dev_status != :production
+                      " (#{dev_status})"
+                    elsif prototype_status
+                      ' (prototype)'
+                    else
+                      ''
+                    end
+
       h('div.header', div_props, [
         h(:div, text_props, [
-          h(:div, "Game: #{game.display_title}"),
+          h(:div, "Game: #{game.display_title}" + game_status),
           h('div.nowrap', owner_props, "Owner: #{@gdata['user']['name']}"),
         ]),
         h(:div, buttons_props, buttons),

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -123,21 +123,13 @@ module View
       }
 
       dev_status = game.meta::DEV_STAGE
-      prototype_status = game.meta::PROTOTYPE
-
-      game_status = if dev_status != :production && prototype_status
-                      " (#{dev_status} prototype)"
-                    elsif dev_status != :production
-                      " (#{dev_status})"
-                    elsif prototype_status
-                      ' (prototype)'
-                    else
-                      ''
-                    end
 
       h('div.header', div_props, [
         h(:div, text_props, [
-          h(:div, "Game: #{game.display_title}" + game_status),
+          h(:div, [
+            "Game: #{game.display_title}",
+            (dev_status != :production ? " (#{dev_status})" : ''),
+          ].join),
           h('div.nowrap', owner_props, "Owner: #{@gdata['user']['name']}"),
         ]),
         h(:div, buttons_props, buttons),


### PR DESCRIPTION
Fixes #9913

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Adds the dev_stage of games in the game card on the main page, unless the game is already in production.

* **Screenshots**
![image](https://github.com/tobymao/18xx/assets/26125362/24800634-fa01-4fc6-9d8d-37065fb24204)

* **Any Assumptions / Hacks**
You can ignore the first commit, I was initially also including prototype status, and the game location. Toby requested not to include location, and it was decided that prototype was also unnecessary.