### PR TITLE
[1844] Fixes payout on sales of unoperated corps

### DIFF
--- a/lib/engine/game/g_1844/game.rb
+++ b/lib/engine/game/g_1844/game.rb
@@ -703,7 +703,7 @@ module Engine
           return bundles if bundles.empty? || corporation.operated?
 
           bundles.each do |bundle|
-            bundle.share_price = @stock_market.find_share_price(corporation, Array.new(bundle.num_shares) { :down }).price
+            bundle.share_price = @stock_market.find_share_price(corporation, :down).price
           end
           bundles
         end


### PR DESCRIPTION
Fixes #9916


### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
In the current implementation, when selling shares of an unoperated corp, the payout was determined by checking the find_share_price method and then going :down a number of spaces equal to the amount of shares sold. However, in 1844, the price only drops once per bundle sold. 

I corrected the calculation.
