### PR TITLE
[1849] autopass tweak

### DIFF
--- a/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
@@ -71,9 +71,16 @@ module Engine
             if !share_to_buy || !share_to_buy.last_cert
               @game.corporations.each do |corporation|
                 share = corporation.ipo_shares.find(&:last_cert)
+                if share && @game.last_cert_last?(share.to_bundle) &&
+                  corporation.holding_ok?(entity, share.percent) &&
+                  !@round.players_sold[entity][corporation]
+                  return "20% double cert for #{corporation.name} is currently available from the treasury"
+                end
+
                 share ||= @game.share_pool.shares_by_corporation[corporation].find(&:last_cert)
-                if share && @game.last_cert_last?(share.to_bundle) && corporation.holding_ok?(entity, share.percent)
-                  return "Last cert available for #{corporation.name}"
+                if share && @game.last_cert_last?(share.to_bundle) &&
+                  corporation.holding_ok?(entity, share.percent)
+                  return "20% double cert for #{corporation.name} is currently available from the bank pool"
                 end
               end
             end


### PR DESCRIPTION
Fixes #8384

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Currently, autopass always disables if the 20% final cert is available for purchase and you can afford it. 

This update first checks if the share is in the treasury, and then verifies if the active player has sold shares this round. If yes, autopass remains enabled. It then checks if the share is available from the bank pool. In that case, autopass is disabled even if the player has previously sold shares, in the event that the active player wants to sell a share to block the purchase of the double share. 

* **Screenshots**

* **Any Assumptions / Hacks**
