### PR TITLE
[1868WY] move to beta; also add "simple" 2p variant

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -17,7 +17,7 @@ module View
 
     def render_notification
       message = <<~MESSAGE
-        <p><a href="https://github.com/tobymao/18xx/wiki/1894">1894</a> and <a href="https://github.com/tobymao/18xx/wiki/1844">1844</a> are now in alpha. <a href="https://github.com/tobymao/18xx/wiki/1858">1858</a> is in beta.</p>
+        <p><a href="https://github.com/tobymao/18xx/wiki/1868%20Wyoming">1868 Wyoming</a> is in beta.</p>
         <p>Learn how to get <a href='https://github.com/tobymao/18xx/wiki/Notifications'>notifications</a> by email, Slack, Discord, and Telegram.</p>
         <p>Please submit problem reports and make suggestions for improvements on
         <a href='https://github.com/tobymao/18xx/issues'>GitHub</a>. Join the

--- a/lib/engine/game/g_1868_wy/meta.rb
+++ b/lib/engine/game/g_1868_wy/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :alpha
+        DEV_STAGE = :beta
 
         GAME_DESIGNER = 'John Harres'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1868-Wyoming'
@@ -23,6 +23,16 @@ module Engine
         GAME_ISSUE_LABEL = '1868WY'
 
         PLAYER_RANGE = [3, 5].freeze
+
+        GAME_VARIANTS = [
+          {
+            sym: :simple_2p,
+            name: 'Simple 2p Variant',
+            title: '1868 Wyoming Simple 2p',
+            desc: 'Adjusted cert limit and starting cash, but does not use 2-player rules from '\
+                  'section 11 of the rulebook.',
+          },
+        ].freeze
 
         OPTIONAL_RULES = [
           {

--- a/lib/engine/game/g_1868_wy_simple_2p.rb
+++ b/lib/engine/game/g_1868_wy_simple_2p.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1868WYSimple2p
+    end
+  end
+end

--- a/lib/engine/game/g_1868_wy_simple_2p/game.rb
+++ b/lib/engine/game/g_1868_wy_simple_2p/game.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative 'meta'
+require_relative '../g_1868_wy/game'
+
+module Engine
+  module Game
+    module G1868WYSimple2p
+      class Game < G1868WY::Game
+        include_meta(G1868WYSimple2p::Meta)
+
+        STARTING_CASH = { 2 => 1100 }.freeze
+        CERT_LIMIT = { 2 => 30 }.freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1868_wy_simple_2p/meta.rb
+++ b/lib/engine/game/g_1868_wy_simple_2p/meta.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative '../meta'
+require_relative '../g_1868_wy/meta'
+
+module Engine
+  module Game
+    module G1868WYSimple2p
+      module Meta
+        include Game::Meta
+        include G1868WY::Meta
+
+        DEPENDS_ON = '1868 Wyoming'
+
+        GAME_ALIASES = ['1868 Wyoming 2p'].freeze
+        GAME_IS_VARIANT_OF = G1868WY::Meta
+        GAME_SUBTITLE = nil
+        GAME_TITLE = '1868 Wyoming Simple 2p'
+        GAME_ISSUE_LABEL = '1868WY'
+        GAME_VARIANTS = [].freeze
+
+        PLAYER_RANGE = [2, 2].freeze
+
+        def self.fs_name
+          'g_1868_wy_simple_2p'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Uses same rules as normal game with scaled cert limit and starting cash. Does not implement 2p rules in rulebook.

This was suggested in discussion with John Harres at TraXX, a few friends of his are interested in playing 2p even without the full rules implementing the "Doc" player (a bit like "Vaclav" from 2p 18CZ).
