### PR TITLE
[1846] highlight "teleport" token hexes for PRR and B&O

### DIFF
--- a/lib/engine/game/g_1846/step/track_and_token.rb
+++ b/lib/engine/game/g_1846/step/track_and_token.rb
@@ -25,6 +25,16 @@ module Engine
             super
             @game.place_token_on_upgrade(action)
           end
+
+          def tokener_available_hex(entity, hex)
+            if ([entity.id, hex.id] == ['B&O', 'H12'] ||
+                [entity.id, hex.id] == %w[PRR E11]) &&
+               entity.all_abilities.find { |a| a.type == :token }
+              return true
+            end
+
+            super
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #9788

Before:
![before - tokener highlighting](https://github.com/tobymao/18xx/assets/1045173/008162bb-748b-4b19-884d-2213a3298bc2)

After:
![after - tokener highlighting](https://github.com/tobymao/18xx/assets/1045173/827f2c29-34c9-4dfb-9720-66654ea98798)
