### PR TITLE
[1822CA WRS] fix GNWR sharing home with M18

### DIFF
--- a/lib/engine/game/g_1822_ca/step/destination_token.rb
+++ b/lib/engine/game/g_1822_ca/step/destination_token.rb
@@ -68,7 +68,7 @@ module Engine
             @game.remove_extra_tokens!(hex.tile)
 
             # interactions with ICR's destination and QMOO's home
-            @game.update_qmoo_home if entity.id == 'ICR'
+            @game.update_home(qmoo) if entity.id == 'ICR'
 
             pass!
           end

--- a/lib/engine/game/g_1822_ca_wrs/game.rb
+++ b/lib/engine/game/g_1822_ca_wrs/game.rb
@@ -55,6 +55,34 @@ module Engine
             Company.new(**company.merge(opts))
           end.compact
         end
+
+        def after_lay_tile(hex, _old_tile, _tile)
+          super
+          update_home(gnwr, tile_trigger: true) if hex.id == gnwr.coordinates
+        end
+
+        def after_place_token(_entity, city)
+          super
+          update_home(gnwr) if city.hex.id == gnwr.coordinates
+        end
+
+        # the pending home tokeners are all in the east
+        def pending_home_tokeners
+          []
+        end
+
+        # GNWR and minor 18 both live in Thunder Bay (R16), and they might both
+        # be there before there are actually 2 token slots available
+        def home_token_can_be_cheater
+          true
+        end
+
+        def place_home_token(corporation)
+          # placing the "cheater" token while GNWR also has a reservation
+          # creates a third slot in green/brown
+          hex_by_id(gnwr.coordinates).tile.remove_reservation!(gnwr) if corporation == gnwr
+          super
+        end
       end
     end
   end

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -103,7 +103,7 @@ module Engine
           end
           next true if reserved_by?(corporation)
 
-          if @tile.token_blocked_by_reservation?(corporation)
+          if @tile.token_blocked_by_reservation?(corporation) && !cheater
             @error = :blocked_reservation
             next false
           end


### PR DESCRIPTION
In the full game, M18's home is on the eastern half

Similar to QMOO/Quebec issues, so some of the logic in #9936 is generalized here.

Core change: allow a "cheater" token to create its (temporary) extra slot if other slots are occupied by reservations, not just tokens; this allows GNWR's home token to appear next to Minor 18's home reservation

#9376