### PR TITLE
[1822 family] don't break rendering on bidding due to player debt

### DIFF
--- a/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
@@ -29,7 +29,7 @@ module Engine
             actions << 'buy_shares' if @bid_actions.zero? && can_buy_any?(entity) && player_debt.zero?
             actions << 'par' if @bid_actions.zero? && can_ipo_any?(entity) && player_debt.zero?
             actions << 'sell_shares' if can_sell_any?(entity)
-            actions << 'bid' if player_debt.zero?
+            actions << 'bid'
             actions << 'payoff_player_debt' if player_debt.positive? && entity.cash.positive?
             actions << 'pass' unless actions.empty?
             actions
@@ -141,6 +141,8 @@ module Engine
           end
 
           def process_bid(action)
+            raise GameError, 'Cannot bid while in debt' if @game.player_debt(action.entity).positive?
+
             @game.something_sold_in_sr! if @game.nothing_sold_in_sr?
             action.entity.unpass!
             add_bid(action)


### PR DESCRIPTION
A lot of bid-related rendering depends on `bid` appearing as one of the step's current actions, e.g.,
https://github.com/tobymao/18xx/blob/0bad615d8eda50db7bb2885ebdb9f94da2863fea/assets/app/view/game/round/stock.rb#L356

This causes a bug where if one player has debt (and therefore does not have the `bid` action available), previous bids and bid tokens can fail to render.

Screenshot 1 - JFParadis has made bids on 3 privates, no bid is visible on P6 (Pullman) -- the other privates are rendered below the screen:

![no bid shown on pullman](https://github.com/tobymao/18xx/assets/1045173/faafddab-8eda-4d85-9195-df9c9b6eab03)

Screenshot 2 - no bids shown on the other two privates, bid token count is not listed for any of the players; note that jonathan has a loan

![Screenshot 2023-11-26 123153](https://github.com/tobymao/18xx/assets/1045173/d1d507a0-0493-4057-b27b-ab2ca5176198)


This change makes `bid` always included in the possible actions, and raises a `GameError` to prevent indebted players from actually making bids.

 #9376
