### PR TITLE
18tokaido limited express

### DIFF
--- a/lib/engine/game/g_18_tokaido/game.rb
+++ b/lib/engine/game/g_18_tokaido/game.rb
@@ -141,9 +141,8 @@ module Engine
           limited_express ? { float_percent: 50 } : {}
         end
 
+        # Not actually used (see game_end_check_values), but required by class validation
         SELL_BUY_ORDER = :sell_buy
-
-        GAME_END_CHECK = { bankrupt: :immediate, final_phase: :full_or }.freeze
 
         def game_tiles
           if newbie_rules
@@ -182,16 +181,13 @@ module Engine
 
         def game_end_check_values
           if limited_express
-            check = G18Tokaido::GAME_END_CHECK.dup
-            check.merge(stock_market: :current_round)
+            { bankrupt: :immediate, stock_market: :current_round, final_phase: :full_or }
           else
-            G18Tokaido::GAME_END_CHECK
+            { bankrupt: :immediate, final_phase: :full_or }
           end
         end
 
         def setup
-          G18Tokaido.const_set(SELL_BUY_ORDER, :sell_buy_sell) if limited_express
-
           if waterfall_auction
             @companies.each do |c|
               new_value = c.value - ((c.value - 20) / 4)

--- a/lib/engine/game/g_18_tokaido/game.rb
+++ b/lib/engine/game/g_18_tokaido/game.rb
@@ -170,7 +170,7 @@ module Engine
               c.min_price = (new_value / 2).to_i
               c.max_price = new_value * 2
             end
-          elsif @optional_rules&.include?(:snake_draft)
+          elsif snake_draft
             setup_company_price_up_to_face
             @reverse = true
           else
@@ -222,7 +222,7 @@ module Engine
               Engine::Step::CompanyPendingPar,
               Engine::Step::WaterfallAuction,
             ])
-          elsif @optional_rules&.include?(:snake_draft)
+          elsif snake_draft
             Engine::Round::Draft.new(
               self,
               [G18Tokaido::Step::DraftDistribution],
@@ -380,7 +380,7 @@ module Engine
             'At the end of each set of ORs the next available train will be exported (removed, triggering ' \
             'phase change as if purchased)',
           ]
-          timeline.unshift('First stock round is in reverse order of draft order') unless waterfall_auction
+          timeline.unshift('First stock round is in reverse order of draft order') if snake_draft
           @timeline = timeline
         end
 
@@ -396,6 +396,10 @@ module Engine
 
         def waterfall_auction
           @optional_rules&.include?(:waterfall_auction)
+        end
+
+        def snake_draft
+          @optional_rules&.include?(:snake_draft)
         end
 
         def payout_companies(ignore: [])

--- a/lib/engine/game/g_18_tokaido/game.rb
+++ b/lib/engine/game/g_18_tokaido/game.rb
@@ -142,7 +142,7 @@ module Engine
         GAME_END_CHECK = { bankrupt: :immediate, final_phase: :full_or }.freeze
 
         def game_tiles
-          if @optional_rules&.include?(:expanded_tileset)
+          if @optional_rules&.include?(:newbie_rules)
             tiles = G18Tokaido::Tiles::TILES.dup
             %w[204 207 208 619 622].each { |t| tiles[t] += 1 }
             tiles
@@ -152,7 +152,7 @@ module Engine
         end
 
         def game_market
-          if @optional_rules&.include?(:no_yellow_zone)
+          if @optional_rules&.include?(:newbie_rules)
             market = G18Tokaido::StockMarket::MARKET.dup
             market.map do |row|
               row.map { |p| p.include?('y') ? p.chop : p }

--- a/lib/engine/game/g_18_tokaido/game.rb
+++ b/lib/engine/game/g_18_tokaido/game.rb
@@ -141,9 +141,6 @@ module Engine
           limited_express ? { float_percent: 50 } : {}
         end
 
-        # Not actually used (see game_end_check_values), but required by class validation
-        SELL_BUY_ORDER = :sell_buy
-
         def game_tiles
           if newbie_rules
             tiles = G18Tokaido::Tiles::TILES.dup

--- a/lib/engine/game/g_18_tokaido/meta.rb
+++ b/lib/engine/game/g_18_tokaido/meta.rb
@@ -51,19 +51,15 @@ module Engine
             desc: 'removes one of the 6 trains from the game (for a faster train rush)',
           },
           {
-            sym: :expanded_tileset,
-            short_name: 'Expanded Tileset',
-            desc: 'slightly expanded (newbie-friendly) tileset',
-          },
-          {
-            sym: :no_yellow_zone,
-            short_name: 'No Yellow Zone',
-            desc: 'removes yellow zone from stock market (for slightly more newbie-friendly game)',
+            sym: :newbie_rules,
+            short_name: 'Newbie Friendly',
+            desc: 'slightly expanded tileset, removes yellow zone from stock market',
           },
         ].freeze
 
         MUTEX_RULES = [
-          %i[snake_draft waterfall_auction]
+          %i[snake_draft waterfall_auction],
+          %i[limited_express newbie_rules]
         ].freeze
       end
     end

--- a/lib/engine/game/g_18_tokaido/meta.rb
+++ b/lib/engine/game/g_18_tokaido/meta.rb
@@ -21,6 +21,7 @@ module Engine
         GAME_RULES_URL = 'https://github.com/tobymao/18xx/wiki/18Tokaido'
 
         PLAYER_RANGE = [2, 4].freeze
+
         OPTIONAL_RULES = [
           {
             sym: :pass_priority,
@@ -35,11 +36,6 @@ module Engine
             desc: 'skips removing a random railroad corporation from the game',
           },
           {
-            sym: :limited_express,
-            short_name: 'Limited Express',
-            desc: 'removes one of the 6 trains from the game (for a faster train rush)',
-          },
-          {
             sym: :snake_draft,
             short_name: 'Snake Draft',
             desc: 'snake draft for privates',
@@ -48,6 +44,11 @@ module Engine
             sym: :waterfall_auction,
             short_name: 'Waterfall Auction',
             desc: 'standard waterfall auction for privates',
+          },
+          {
+            sym: :limited_express,
+            short_name: 'Limited Express',
+            desc: 'removes one of the 6 trains from the game (for a faster train rush)',
           },
           {
             sym: :expanded_tileset,
@@ -59,6 +60,10 @@ module Engine
             short_name: 'No Yellow Zone',
             desc: 'removes yellow zone from stock market (for slightly more newbie-friendly game)',
           },
+        ].freeze
+
+        MUTEX_RULES = [
+          %i[snake_draft waterfall_auction]
         ].freeze
       end
     end

--- a/lib/engine/game/g_18_tokaido/meta.rb
+++ b/lib/engine/game/g_18_tokaido/meta.rb
@@ -48,7 +48,7 @@ module Engine
           {
             sym: :limited_express,
             short_name: 'Limited Express',
-            desc: 'removes one of the 6 trains from the game (for a faster train rush)',
+            desc: 'one less 6 train, 50% to float, 1882-like stock market',
           },
           {
             sym: :newbie_rules,

--- a/lib/engine/game/g_18_tokaido/meta.rb
+++ b/lib/engine/game/g_18_tokaido/meta.rb
@@ -24,6 +24,16 @@ module Engine
 
         OPTIONAL_RULES = [
           {
+            sym: :newbie_rules,
+            short_name: 'Local 普通',
+            desc: '[newbie variant] slightly expanded tileset, removes yellow zone from stock market',
+          },
+          {
+            sym: :limited_express,
+            short_name: 'Limited Express 特急',
+            desc: '[brutal variant] one less 6 train, 50% to float, 1882-like stock market',
+          },
+          {
             sym: :pass_priority,
             short_name: 'Pass Priority',
             players: [3, 4],
@@ -44,16 +54,6 @@ module Engine
             sym: :waterfall_auction,
             short_name: 'Waterfall Auction',
             desc: 'standard waterfall auction for privates',
-          },
-          {
-            sym: :limited_express,
-            short_name: 'Limited Express',
-            desc: 'one less 6 train, 50% to float, 1882-like stock market',
-          },
-          {
-            sym: :newbie_rules,
-            short_name: 'Newbie Friendly',
-            desc: 'slightly expanded tileset, removes yellow zone from stock market',
           },
         ].freeze
 

--- a/lib/engine/game/g_18_tokaido/meta.rb
+++ b/lib/engine/game/g_18_tokaido/meta.rb
@@ -59,7 +59,7 @@ module Engine
 
         MUTEX_RULES = [
           %i[snake_draft waterfall_auction],
-          %i[limited_express newbie_rules]
+          %i[limited_express newbie_rules],
         ].freeze
       end
     end

--- a/lib/engine/game/g_18_tokaido/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_tokaido/step/buy_sell_par_shares.rb
@@ -18,6 +18,14 @@ module Engine
 
             @round.last_to_act = action.entity.player
           end
+
+          def description
+            @game.limited_express ? 'Sell/BuySell Shares' : 'Sell then Buy Shares'
+          end
+
+          def can_sell_order?
+            @game.limited_express ? true : !bought?
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_tokaido/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_tokaido/step/buy_sell_par_shares.rb
@@ -20,7 +20,7 @@ module Engine
           end
 
           def description
-            @game.limited_express ? 'Sell/BuySell Shares' : 'Sell then Buy Shares'
+            @game.limited_express ? 'Sell/Buy/Sell Shares' : 'Sell then Buy Shares'
           end
 
           def can_sell_order?


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

- Combined newbie options, gave it a thematic name.
- Created new "off the rails" option, combined with limited express option (and used that name)
  - Changes stock market/float threshold/sell-buy order
- Added mutex for mutually exclusive options (waterfall vs. draft, local vs. limited express)
- Some additional minor tweaks/code cleanup