### PR TITLE
Home page: sort hotseat games by last updated time

### DIFF
--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -37,12 +37,12 @@ module View
         ]
       end
 
+      now = Time.now.to_i
       hotseat = Lib::Storage
         .all_keys
         .select { |k| k.start_with?('hs_') }
         .map { |k| Lib::Storage[k] }
-        .sort_by { |gd| gd[:id] }
-        .reverse
+        .sort_by { |gd| [-(gd[:updated_at] || now), gd[:id]] }
 
       render_row(children, 'Your Games', your_games, :personal) if @user
       render_row(children, 'Hotseat Games', hotseat, :hotseat) if hotseat.any?


### PR DESCRIPTION
Games without `updated_at` are put at the front, alpha-sorted by id.