### PR TITLE
[1850] Fix price protection

### DIFF
--- a/lib/engine/game/g_1850/game.rb
+++ b/lib/engine/game/g_1850/game.rb
@@ -188,7 +188,7 @@ module Engine
             Engine::Step::DiscardTrain,
             G1850::Step::BuyTrain,
             [G1870::Step::BuyCompany, { blocks: true }],
-            G1870::Step::PriceProtection,
+            G1850::Step::PriceProtection,
           ], round_num: round_num)
         end
 
@@ -196,7 +196,7 @@ module Engine
           G1870::Round::Stock.new(self, [
             Engine::Step::DiscardTrain,
             G1870::Step::BuySellParShares,
-            G1870::Step::PriceProtection,
+            G1850::Step::PriceProtection,
           ])
         end
 
@@ -330,7 +330,7 @@ module Engine
         end
 
         def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
-          @sell_queue << [bundle, bundle.corporation.owner]
+          @sell_queue << [bundle, bundle.corporation.owner, bundle.owner]
 
           @share_pool.sell_shares(bundle)
         end

--- a/lib/engine/game/g_1850/step/price_protection.rb
+++ b/lib/engine/game/g_1850/step/price_protection.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1870/step/price_protection'
+
+module Engine
+  module Game
+    module G1850
+      module Step
+        class PriceProtection < G1870::Step::PriceProtection
+          def price_protection_seller
+            @game.sell_queue.dig(0, 2)
+          end
+
+          def can_buy?(entity, bundle)
+            return unless bundle&.buyable
+            return unless bundle == price_protection
+
+            have_cert_room = if bundle.corporation.counts_for_limit
+                               @game.num_certs(entity, price_protecting: true) + bundle.num_shares <= @game.cert_limit
+                             else
+                               true # can price protect yellow/green/brown even if over cert limit
+                             end
+
+            entity.cash >= bundle.price &&
+              price_protection_seller != entity &&
+              have_cert_room
+          end
+        end
+      end
+    end
+  end
+end

--- a/public/fixtures/1850/115810.json
+++ b/public/fixtures/1850/115810.json
@@ -1,15199 +1,13471 @@
 {
-    "id": 115810,
-    "description": "",
-    "user": {
+  "id": 115810,
+  "description": "",
+  "user": {
+    "id": 4311,
+    "name": "hatsu"
+  },
+  "players": [
+    {
       "id": 4311,
       "name": "hatsu"
     },
-    "players": [
-      {
-        "id": 4311,
-        "name": "hatsu"
-      },
-      {
-        "id": 1761,
-        "name": "gonta"
-      },
-      {
-        "id": 2122,
-        "name": "Arita"
-      }
-    ],
-    "min_players": 3,
-    "max_players": 3,
-    "title": "1850",
-    "settings": {
-      "seed": 6728296,
-      "is_async": true,
-      "unlisted": true,
-      "auto_routing": true,
-      "player_order": null,
-      "optional_rules": []
+    {
+      "id": 1761,
+      "name": "gonta"
     },
-    "user_settings": null,
-    "status": "finished",
-    "turn": 8,
-    "round": "Operating Round",
-    "acting": [
-      4311,
-      1761,
-      2122
-    ],
-    "result": {
-      "1761": 10256,
-      "2122": 10301,
-      "4311": 7757
+    {
+      "id": 2122,
+      "name": "Arita"
+    }
+  ],
+  "min_players": 3,
+  "max_players": 3,
+  "title": "1850",
+  "settings": {
+    "seed": 6728296,
+    "is_async": true,
+    "unlisted": true,
+    "auto_routing": true,
+    "player_order": null,
+    "optional_rules": [
+
+    ]
+  },
+  "user_settings": null,
+  "status": "finished",
+  "turn": 8,
+  "round": "Operating Round",
+  "acting": [
+    4311,
+    1761,
+    2122
+  ],
+  "result": {
+    "1761": 10256,
+    "2122": 10301,
+    "4311": 7757
+  },
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1678105711,
+      "company": "MRB",
+      "price": 45,
+      "original_id": 1
     },
-    "actions": [
-      {
-        "type": "bid",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 1,
-        "created_at": 1678105711,
-        "company": "MRB",
-        "price": 45
-      },
-      {
-        "type": "bid",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 2,
-        "created_at": 1678107832,
-        "company": "CM",
-        "price": 45
-      },
-      {
-        "type": "bid",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 6,
-        "created_at": 1678116699,
-        "company": "GBC",
-        "price": 55
-      },
-      {
-        "type": "bid",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 7,
-        "created_at": 1678116831,
-        "company": "WLG",
-        "price": 95
-      },
-      {
-        "type": "bid",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 10,
-        "created_at": 1678139738,
-        "company": "MMR",
-        "price": 165
-      },
-      {
-        "type": "bid",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 11,
-        "created_at": 1678143876,
-        "company": "MRC",
-        "price": 85
-      },
-      {
-        "type": "bid",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 12,
-        "created_at": 1678148623,
-        "company": "GRSC",
-        "price": 20
-      },
-      {
-        "type": "par",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 13,
-        "created_at": 1678153100,
-        "corporation": "RI",
-        "share_price": "90,1,6"
-      },
-      {
-        "type": "program_buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 14,
-        "created_at": 1678153109,
-        "corporation": "RI",
-        "until_condition": "float",
-        "from_market": false,
-        "auto_pass_after": false
-      },
-      {
-        "type": "par",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 15,
-        "created_at": 1678182338,
-        "corporation": "NP",
-        "share_price": "90,1,6"
-      },
-      {
-        "type": "par",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 16,
-        "created_at": 1678198562,
-        "auto_actions": [
-          {
-            "type": "buy_shares",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1678198562,
-            "shares": [
-              "RI_2"
-            ],
-            "percent": 10
-          }
-        ],
-        "corporation": "KATY",
-        "share_price": "76,3,6"
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 17,
-        "created_at": 1678200093,
-        "shares": [
-          "NP_1"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 18,
-        "created_at": 1678200140,
-        "auto_actions": [
-          {
-            "type": "buy_shares",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1678200140,
-            "shares": [
-              "RI_3"
-            ],
-            "percent": 10
-          }
-        ],
-        "shares": [
-          "KATY_1"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 19,
-        "created_at": 1678200603,
-        "shares": [
-          "NP_2"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 20,
-        "created_at": 1678231264,
-        "auto_actions": [
-          {
-            "type": "buy_shares",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1678231263,
-            "shares": [
-              "RI_4"
-            ],
-            "percent": 10
-          }
-        ],
-        "shares": [
-          "KATY_2"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 21,
-        "created_at": 1678274265,
-        "shares": [
-          "NP_3"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 22,
-        "created_at": 1678286270,
-        "shares": [
-          "KATY_3"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 23,
-        "created_at": 1678289180,
-        "shares": [
-          "NP_4"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 24,
-        "created_at": 1678315122,
-        "shares": [
-          "KATY_4"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "hex": "H13",
-        "tile": "9-0",
-        "type": "lay_tile",
-        "entity": "RI",
-        "rotation": 1,
-        "entity_type": "corporation",
-        "id": 25,
-        "user": 1761,
-        "created_at": 1678317706
-      },
-      {
-        "hex": "H15",
-        "tile": "9-1",
-        "type": "lay_tile",
-        "entity": "RI",
-        "rotation": 1,
-        "entity_type": "corporation",
-        "id": 26,
-        "user": 1761,
-        "created_at": 1678317714
-      },
-      {
-        "type": "buy_train",
-        "price": 80,
-        "train": "2-0",
-        "entity": "RI",
-        "variant": "2",
-        "entity_type": "corporation",
-        "id": 27,
-        "user": 1761,
-        "created_at": 1678317740
-      },
-      {
-        "type": "undo",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 28,
-        "user": 1761,
-        "created_at": 1678317754
-      },
-      {
-        "type": "undo",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 29,
-        "user": 1761,
-        "created_at": 1678317756
-      },
-      {
-        "type": "undo",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 30,
-        "user": 1761,
-        "created_at": 1678317758
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 31,
-        "created_at": 1678317795,
-        "hex": "H13",
-        "tile": "9-0",
-        "rotation": 1
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 32,
-        "created_at": 1678317798,
-        "hex": "H15",
-        "tile": "9-1",
-        "rotation": 1
-      },
-      {
-        "type": "buy_train",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 33,
-        "created_at": 1678317800,
-        "train": "2-0",
-        "price": 80,
-        "variant": "2"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 34,
-        "created_at": 1678361987,
-        "hex": "B11",
-        "tile": "5-0",
-        "rotation": 1
-      },
-      {
-        "type": "buy_company",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 35,
-        "created_at": 1678362011,
-        "company": "MRC",
-        "price": 80
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 36,
-        "created_at": 1678362085,
-        "hex": "B9",
-        "tile": "7-0",
-        "rotation": 3
-      },
-      {
-        "type": "buy_train",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 37,
-        "created_at": 1678362099,
-        "train": "2-1",
-        "price": 80,
-        "variant": "2"
-      },
-      {
-        "type": "pass",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 38,
-        "created_at": 1678362285
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 39,
-        "created_at": 1678363322,
-        "hex": "K6",
-        "tile": "6-0",
-        "rotation": 1
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 40,
-        "created_at": 1678363328,
-        "hex": "K4",
-        "tile": "6-1",
-        "rotation": 4
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 41,
-        "created_at": 1678363383
-      },
-      {
-        "type": "buy_train",
-        "price": 80,
-        "train": "2-2",
-        "entity": "KATY",
-        "variant": "2",
-        "entity_type": "corporation",
-        "id": 42,
-        "user": 4311,
-        "created_at": 1678363387
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 43,
-        "user": 4311,
-        "created_at": 1678363403
-      },
-      {
-        "type": "buy_train",
-        "price": 80,
-        "train": "2-2",
-        "entity": "KATY",
-        "variant": "2",
-        "entity_type": "corporation",
-        "id": 44,
-        "user": 4311,
-        "created_at": 1678363404
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 45,
-        "user": 4311,
-        "created_at": 1678363418
-      },
-      {
-        "type": "buy_train",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 46,
-        "created_at": 1678363423,
-        "train": "2-2",
-        "price": 80,
-        "variant": "2"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 47,
-        "created_at": 1678363429
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 48,
-        "created_at": 1678363843
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 49,
-        "created_at": 1678370064,
-        "shares": [
-          "KATY_5"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 50,
-        "created_at": 1678370087
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 51,
-        "created_at": 1678370898,
-        "shares": [
-          "NP_5"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 52,
-        "created_at": 1678370950
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 53,
-        "created_at": 1678370957
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 54,
-        "created_at": 1678376511
-      },
-      {
-        "type": "buy_shares",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 55,
-        "created_at": 1678377164,
-        "shares": [
-          "KATY_1"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 56,
-        "created_at": 1678381484
-      },
-      {
-        "type": "buy_shares",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 57,
-        "created_at": 1678403148,
-        "shares": [
-          "NP_1"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 58,
-        "created_at": 1678404270,
-        "shares": [
-          "RI_5"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 59,
-        "created_at": 1678404280
-      },
-      {
-        "type": "buy_shares",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 60,
-        "created_at": 1678406413,
-        "shares": [
-          "RI_1"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 61,
-        "created_at": 1678440085,
-        "shares": [
-          "KATY_6"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 62,
-        "created_at": 1678440141
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 63,
-        "created_at": 1678442823
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 64,
-        "created_at": 1678450806,
-        "shares": [
-          "KATY_7"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 65,
-        "created_at": 1678450809
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 66,
-        "created_at": 1678451799
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 67,
-        "created_at": 1678452075
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 68,
-        "created_at": 1678454593,
-        "shares": [
-          "KATY_8"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 69,
-        "created_at": 1678454600
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 70,
-        "created_at": 1678457405
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 71,
-        "created_at": 1678458195
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 72,
-        "created_at": 1678463008
-      },
-      {
-        "hex": "H17",
-        "tile": "58-0",
-        "type": "lay_tile",
-        "entity": "RI",
-        "rotation": 5,
-        "entity_type": "corporation",
-        "id": 73,
-        "user": 1761,
-        "created_at": 1678463016
-      },
-      {
-        "type": "undo",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 74,
-        "user": 1761,
-        "created_at": 1678463040
-      },
-      {
-        "hex": "H9",
-        "tile": "57-0",
-        "type": "lay_tile",
-        "entity": "RI",
-        "rotation": 1,
-        "entity_type": "corporation",
-        "id": 75,
-        "user": 1761,
-        "created_at": 1678463051
-      },
-      {
-        "type": "undo",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 76,
-        "user": 1761,
-        "created_at": 1678463056
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 77,
-        "created_at": 1678463062,
-        "hex": "H17",
-        "tile": "58-0",
-        "rotation": 5
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 78,
-        "created_at": 1678463080,
-        "routes": [
-          {
-            "train": "2-0",
-            "connections": [
-              [
-                "H11",
-                "H13",
-                "H15",
-                "H17"
-              ]
-            ],
-            "hexes": [
+    {
+      "type": "bid",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1678107832,
+      "company": "CM",
+      "price": 45,
+      "original_id": 2
+    },
+    {
+      "type": "bid",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1678116699,
+      "company": "GBC",
+      "price": 55,
+      "original_id": 6
+    },
+    {
+      "type": "bid",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1678116831,
+      "company": "WLG",
+      "price": 95,
+      "original_id": 7
+    },
+    {
+      "type": "bid",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1678139738,
+      "company": "MMR",
+      "price": 165,
+      "original_id": 10
+    },
+    {
+      "type": "bid",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1678143876,
+      "company": "MRC",
+      "price": 85,
+      "original_id": 11
+    },
+    {
+      "type": "bid",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1678148623,
+      "company": "GRSC",
+      "price": 20,
+      "original_id": 12
+    },
+    {
+      "type": "par",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1678153100,
+      "corporation": "RI",
+      "share_price": "90,1,6",
+      "original_id": 13
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1678153109,
+      "corporation": "RI",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false,
+      "original_id": 14
+    },
+    {
+      "type": "par",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1678182338,
+      "corporation": "NP",
+      "share_price": "90,1,6",
+      "original_id": 15
+    },
+    {
+      "type": "par",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1678198562,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1678198562,
+          "shares": [
+            "RI_2"
+          ],
+          "percent": 10
+        }
+      ],
+      "corporation": "KATY",
+      "share_price": "76,3,6",
+      "original_id": 16
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1678200093,
+      "shares": [
+        "NP_1"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 17
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1678200140,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1678200140,
+          "shares": [
+            "RI_3"
+          ],
+          "percent": 10
+        }
+      ],
+      "shares": [
+        "KATY_1"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 18
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1678200603,
+      "shares": [
+        "NP_2"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 19
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1678231264,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1678231263,
+          "shares": [
+            "RI_4"
+          ],
+          "percent": 10
+        }
+      ],
+      "shares": [
+        "KATY_2"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1678274265,
+      "shares": [
+        "NP_3"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 21
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1678286270,
+      "shares": [
+        "KATY_3"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 22
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1678289180,
+      "shares": [
+        "NP_4"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 23
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1678315122,
+      "shares": [
+        "KATY_4"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 24
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 20,
+      "created_at": 1678317795,
+      "hex": "H13",
+      "tile": "9-0",
+      "rotation": 1,
+      "original_id": 31
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 21,
+      "created_at": 1678317798,
+      "hex": "H15",
+      "tile": "9-1",
+      "rotation": 1,
+      "original_id": 32
+    },
+    {
+      "type": "buy_train",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 22,
+      "created_at": 1678317800,
+      "train": "2-0",
+      "price": 80,
+      "variant": "2",
+      "original_id": 33
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 23,
+      "created_at": 1678361987,
+      "hex": "B11",
+      "tile": "5-0",
+      "rotation": 1,
+      "original_id": 34
+    },
+    {
+      "type": "buy_company",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 24,
+      "created_at": 1678362011,
+      "company": "MRC",
+      "price": 80,
+      "original_id": 35
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 25,
+      "created_at": 1678362085,
+      "hex": "B9",
+      "tile": "7-0",
+      "rotation": 3,
+      "original_id": 36
+    },
+    {
+      "type": "buy_train",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 26,
+      "created_at": 1678362099,
+      "train": "2-1",
+      "price": 80,
+      "variant": "2",
+      "original_id": 37
+    },
+    {
+      "type": "pass",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 27,
+      "created_at": 1678362285,
+      "original_id": 38
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 28,
+      "created_at": 1678363322,
+      "hex": "K6",
+      "tile": "6-0",
+      "rotation": 1,
+      "original_id": 39
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 29,
+      "created_at": 1678363328,
+      "hex": "K4",
+      "tile": "6-1",
+      "rotation": 4,
+      "original_id": 40
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 30,
+      "created_at": 1678363383,
+      "original_id": 41
+    },
+    {
+      "type": "buy_train",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 31,
+      "created_at": 1678363423,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2",
+      "original_id": 46
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 32,
+      "created_at": 1678363429,
+      "original_id": 47
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 33,
+      "created_at": 1678363843,
+      "original_id": 48
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1678370064,
+      "shares": [
+        "KATY_5"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 49
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1678370087,
+      "original_id": 50
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1678370898,
+      "shares": [
+        "NP_5"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 51
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 37,
+      "created_at": 1678370950,
+      "original_id": 52
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 38,
+      "created_at": 1678370957,
+      "original_id": 53
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 39,
+      "created_at": 1678376511,
+      "original_id": 54
+    },
+    {
+      "type": "buy_shares",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 40,
+      "created_at": 1678377164,
+      "shares": [
+        "KATY_1"
+      ],
+      "percent": 10,
+      "original_id": 55
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 41,
+      "created_at": 1678381484,
+      "original_id": 56
+    },
+    {
+      "type": "buy_shares",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 42,
+      "created_at": 1678403148,
+      "shares": [
+        "NP_1"
+      ],
+      "percent": 10,
+      "original_id": 57
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 43,
+      "created_at": 1678404270,
+      "shares": [
+        "RI_5"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 58
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 44,
+      "created_at": 1678404280,
+      "original_id": 59
+    },
+    {
+      "type": "buy_shares",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 45,
+      "created_at": 1678406413,
+      "shares": [
+        "RI_1"
+      ],
+      "percent": 10,
+      "original_id": 60
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 46,
+      "created_at": 1678440085,
+      "shares": [
+        "KATY_6"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 61
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 47,
+      "created_at": 1678440141,
+      "original_id": 62
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 48,
+      "created_at": 1678442823,
+      "original_id": 63
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 49,
+      "created_at": 1678450806,
+      "shares": [
+        "KATY_7"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 64
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 50,
+      "created_at": 1678450809,
+      "original_id": 65
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 51,
+      "created_at": 1678451799,
+      "original_id": 66
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 52,
+      "created_at": 1678452075,
+      "original_id": 67
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 53,
+      "created_at": 1678454593,
+      "shares": [
+        "KATY_8"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 68
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 54,
+      "created_at": 1678454600,
+      "original_id": 69
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 55,
+      "created_at": 1678457405,
+      "original_id": 70
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 56,
+      "created_at": 1678458195,
+      "original_id": 71
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 57,
+      "created_at": 1678463008,
+      "original_id": 72
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 58,
+      "created_at": 1678463062,
+      "hex": "H17",
+      "tile": "58-0",
+      "rotation": 5,
+      "original_id": 77
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 59,
+      "created_at": 1678463080,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
               "H11",
+              "H13",
+              "H15",
               "H17"
-            ],
-            "revenue": 30,
-            "revenue_str": "H11-H17",
-            "nodes": [
-              "H11-0",
-              "H17-0"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 79,
-        "created_at": 1678463083,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 80,
-        "created_at": 1678463093,
-        "train": "2-3",
-        "price": 80,
-        "variant": "2"
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 81,
-        "created_at": 1678463095
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 83,
-        "created_at": 1678465486,
-        "hex": "A8",
-        "tile": "9-2",
-        "rotation": 1
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 84,
-        "created_at": 1678465527,
-        "routes": [
-          {
-            "train": "2-1",
-            "connections": [
-              [
-                "B11",
-                "A10"
-              ]
-            ],
-            "hexes": [
-              "A10",
-              "B11"
-            ],
-            "revenue": 50,
-            "revenue_str": "A10-B11",
-            "nodes": [
-              "B11-0",
-              "A10-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 85,
-        "created_at": 1678465543,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 86,
-        "created_at": 1678465570,
-        "train": "2-4",
-        "price": 80,
-        "variant": "2"
-      },
-      {
-        "type": "pass",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 87,
-        "created_at": 1678465583
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 89,
-        "created_at": 1678467887,
-        "hex": "L3",
-        "tile": "9-3",
-        "rotation": 0
-      },
-      {
-        "type": "choose",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 90,
-        "created_at": 1678467902,
-        "choice": "Place Edge Token"
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 91,
-        "created_at": 1678467907,
-        "routes": [
-          {
-            "train": "2-2",
-            "connections": [
-              [
-                "K6",
-                "K4"
-              ]
-            ],
-            "hexes": [
-              "K6",
-              "K4"
-            ],
-            "revenue": 40,
-            "revenue_str": "K6-K4",
-            "nodes": [
-              "K6-0",
-              "K4-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 92,
-        "created_at": 1678467915,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 93,
-        "created_at": 1678467924,
-        "train": "2-5",
-        "price": 80,
-        "variant": "2"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 94,
-        "created_at": 1678467928
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 95,
-        "created_at": 1678491991,
-        "shares": [
-          "NP_6"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 96,
-        "created_at": 1678492008
-      },
-      {
-        "type": "buy_shares",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 97,
-        "created_at": 1678492216,
-        "shares": [
-          "KATY_2"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 98,
-        "created_at": 1678493102
-      },
-      {
-        "type": "buy_shares",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 99,
-        "created_at": 1678532289,
-        "shares": [
-          "NP_2"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 100,
-        "created_at": 1678532773,
-        "shares": [
-          "NP_7"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 101,
-        "created_at": 1678532792
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 102,
-        "created_at": 1678540754
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 103,
-        "created_at": 1678542194,
-        "shares": [
-          "NP_8"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 104,
-        "created_at": 1678542235
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 105,
-        "created_at": 1678543698
-      },
-      {
-        "type": "sell_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 106,
-        "created_at": 1678543776,
-        "shares": [
-          "KATY_7",
-          "KATY_8"
-        ],
-        "percent": 20
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 107,
-        "created_at": 1678543781,
-        "shares": [
-          "RI_6"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 108,
-        "created_at": 1678544898
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 109,
-        "created_at": 1678547570,
-        "shares": [
-          "RI_5"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 110,
-        "created_at": 1678547578,
-        "shares": [
-          "KATY_7"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 111,
-        "created_at": 1678555752,
-        "shares": [
-          "RI_5"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 112,
-        "created_at": 1678563064
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 113,
-        "created_at": 1678578810,
-        "shares": [
-          "KATY_8"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 114,
-        "created_at": 1678578827
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 115,
-        "created_at": 1678579221
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 116,
-        "created_at": 1678580779
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 117,
-        "created_at": 1678586985
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 118,
-        "created_at": 1678618784,
-        "hex": "A6",
-        "tile": "8-0",
-        "rotation": 4
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 119,
-        "created_at": 1678618822,
-        "routes": [
-          {
-            "train": "2-1",
-            "connections": [
-              [
-                "B11",
-                "A10"
-              ]
-            ],
-            "hexes": [
+          ],
+          "hexes": [
+            "H11",
+            "H17"
+          ],
+          "revenue": 30,
+          "revenue_str": "H11-H17",
+          "nodes": [
+            "H11-0",
+            "H17-0"
+          ]
+        }
+      ],
+      "original_id": 78
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 60,
+      "created_at": 1678463083,
+      "kind": "payout",
+      "original_id": 79
+    },
+    {
+      "type": "buy_train",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 61,
+      "created_at": 1678463093,
+      "train": "2-3",
+      "price": 80,
+      "variant": "2",
+      "original_id": 80
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 62,
+      "created_at": 1678463095,
+      "original_id": 81
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 63,
+      "created_at": 1678465486,
+      "hex": "A8",
+      "tile": "9-2",
+      "rotation": 1,
+      "original_id": 83
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 64,
+      "created_at": 1678465527,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
               "B11",
               "A10"
-            ],
-            "revenue": 50,
-            "revenue_str": "B11-A10",
-            "nodes": [
-              "B11-0",
-              "A10-0"
             ]
-          },
-          {
-            "train": "2-4",
-            "connections": [
-              [
-                "B11",
-                "B9",
-                "A10"
-              ]
-            ],
-            "hexes": [
-              "A10",
-              "B11"
-            ],
-            "revenue": 50,
-            "revenue_str": "A10-B11",
-            "nodes": [
-              "B11-0",
-              "A10-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 120,
-        "created_at": 1678618841,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 121,
-        "created_at": 1678618846,
-        "train": "3-0",
-        "price": 180,
-        "variant": "3"
-      },
-      {
-        "type": "buy_company",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 122,
-        "created_at": 1678618869,
-        "company": "GBC",
-        "price": 100
-      },
-      {
-        "type": "pass",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 123,
-        "created_at": 1678618955
-      },
-      {
-        "type": "pass",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 124,
-        "created_at": 1678618982
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 125,
-        "created_at": 1678622508,
-        "hex": "I18",
-        "tile": "128-0",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 126,
-        "user": 1761,
-        "created_at": 1678622533
-      },
-      {
-        "type": "undo",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 127,
-        "user": 1761,
-        "created_at": 1678622535
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 129,
-        "created_at": 1678622665
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 130,
-        "created_at": 1678622671,
-        "routes": [
-          {
-            "train": "2-0",
-            "connections": [
-              [
-                "H11",
-                "H13",
-                "H15",
-                "H17"
-              ]
-            ],
-            "hexes": [
-              "H11",
-              "H17"
-            ],
-            "revenue": 30,
-            "revenue_str": "H11-H17",
-            "nodes": [
-              "H11-0",
-              "H17-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 131,
-        "created_at": 1678622677,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 132,
-        "created_at": 1678622681
-      },
-      {
-        "type": "buy_company",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 133,
-        "created_at": 1678622701,
-        "company": "MMR",
-        "price": 320
-      },
-      {
-        "type": "buy_company",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 134,
-        "created_at": 1678622704,
-        "company": "CM",
-        "price": 80
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 135,
-        "created_at": 1678622815
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 136,
-        "created_at": 1678623580,
-        "hex": "J7",
-        "tile": "8-1",
-        "rotation": 4
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 137,
-        "created_at": 1678623589
-      },
-      {
-        "type": "place_token",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 138,
-        "created_at": 1678623593,
-        "city": "6-1-0",
-        "slot": 0,
-        "tokener": "KATY"
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 139,
-        "created_at": 1678623614,
-        "routes": [
-          {
-            "train": "2-2",
-            "connections": [
-              [
-                "K6",
-                "K4"
-              ]
-            ],
-            "hexes": [
+          ],
+          "hexes": [
+            "A10",
+            "B11"
+          ],
+          "revenue": 50,
+          "revenue_str": "A10-B11",
+          "nodes": [
+            "B11-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "original_id": 84
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 65,
+      "created_at": 1678465543,
+      "kind": "payout",
+      "original_id": 85
+    },
+    {
+      "type": "buy_train",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 66,
+      "created_at": 1678465570,
+      "train": "2-4",
+      "price": 80,
+      "variant": "2",
+      "original_id": 86
+    },
+    {
+      "type": "pass",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 67,
+      "created_at": 1678465583,
+      "original_id": 87
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 68,
+      "created_at": 1678467887,
+      "hex": "L3",
+      "tile": "9-3",
+      "rotation": 0,
+      "original_id": 89
+    },
+    {
+      "type": "choose",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 69,
+      "created_at": 1678467902,
+      "choice": "Place Edge Token",
+      "original_id": 90
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 70,
+      "created_at": 1678467907,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
               "K6",
               "K4"
-            ],
-            "revenue": 40,
-            "revenue_str": "K6-K4",
-            "nodes": [
-              "K6-0",
-              "K4-0"
             ]
-          },
-          {
-            "train": "2-5",
-            "connections": [
-              [
-                "K4",
-                "L3",
-                "M2"
-              ]
-            ],
-            "hexes": [
-              "M2",
-              "K4"
-            ],
-            "revenue": 80,
-            "revenue_str": "M2-K4 + Edge Token",
-            "nodes": [
-              "K4-0",
-              "M2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 140,
-        "created_at": 1678623620,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 141,
-        "created_at": 1678623623,
-        "train": "3-1",
-        "price": 180,
-        "variant": "3"
-      },
-      {
-        "type": "buy_company",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 142,
-        "created_at": 1678623661,
-        "company": "WLG",
-        "price": 164
-      },
-      {
-        "type": "par",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 143,
-        "created_at": 1678625654,
-        "corporation": "CBQ",
-        "share_price": "90,1,6"
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 144,
-        "created_at": 1678625690
-      },
-      {
-        "type": "sell_shares",
-        "entity": 2122,
-        "shares": [
-          "NP_3"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "id": 145,
-        "user": 2122,
-        "created_at": 1678630431
-      },
-      {
-        "type": "sell_shares",
-        "entity": 2122,
-        "shares": [
-          "KATY_5",
-          "KATY_6"
-        ],
-        "percent": 20,
-        "entity_type": "player",
-        "id": 146,
-        "user": 2122,
-        "created_at": 1678630437
-      },
-      {
-        "type": "undo",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 147,
-        "user": 2122,
-        "created_at": 1678630650
-      },
-      {
-        "type": "undo",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 148,
-        "user": 2122,
-        "created_at": 1678630654
-      },
-      {
-        "type": "sell_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 149,
-        "created_at": 1678630672,
-        "shares": [
-          "NP_3",
-          "NP_4"
-        ],
-        "percent": 20
-      },
-      {
-        "type": "sell_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 150,
-        "created_at": 1678630680,
-        "shares": [
-          "KATY_5",
-          "KATY_6"
-        ],
-        "percent": 20
-      },
-      {
-        "type": "par",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 151,
-        "created_at": 1678630702,
-        "corporation": "GN",
-        "share_price": "90,1,6"
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 152,
-        "created_at": 1678674017
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 153,
-        "created_at": 1678674058,
-        "shares": [
-          "NP_5",
-          "NP_7"
-        ],
-        "percent": 20
-      },
-      {
-        "type": "par",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 154,
-        "created_at": 1678674193,
-        "corporation": "UP",
-        "share_price": "76,3,6"
-      },
-      {
-        "type": "buy_shares",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 155,
-        "created_at": 1678674524,
-        "shares": [
-          "RI_2"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "program_buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 156,
-        "created_at": 1678674643,
-        "corporation": "CBQ",
-        "until_condition": "float",
-        "from_market": false,
-        "auto_pass_after": false
-      },
-      {
-        "type": "buy_shares",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 157,
-        "created_at": 1678706058,
-        "shares": [
-          "NP_3"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 158,
-        "created_at": 1678715611,
-        "shares": [
-          "UP_1"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 159,
-        "created_at": 1678715623,
-        "auto_actions": [
-          {
-            "type": "program_disable",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1678715622,
-            "reason": "NP redeemed a share."
-          }
-        ]
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 160,
-        "created_at": 1678716651,
-        "shares": [
-          "CBQ_1"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 161,
-        "created_at": 1678716654
-      },
-      {
-        "type": "program_buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 162,
-        "created_at": 1678716660,
-        "corporation": "CBQ",
-        "until_condition": "float",
-        "from_market": false,
-        "auto_pass_after": false
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 163,
-        "created_at": 1678718468,
-        "shares": [
-          "GN_1"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 164,
-        "created_at": 1678718479
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 165,
-        "created_at": 1678748900,
-        "shares": [
-          "UP_2"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 166,
-        "created_at": 1678748907,
-        "auto_actions": [
-          {
-            "type": "buy_shares",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1678748907,
-            "shares": [
-              "CBQ_2"
-            ],
-            "percent": 10
-          },
-          {
-            "type": "pass",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1678748907
-          }
-        ]
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 167,
-        "created_at": 1678749183,
-        "shares": [
-          "GN_2"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 168,
-        "created_at": 1678749191
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 169,
-        "created_at": 1678763436,
-        "shares": [
-          "UP_3"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 170,
-        "created_at": 1678763479,
-        "auto_actions": [
-          {
-            "type": "buy_shares",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1678763479,
-            "shares": [
-              "CBQ_3"
-            ],
-            "percent": 10
-          },
-          {
-            "type": "pass",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1678763479
-          }
-        ]
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 171,
-        "created_at": 1678788515,
-        "shares": [
-          "GN_3"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 172,
-        "created_at": 1678788519
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 173,
-        "created_at": 1678843337,
-        "shares": [
-          "UP_4"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 174,
-        "created_at": 1678843522,
-        "auto_actions": [
-          {
-            "type": "buy_shares",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1678843522,
-            "shares": [
-              "CBQ_4"
-            ],
-            "percent": 10
-          },
-          {
-            "type": "program_disable",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1678843522,
-            "reason": "CBQ is floated"
-          }
-        ]
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 175,
-        "created_at": 1678848557
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 176,
-        "created_at": 1678878599,
-        "shares": [
-          "GN_4"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 177,
-        "created_at": 1678878627
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 178,
-        "created_at": 1678882387
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 179,
-        "created_at": 1678883418
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 180,
-        "created_at": 1678883501
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 181,
-        "created_at": 1678884680,
-        "hex": "I18",
-        "tile": "129-0",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 182,
-        "user": 1761,
-        "created_at": 1678884696
-      },
-      {
-        "type": "undo",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 183,
-        "user": 1761,
-        "created_at": 1678884701
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 184,
-        "created_at": 1678884712
-      },
-      {
-        "type": "place_token",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 185,
-        "created_at": 1678884715,
-        "city": "129-0-1",
-        "slot": 1,
-        "tokener": "RI"
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 186,
-        "created_at": 1678884723,
-        "routes": [
-          {
-            "train": "2-3",
-            "connections": [
-              [
-                "I18",
-                "H17"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "H17"
-            ],
-            "revenue": 60,
-            "revenue_str": "I18-H17",
-            "nodes": [
-              "I18-1",
-              "H17-0"
-            ]
-          },
-          {
-            "train": "2-0",
-            "connections": [
-              [
-                "H11",
-                "H13",
-                "H15",
-                "H17"
-              ]
-            ],
-            "hexes": [
-              "H11",
-              "H17"
-            ],
-            "revenue": 30,
-            "revenue_str": "H11-H17",
-            "nodes": [
-              "H11-0",
-              "H17-0"
-            ]
-          }
-        ]
-      },
-      {
-        "kind": "half",
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 187,
-        "user": 1761,
-        "created_at": 1678884759
-      },
-      {
-        "type": "undo",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 188,
-        "user": 1761,
-        "created_at": 1678884767
-      },
-      {
-        "kind": "half",
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 189,
-        "user": 1761,
-        "created_at": 1678884772
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 190,
-        "user": 1761,
-        "created_at": 1678884773
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 191,
-        "user": 1761,
-        "created_at": 1678884779
-      },
-      {
-        "hex": "I16",
-        "tile": "58-1",
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "rotation": 2,
-        "entity_type": "corporation",
-        "id": 192,
-        "user": 1761,
-        "created_at": 1678884802
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 193,
-        "user": 1761,
-        "created_at": 1678884809
-      },
-      {
-        "hex": "I16",
-        "tile": "3-0",
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "rotation": 4,
-        "entity_type": "corporation",
-        "id": 194,
-        "user": 1761,
-        "created_at": 1678884815
-      },
-      {
-        "hex": "J17",
-        "tile": "7-1",
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "rotation": 2,
-        "entity_type": "corporation",
-        "id": 195,
-        "user": 1761,
-        "created_at": 1678884819
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 196,
-        "user": 1761,
-        "created_at": 1678884827
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 197,
-        "user": 1761,
-        "created_at": 1678884833
-      },
-      {
-        "hex": "I16",
-        "tile": "4-0",
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "rotation": 1,
-        "entity_type": "corporation",
-        "id": 198,
-        "user": 1761,
-        "created_at": 1678884860
-      },
-      {
-        "hex": "I14",
-        "tile": "9-4",
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "rotation": 1,
-        "entity_type": "corporation",
-        "id": 199,
-        "user": 1761,
-        "created_at": 1678884864
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 200,
-        "user": 1761,
-        "created_at": 1678884869
-      },
-      {
-        "type": "buy_train",
-        "price": 180,
-        "train": "3-2",
-        "entity": "CBQ",
-        "variant": "3",
-        "entity_type": "corporation",
-        "id": 201,
-        "user": 1761,
-        "created_at": 1678884871
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 202,
-        "user": 1761,
-        "created_at": 1678884889
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 203,
-        "user": 1761,
-        "created_at": 1678884890
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 204,
-        "user": 1761,
-        "created_at": 1678884892
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 205,
-        "user": 1761,
-        "created_at": 1678884893
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 206,
-        "user": 1761,
-        "created_at": 1678884895
-      },
-      {
-        "type": "undo",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 207,
-        "user": 1761,
-        "created_at": 1678884900
-      },
-      {
-        "type": "undo",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 208,
-        "user": 1761,
-        "created_at": 1678884903
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 209,
-        "created_at": 1678884904,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 210,
-        "created_at": 1678884906
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 211,
-        "created_at": 1678884906
-      },
-      {
-        "hex": "I16",
-        "tile": "4-0",
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "rotation": 1,
-        "entity_type": "corporation",
-        "id": 212,
-        "user": 1761,
-        "created_at": 1678884958
-      },
-      {
-        "hex": "I14",
-        "tile": "9-4",
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "rotation": 1,
-        "entity_type": "corporation",
-        "id": 213,
-        "user": 1761,
-        "created_at": 1678884963
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 214,
-        "user": 1761,
-        "created_at": 1678884971
-      },
-      {
-        "type": "buy_train",
-        "price": 180,
-        "train": "3-2",
-        "entity": "CBQ",
-        "variant": "3",
-        "entity_type": "corporation",
-        "id": 215,
-        "user": 1761,
-        "created_at": 1678884973
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 216,
-        "user": 1761,
-        "created_at": 1678885048
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 217,
-        "user": 1761,
-        "created_at": 1678885050
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 218,
-        "user": 1761,
-        "created_at": 1678885052
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 219,
-        "user": 1761,
-        "created_at": 1678885053
-      },
-      {
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 220,
-        "created_at": 1678885059,
-        "hex": "I16",
-        "tile": "58-1",
-        "rotation": 4
-      },
-      {
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 221,
-        "created_at": 1678885062,
-        "hex": "J15",
-        "tile": "9-4",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 222,
-        "created_at": 1678885076
-      },
-      {
-        "type": "buy_train",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 223,
-        "created_at": 1678885077,
-        "train": "3-2",
-        "price": 180,
-        "variant": "3"
-      },
-      {
-        "type": "buy_train",
-        "price": 305,
-        "train": "2-0",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 224,
-        "user": 1761,
-        "created_at": 1678885112
-      },
-      {
-        "type": "buy_train",
-        "price": 305,
-        "train": "2-3",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 225,
-        "user": 1761,
-        "created_at": 1678885113
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 226,
-        "user": 1761,
-        "created_at": 1678885124
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 227,
-        "user": 1761,
-        "created_at": 1678885126
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 228,
-        "user": 1761,
-        "created_at": 1678885129
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 229,
-        "user": 1761,
-        "created_at": 1678885147
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 230,
-        "user": 1761,
-        "created_at": 1678885150
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 231,
-        "user": 1761,
-        "created_at": 1678885153
-      },
-      {
-        "type": "buy_train",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 232,
-        "created_at": 1678885180,
-        "train": "2-0",
-        "price": 365
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 233,
-        "created_at": 1678885189
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 234,
-        "created_at": 1678885190
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 235,
-        "created_at": 1678887014,
-        "hex": "D9",
-        "tile": "5-1",
-        "rotation": 3
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 236,
-        "created_at": 1678887019,
-        "hex": "C10",
-        "tile": "9-5",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 237,
-        "created_at": 1678887027
-      },
-      {
-        "type": "buy_train",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 238,
-        "created_at": 1678887043,
-        "train": "3-3",
-        "price": 180,
-        "variant": "3"
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 239,
-        "created_at": 1678887054
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 240,
-        "created_at": 1678887065
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 241,
-        "created_at": 1678887089,
-        "hex": "B11",
-        "tile": "15-0",
-        "rotation": 5
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GBC",
-        "entity_type": "company",
-        "id": 242,
-        "created_at": 1678887120,
-        "hex": "B5",
-        "tile": "5-0",
-        "rotation": 2
-      },
-      {
-        "type": "pass",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 243,
-        "created_at": 1678887126
-      },
-      {
-        "type": "pass",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 244,
-        "created_at": 1678887142
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 245,
-        "created_at": 1678887198,
-        "routes": [
-          {
-            "train": "2-1",
-            "connections": [
-              [
-                "D9",
-                "C10",
-                "B11"
-              ]
-            ],
-            "hexes": [
-              "B11",
-              "D9"
-            ],
-            "revenue": 50,
-            "revenue_str": "B11-D9",
-            "nodes": [
-              "D9-0",
-              "B11-0"
-            ]
-          },
-          {
-            "train": "2-4",
-            "connections": [
-              [
-                "B11",
-                "B9",
-                "A10"
-              ]
-            ],
-            "hexes": [
+          ],
+          "hexes": [
+            "K6",
+            "K4"
+          ],
+          "revenue": 40,
+          "revenue_str": "K6-K4",
+          "nodes": [
+            "K6-0",
+            "K4-0"
+          ]
+        }
+      ],
+      "original_id": 91
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 71,
+      "created_at": 1678467915,
+      "kind": "payout",
+      "original_id": 92
+    },
+    {
+      "type": "buy_train",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 72,
+      "created_at": 1678467924,
+      "train": "2-5",
+      "price": 80,
+      "variant": "2",
+      "original_id": 93
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 73,
+      "created_at": 1678467928,
+      "original_id": 94
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 74,
+      "created_at": 1678491991,
+      "shares": [
+        "NP_6"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 95
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 75,
+      "created_at": 1678492008,
+      "original_id": 96
+    },
+    {
+      "type": "buy_shares",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 76,
+      "created_at": 1678492216,
+      "shares": [
+        "KATY_2"
+      ],
+      "percent": 10,
+      "original_id": 97
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 77,
+      "created_at": 1678493102,
+      "original_id": 98
+    },
+    {
+      "type": "buy_shares",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 78,
+      "created_at": 1678532289,
+      "shares": [
+        "NP_2"
+      ],
+      "percent": 10,
+      "original_id": 99
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 79,
+      "created_at": 1678532773,
+      "shares": [
+        "NP_7"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 100
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 80,
+      "created_at": 1678532792,
+      "original_id": 101
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 81,
+      "created_at": 1678540754,
+      "original_id": 102
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 82,
+      "created_at": 1678542194,
+      "shares": [
+        "NP_8"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 103
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 83,
+      "created_at": 1678542235,
+      "original_id": 104
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 84,
+      "created_at": 1678543698,
+      "original_id": 105
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 85,
+      "created_at": 1678543776,
+      "shares": [
+        "KATY_7",
+        "KATY_8"
+      ],
+      "percent": 20,
+      "original_id": 106
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 86,
+      "created_at": 1678543781,
+      "shares": [
+        "RI_6"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 107
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 87,
+      "created_at": 1678544898,
+      "original_id": 108
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 88,
+      "created_at": 1678547570,
+      "shares": [
+        "RI_5"
+      ],
+      "percent": 10,
+      "original_id": 109
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 89,
+      "created_at": 1678547578,
+      "shares": [
+        "KATY_7"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 110
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 90,
+      "created_at": 1678555752,
+      "shares": [
+        "RI_5"
+      ],
+      "percent": 10,
+      "original_id": 111
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 91,
+      "created_at": 1678563064,
+      "original_id": 112
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 92,
+      "created_at": 1678578810,
+      "shares": [
+        "KATY_8"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 113
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 93,
+      "created_at": 1678578827,
+      "original_id": 114
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 94,
+      "created_at": 1678579221,
+      "original_id": 115
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 95,
+      "created_at": 1678580779,
+      "original_id": 116
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 96,
+      "created_at": 1678586985,
+      "original_id": 117
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 97,
+      "created_at": 1678618784,
+      "hex": "A6",
+      "tile": "8-0",
+      "rotation": 4,
+      "original_id": 118
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 98,
+      "created_at": 1678618822,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
               "B11",
               "A10"
-            ],
-            "revenue": 60,
-            "revenue_str": "B11-A10",
-            "nodes": [
-              "B11-0",
-              "A10-0"
             ]
-          },
-          {
-            "train": "3-0",
-            "connections": [
-              [
-                "A10",
-                "A8",
-                "A6",
-                "B5"
-              ],
-              [
-                "B11",
-                "A10"
-              ]
-            ],
-            "hexes": [
-              "B5",
-              "A10",
-              "B11"
-            ],
-            "revenue": 80,
-            "revenue_str": "B5-A10-B11",
-            "nodes": [
-              "A10-0",
-              "B5-0",
-              "B11-0"
+          ],
+          "hexes": [
+            "B11",
+            "A10"
+          ],
+          "revenue": 50,
+          "revenue_str": "B11-A10",
+          "nodes": [
+            "B11-0",
+            "A10-0"
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "B11",
+              "B9",
+              "A10"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 246,
-        "created_at": 1678887206,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 247,
-        "created_at": 1678887238
-      },
-      {
-        "type": "pass",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 248,
-        "created_at": 1678887251
-      },
-      {
-        "type": "lay_tile",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 249,
-        "created_at": 1678887713,
-        "hex": "I4",
-        "tile": "57-0",
-        "rotation": 2
-      },
-      {
-        "type": "lay_tile",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 250,
-        "created_at": 1678887717,
-        "hex": "J5",
-        "tile": "9-6",
-        "rotation": 2
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 251,
-        "created_at": 1678887725
-      },
-      {
-        "type": "buy_train",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 252,
-        "created_at": 1678887727,
-        "train": "3-4",
-        "price": 180,
-        "variant": "3"
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 253,
-        "created_at": 1678887731
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 254,
-        "created_at": 1678887736
-      },
-      {
-        "hex": "K6",
-        "tile": "14-0",
-        "type": "lay_tile",
-        "entity": "KATY",
-        "rotation": 0,
-        "entity_type": "corporation",
-        "id": 255,
-        "user": 4311,
-        "created_at": 1678887747
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 256,
-        "user": 4311,
-        "created_at": 1678887754
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 257,
-        "created_at": 1678887765,
-        "hex": "K6",
-        "tile": "15-1",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 258,
-        "created_at": 1678887784
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 259,
-        "created_at": 1678887815,
-        "routes": [
-          {
-            "train": "2-2",
-            "connections": [
-              [
-                "K6",
-                "K4"
-              ]
-            ],
-            "hexes": [
+          ],
+          "hexes": [
+            "A10",
+            "B11"
+          ],
+          "revenue": 50,
+          "revenue_str": "A10-B11",
+          "nodes": [
+            "B11-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "original_id": 119
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 99,
+      "created_at": 1678618841,
+      "kind": "payout",
+      "original_id": 120
+    },
+    {
+      "type": "buy_train",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 100,
+      "created_at": 1678618846,
+      "train": "3-0",
+      "price": 180,
+      "variant": "3",
+      "original_id": 121
+    },
+    {
+      "type": "buy_company",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 101,
+      "created_at": 1678618869,
+      "company": "GBC",
+      "price": 100,
+      "original_id": 122
+    },
+    {
+      "type": "pass",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 102,
+      "created_at": 1678618955,
+      "original_id": 123
+    },
+    {
+      "type": "pass",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 103,
+      "created_at": 1678618982,
+      "original_id": 124
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 104,
+      "created_at": 1678622508,
+      "hex": "I18",
+      "tile": "128-0",
+      "rotation": 0,
+      "original_id": 125
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 105,
+      "created_at": 1678622665,
+      "original_id": 129
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 106,
+      "created_at": 1678622671,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "H11",
+              "H13",
+              "H15",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "H11",
+            "H17"
+          ],
+          "revenue": 30,
+          "revenue_str": "H11-H17",
+          "nodes": [
+            "H11-0",
+            "H17-0"
+          ]
+        }
+      ],
+      "original_id": 130
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 107,
+      "created_at": 1678622677,
+      "kind": "payout",
+      "original_id": 131
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 108,
+      "created_at": 1678622681,
+      "original_id": 132
+    },
+    {
+      "type": "buy_company",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 109,
+      "created_at": 1678622701,
+      "company": "MMR",
+      "price": 320,
+      "original_id": 133
+    },
+    {
+      "type": "buy_company",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 110,
+      "created_at": 1678622704,
+      "company": "CM",
+      "price": 80,
+      "original_id": 134
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 111,
+      "created_at": 1678622815,
+      "original_id": 135
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 112,
+      "created_at": 1678623580,
+      "hex": "J7",
+      "tile": "8-1",
+      "rotation": 4,
+      "original_id": 136
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 113,
+      "created_at": 1678623589,
+      "original_id": 137
+    },
+    {
+      "type": "place_token",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 114,
+      "created_at": 1678623593,
+      "city": "6-1-0",
+      "slot": 0,
+      "tokener": "KATY",
+      "original_id": 138
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 115,
+      "created_at": 1678623614,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
               "K6",
               "K4"
-            ],
-            "revenue": 50,
-            "revenue_str": "K6-K4",
-            "nodes": [
-              "K6-0",
-              "K4-0"
             ]
-          },
-          {
-            "train": "2-5",
-            "connections": [
-              [
-                "K4",
-                "L3",
-                "M2"
-              ]
-            ],
-            "hexes": [
+          ],
+          "hexes": [
+            "K6",
+            "K4"
+          ],
+          "revenue": 40,
+          "revenue_str": "K6-K4",
+          "nodes": [
+            "K6-0",
+            "K4-0"
+          ]
+        },
+        {
+          "train": "2-5",
+          "connections": [
+            [
               "K4",
+              "L3",
               "M2"
-            ],
-            "revenue": 80,
-            "revenue_str": "K4-M2 + Edge Token",
-            "nodes": [
-              "K4-0",
-              "M2-0"
             ]
-          },
-          {
-            "train": "3-1",
-            "connections": [
-              [
-                "K6",
-                "J5",
-                "I4"
-              ]
-            ],
-            "hexes": [
-              "I4",
-              "K6"
-            ],
-            "revenue": 50,
-            "revenue_str": "I4-K6",
-            "nodes": [
-              "K6-0",
-              "I4-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 260,
-        "created_at": 1678887818,
-        "kind": "half"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 261,
-        "created_at": 1678887822
-      },
-      {
-        "type": "buy_company",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 262,
-        "created_at": 1678887837,
-        "company": "GRSC",
-        "price": 40
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 263,
-        "created_at": 1678887841
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 264,
-        "created_at": 1678892942,
-        "hex": "K14",
-        "tile": "57-1",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 265,
-        "created_at": 1678892949
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 266,
-        "created_at": 1678892955
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 267,
-        "created_at": 1678892961,
-        "routes": [
-          {
-            "train": "2-3",
-            "connections": [
-              [
-                "I18",
-                "H17"
-              ]
-            ],
-            "hexes": [
+          ],
+          "hexes": [
+            "M2",
+            "K4"
+          ],
+          "revenue": 80,
+          "revenue_str": "M2-K4 + Edge Token",
+          "nodes": [
+            "K4-0",
+            "M2-0"
+          ]
+        }
+      ],
+      "original_id": 139
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 116,
+      "created_at": 1678623620,
+      "kind": "payout",
+      "original_id": 140
+    },
+    {
+      "type": "buy_train",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 117,
+      "created_at": 1678623623,
+      "train": "3-1",
+      "price": 180,
+      "variant": "3",
+      "original_id": 141
+    },
+    {
+      "type": "buy_company",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 118,
+      "created_at": 1678623661,
+      "company": "WLG",
+      "price": 164,
+      "original_id": 142
+    },
+    {
+      "type": "par",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 119,
+      "created_at": 1678625654,
+      "corporation": "CBQ",
+      "share_price": "90,1,6",
+      "original_id": 143
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 120,
+      "created_at": 1678625690,
+      "original_id": 144
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 121,
+      "created_at": 1678630672,
+      "shares": [
+        "NP_3",
+        "NP_4"
+      ],
+      "percent": 20,
+      "original_id": 149
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 122,
+      "created_at": 1678630680,
+      "shares": [
+        "KATY_5",
+        "KATY_6"
+      ],
+      "percent": 20,
+      "original_id": 150
+    },
+    {
+      "type": "par",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 123,
+      "created_at": 1678630702,
+      "corporation": "GN",
+      "share_price": "90,1,6",
+      "original_id": 151
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 124,
+      "created_at": 1678674017,
+      "original_id": 152
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 125,
+      "created_at": 1678674058,
+      "shares": [
+        "NP_5",
+        "NP_7"
+      ],
+      "percent": 20,
+      "original_id": 153
+    },
+    {
+      "type": "par",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 126,
+      "created_at": 1678674193,
+      "corporation": "UP",
+      "share_price": "76,3,6",
+      "original_id": 154
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "user": 2122,
+      "created_at": 1701691028,
+      "original_id": null,
+      "id": 127
+    },
+    {
+      "type": "buy_shares",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 128,
+      "created_at": 1678674524,
+      "shares": [
+        "RI_2"
+      ],
+      "percent": 10,
+      "original_id": 155
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 129,
+      "created_at": 1678674643,
+      "corporation": "CBQ",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false,
+      "original_id": 156
+    },
+    {
+      "type": "buy_shares",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 130,
+      "created_at": 1678706058,
+      "shares": [
+        "NP_3"
+      ],
+      "percent": 10,
+      "original_id": 157
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 131,
+      "created_at": 1678715611,
+      "shares": [
+        "UP_1"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 158
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 132,
+      "created_at": 1678715623,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1678715622,
+          "reason": "NP redeemed a share."
+        }
+      ],
+      "original_id": 159
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 133,
+      "created_at": 1678716651,
+      "shares": [
+        "CBQ_1"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 160
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 134,
+      "created_at": 1678716654,
+      "original_id": 161
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 135,
+      "created_at": 1678716660,
+      "corporation": "CBQ",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false,
+      "original_id": 162
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 136,
+      "created_at": 1678718468,
+      "shares": [
+        "GN_1"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 163
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 137,
+      "created_at": 1678718479,
+      "original_id": 164
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 138,
+      "created_at": 1678748900,
+      "shares": [
+        "UP_2"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 165
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 139,
+      "created_at": 1678748907,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1678748907,
+          "shares": [
+            "CBQ_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1678748907
+        }
+      ],
+      "original_id": 166
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 140,
+      "created_at": 1678749183,
+      "shares": [
+        "GN_2"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 167
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 141,
+      "created_at": 1678749191,
+      "original_id": 168
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 142,
+      "created_at": 1678763436,
+      "shares": [
+        "UP_3"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 169
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 143,
+      "created_at": 1678763479,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1678763479,
+          "shares": [
+            "CBQ_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1678763479
+        }
+      ],
+      "original_id": 170
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 144,
+      "created_at": 1678788515,
+      "shares": [
+        "GN_3"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 171
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 145,
+      "created_at": 1678788519,
+      "original_id": 172
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 146,
+      "created_at": 1678843337,
+      "shares": [
+        "UP_4"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 173
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 147,
+      "created_at": 1678843522,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1678843522,
+          "shares": [
+            "CBQ_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1678843522,
+          "reason": "CBQ is floated"
+        }
+      ],
+      "original_id": 174
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 148,
+      "created_at": 1678848557,
+      "original_id": 175
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 149,
+      "created_at": 1678878599,
+      "shares": [
+        "GN_4"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 176
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 150,
+      "created_at": 1678878627,
+      "original_id": 177
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 151,
+      "created_at": 1678882387,
+      "original_id": 178
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 152,
+      "created_at": 1678883418,
+      "original_id": 179
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 153,
+      "created_at": 1678883501,
+      "original_id": 180
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 154,
+      "created_at": 1678884680,
+      "hex": "I18",
+      "tile": "129-0",
+      "rotation": 0,
+      "original_id": 181
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 155,
+      "created_at": 1678884712,
+      "original_id": 184
+    },
+    {
+      "type": "place_token",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 156,
+      "created_at": 1678884715,
+      "city": "129-0-1",
+      "slot": 1,
+      "tokener": "RI",
+      "original_id": 185
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 157,
+      "created_at": 1678884723,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
               "I18",
               "H17"
-            ],
-            "revenue": 60,
-            "revenue_str": "I18-H17",
-            "nodes": [
-              "I18-1",
-              "H17-0"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 268,
-        "created_at": 1678892963,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 269,
-        "created_at": 1678892983,
-        "train": "3-5",
-        "price": 180,
-        "variant": "3"
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 270,
-        "created_at": 1678893018
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 271,
-        "created_at": 1678893020
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 272,
-        "created_at": 1678893754,
-        "hex": "B5",
-        "tile": "14-0",
-        "rotation": 2
-      },
-      {
-        "type": "pass",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 273,
-        "created_at": 1678893789
-      },
-      {
-        "type": "pass",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 274,
-        "created_at": 1678893801
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 275,
-        "created_at": 1678893814,
-        "routes": [
-          {
-            "train": "2-1",
-            "connections": [
-              [
-                "D9",
-                "C10",
-                "B11"
-              ]
-            ],
-            "hexes": [
+          ],
+          "hexes": [
+            "I18",
+            "H17"
+          ],
+          "revenue": 60,
+          "revenue_str": "I18-H17",
+          "nodes": [
+            "I18-1",
+            "H17-0"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "H11",
+              "H13",
+              "H15",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "H11",
+            "H17"
+          ],
+          "revenue": 30,
+          "revenue_str": "H11-H17",
+          "nodes": [
+            "H11-0",
+            "H17-0"
+          ]
+        }
+      ],
+      "original_id": 186
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 158,
+      "created_at": 1678884904,
+      "kind": "payout",
+      "original_id": 209
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 159,
+      "created_at": 1678884906,
+      "original_id": 210
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 160,
+      "created_at": 1678884906,
+      "original_id": 211
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 161,
+      "created_at": 1678885059,
+      "hex": "I16",
+      "tile": "58-1",
+      "rotation": 4,
+      "original_id": 220
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 162,
+      "created_at": 1678885062,
+      "hex": "J15",
+      "tile": "9-4",
+      "rotation": 0,
+      "original_id": 221
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 163,
+      "created_at": 1678885076,
+      "original_id": 222
+    },
+    {
+      "type": "buy_train",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 164,
+      "created_at": 1678885077,
+      "train": "3-2",
+      "price": 180,
+      "variant": "3",
+      "original_id": 223
+    },
+    {
+      "type": "buy_train",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 165,
+      "created_at": 1678885180,
+      "train": "2-0",
+      "price": 365,
+      "original_id": 232
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 166,
+      "created_at": 1678885189,
+      "original_id": 233
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 167,
+      "created_at": 1678885190,
+      "original_id": 234
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 168,
+      "created_at": 1678887014,
+      "hex": "D9",
+      "tile": "5-1",
+      "rotation": 3,
+      "original_id": 235
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 169,
+      "created_at": 1678887019,
+      "hex": "C10",
+      "tile": "9-5",
+      "rotation": 0,
+      "original_id": 236
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 170,
+      "created_at": 1678887027,
+      "original_id": 237
+    },
+    {
+      "type": "buy_train",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 171,
+      "created_at": 1678887043,
+      "train": "3-3",
+      "price": 180,
+      "variant": "3",
+      "original_id": 238
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 172,
+      "created_at": 1678887054,
+      "original_id": 239
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 173,
+      "created_at": 1678887065,
+      "original_id": 240
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 174,
+      "created_at": 1678887089,
+      "hex": "B11",
+      "tile": "15-0",
+      "rotation": 5,
+      "original_id": 241
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GBC",
+      "entity_type": "company",
+      "id": 175,
+      "created_at": 1678887120,
+      "hex": "B5",
+      "tile": "5-0",
+      "rotation": 2,
+      "original_id": 242
+    },
+    {
+      "type": "pass",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 176,
+      "created_at": 1678887126,
+      "original_id": 243
+    },
+    {
+      "type": "pass",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 177,
+      "created_at": 1678887142,
+      "original_id": 244
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 178,
+      "created_at": 1678887198,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
               "D9",
+              "C10",
               "B11"
-            ],
-            "revenue": 50,
-            "revenue_str": "D9-B11",
-            "nodes": [
-              "D9-0",
-              "B11-0"
             ]
-          },
-          {
-            "train": "2-4",
-            "connections": [
-              [
-                "B11",
-                "B9",
-                "A10"
-              ]
-            ],
-            "hexes": [
+          ],
+          "hexes": [
+            "B11",
+            "D9"
+          ],
+          "revenue": 50,
+          "revenue_str": "B11-D9",
+          "nodes": [
+            "D9-0",
+            "B11-0"
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
               "B11",
+              "B9",
               "A10"
-            ],
-            "revenue": 60,
-            "revenue_str": "B11-A10",
-            "nodes": [
-              "B11-0",
-              "A10-0"
             ]
-          },
-          {
-            "train": "3-0",
-            "connections": [
-              [
-                "A10",
-                "A8",
-                "A6",
-                "B5"
-              ],
-              [
-                "B11",
-                "A10"
-              ]
-            ],
-            "hexes": [
-              "B5",
+          ],
+          "hexes": [
+            "B11",
+            "A10"
+          ],
+          "revenue": 60,
+          "revenue_str": "B11-A10",
+          "nodes": [
+            "B11-0",
+            "A10-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
               "A10",
-              "B11"
-            ],
-            "revenue": 90,
-            "revenue_str": "B5-A10-B11",
-            "nodes": [
-              "A10-0",
-              "B5-0",
-              "B11-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 276,
-        "created_at": 1678893830,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 277,
-        "created_at": 1678893841,
-        "train": "4-0",
-        "price": 300,
-        "variant": "4"
-      },
-      {
-        "type": "pass",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 278,
-        "created_at": 1678893964
-      },
-      {
-        "type": "pass",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 279,
-        "created_at": 1678893967
-      },
-      {
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 280,
-        "created_at": 1678894003,
-        "hex": "K14",
-        "tile": "15-2",
-        "rotation": 3
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 281,
-        "created_at": 1678894011
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 282,
-        "created_at": 1678894020
-      },
-      {
-        "type": "run_routes",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 283,
-        "created_at": 1678894024,
-        "routes": [
-          {
-            "train": "3-2",
-            "connections": [
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "I16",
-              "K14"
-            ],
-            "revenue": 90,
-            "revenue_str": "I18-I16-K14",
-            "nodes": [
-              "I18-1",
-              "I16-0",
-              "K14-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 284,
-        "created_at": 1678894030,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 285,
-        "created_at": 1678894113,
-        "train": "4-1",
-        "price": 300,
-        "variant": "4"
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 286,
-        "created_at": 1678894115
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 287,
-        "created_at": 1678894118
-      },
-      {
-        "hex": "D9",
-        "tile": "15-3",
-        "type": "lay_tile",
-        "entity": "GN",
-        "rotation": 1,
-        "entity_type": "corporation",
-        "id": 288,
-        "user": 2122,
-        "created_at": 1678894236
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 289,
-        "user": 2122,
-        "created_at": 1678894241
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 290,
-        "user": 2122,
-        "created_at": 1678894341
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 291,
-        "user": 2122,
-        "created_at": 1678894366
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 292,
-        "user": 2122,
-        "created_at": 1678894370
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 293,
-        "user": 2122,
-        "created_at": 1678894402
-      },
-      {
-        "type": "choose",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 294,
-        "created_at": 1678894421,
-        "choice": "Buy Mesabi Token"
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 295,
-        "created_at": 1678894439
-      },
-      {
-        "type": "place_token",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 296,
-        "created_at": 1678894447,
-        "city": "14-0-0",
-        "slot": 0,
-        "tokener": "GN"
-      },
-      {
-        "type": "run_routes",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 297,
-        "created_at": 1678894464,
-        "routes": [
-          {
-            "train": "3-3",
-            "connections": [
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ]
-            ],
-            "hexes": [
-              "B11",
-              "A10",
+              "A8",
+              "A6",
               "B5"
             ],
-            "revenue": 90,
-            "revenue_str": "B11-A10-B5",
-            "nodes": [
-              "A10-0",
-              "B11-0",
-              "B5-0"
+            [
+              "B11",
+              "A10"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 298,
-        "created_at": 1678894475,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 299,
-        "created_at": 1678894478,
-        "train": "4-2",
-        "price": 300,
-        "variant": "4"
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 300,
-        "created_at": 1678894497
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 301,
-        "created_at": 1678894499
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 302,
-        "created_at": 1678941551,
-        "hex": "K4",
-        "tile": "14-1",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 303,
-        "created_at": 1678941554
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 304,
-        "created_at": 1678941569,
-        "routes": [
-          {
-            "train": "3-1",
-            "connections": [
-              [
-                "K6",
-                "K4"
-              ],
-              [
-                "K4",
-                "L3",
-                "M2"
-              ]
-            ],
-            "hexes": [
+          ],
+          "hexes": [
+            "B5",
+            "A10",
+            "B11"
+          ],
+          "revenue": 80,
+          "revenue_str": "B5-A10-B11",
+          "nodes": [
+            "A10-0",
+            "B5-0",
+            "B11-0"
+          ]
+        }
+      ],
+      "original_id": 245
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 179,
+      "created_at": 1678887206,
+      "kind": "payout",
+      "original_id": 246
+    },
+    {
+      "type": "pass",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 180,
+      "created_at": 1678887238,
+      "original_id": 247
+    },
+    {
+      "type": "pass",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 181,
+      "created_at": 1678887251,
+      "original_id": 248
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 182,
+      "created_at": 1678887713,
+      "hex": "I4",
+      "tile": "57-0",
+      "rotation": 2,
+      "original_id": 249
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 183,
+      "created_at": 1678887717,
+      "hex": "J5",
+      "tile": "9-6",
+      "rotation": 2,
+      "original_id": 250
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 184,
+      "created_at": 1678887725,
+      "original_id": 251
+    },
+    {
+      "type": "buy_train",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 185,
+      "created_at": 1678887727,
+      "train": "3-4",
+      "price": 180,
+      "variant": "3",
+      "original_id": 252
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 186,
+      "created_at": 1678887731,
+      "original_id": 253
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 187,
+      "created_at": 1678887736,
+      "original_id": 254
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 188,
+      "created_at": 1678887765,
+      "hex": "K6",
+      "tile": "15-1",
+      "rotation": 0,
+      "original_id": 257
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 189,
+      "created_at": 1678887784,
+      "original_id": 258
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 190,
+      "created_at": 1678887815,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
               "K6",
-              "K4",
-              "M2"
-            ],
-            "revenue": 120,
-            "revenue_str": "K6-K4-M2 + Edge Token",
-            "nodes": [
-              "K6-0",
-              "K4-0",
-              "M2-0"
+              "K4"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 305,
-        "created_at": 1678941571,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 306,
-        "created_at": 1678941577
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 307,
-        "created_at": 1678941586
-      },
-      {
-        "type": "lay_tile",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 308,
-        "created_at": 1678941592,
-        "hex": "H3",
-        "tile": "9-7",
-        "rotation": 2
-      },
-      {
-        "type": "buy_company",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 309,
-        "created_at": 1678941606,
-        "company": "MRB",
-        "price": 80
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 310,
-        "created_at": 1678941615
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 311,
-        "created_at": 1678941617
-      },
-      {
-        "type": "run_routes",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 312,
-        "created_at": 1678941626,
-        "routes": [
-          {
-            "train": "3-4",
-            "connections": [
-              [
-                "I4",
-                "J5",
-                "K6"
-              ],
-              [
-                "K6",
-                "K4"
-              ]
+          ],
+          "hexes": [
+            "K6",
+            "K4"
+          ],
+          "revenue": 50,
+          "revenue_str": "K6-K4",
+          "nodes": [
+            "K6-0",
+            "K4-0"
+          ]
+        },
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "K4",
+              "L3",
+              "M2"
+            ]
+          ],
+          "hexes": [
+            "K4",
+            "M2"
+          ],
+          "revenue": 80,
+          "revenue_str": "K4-M2 + Edge Token",
+          "nodes": [
+            "K4-0",
+            "M2-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "K6",
+              "J5",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "I4",
+            "K6"
+          ],
+          "revenue": 50,
+          "revenue_str": "I4-K6",
+          "nodes": [
+            "K6-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "original_id": 259
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 191,
+      "created_at": 1678887818,
+      "kind": "half",
+      "original_id": 260
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 192,
+      "created_at": 1678887822,
+      "original_id": 261
+    },
+    {
+      "type": "buy_company",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 193,
+      "created_at": 1678887837,
+      "company": "GRSC",
+      "price": 40,
+      "original_id": 262
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 194,
+      "created_at": 1678887841,
+      "original_id": 263
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 195,
+      "created_at": 1678892942,
+      "hex": "K14",
+      "tile": "57-1",
+      "rotation": 0,
+      "original_id": 264
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 196,
+      "created_at": 1678892949,
+      "original_id": 265
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 197,
+      "created_at": 1678892955,
+      "original_id": 266
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 198,
+      "created_at": 1678892961,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "I18",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "H17"
+          ],
+          "revenue": 60,
+          "revenue_str": "I18-H17",
+          "nodes": [
+            "I18-1",
+            "H17-0"
+          ]
+        }
+      ],
+      "original_id": 267
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 199,
+      "created_at": 1678892963,
+      "kind": "payout",
+      "original_id": 268
+    },
+    {
+      "type": "buy_train",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 200,
+      "created_at": 1678892983,
+      "train": "3-5",
+      "price": 180,
+      "variant": "3",
+      "original_id": 269
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 201,
+      "created_at": 1678893018,
+      "original_id": 270
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 202,
+      "created_at": 1678893020,
+      "original_id": 271
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 203,
+      "created_at": 1678893754,
+      "hex": "B5",
+      "tile": "14-0",
+      "rotation": 2,
+      "original_id": 272
+    },
+    {
+      "type": "pass",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 204,
+      "created_at": 1678893789,
+      "original_id": 273
+    },
+    {
+      "type": "pass",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 205,
+      "created_at": 1678893801,
+      "original_id": 274
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 206,
+      "created_at": 1678893814,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "D9",
+              "C10",
+              "B11"
+            ]
+          ],
+          "hexes": [
+            "D9",
+            "B11"
+          ],
+          "revenue": 50,
+          "revenue_str": "D9-B11",
+          "nodes": [
+            "D9-0",
+            "B11-0"
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "B11",
+              "B9",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "A10"
+          ],
+          "revenue": 60,
+          "revenue_str": "B11-A10",
+          "nodes": [
+            "B11-0",
+            "A10-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "A10",
+              "A8",
+              "A6",
+              "B5"
             ],
-            "hexes": [
-              "I4",
+            [
+              "B11",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "B5",
+            "A10",
+            "B11"
+          ],
+          "revenue": 90,
+          "revenue_str": "B5-A10-B11",
+          "nodes": [
+            "A10-0",
+            "B5-0",
+            "B11-0"
+          ]
+        }
+      ],
+      "original_id": 275
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 207,
+      "created_at": 1678893830,
+      "kind": "payout",
+      "original_id": 276
+    },
+    {
+      "type": "buy_train",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 208,
+      "created_at": 1678893841,
+      "train": "4-0",
+      "price": 300,
+      "variant": "4",
+      "original_id": 277
+    },
+    {
+      "type": "pass",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 209,
+      "created_at": 1678893964,
+      "original_id": 278
+    },
+    {
+      "type": "pass",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 210,
+      "created_at": 1678893967,
+      "original_id": 279
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 211,
+      "created_at": 1678894003,
+      "hex": "K14",
+      "tile": "15-2",
+      "rotation": 3,
+      "original_id": 280
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 212,
+      "created_at": 1678894011,
+      "original_id": 281
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 213,
+      "created_at": 1678894020,
+      "original_id": 282
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 214,
+      "created_at": 1678894024,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "I18",
+              "I16"
+            ],
+            [
+              "I16",
+              "J15",
+              "K14"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "I16",
+            "K14"
+          ],
+          "revenue": 90,
+          "revenue_str": "I18-I16-K14",
+          "nodes": [
+            "I18-1",
+            "I16-0",
+            "K14-0"
+          ]
+        }
+      ],
+      "original_id": 283
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 215,
+      "created_at": 1678894030,
+      "kind": "payout",
+      "original_id": 284
+    },
+    {
+      "type": "buy_train",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 216,
+      "created_at": 1678894113,
+      "train": "4-1",
+      "price": 300,
+      "variant": "4",
+      "original_id": 285
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 217,
+      "created_at": 1678894115,
+      "original_id": 286
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 218,
+      "created_at": 1678894118,
+      "original_id": 287
+    },
+    {
+      "type": "choose",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 219,
+      "created_at": 1678894421,
+      "choice": "Buy Mesabi Token",
+      "original_id": 294
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 220,
+      "created_at": 1678894439,
+      "original_id": 295
+    },
+    {
+      "type": "place_token",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 221,
+      "created_at": 1678894447,
+      "city": "14-0-0",
+      "slot": 0,
+      "tokener": "GN",
+      "original_id": 296
+    },
+    {
+      "type": "run_routes",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 222,
+      "created_at": 1678894464,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "A10",
+            "B5"
+          ],
+          "revenue": 90,
+          "revenue_str": "B11-A10-B5",
+          "nodes": [
+            "A10-0",
+            "B11-0",
+            "B5-0"
+          ]
+        }
+      ],
+      "original_id": 297
+    },
+    {
+      "type": "dividend",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 223,
+      "created_at": 1678894475,
+      "kind": "payout",
+      "original_id": 298
+    },
+    {
+      "type": "buy_train",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 224,
+      "created_at": 1678894478,
+      "train": "4-2",
+      "price": 300,
+      "variant": "4",
+      "original_id": 299
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 225,
+      "created_at": 1678894497,
+      "original_id": 300
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 226,
+      "created_at": 1678894499,
+      "original_id": 301
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 227,
+      "created_at": 1678941551,
+      "hex": "K4",
+      "tile": "14-1",
+      "rotation": 0,
+      "original_id": 302
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 228,
+      "created_at": 1678941554,
+      "original_id": 303
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 229,
+      "created_at": 1678941569,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
               "K6",
               "K4"
             ],
-            "revenue": 80,
-            "revenue_str": "I4-K6-K4",
-            "nodes": [
-              "I4-0",
-              "K6-0",
-              "K4-0"
+            [
+              "K4",
+              "L3",
+              "M2"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 313,
-        "created_at": 1678941627,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 314,
-        "created_at": 1678941637,
-        "train": "4-3",
-        "price": 300,
-        "variant": "4"
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 315,
-        "created_at": 1678941640
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 316,
-        "user": 4311,
-        "created_at": 1678941679
-      },
-      {
-        "type": "undo",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 317,
-        "user": 4311,
-        "created_at": 1678941683
-      },
-      {
-        "type": "buy_shares",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 318,
-        "created_at": 1678941692,
-        "shares": [
-          "KATY_5"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 319,
-        "created_at": 1678941776,
-        "shares": [
-          "NP_4"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 320,
-        "created_at": 1678941780
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 321,
-        "created_at": 1678964015,
-        "shares": [
-          "NP_5"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 322,
-        "created_at": 1678964071
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "shares": [
-          "GN_5"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "share_price": false,
-        "id": 323,
-        "user": 4311,
-        "created_at": 1678965582
-      },
-      {
-        "type": "undo",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 324,
-        "user": 4311,
-        "created_at": 1678965686
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 325,
-        "created_at": 1678965690,
-        "shares": [
-          "NP_7"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 326,
-        "created_at": 1678965696
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 327,
-        "created_at": 1678968660,
-        "shares": [
-          "UP_5"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 328,
-        "created_at": 1678968665
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 329,
-        "created_at": 1678969966,
-        "shares": [
-          "UP_6"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 330,
-        "created_at": 1678969973
-      },
-      {
-        "type": "buy_shares",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 331,
-        "created_at": 1678972628,
-        "shares": [
-          "UP_1"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 332,
-        "created_at": 1678974332
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "shares": [
-          "RI_7"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "share_price": false,
-        "id": 333,
-        "user": 2122,
-        "created_at": 1678977047
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 334,
-        "user": 2122,
-        "created_at": 1678977090
-      },
-      {
-        "type": "undo",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 335,
-        "user": 2122,
-        "created_at": 1678977335
-      },
-      {
-        "type": "undo",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 336,
-        "user": 2122,
-        "created_at": 1678977356
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 337,
-        "created_at": 1678977374,
-        "shares": [
-          "CBQ_5"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 338,
-        "created_at": 1678977410
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 339,
-        "created_at": 1679013288,
-        "shares": [
-          "UP_7"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 340,
-        "created_at": 1679024066
-      },
-      {
-        "type": "buy_shares",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 341,
-        "created_at": 1679026978,
-        "shares": [
-          "CBQ_1"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 342,
-        "created_at": 1679044921
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 343,
-        "created_at": 1679047656,
-        "shares": [
-          "RI_7"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 344,
-        "created_at": 1679047737
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 345,
-        "created_at": 1679050705,
-        "shares": [
-          "CBQ_6"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 346,
-        "created_at": 1679050738
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 347,
-        "created_at": 1679055128
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 348,
-        "created_at": 1679056597,
-        "shares": [
-          "RI_8"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 349,
-        "created_at": 1679056631
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 350,
-        "created_at": 1679058086
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 351,
-        "created_at": 1679059370
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 352,
-        "created_at": 1679063650
-      },
-      {
-        "hex": "K16",
-        "tile": "9-8",
-        "type": "lay_tile",
-        "entity": "RI",
-        "rotation": 1,
-        "entity_type": "corporation",
-        "id": 353,
-        "user": 1761,
-        "created_at": 1679078031
-      },
-      {
-        "type": "undo",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 354,
-        "user": 1761,
-        "created_at": 1679078038
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 355,
-        "created_at": 1679078079,
-        "hex": "K16",
-        "tile": "9-8",
-        "rotation": 1
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 356,
-        "created_at": 1679078084
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 357,
-        "created_at": 1679078094
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 358,
-        "created_at": 1679078097,
-        "routes": [
-          {
-            "train": "3-5",
-            "connections": [
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ]
+          ],
+          "hexes": [
+            "K6",
+            "K4",
+            "M2"
+          ],
+          "revenue": 120,
+          "revenue_str": "K6-K4-M2 + Edge Token",
+          "nodes": [
+            "K6-0",
+            "K4-0",
+            "M2-0"
+          ]
+        }
+      ],
+      "original_id": 304
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 230,
+      "created_at": 1678941571,
+      "kind": "payout",
+      "original_id": 305
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 231,
+      "created_at": 1678941577,
+      "original_id": 306
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 232,
+      "created_at": 1678941586,
+      "original_id": 307
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 233,
+      "created_at": 1678941592,
+      "hex": "H3",
+      "tile": "9-7",
+      "rotation": 2,
+      "original_id": 308
+    },
+    {
+      "type": "buy_company",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 234,
+      "created_at": 1678941606,
+      "company": "MRB",
+      "price": 80,
+      "original_id": 309
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 235,
+      "created_at": 1678941615,
+      "original_id": 310
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 236,
+      "created_at": 1678941617,
+      "original_id": 311
+    },
+    {
+      "type": "run_routes",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 237,
+      "created_at": 1678941626,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "I4",
+              "J5",
+              "K6"
             ],
-            "hexes": [
+            [
+              "K6",
+              "K4"
+            ]
+          ],
+          "hexes": [
+            "I4",
+            "K6",
+            "K4"
+          ],
+          "revenue": 80,
+          "revenue_str": "I4-K6-K4",
+          "nodes": [
+            "I4-0",
+            "K6-0",
+            "K4-0"
+          ]
+        }
+      ],
+      "original_id": 312
+    },
+    {
+      "type": "dividend",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 238,
+      "created_at": 1678941627,
+      "kind": "payout",
+      "original_id": 313
+    },
+    {
+      "type": "buy_train",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 239,
+      "created_at": 1678941637,
+      "train": "4-3",
+      "price": 300,
+      "variant": "4",
+      "original_id": 314
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 240,
+      "created_at": 1678941640,
+      "original_id": 315
+    },
+    {
+      "type": "buy_shares",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 241,
+      "created_at": 1678941692,
+      "shares": [
+        "KATY_5"
+      ],
+      "percent": 10,
+      "original_id": 318
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 242,
+      "created_at": 1678941776,
+      "shares": [
+        "NP_4"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 319
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 243,
+      "created_at": 1678941780,
+      "original_id": 320
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 244,
+      "created_at": 1678964015,
+      "shares": [
+        "NP_5"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 321
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 245,
+      "created_at": 1678964071,
+      "original_id": 322
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 246,
+      "created_at": 1678965690,
+      "shares": [
+        "NP_7"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 325
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 247,
+      "created_at": 1678965696,
+      "original_id": 326
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 248,
+      "created_at": 1678968660,
+      "shares": [
+        "UP_5"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 327
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 249,
+      "created_at": 1678968665,
+      "original_id": 328
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 250,
+      "created_at": 1678969966,
+      "shares": [
+        "UP_6"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 329
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 251,
+      "created_at": 1678969973,
+      "original_id": 330
+    },
+    {
+      "type": "buy_shares",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 252,
+      "created_at": 1678972628,
+      "shares": [
+        "UP_1"
+      ],
+      "percent": 10,
+      "original_id": 331
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 253,
+      "created_at": 1678974332,
+      "original_id": 332
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 254,
+      "created_at": 1678977374,
+      "shares": [
+        "CBQ_5"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 337
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 255,
+      "created_at": 1678977410,
+      "original_id": 338
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 256,
+      "created_at": 1679013288,
+      "shares": [
+        "UP_7"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 339
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 257,
+      "created_at": 1679024066,
+      "original_id": 340
+    },
+    {
+      "type": "buy_shares",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 258,
+      "created_at": 1679026978,
+      "shares": [
+        "CBQ_1"
+      ],
+      "percent": 10,
+      "original_id": 341
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 259,
+      "created_at": 1679044921,
+      "original_id": 342
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 260,
+      "created_at": 1679047656,
+      "shares": [
+        "RI_7"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 343
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 261,
+      "created_at": 1679047737,
+      "original_id": 344
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 262,
+      "created_at": 1679050705,
+      "shares": [
+        "CBQ_6"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 345
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 263,
+      "created_at": 1679050738,
+      "original_id": 346
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 264,
+      "created_at": 1679055128,
+      "original_id": 347
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 265,
+      "created_at": 1679056597,
+      "shares": [
+        "RI_8"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 348
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 266,
+      "created_at": 1679056631,
+      "original_id": 349
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 267,
+      "created_at": 1679058086,
+      "original_id": 350
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 268,
+      "created_at": 1679059370,
+      "original_id": 351
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 269,
+      "created_at": 1679063650,
+      "original_id": 352
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 270,
+      "created_at": 1679078079,
+      "hex": "K16",
+      "tile": "9-8",
+      "rotation": 1,
+      "original_id": 355
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 271,
+      "created_at": 1679078084,
+      "original_id": 356
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 272,
+      "created_at": 1679078094,
+      "original_id": 357
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 273,
+      "created_at": 1679078097,
+      "routes": [
+        {
+          "train": "3-5",
+          "connections": [
+            [
               "I18",
+              "I16"
+            ],
+            [
               "I16",
+              "J15",
+              "K14"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "I16",
+            "K14"
+          ],
+          "revenue": 90,
+          "revenue_str": "I18-I16-K14",
+          "nodes": [
+            "I18-1",
+            "I16-0",
+            "K14-0"
+          ]
+        }
+      ],
+      "original_id": 358
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 274,
+      "created_at": 1679078098,
+      "kind": "withhold",
+      "original_id": 359
+    },
+    {
+      "type": "buy_train",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 275,
+      "created_at": 1679078100,
+      "train": "5-0",
+      "price": 450,
+      "variant": "5",
+      "original_id": 360
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 276,
+      "created_at": 1679099636,
+      "hex": "B11",
+      "tile": "63-0",
+      "rotation": 0,
+      "original_id": 361
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GBC",
+      "entity_type": "company",
+      "id": 277,
+      "created_at": 1679099647,
+      "hex": "A4",
+      "tile": "8-2",
+      "rotation": 5,
+      "original_id": 362
+    },
+    {
+      "type": "choose",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 278,
+      "created_at": 1679099655,
+      "choice": "Place Edge Token",
+      "original_id": 363
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 279,
+      "created_at": 1679099735,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "B11",
+              "C10",
+              "D9"
+            ],
+            [
+              "A10",
+              "B11"
+            ]
+          ],
+          "hexes": [
+            "D9",
+            "B11",
+            "A10"
+          ],
+          "revenue": 100,
+          "revenue_str": "D9-B11-A10",
+          "nodes": [
+            "B11-0",
+            "D9-0",
+            "A10-0"
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 190,
+          "revenue_str": "B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "A10-0",
+            "B11-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 364
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 280,
+      "created_at": 1679099744,
+      "kind": "payout",
+      "original_id": 365
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 281,
+      "created_at": 1679099977,
+      "hex": "K18",
+      "tile": "9-9",
+      "rotation": 1,
+      "original_id": 366
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 282,
+      "created_at": 1679099984,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "I18",
+              "I16"
+            ],
+            [
+              "I16",
+              "J15",
               "K14"
             ],
-            "revenue": 90,
-            "revenue_str": "I18-I16-K14",
-            "nodes": [
-              "I18-1",
-              "I16-0",
-              "K14-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 359,
-        "created_at": 1679078098,
-        "kind": "withhold"
-      },
-      {
-        "type": "buy_train",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 360,
-        "created_at": 1679078100,
-        "train": "5-0",
-        "price": 450,
-        "variant": "5"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 361,
-        "created_at": 1679099636,
-        "hex": "B11",
-        "tile": "63-0",
-        "rotation": 0
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GBC",
-        "entity_type": "company",
-        "id": 362,
-        "created_at": 1679099647,
-        "hex": "A4",
-        "tile": "8-2",
-        "rotation": 5
-      },
-      {
-        "type": "choose",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 363,
-        "created_at": 1679099655,
-        "choice": "Place Edge Token"
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 364,
-        "created_at": 1679099735,
-        "routes": [
-          {
-            "train": "3-0",
-            "connections": [
-              [
-                "B11",
-                "C10",
-                "D9"
-              ],
-              [
-                "A10",
-                "B11"
-              ]
-            ],
-            "hexes": [
-              "D9",
-              "B11",
-              "A10"
-            ],
-            "revenue": 100,
-            "revenue_str": "D9-B11-A10",
-            "nodes": [
-              "B11-0",
-              "D9-0",
-              "A10-0"
-            ]
-          },
-          {
-            "train": "4-0",
-            "connections": [
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 190,
-            "revenue_str": "B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "A10-0",
-              "B11-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 365,
-        "created_at": 1679099744,
-        "kind": "payout"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 366,
-        "created_at": 1679099977,
-        "hex": "K18",
-        "tile": "9-9",
-        "rotation": 1
-      },
-      {
-        "type": "run_routes",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 367,
-        "created_at": 1679099984,
-        "routes": [
-          {
-            "train": "4-1",
-            "connections": [
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ],
-              [
-                "K14",
-                "K16",
-                "K18",
-                "K20"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "I16",
+            [
               "K14",
+              "K16",
+              "K18",
               "K20"
-            ],
-            "revenue": 130,
-            "revenue_str": "I18-I16-K14-K20",
-            "nodes": [
-              "I18-1",
-              "I16-0",
-              "K14-0",
-              "K20-0"
             ]
-          },
-          {
-            "train": "3-2",
-            "connections": [
-              [
-                "I18",
-                "H17"
-              ],
-              [
-                "H17",
-                "H15",
-                "H13",
-                "H11"
-              ]
-            ],
-            "hexes": [
+          ],
+          "hexes": [
+            "I18",
+            "I16",
+            "K14",
+            "K20"
+          ],
+          "revenue": 130,
+          "revenue_str": "I18-I16-K14-K20",
+          "nodes": [
+            "I18-1",
+            "I16-0",
+            "K14-0",
+            "K20-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
               "I18",
+              "H17"
+            ],
+            [
               "H17",
+              "H15",
+              "H13",
               "H11"
-            ],
-            "revenue": 80,
-            "revenue_str": "I18-H17-H11",
-            "nodes": [
-              "I18-1",
-              "H17-0",
-              "H11-0"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 368,
-        "created_at": 1679100008,
-        "kind": "payout"
-      },
-      {
-        "hex": "D9",
-        "tile": "15-3",
-        "type": "lay_tile",
-        "entity": "GN",
-        "rotation": 1,
-        "entity_type": "corporation",
-        "id": 369,
-        "user": 2122,
-        "created_at": 1679100175
-      },
-      {
-        "type": "choose",
-        "choice": "Place Edge Token",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 370,
-        "user": 2122,
-        "created_at": 1679100180
-      },
-      {
-        "type": "run_routes",
-        "entity": "GN",
-        "routes": [
-          {
-            "hexes": [
-              "D9",
+          ],
+          "hexes": [
+            "I18",
+            "H17",
+            "H11"
+          ],
+          "revenue": 80,
+          "revenue_str": "I18-H17-H11",
+          "nodes": [
+            "I18-1",
+            "H17-0",
+            "H11-0"
+          ]
+        }
+      ],
+      "original_id": 367
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 283,
+      "created_at": 1679100008,
+      "kind": "payout",
+      "original_id": 368
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 284,
+      "created_at": 1679101199,
+      "hex": "B5",
+      "tile": "63-1",
+      "rotation": 0,
+      "original_id": 377
+    },
+    {
+      "type": "choose",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 285,
+      "created_at": 1679101201,
+      "choice": "Place Edge Token",
+      "original_id": 378
+    },
+    {
+      "type": "run_routes",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 286,
+      "created_at": 1679101222,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
               "B11",
+              "C10",
+              "D9"
+            ],
+            [
+              "A10",
+              "B11"
+            ]
+          ],
+          "hexes": [
+            "D9",
+            "B11",
+            "A10"
+          ],
+          "revenue": 100,
+          "revenue_str": "D9-B11-A10",
+          "nodes": [
+            "B11-0",
+            "D9-0",
+            "A10-0"
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
               "A10"
             ],
-            "nodes": [
-              "B11-0",
-              "D9-0",
-              "A10-0"
-            ],
-            "train": "3-3",
-            "revenue": 110,
-            "connections": [
-              [
-                "B11",
-                "C10",
-                "D9"
-              ],
-              [
-                "A10",
-                "B11"
-              ]
-            ],
-            "revenue_str": "D9-B11-A10"
-          },
-          {
-            "hexes": [
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "nodes": [
-              "A10-0",
-              "B11-0",
-              "B5-0",
-              "A2-0"
-            ],
-            "train": "4-2",
-            "revenue": 190,
-            "connections": [
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "revenue_str": "B11-A10-B5-A2 + Edge Token"
-          }
-        ],
-        "entity_type": "corporation",
-        "id": 371,
-        "user": 2122,
-        "created_at": 1679100206
-      },
-      {
-        "kind": "payout",
-        "type": "dividend",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 372,
-        "user": 2122,
-        "created_at": 1679100213
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 373,
-        "user": 2122,
-        "created_at": 1679101181
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 374,
-        "user": 2122,
-        "created_at": 1679101184
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 375,
-        "user": 2122,
-        "created_at": 1679101186
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 376,
-        "user": 2122,
-        "created_at": 1679101189
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 377,
-        "created_at": 1679101199,
-        "hex": "B5",
-        "tile": "63-1",
-        "rotation": 0
-      },
-      {
-        "type": "choose",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 378,
-        "created_at": 1679101201,
-        "choice": "Place Edge Token"
-      },
-      {
-        "type": "run_routes",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 379,
-        "created_at": 1679101222,
-        "routes": [
-          {
-            "train": "3-3",
-            "connections": [
-              [
-                "B11",
-                "C10",
-                "D9"
-              ],
-              [
-                "A10",
-                "B11"
-              ]
-            ],
-            "hexes": [
-              "D9",
-              "B11",
-              "A10"
-            ],
-            "revenue": 100,
-            "revenue_str": "D9-B11-A10",
-            "nodes": [
-              "B11-0",
-              "D9-0",
-              "A10-0"
+            [
+              "A2",
+              "A4",
+              "B5"
             ]
-          },
-          {
-            "train": "4-2",
-            "connections": [
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 200,
-            "revenue_str": "B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "A10-0",
-              "B11-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 380,
-        "created_at": 1679101226,
-        "kind": "payout"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 381,
-        "created_at": 1679102017,
-        "hex": "J9",
-        "tile": "9-10",
-        "rotation": 1
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 382,
-        "created_at": 1679102023
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 383,
-        "created_at": 1679102026,
-        "routes": [
-          {
-            "train": "3-1",
-            "connections": [
-              [
-                "K6",
-                "K4"
-              ],
-              [
-                "K4",
-                "L3",
-                "M2"
-              ]
-            ],
-            "hexes": [
-              "K6",
-              "K4",
-              "M2"
-            ],
-            "revenue": 140,
-            "revenue_str": "K6-K4-M2 + Edge Token",
-            "nodes": [
-              "K6-0",
-              "K4-0",
-              "M2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 384,
-        "created_at": 1679102034,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 385,
-        "created_at": 1679102039
-      },
-      {
-        "hex": "J11",
-        "tile": "69-0",
-        "type": "lay_tile",
-        "entity": "UP",
-        "rotation": 1,
-        "entity_type": "corporation",
-        "id": 386,
-        "user": 4311,
-        "created_at": 1679102053
-      },
-      {
-        "city": "15-1-0",
-        "slot": 1,
-        "type": "place_token",
-        "entity": "UP",
-        "tokener": "UP",
-        "entity_type": "corporation",
-        "id": 387,
-        "user": 4311,
-        "created_at": 1679102066
-      },
-      {
-        "type": "undo",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 388,
-        "user": 4311,
-        "created_at": 1679102078
-      },
-      {
-        "type": "undo",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 389,
-        "user": 4311,
-        "created_at": 1679102084
-      },
-      {
-        "type": "lay_tile",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 390,
-        "created_at": 1679102091,
-        "hex": "G2",
-        "tile": "9-11",
-        "rotation": 2
-      },
-      {
-        "type": "choose",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 391,
-        "created_at": 1679102094,
-        "choice": "Place Edge Token"
-      },
-      {
-        "type": "run_routes",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 392,
-        "created_at": 1679102120,
-        "routes": [
-          {
-            "train": "3-4",
-            "connections": [
-              [
-                "I4",
-                "H3",
-                "G2",
-                "F1"
-              ]
-            ],
-            "hexes": [
-              "F1",
-              "I4"
-            ],
-            "revenue": 100,
-            "revenue_str": "F1-I4 + Edge Token",
-            "nodes": [
-              "I4-0",
-              "F1-0"
-            ]
-          },
-          {
-            "train": "4-3",
-            "connections": [
-              [
-                "K4",
-                "L3",
-                "M2"
-              ],
-              [
-                "K6",
-                "K4"
-              ],
-              [
-                "I4",
-                "J5",
-                "K6"
-              ]
-            ],
-            "hexes": [
-              "M2",
-              "K4",
-              "K6",
-              "I4"
-            ],
-            "revenue": 120,
-            "revenue_str": "M2-K4-K6-I4",
-            "nodes": [
-              "K4-0",
-              "M2-0",
-              "K6-0",
-              "I4-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 393,
-        "created_at": 1679102126,
-        "kind": "payout"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 394,
-        "created_at": 1679118082,
-        "hex": "I18",
-        "tile": "130-0",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 395,
-        "created_at": 1679118098
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 396,
-        "created_at": 1679118106,
-        "routes": [
-          {
-            "train": "5-0",
-            "connections": [
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ],
-              [
-                "K14",
-                "K16",
-                "K18",
-                "K20"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "I16",
-              "K14",
-              "K20"
-            ],
-            "revenue": 150,
-            "revenue_str": "I18-I16-K14-K20",
-            "nodes": [
-              "I18-0",
-              "I16-0",
-              "K14-0",
-              "K20-0"
-            ]
-          },
-          {
-            "train": "3-5",
-            "connections": [
-              [
-                "I18",
-                "H17"
-              ],
-              [
-                "H17",
-                "H15",
-                "H13",
-                "H11"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "H17",
-              "H11"
-            ],
-            "revenue": 100,
-            "revenue_str": "I18-H17-H11",
-            "nodes": [
-              "I18-0",
-              "H17-0",
-              "H11-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 397,
-        "created_at": 1679118109,
-        "kind": "payout"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 398,
-        "created_at": 1679136351,
-        "hex": "D9",
-        "tile": "15-3",
-        "rotation": 1
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GBC",
-        "entity_type": "company",
-        "id": 399,
-        "created_at": 1679136371,
-        "hex": "C8",
-        "tile": "8-3",
-        "rotation": 5
-      },
-      {
-        "type": "place_token",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 400,
-        "created_at": 1679136377,
-        "city": "15-3-0",
-        "slot": 1,
-        "tokener": "NP"
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 401,
-        "created_at": 1679136400,
-        "routes": [
-          {
-            "train": "3-0",
-            "connections": [
-              [
-                "B11",
-                "C10",
-                "D9"
-              ],
-              [
-                "A10",
-                "B11"
-              ]
-            ],
-            "hexes": [
-              "D9",
-              "B11",
-              "A10"
-            ],
-            "revenue": 110,
-            "revenue_str": "D9-B11-A10",
-            "nodes": [
-              "B11-0",
-              "D9-0",
-              "A10-0"
-            ]
-          },
-          {
-            "train": "4-0",
-            "connections": [
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 200,
-            "revenue_str": "B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "A10-0",
-              "B11-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 402,
-        "created_at": 1679136407,
-        "kind": "payout"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 403,
-        "created_at": 1679139658,
-        "hex": "J19",
-        "tile": "9-12",
-        "rotation": 2
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 404,
-        "created_at": 1679139662
-      },
-      {
-        "type": "run_routes",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 405,
-        "created_at": 1679139674,
-        "routes": [
-          {
-            "train": "4-1",
-            "connections": [
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ],
-              [
-                "K14",
-                "K16",
-                "K18",
-                "K20"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "I16",
-              "K14",
-              "K20"
-            ],
-            "revenue": 150,
-            "revenue_str": "I18-I16-K14-K20",
-            "nodes": [
-              "I18-0",
-              "I16-0",
-              "K14-0",
-              "K20-0"
-            ]
-          },
-          {
-            "train": "3-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "H17"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "H17"
-            ],
-            "revenue": 120,
-            "revenue_str": "K20-I18-H17",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "H17-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 406,
-        "created_at": 1679139675,
-        "kind": "payout"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 407,
-        "created_at": 1679140239,
-        "hex": "D9",
-        "tile": "135-0",
-        "rotation": 4
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 408,
-        "created_at": 1679140246
-      },
-      {
-        "type": "run_routes",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 409,
-        "created_at": 1679140255,
-        "routes": [
-          {
-            "train": "3-3",
-            "connections": [
-              [
-                "B11",
-                "C10",
-                "D9"
-              ],
-              [
-                "A10",
-                "B11"
-              ]
-            ],
-            "hexes": [
-              "D9",
-              "B11",
-              "A10"
-            ],
-            "revenue": 130,
-            "revenue_str": "D9-B11-A10",
-            "nodes": [
-              "B11-0",
-              "D9-0",
-              "A10-0"
-            ]
-          },
-          {
-            "train": "4-2",
-            "connections": [
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 200,
-            "revenue_str": "B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "A10-0",
-              "B11-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 410,
-        "created_at": 1679140259,
-        "kind": "payout"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 411,
-        "created_at": 1679144957,
-        "hex": "J11",
-        "tile": "55-0",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 412,
-        "created_at": 1679144964
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 413,
-        "created_at": 1679144972,
-        "routes": [
-          {
-            "train": "3-1",
-            "connections": [
-              [
-                "K6",
-                "K4"
-              ],
-              [
-                "K4",
-                "L3",
-                "M2"
-              ]
-            ],
-            "hexes": [
-              "K6",
-              "K4",
-              "M2"
-            ],
-            "revenue": 140,
-            "revenue_str": "K6-K4-M2 + Edge Token",
-            "nodes": [
-              "K6-0",
-              "K4-0",
-              "M2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 414,
-        "created_at": 1679144974,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 415,
-        "created_at": 1679144978
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 416,
-        "user": 4311,
-        "created_at": 1679145000
-      },
-      {
-        "city": "15-1-0",
-        "slot": 1,
-        "type": "place_token",
-        "entity": "UP",
-        "tokener": "UP",
-        "entity_type": "corporation",
-        "id": 417,
-        "user": 4311,
-        "created_at": 1679145006
-      },
-      {
-        "type": "undo",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 418,
-        "user": 4311,
-        "created_at": 1679145016
-      },
-      {
-        "type": "undo",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 419,
-        "user": 4311,
-        "created_at": 1679145018
-      },
-      {
-        "type": "lay_tile",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 420,
-        "created_at": 1679145023,
-        "hex": "I4",
-        "tile": "15-0",
-        "rotation": 2
-      },
-      {
-        "type": "place_token",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 421,
-        "created_at": 1679145024,
-        "city": "15-1-0",
-        "slot": 1,
-        "tokener": "UP"
-      },
-      {
-        "type": "run_routes",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 422,
-        "created_at": 1679145062,
-        "routes": [
-          {
-            "train": "3-4",
-            "connections": [
-              [
-                "I4",
-                "J5",
-                "K6"
-              ],
-              [
-                "F1",
-                "G2",
-                "H3",
-                "I4"
-              ]
-            ],
-            "hexes": [
-              "K6",
-              "I4",
-              "F1"
-            ],
-            "revenue": 140,
-            "revenue_str": "K6-I4-F1 + Edge Token",
-            "nodes": [
-              "I4-0",
-              "K6-0",
-              "F1-0"
-            ]
-          },
-          {
-            "train": "4-3",
-            "connections": [
-              [
-                "K6",
-                "J7",
-                "J9",
-                "J11"
-              ],
-              [
-                "K4",
-                "K6"
-              ],
-              [
-                "M2",
-                "L3",
-                "K4"
-              ]
-            ],
-            "hexes": [
-              "J11",
-              "K6",
-              "K4",
-              "M2"
-            ],
-            "revenue": 110,
-            "revenue_str": "J11-K6-K4-M2",
-            "nodes": [
-              "K6-0",
-              "J11-1",
-              "K4-0",
-              "M2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 423,
-        "created_at": 1679145068,
-        "kind": "half"
-      },
-      {
-        "type": "par",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 424,
-        "created_at": 1679147900,
-        "corporation": "MP",
-        "share_price": "100,0,6"
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 425,
-        "created_at": 1679147905
-      },
-      {
-        "type": "par",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 426,
-        "created_at": 1679149455,
-        "corporation": "MILW",
-        "share_price": "100,0,6"
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 427,
-        "created_at": 1679149487
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 428,
-        "created_at": 1679222700,
-        "shares": [
-          "RI_7",
-          "RI_8"
-        ],
-        "percent": 20
-      },
-      {
-        "type": "par",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 429,
-        "created_at": 1679222728,
-        "corporation": "SOO",
-        "share_price": "100,0,6"
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 430,
-        "created_at": 1679225788,
-        "shares": [
-          "RI_7",
-          "RI_8"
-        ],
-        "percent": 20
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 431,
-        "created_at": 1679227645,
-        "shares": [
-          "MILW_1"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 432,
-        "created_at": 1679227661
-      },
-      {
-        "type": "buy_shares",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 433,
-        "created_at": 1679241211,
-        "shares": [
-          "KATY_6"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 434,
-        "created_at": 1679250556,
-        "shares": [
-          "CBQ_2"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 435,
-        "created_at": 1679267228,
-        "shares": [
-          "MILW_2"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 436,
-        "created_at": 1679267251
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "shares": [
-          "SOO_1"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "share_price": false,
-        "id": 437,
-        "user": 4311,
-        "created_at": 1679269845
-      },
-      {
-        "type": "undo",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 438,
-        "user": 4311,
-        "created_at": 1679269893
-      },
-      {
-        "type": "buy_shares",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 439,
-        "created_at": 1679269899,
-        "shares": [
-          "UP_2"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 440,
-        "created_at": 1679282515,
-        "shares": [
-          "MP_1"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 441,
-        "created_at": 1679282517
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 442,
-        "created_at": 1679304396,
-        "shares": [
-          "MILW_3"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 443,
-        "created_at": 1679304400
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "shares": [
-          "SOO_1"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "share_price": false,
-        "id": 444,
-        "user": 4311,
-        "created_at": 1679368171
-      },
-      {
-        "type": "undo",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 445,
-        "user": 4311,
-        "created_at": 1679368186
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 446,
-        "created_at": 1679368197,
-        "shares": [
-          "UP_8"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 447,
-        "created_at": 1679368211
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 448,
-        "created_at": 1679371286,
-        "shares": [
-          "MP_2"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 449,
-        "created_at": 1679371292
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 450,
-        "created_at": 1679372257,
-        "shares": [
-          "MILW_4"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 451,
-        "created_at": 1679372272
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 452,
-        "created_at": 1679410504,
-        "shares": [
-          "SOO_1"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 453,
-        "created_at": 1679410655
-      },
-      {
-        "type": "sell_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 454,
-        "created_at": 1679436958,
-        "shares": [
-          "NP_4"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "sell_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 455,
-        "created_at": 1679436976,
-        "shares": [
-          "UP_5"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 456,
-        "created_at": 1679436992,
-        "shares": [
-          "MP_3"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 457,
-        "created_at": 1679440874,
-        "shares": [
-          "NP_4"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 458,
-        "created_at": 1679442796
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 459,
-        "created_at": 1679442870,
-        "shares": [
-          "SOO_2"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 460,
-        "created_at": 1679442917
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 461,
-        "created_at": 1679444304,
-        "shares": [
-          "MP_4"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 462,
-        "created_at": 1679444306
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 463,
-        "created_at": 1679485955
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 464,
-        "created_at": 1679492643,
-        "shares": [
-          "SOO_3"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 465,
-        "created_at": 1679492667
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 466,
-        "created_at": 1679494411
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 467,
-        "created_at": 1679494668
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 468,
-        "created_at": 1679525428,
-        "shares": [
-          "SOO_4"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 469,
-        "created_at": 1679525434
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 470,
-        "created_at": 1679526107
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 471,
-        "created_at": 1679526991
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 472,
-        "created_at": 1679546479,
-        "shares": [
-          "CBQ_7"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 473,
-        "created_at": 1679546485
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 474,
-        "created_at": 1679546604
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 475,
-        "created_at": 1679574676
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "shares": [
-          "CBQ_7"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "id": 476,
-        "user": 4311,
-        "created_at": 1679575415
-      },
-      {
-        "type": "undo",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 477,
-        "user": 4311,
-        "created_at": 1679575421
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 478,
-        "created_at": 1679575430
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 479,
-        "created_at": 1679575971,
-        "hex": "C12",
-        "tile": "9-13",
-        "rotation": 2
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GBC",
-        "entity_type": "company",
-        "id": 480,
-        "created_at": 1679575985,
-        "hex": "D13",
-        "tile": "4-0",
-        "rotation": 2
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 481,
-        "created_at": 1679575993,
-        "routes": [
-          {
-            "train": "3-0",
-            "connections": [
-              [
-                "B11",
-                "C10",
-                "D9"
-              ],
-              [
-                "A10",
-                "B11"
-              ]
-            ],
-            "hexes": [
-              "D9",
-              "B11",
-              "A10"
-            ],
-            "revenue": 130,
-            "revenue_str": "D9-B11-A10",
-            "nodes": [
-              "B11-0",
-              "D9-0",
-              "A10-0"
-            ]
-          },
-          {
-            "train": "4-0",
-            "connections": [
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 200,
-            "revenue_str": "B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "A10-0",
-              "B11-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 482,
-        "created_at": 1679576036,
-        "kind": "withhold"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 483,
-        "created_at": 1679576508,
-        "hex": "L13",
-        "tile": "5-0",
-        "rotation": 3
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 484,
-        "user": 1761,
-        "created_at": 1679576514
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "routes": [
-          {
-            "hexes": [
-              "I18",
-              "I16",
-              "K14",
-              "K20"
-            ],
-            "nodes": [
-              "I18-0",
-              "I16-0",
-              "K14-0",
-              "K20-0"
-            ],
-            "train": "5-0",
-            "revenue": 150,
-            "connections": [
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ],
-              [
-                "K14",
-                "K16",
-                "K18",
-                "K20"
-              ]
-            ],
-            "revenue_str": "I18-I16-K14-K20"
-          },
-          {
-            "hexes": [
-              "K20",
-              "I18",
-              "H17"
-            ],
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "H17-0"
-            ],
-            "train": "3-5",
-            "revenue": 120,
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "H17"
-              ]
-            ],
-            "revenue_str": "K20-I18-H17"
-          }
-        ],
-        "entity_type": "corporation",
-        "id": 485,
-        "user": 1761,
-        "created_at": 1679576538
-      },
-      {
-        "kind": "payout",
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 486,
-        "user": 1761,
-        "created_at": 1679576540
-      },
-      {
-        "hex": "L13",
-        "tile": "14-2",
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "rotation": 0,
-        "entity_type": "corporation",
-        "id": 487,
-        "user": 1761,
-        "created_at": 1679576558
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 488,
-        "user": 1761,
-        "created_at": 1679576575
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 489,
-        "user": 1761,
-        "created_at": 1679576578
-      },
-      {
-        "type": "undo",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 490,
-        "user": 1761,
-        "created_at": 1679576593
-      },
-      {
-        "type": "undo",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 491,
-        "user": 1761,
-        "created_at": 1679576647
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 492,
-        "created_at": 1679576659
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 493,
-        "created_at": 1679576665,
-        "routes": [
-          {
-            "train": "5-0",
-            "connections": [
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ],
-              [
-                "K14",
-                "K16",
-                "K18",
-                "K20"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "I16",
-              "K14",
-              "K20"
-            ],
-            "revenue": 150,
-            "revenue_str": "I18-I16-K14-K20",
-            "nodes": [
-              "I18-0",
-              "I16-0",
-              "K14-0",
-              "K20-0"
-            ]
-          },
-          {
-            "train": "3-5",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "H17"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "H17"
-            ],
-            "revenue": 120,
-            "revenue_str": "K20-I18-H17",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "H17-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 494,
-        "created_at": 1679576667,
-        "kind": "payout"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 495,
-        "created_at": 1679576674,
-        "hex": "L13",
-        "tile": "14-2",
-        "rotation": 0
-      },
-      {
-        "type": "run_routes",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 496,
-        "created_at": 1679576677,
-        "routes": [
-          {
-            "train": "4-1",
-            "connections": [
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ],
-              [
-                "K14",
-                "K16",
-                "K18",
-                "K20"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "I16",
-              "K14",
-              "K20"
-            ],
-            "revenue": 150,
-            "revenue_str": "I18-I16-K14-K20",
-            "nodes": [
-              "I18-0",
-              "I16-0",
-              "K14-0",
-              "K20-0"
-            ]
-          },
-          {
-            "train": "3-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "H17"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "H17"
-            ],
-            "revenue": 120,
-            "revenue_str": "K20-I18-H17",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "H17-0"
-            ]
-          }
-        ]
-      },
-      {
-        "kind": "payout",
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 497,
-        "user": 1761,
-        "created_at": 1679576695
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 498,
-        "user": 1761,
-        "created_at": 1679576731
-      },
-      {
-        "kind": "withhold",
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 499,
-        "user": 1761,
-        "created_at": 1679576740
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 500,
-        "user": 1761,
-        "created_at": 1679576762
-      },
-      {
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 501,
-        "created_at": 1679576766,
-        "kind": "payout"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 502,
-        "created_at": 1679577284,
-        "hex": "E14",
-        "tile": "9-14",
-        "rotation": 2
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 503,
-        "created_at": 1679577296
-      },
-      {
-        "type": "run_routes",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 504,
-        "created_at": 1679577303,
-        "routes": [
-          {
-            "train": "3-3",
-            "connections": [
-              [
-                "B11",
-                "C10",
-                "D9"
-              ],
-              [
-                "A10",
-                "B11"
-              ]
-            ],
-            "hexes": [
-              "D9",
-              "B11",
-              "A10"
-            ],
-            "revenue": 130,
-            "revenue_str": "D9-B11-A10",
-            "nodes": [
-              "B11-0",
-              "D9-0",
-              "A10-0"
-            ]
-          },
-          {
-            "train": "4-2",
-            "connections": [
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 200,
-            "revenue_str": "B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "A10-0",
-              "B11-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 505,
-        "created_at": 1679577306,
-        "kind": "withhold"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 506,
-        "created_at": 1679579410,
-        "hex": "K6",
-        "tile": "135-1",
-        "rotation": 2
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 507,
-        "created_at": 1679579432
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 508,
-        "created_at": 1679579436,
-        "routes": [
-          {
-            "train": "3-1",
-            "connections": [
-              [
-                "K6",
-                "K4"
-              ],
-              [
-                "K4",
-                "L3",
-                "M2"
-              ]
-            ],
-            "hexes": [
-              "K6",
-              "K4",
-              "M2"
-            ],
-            "revenue": 160,
-            "revenue_str": "K6-K4-M2 + Edge Token",
-            "nodes": [
-              "K6-0",
-              "K4-0",
-              "M2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 509,
-        "created_at": 1679579440,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 510,
-        "created_at": 1679579444
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 511,
-        "created_at": 1679583585,
-        "hex": "K14",
-        "tile": "63-2",
-        "rotation": 0
-      },
-      {
-        "type": "place_token",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 512,
-        "created_at": 1679583595,
-        "city": "130-0-0",
-        "slot": 3,
-        "tokener": "MP"
-      },
-      {
-        "type": "buy_train",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 513,
-        "created_at": 1679583605,
-        "train": "5-1",
-        "price": 450,
-        "variant": "5"
-      },
-      {
-        "type": "buy_train",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 514,
-        "created_at": 1679583653,
-        "train": "3-2",
-        "price": 510
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 515,
-        "created_at": 1679584364,
-        "hex": "G16",
-        "tile": "6-0",
-        "rotation": 2
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 516,
-        "created_at": 1679584369,
-        "hex": "F15",
-        "tile": "4-1",
-        "rotation": 2
-      },
-      {
-        "type": "place_token",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 517,
-        "created_at": 1679584399,
-        "city": "63-0-0",
-        "slot": 1,
-        "tokener": "MILW"
-      },
-      {
-        "type": "buy_train",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 518,
-        "created_at": 1679584406,
-        "train": "5-2",
-        "price": 450,
-        "variant": "5"
-      },
-      {
-        "type": "buy_train",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 519,
-        "created_at": 1679584529,
-        "train": "3-0",
-        "price": 380
-      },
-      {
-        "type": "lay_tile",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 520,
-        "created_at": 1679632972,
-        "hex": "F13",
-        "tile": "57-2",
-        "rotation": 1
-      },
-      {
-        "type": "lay_tile",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 521,
-        "created_at": 1679632977,
-        "hex": "F11",
-        "tile": "8-4",
-        "rotation": 4
-      },
-      {
-        "type": "buy_train",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 522,
-        "created_at": 1679633045,
-        "train": "3-4",
-        "price": 180
-      },
-      {
-        "type": "buy_train",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 523,
-        "created_at": 1679633048,
-        "train": "6-0",
-        "price": 630,
-        "variant": "6"
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 524,
-        "created_at": 1679633060
-      },
-      {
-        "type": "lay_tile",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 525,
-        "created_at": 1679633075,
-        "hex": "J13",
-        "tile": "8-5",
-        "rotation": 5
-      },
-      {
-        "type": "place_token",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 526,
-        "created_at": 1679633077,
-        "city": "130-0-0",
-        "slot": 3,
-        "tokener": "UP"
-      },
-      {
-        "type": "run_routes",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 527,
-        "created_at": 1679633106,
-        "routes": [
-          {
-            "train": "4-3",
-            "connections": [
-              [
-                "F1",
-                "G2",
-                "H3",
-                "I4"
-              ],
-              [
-                "I4",
-                "J5",
-                "K6"
-              ],
-              [
-                "K6",
-                "K4"
-              ]
-            ],
-            "hexes": [
-              "F1",
-              "I4",
+          ],
+          "hexes": [
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 200,
+          "revenue_str": "B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "A10-0",
+            "B11-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 379
+    },
+    {
+      "type": "dividend",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 287,
+      "created_at": 1679101226,
+      "kind": "payout",
+      "original_id": 380
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 288,
+      "created_at": 1679102017,
+      "hex": "J9",
+      "tile": "9-10",
+      "rotation": 1,
+      "original_id": 381
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 289,
+      "created_at": 1679102023,
+      "original_id": 382
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 290,
+      "created_at": 1679102026,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
               "K6",
               "K4"
             ],
-            "revenue": 190,
-            "revenue_str": "F1-I4-K6-K4 + Edge Token",
-            "nodes": [
-              "F1-0",
-              "I4-0",
-              "K6-0",
-              "K4-0"
+            [
+              "K4",
+              "L3",
+              "M2"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 528,
-        "created_at": 1679633110,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 529,
-        "created_at": 1679633114
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 530,
-        "created_at": 1679634708,
-        "hex": "L13",
-        "tile": "135-2",
-        "rotation": 0
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 531,
-        "created_at": 1679634716,
-        "routes": [
-          {
-            "train": "5-0",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ],
-              [
-                "K14",
-                "L13"
-              ]
+          ],
+          "hexes": [
+            "K6",
+            "K4",
+            "M2"
+          ],
+          "revenue": 140,
+          "revenue_str": "K6-K4-M2 + Edge Token",
+          "nodes": [
+            "K6-0",
+            "K4-0",
+            "M2-0"
+          ]
+        }
+      ],
+      "original_id": 383
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 291,
+      "created_at": 1679102034,
+      "kind": "payout",
+      "original_id": 384
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 292,
+      "created_at": 1679102039,
+      "original_id": 385
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 293,
+      "created_at": 1679102091,
+      "hex": "G2",
+      "tile": "9-11",
+      "rotation": 2,
+      "original_id": 390
+    },
+    {
+      "type": "choose",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 294,
+      "created_at": 1679102094,
+      "choice": "Place Edge Token",
+      "original_id": 391
+    },
+    {
+      "type": "run_routes",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 295,
+      "created_at": 1679102120,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "I4",
+              "H3",
+              "G2",
+              "F1"
+            ]
+          ],
+          "hexes": [
+            "F1",
+            "I4"
+          ],
+          "revenue": 100,
+          "revenue_str": "F1-I4 + Edge Token",
+          "nodes": [
+            "I4-0",
+            "F1-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "K4",
+              "L3",
+              "M2"
             ],
-            "hexes": [
-              "K20",
+            [
+              "K6",
+              "K4"
+            ],
+            [
+              "I4",
+              "J5",
+              "K6"
+            ]
+          ],
+          "hexes": [
+            "M2",
+            "K4",
+            "K6",
+            "I4"
+          ],
+          "revenue": 120,
+          "revenue_str": "M2-K4-K6-I4",
+          "nodes": [
+            "K4-0",
+            "M2-0",
+            "K6-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "original_id": 392
+    },
+    {
+      "type": "dividend",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 296,
+      "created_at": 1679102126,
+      "kind": "payout",
+      "original_id": 393
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 297,
+      "created_at": 1679118082,
+      "hex": "I18",
+      "tile": "130-0",
+      "rotation": 0,
+      "original_id": 394
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 298,
+      "created_at": 1679118098,
+      "original_id": 395
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 299,
+      "created_at": 1679118106,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
               "I18",
+              "I16"
+            ],
+            [
               "I16",
+              "J15",
+              "K14"
+            ],
+            [
               "K14",
-              "L13"
-            ],
-            "revenue": 210,
-            "revenue_str": "K20-I18-I16-K14-L13",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "I16-0",
-              "K14-0",
-              "L13-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 532,
-        "created_at": 1679634725,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 533,
-        "created_at": 1679634754
-      },
-      {
-        "hex": "C6",
-        "tile": "8-6",
-        "type": "lay_tile",
-        "entity": "NP",
-        "rotation": 2,
-        "entity_type": "corporation",
-        "id": 534,
-        "user": 2122,
-        "created_at": 1679657925
-      },
-      {
-        "type": "undo",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 535,
-        "user": 2122,
-        "created_at": 1679657984
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 536,
-        "created_at": 1679658004,
-        "hex": "G18",
-        "tile": "132-0",
-        "rotation": 0
-      },
-      {
-        "type": "place_token",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 537,
-        "created_at": 1679658006,
-        "city": "132-0-0",
-        "slot": 1,
-        "tokener": "NP"
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 538,
-        "created_at": 1679658033,
-        "routes": [
-          {
-            "train": "4-0",
-            "connections": [
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 200,
-            "revenue_str": "B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "A10-0",
-              "B11-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 539,
-        "created_at": 1679658039,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 540,
-        "created_at": 1679658051,
-        "train": "6-1",
-        "price": 630,
-        "variant": "6"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 541,
-        "created_at": 1679659413,
-        "hex": "J17",
-        "tile": "9-15",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 542,
-        "created_at": 1679659417
-      },
-      {
-        "type": "run_routes",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 543,
-        "created_at": 1679659421,
-        "routes": [
-          {
-            "train": "4-1",
-            "connections": [
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ],
-              [
-                "K14",
-                "L13"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "I16",
-              "K14",
-              "L13"
-            ],
-            "revenue": 170,
-            "revenue_str": "I18-I16-K14-L13",
-            "nodes": [
-              "I18-0",
-              "I16-0",
-              "K14-0",
-              "L13-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 544,
-        "created_at": 1679659424,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 545,
-        "created_at": 1679659425,
-        "train": "6-2",
-        "price": 630,
-        "variant": "6"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 546,
-        "created_at": 1679661202,
-        "hex": "K4",
-        "tile": "63-3",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 547,
-        "created_at": 1679661205
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 548,
-        "created_at": 1679661244,
-        "shares": [
-          "CBQ_7"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "shares": [
-          "UP_3"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "id": 549,
-        "user": 4311,
-        "created_at": 1679661286
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "shares": [
-          "SOO_1"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "id": 550,
-        "user": 4311,
-        "created_at": 1679661289
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 551,
-        "user": 4311,
-        "created_at": 1679661299
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 552,
-        "user": 4311,
-        "created_at": 1679661300
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 553,
-        "created_at": 1679661337,
-        "shares": [
-          "NP_7"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_train",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 554,
-        "created_at": 1679661349,
-        "train": "8-0",
-        "price": 800,
-        "variant": "8"
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 555,
-        "created_at": 1679661417,
-        "shares": [
-          "CBQ_7"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 556,
-        "created_at": 1679661475,
-        "hex": "D9",
-        "tile": "138-0",
-        "rotation": 0
-      },
-      {
-        "type": "buy_train",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 557,
-        "created_at": 1679661489,
-        "train": "8-1",
-        "price": 800,
-        "variant": "8"
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 558,
-        "created_at": 1679661501
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 559,
-        "created_at": 1679662241,
-        "hex": "I18",
-        "tile": "131-0",
-        "rotation": 0
-      },
-      {
-        "type": "run_routes",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 560,
-        "created_at": 1679662249,
-        "routes": [
-          {
-            "train": "5-1",
-            "connections": [
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J15",
-                "I16"
-              ],
-              [
-                "I16",
-                "I18"
-              ],
-              [
-                "I18",
-                "J19",
-                "K20"
-              ]
-            ],
-            "hexes": [
-              "L13",
-              "K14",
-              "I16",
-              "I18",
+              "K16",
+              "K18",
               "K20"
-            ],
-            "revenue": 250,
-            "revenue_str": "L13-K14-I16-I18-K20",
-            "nodes": [
-              "L13-0",
-              "K14-0",
-              "I16-0",
-              "I18-0",
-              "K20-0"
             ]
-          }
-        ]
-      },
-      {
-        "kind": "payout",
-        "type": "dividend",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 561,
-        "user": 1761,
-        "created_at": 1679662252
-      },
-      {
-        "type": "undo",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 562,
-        "user": 1761,
-        "created_at": 1679662258
-      },
-      {
-        "type": "dividend",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 563,
-        "created_at": 1679662292,
-        "kind": "withhold"
-      },
-      {
-        "type": "pass",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 564,
-        "created_at": 1679662293
-      },
-      {
-        "type": "choose",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 565,
-        "created_at": 1679662415,
-        "choice": "Buy Mesabi Token"
-      },
-      {
-        "type": "choose",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 566,
-        "created_at": 1679662420,
-        "choice": "Place Edge Token"
-      },
-      {
-        "type": "run_routes",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 567,
-        "created_at": 1679662439,
-        "routes": [
-          {
-            "train": "5-2",
-            "connections": [
-              [
-                "B11",
-                "C10",
-                "D9"
-              ],
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "D9",
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 280,
-            "revenue_str": "D9-B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "B11-0",
-              "D9-0",
-              "A10-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 568,
-        "created_at": 1679662446,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 569,
-        "created_at": 1679662631
-      },
-      {
-        "type": "lay_tile",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 570,
-        "created_at": 1679702535,
-        "hex": "F15",
-        "tile": "142-0",
-        "rotation": 2
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 571,
-        "created_at": 1679702545
-      },
-      {
-        "type": "run_routes",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 572,
-        "created_at": 1679702551,
-        "routes": [
-          {
-            "train": "6-0",
-            "connections": [
-              [
-                "F13",
-                "F15"
-              ],
-              [
-                "F15",
-                "G16"
-              ],
-              [
-                "G16",
-                "G18"
-              ]
-            ],
-            "hexes": [
-              "F13",
-              "F15",
-              "G16",
-              "G18"
-            ],
-            "revenue": 80,
-            "revenue_str": "F13-F15-G16-G18",
-            "nodes": [
-              "F13-0",
-              "F15-0",
-              "G16-0",
-              "G18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 573,
-        "created_at": 1679702553,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 574,
-        "created_at": 1679702555
-      },
-      {
-        "type": "lay_tile",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 575,
-        "created_at": 1679702580,
-        "hex": "K16",
-        "tile": "24-0",
-        "rotation": 1
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 576,
-        "created_at": 1679702608,
-        "shares": [
-          "KATY_3",
-          "KATY_4",
-          "KATY_7"
-        ],
-        "percent": 30
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "shares": [
-          "UP_3"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "id": 577,
-        "user": 4311,
-        "created_at": 1679702615
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "shares": [
-          "SOO_1"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "id": 578,
-        "user": 4311,
-        "created_at": 1679702620
-      },
-      {
-        "type": "undo",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 579,
-        "user": 4311,
-        "created_at": 1679702638
-      },
-      {
-        "type": "undo",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 580,
-        "user": 4311,
-        "created_at": 1679702641
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 581,
-        "created_at": 1679702664,
-        "shares": [
-          "UP_3",
-          "UP_4"
-        ],
-        "percent": 20
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 582,
-        "created_at": 1679702673,
-        "shares": [
-          "SOO_1"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_train",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 583,
-        "created_at": 1679702677,
-        "train": "8-2",
-        "price": 800,
-        "variant": "8"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 584,
-        "created_at": 1679707659,
-        "hex": "L13",
-        "tile": "138-1",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 585,
-        "created_at": 1679707665
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 586,
-        "created_at": 1679707672,
-        "routes": [
-          {
-            "train": "5-0",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ],
-              [
-                "K14",
-                "L13"
-              ]
-            ],
-            "hexes": [
-              "K20",
+          ],
+          "hexes": [
+            "I18",
+            "I16",
+            "K14",
+            "K20"
+          ],
+          "revenue": 150,
+          "revenue_str": "I18-I16-K14-K20",
+          "nodes": [
+            "I18-0",
+            "I16-0",
+            "K14-0",
+            "K20-0"
+          ]
+        },
+        {
+          "train": "3-5",
+          "connections": [
+            [
               "I18",
-              "I16",
-              "K14",
-              "L13"
+              "H17"
             ],
-            "revenue": 260,
-            "revenue_str": "K20-I18-I16-K14-L13",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "I16-0",
-              "K14-0",
-              "L13-0"
+            [
+              "H17",
+              "H15",
+              "H13",
+              "H11"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 587,
-        "created_at": 1679707674,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 588,
-        "created_at": 1679707687
-      },
-      {
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 589,
-        "created_at": 1679707700,
-        "hex": "K16",
-        "tile": "47-0",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 590,
-        "created_at": 1679707703
-      },
-      {
-        "type": "run_routes",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 591,
-        "created_at": 1679707706,
-        "routes": [
-          {
-            "train": "6-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "J11"
-              ],
-              [
-                "J11",
-                "J9",
-                "J7",
-                "K6"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "I16",
-              "K14",
-              "J11",
-              "K6"
-            ],
-            "revenue": 260,
-            "revenue_str": "K20-I18-I16-K14-J11-K6",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "I16-0",
-              "K14-0",
-              "J11-1",
-              "K6-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 592,
-        "created_at": 1679707721,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 593,
-        "created_at": 1679707722
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 594,
-        "created_at": 1679707894,
-        "hex": "C12",
-        "tile": "27-0",
-        "rotation": 5
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 595,
-        "created_at": 1679707926,
-        "routes": [
-          {
-            "train": "6-1",
-            "connections": [
-              [
-                "B11",
-                "C10",
-                "D9"
-              ],
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "D9",
+          ],
+          "hexes": [
+            "I18",
+            "H17",
+            "H11"
+          ],
+          "revenue": 100,
+          "revenue_str": "I18-H17-H11",
+          "nodes": [
+            "I18-0",
+            "H17-0",
+            "H11-0"
+          ]
+        }
+      ],
+      "original_id": 396
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 300,
+      "created_at": 1679118109,
+      "kind": "payout",
+      "original_id": 397
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 301,
+      "created_at": 1679136351,
+      "hex": "D9",
+      "tile": "15-3",
+      "rotation": 1,
+      "original_id": 398
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GBC",
+      "entity_type": "company",
+      "id": 302,
+      "created_at": 1679136371,
+      "hex": "C8",
+      "tile": "8-3",
+      "rotation": 5,
+      "original_id": 399
+    },
+    {
+      "type": "place_token",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 303,
+      "created_at": 1679136377,
+      "city": "15-3-0",
+      "slot": 1,
+      "tokener": "NP",
+      "original_id": 400
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 304,
+      "created_at": 1679136400,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
               "B11",
+              "C10",
+              "D9"
+            ],
+            [
               "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 280,
-            "revenue_str": "D9-B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "B11-0",
-              "D9-0",
-              "A10-0",
-              "B5-0",
-              "A2-0"
+              "B11"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 596,
-        "created_at": 1679707933,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 597,
-        "created_at": 1679707946
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 598,
-        "created_at": 1679707954,
-        "hex": "D11",
-        "tile": "8-6",
-        "rotation": 1
-      },
-      {
-        "type": "pass",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 599,
-        "created_at": 1679707966
-      },
-      {
-        "type": "run_routes",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 600,
-        "created_at": 1679707972,
-        "routes": [
-          {
-            "train": "5-2",
-            "connections": [
-              [
-                "B11",
-                "C10",
-                "D9"
-              ],
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "D9",
-              "B11",
+          ],
+          "hexes": [
+            "D9",
+            "B11",
+            "A10"
+          ],
+          "revenue": 110,
+          "revenue_str": "D9-B11-A10",
+          "nodes": [
+            "B11-0",
+            "D9-0",
+            "A10-0"
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
               "A10",
+              "B9",
+              "B11"
+            ],
+            [
               "B5",
-              "A2"
+              "A6",
+              "A8",
+              "A10"
             ],
-            "revenue": 280,
-            "revenue_str": "D9-B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "B11-0",
-              "D9-0",
-              "A10-0",
-              "B5-0",
-              "A2-0"
+            [
+              "A2",
+              "A4",
+              "B5"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 601,
-        "created_at": 1679707976,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 602,
-        "created_at": 1679707979
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 603,
-        "created_at": 1679707986,
-        "hex": "C6",
-        "tile": "8-7",
-        "rotation": 2
-      },
-      {
-        "type": "run_routes",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 604,
-        "created_at": 1679708011,
-        "routes": [
-          {
-            "train": "8-1",
-            "connections": [
-              [
-                "G16",
-                "G18"
-              ],
-              [
-                "F15",
-                "G16"
-              ],
-              [
-                "D13",
-                "E14",
-                "F15"
-              ],
-              [
-                "D9",
-                "D11",
-                "C12",
-                "D13"
-              ],
-              [
-                "B5",
-                "C6",
-                "C8",
-                "D9"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "G18",
-              "G16",
-              "F15",
-              "D13",
-              "D9",
-              "B5",
-              "A2"
-            ],
-            "revenue": 250,
-            "revenue_str": "G18-G16-F15-D13-D9-B5-A2 + Edge Token",
-            "nodes": [
-              "G16-0",
-              "G18-0",
-              "F15-0",
-              "D13-0",
-              "D9-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 605,
-        "created_at": 1679708016,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 606,
-        "created_at": 1679708018
-      },
-      {
-        "type": "lay_tile",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 607,
-        "created_at": 1679708059,
-        "hex": "G10",
-        "tile": "4-2",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 608,
-        "created_at": 1679708062
-      },
-      {
-        "type": "run_routes",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 609,
-        "created_at": 1679708065,
-        "routes": [
-          {
-            "train": "6-0",
-            "connections": [
-              [
-                "F13",
-                "F15"
-              ],
-              [
-                "F15",
-                "G16"
-              ],
-              [
-                "G16",
-                "G18"
-              ]
-            ],
-            "hexes": [
-              "F13",
-              "F15",
-              "G16",
-              "G18"
-            ],
-            "revenue": 80,
-            "revenue_str": "F13-F15-G16-G18",
-            "nodes": [
-              "F13-0",
-              "F15-0",
-              "G16-0",
-              "G18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 610,
-        "created_at": 1679708066,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 611,
-        "created_at": 1679708069
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 612,
-        "created_at": 1679708113,
-        "hex": "I6",
-        "tile": "8-8",
-        "rotation": 1
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 613,
-        "created_at": 1679708119,
-        "routes": [
-          {
-            "train": "8-0",
-            "connections": [
-              [
-                "M2",
-                "L3",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ],
-              [
-                "K6",
-                "J7",
-                "J9",
-                "J11"
-              ],
-              [
-                "J11",
-                "J13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J15",
-                "I16"
-              ],
-              [
-                "I16",
-                "I18"
-              ]
-            ],
-            "hexes": [
-              "M2",
-              "K4",
-              "K6",
-              "J11",
-              "K14",
-              "I16",
-              "I18"
-            ],
-            "revenue": 330,
-            "revenue_str": "M2-K4-K6-J11-K14-I16-I18 + Edge Token",
-            "nodes": [
-              "M2-0",
-              "K4-0",
-              "K6-0",
-              "J11-1",
-              "K14-0",
-              "I16-0",
-              "I18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 614,
-        "created_at": 1679708121,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 615,
-        "created_at": 1679708124
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 616,
-        "created_at": 1679735758,
-        "hex": "L15",
-        "tile": "8-9",
-        "rotation": 1
-      },
-      {
-        "type": "pass",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 617,
-        "created_at": 1679735764
-      },
-      {
-        "type": "run_routes",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 618,
-        "created_at": 1679735772,
-        "routes": [
-          {
-            "train": "5-1",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J15",
-                "I16"
-              ]
-            ],
-            "hexes": [
-              "K20",
+          ],
+          "hexes": [
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 200,
+          "revenue_str": "B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "A10-0",
+            "B11-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 401
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 305,
+      "created_at": 1679136407,
+      "kind": "payout",
+      "original_id": 402
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 306,
+      "created_at": 1679139658,
+      "hex": "J19",
+      "tile": "9-12",
+      "rotation": 2,
+      "original_id": 403
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 307,
+      "created_at": 1679139662,
+      "original_id": 404
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 308,
+      "created_at": 1679139674,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
               "I18",
-              "L13",
-              "K14",
               "I16"
             ],
-            "revenue": 260,
-            "revenue_str": "K20-I18-L13-K14-I16",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "I16-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 619,
-        "created_at": 1679735782,
-        "kind": "withhold"
-      },
-      {
-        "type": "pass",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 620,
-        "created_at": 1679735783
-      },
-      {
-        "type": "lay_tile",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 621,
-        "created_at": 1679738720,
-        "hex": "H11",
-        "tile": "14-3",
-        "rotation": 0
-      },
-      {
-        "type": "run_routes",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 622,
-        "created_at": 1679738726,
-        "routes": [
-          {
-            "train": "8-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "J11"
-              ],
-              [
-                "J11",
-                "J9",
-                "J7",
-                "K6"
-              ],
-              [
-                "K6",
-                "J5",
-                "I4"
-              ],
-              [
-                "I4",
-                "H3",
-                "G2",
-                "F1"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "L13",
-              "K14",
-              "J11",
-              "K6",
-              "I4",
-              "F1"
-            ],
-            "revenue": 420,
-            "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "J11-1",
-              "K6-0",
-              "I4-0",
-              "F1-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 623,
-        "created_at": 1679738734,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 624,
-        "created_at": 1679738737
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 625,
-        "user": 1761,
-        "created_at": 1679740871
-      },
-      {
-        "type": "undo",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 626,
-        "user": 1761,
-        "created_at": 1679740933
-      },
-      {
-        "type": "sell_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 627,
-        "created_at": 1679740955,
-        "shares": [
-          "MP_1"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 628,
-        "created_at": 1679740958,
-        "shares": [
-          "UP_5"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "sell_shares",
-        "entity": 2122,
-        "shares": [
-          "CBQ_5"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "id": 629,
-        "user": 2122,
-        "created_at": 1679741653
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "shares": [
-          "UP_3"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "share_price": false,
-        "id": 630,
-        "user": 2122,
-        "created_at": 1679741668
-      },
-      {
-        "type": "undo",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 631,
-        "user": 2122,
-        "created_at": 1679744628
-      },
-      {
-        "type": "undo",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 632,
-        "user": 2122,
-        "created_at": 1679744690
-      },
-      {
-        "type": "buy_shares",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 633,
-        "created_at": 1679744705,
-        "shares": [
-          "NP_7"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "shares": [
-          "KATY_3"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "share_price": false,
-        "id": 634,
-        "user": 4311,
-        "created_at": 1679746566
-      },
-      {
-        "type": "undo",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 635,
-        "user": 4311,
-        "created_at": 1679746579
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 636,
-        "created_at": 1679746586,
-        "shares": [
-          "KATY_3"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 637,
-        "created_at": 1679746625
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 638,
-        "created_at": 1679750033
-      },
-      {
-        "type": "program_share_pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 639,
-        "created_at": 1679750040,
-        "unconditional": false,
-        "indefinite": false
-      },
-      {
-        "type": "sell_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 640,
-        "created_at": 1679750088,
-        "shares": [
-          "CBQ_5"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 641,
-        "created_at": 1679750098,
-        "shares": [
-          "KATY_4"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 642,
-        "created_at": 1679753241,
-        "shares": [
-          "CBQ_8"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 643,
-        "created_at": 1679753244,
-        "shares": [
-          "CBQ_8"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 644,
-        "created_at": 1679753286,
-        "auto_actions": [
-          {
-            "type": "program_disable",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1679753286,
-            "reason": "Shares were sold"
-          }
-        ]
-      },
-      {
-        "type": "buy_shares",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 645,
-        "created_at": 1679753871,
-        "shares": [
-          "CBQ_5"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "program_share_pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 646,
-        "created_at": 1679753920,
-        "unconditional": false,
-        "indefinite": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 647,
-        "created_at": 1679753950
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 648,
-        "created_at": 1679754725,
-        "shares": [
-          "KATY_7"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 649,
-        "created_at": 1679754871,
-        "auto_actions": [
-          {
-            "type": "pass",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1679754870
-          }
-        ]
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 650,
-        "created_at": 1679757055
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 651,
-        "created_at": 1679757508,
-        "shares": [
-          "MILW_5"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "sell_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 652,
-        "created_at": 1679757511,
-        "shares": [
-          "MILW_5"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 653,
-        "created_at": 1679757559,
-        "auto_actions": [
-          {
-            "type": "program_disable",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1679757559,
-            "reason": "Shares were sold"
-          }
-        ]
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 654,
-        "created_at": 1679757651
-      },
-      {
-        "type": "program_share_pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 655,
-        "created_at": 1679757657,
-        "unconditional": false,
-        "indefinite": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 656,
-        "created_at": 1679758295
-      },
-      {
-        "type": "buy_shares",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 657,
-        "created_at": 1679795895,
-        "auto_actions": [
-          {
-            "type": "program_disable",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1679795895,
-            "reason": "UP redeemed a share."
-          }
-        ],
-        "shares": [
-          "UP_3"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 658,
-        "created_at": 1679804921
-      },
-      {
-        "type": "program_share_pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 659,
-        "created_at": 1679804927,
-        "unconditional": false,
-        "indefinite": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 660,
-        "created_at": 1679824657
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "shares": [
-          "MP_1"
-        ],
-        "percent": 10,
-        "entity_type": "player",
-        "share_price": false,
-        "id": 661,
-        "user": 4311,
-        "created_at": 1679825000
-      },
-      {
-        "type": "undo",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 662,
-        "user": 4311,
-        "created_at": 1679825043
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 663,
-        "created_at": 1679825055,
-        "shares": [
-          "UP_4"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 664,
-        "created_at": 1679825081,
-        "auto_actions": [
-          {
-            "type": "pass",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1679825081
-          }
-        ]
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 665,
-        "created_at": 1679825302
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 666,
-        "created_at": 1679826810,
-        "shares": [
-          "SOO_5"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 667,
-        "created_at": 1679827104,
-        "auto_actions": [
-          {
-            "type": "pass",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1679827103
-          }
-        ]
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 668,
-        "created_at": 1679827123
-      },
-      {
-        "type": "buy_shares",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 669,
-        "created_at": 1679827345,
-        "auto_actions": [
-          {
-            "type": "program_disable",
-            "entity": 1761,
-            "entity_type": "player",
-            "created_at": 1679827344,
-            "reason": "SOO redeemed a share."
-          }
-        ],
-        "shares": [
-          "SOO_1"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 670,
-        "created_at": 1679827475
-      },
-      {
-        "type": "program_share_pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 671,
-        "created_at": 1679827480,
-        "unconditional": false,
-        "indefinite": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 672,
-        "created_at": 1679827819
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 673,
-        "created_at": 1679828590
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 674,
-        "created_at": 1679831892,
-        "hex": "J13",
-        "tile": "25-0",
-        "rotation": 5
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 675,
-        "created_at": 1679831895
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 676,
-        "created_at": 1679831928,
-        "routes": [
-          {
-            "train": "5-0",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ],
-              [
-                "K14",
-                "L13"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
+            [
               "I16",
+              "J15",
+              "K14"
+            ],
+            [
               "K14",
-              "L13"
-            ],
-            "revenue": 260,
-            "revenue_str": "K20-I18-I16-K14-L13",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "I16-0",
-              "K14-0",
-              "L13-0"
+              "K16",
+              "K18",
+              "K20"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 677,
-        "created_at": 1679831929,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 678,
-        "created_at": 1679831944
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 679,
-        "created_at": 1679832394,
-        "hex": "G18",
-        "tile": "133-0",
-        "rotation": 0
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 680,
-        "created_at": 1679832412,
-        "routes": [
-          {
-            "train": "6-1",
-            "connections": [
-              [
-                "D9",
-                "D11",
-                "C12",
-                "D13"
-              ],
-              [
-                "B11",
-                "C10",
-                "D9"
-              ],
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "D13",
-              "D9",
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 290,
-            "revenue_str": "D13-D9-B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "D9-0",
-              "D13-0",
-              "B11-0",
-              "A10-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 681,
-        "created_at": 1679832417,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 682,
-        "created_at": 1679832447,
-        "train": "5-2",
-        "price": 124
-      },
-      {
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 683,
-        "created_at": 1679832767,
-        "hex": "I14",
-        "tile": "8-10",
-        "rotation": 0
-      },
-      {
-        "type": "run_routes",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 684,
-        "created_at": 1679832779,
-        "routes": [
-          {
-            "train": "6-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "J11"
-              ],
-              [
-                "J11",
-                "J9",
-                "J7",
-                "K6"
-              ]
-            ],
-            "hexes": [
+          ],
+          "hexes": [
+            "I18",
+            "I16",
+            "K14",
+            "K20"
+          ],
+          "revenue": 150,
+          "revenue_str": "I18-I16-K14-K20",
+          "nodes": [
+            "I18-0",
+            "I16-0",
+            "K14-0",
+            "K20-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
               "K20",
+              "J19",
+              "I18"
+            ],
+            [
               "I18",
-              "L13",
-              "K14",
-              "J11",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "H17"
+          ],
+          "revenue": 120,
+          "revenue_str": "K20-I18-H17",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "H17-0"
+          ]
+        }
+      ],
+      "original_id": 405
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 309,
+      "created_at": 1679139675,
+      "kind": "payout",
+      "original_id": 406
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 310,
+      "created_at": 1679140239,
+      "hex": "D9",
+      "tile": "135-0",
+      "rotation": 4,
+      "original_id": 407
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 311,
+      "created_at": 1679140246,
+      "original_id": 408
+    },
+    {
+      "type": "run_routes",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 312,
+      "created_at": 1679140255,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "B11",
+              "C10",
+              "D9"
+            ],
+            [
+              "A10",
+              "B11"
+            ]
+          ],
+          "hexes": [
+            "D9",
+            "B11",
+            "A10"
+          ],
+          "revenue": 130,
+          "revenue_str": "D9-B11-A10",
+          "nodes": [
+            "B11-0",
+            "D9-0",
+            "A10-0"
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 200,
+          "revenue_str": "B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "A10-0",
+            "B11-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 409
+    },
+    {
+      "type": "dividend",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 313,
+      "created_at": 1679140259,
+      "kind": "payout",
+      "original_id": 410
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 314,
+      "created_at": 1679144957,
+      "hex": "J11",
+      "tile": "55-0",
+      "rotation": 0,
+      "original_id": 411
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 315,
+      "created_at": 1679144964,
+      "original_id": 412
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 316,
+      "created_at": 1679144972,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "K6",
+              "K4"
+            ],
+            [
+              "K4",
+              "L3",
+              "M2"
+            ]
+          ],
+          "hexes": [
+            "K6",
+            "K4",
+            "M2"
+          ],
+          "revenue": 140,
+          "revenue_str": "K6-K4-M2 + Edge Token",
+          "nodes": [
+            "K6-0",
+            "K4-0",
+            "M2-0"
+          ]
+        }
+      ],
+      "original_id": 413
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 317,
+      "created_at": 1679144974,
+      "kind": "payout",
+      "original_id": 414
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 318,
+      "created_at": 1679144978,
+      "original_id": 415
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 319,
+      "created_at": 1679145023,
+      "hex": "I4",
+      "tile": "15-0",
+      "rotation": 2,
+      "original_id": 420
+    },
+    {
+      "type": "place_token",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 320,
+      "created_at": 1679145024,
+      "city": "15-1-0",
+      "slot": 1,
+      "tokener": "UP",
+      "original_id": 421
+    },
+    {
+      "type": "run_routes",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 321,
+      "created_at": 1679145062,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "I4",
+              "J5",
               "K6"
             ],
-            "revenue": 310,
-            "revenue_str": "K20-I18-L13-K14-J11-K6",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "J11-1",
-              "K6-0"
+            [
+              "F1",
+              "G2",
+              "H3",
+              "I4"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 685,
-        "created_at": 1679832783,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 686,
-        "created_at": 1679832849
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 687,
-        "user": 4311,
-        "created_at": 1679871587
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 688,
-        "user": 4311,
-        "created_at": 1679871588
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "routes": [
-          {
-            "hexes": [
-              "M2",
+          ],
+          "hexes": [
+            "K6",
+            "I4",
+            "F1"
+          ],
+          "revenue": 140,
+          "revenue_str": "K6-I4-F1 + Edge Token",
+          "nodes": [
+            "I4-0",
+            "K6-0",
+            "F1-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "K6",
+              "J7",
+              "J9",
+              "J11"
+            ],
+            [
               "K4",
-              "K6",
-              "J11",
-              "K14",
-              "L13",
-              "I18"
+              "K6"
             ],
-            "nodes": [
-              "M2-0",
-              "K4-0",
-              "K6-0",
-              "J11-1",
-              "K14-0",
-              "L13-0",
-              "I18-0"
-            ],
-            "train": "8-0",
-            "revenue": 380,
-            "connections": [
-              [
-                "M2",
-                "L3",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ],
-              [
-                "K6",
-                "J7",
-                "J9",
-                "J11"
-              ],
-              [
-                "J11",
-                "J13",
-                "K14"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I18"
-              ]
-            ],
-            "revenue_str": "M2-K4-K6-J11-K14-L13-I18 + Edge Token"
-          }
-        ],
-        "entity_type": "corporation",
-        "id": 689,
-        "user": 4311,
-        "created_at": 1679871607
-      },
-      {
-        "kind": "payout",
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 690,
-        "user": 4311,
-        "created_at": 1679871610
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 691,
-        "user": 4311,
-        "created_at": 1679871614
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 698,
-        "user": 2122,
-        "created_at": 1679872779
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 699,
-        "user": 2122,
-        "created_at": 1679872793
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 700,
-        "user": 2122,
-        "created_at": 1679872804
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 701,
-        "user": 2122,
-        "created_at": 1679872811
-      },
-      {
-        "type": "run_routes",
-        "entity": "GN",
-        "routes": [
-          {
-            "hexes": [
-              "G18",
-              "G16",
-              "F15",
-              "D13",
-              "D9",
-              "B5",
-              "A2"
-            ],
-            "nodes": [
-              "G16-0",
-              "G18-0",
-              "F15-0",
-              "D13-0",
-              "D9-0",
-              "B5-0",
-              "A2-0"
-            ],
-            "train": "8-1",
-            "revenue": 270,
-            "connections": [
-              [
-                "G16",
-                "G18"
-              ],
-              [
-                "F15",
-                "G16"
-              ],
-              [
-                "D13",
-                "E14",
-                "F15"
-              ],
-              [
-                "D9",
-                "D11",
-                "C12",
-                "D13"
-              ],
-              [
-                "B5",
-                "C6",
-                "C8",
-                "D9"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "revenue_str": "G18-G16-F15-D13-D9-B5-A2 + Edge Token"
-          }
-        ],
-        "entity_type": "corporation",
-        "id": 702,
-        "user": 2122,
-        "created_at": 1679872823
-      },
-      {
-        "kind": "payout",
-        "type": "dividend",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 703,
-        "user": 2122,
-        "created_at": 1679872825
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 704,
-        "user": 2122,
-        "created_at": 1679872842
-      },
-      {
-        "hex": "H9",
-        "tile": "5-1",
-        "type": "lay_tile",
-        "entity": "SOO",
-        "rotation": 3,
-        "entity_type": "corporation",
-        "id": 708,
-        "user": 4311,
-        "created_at": 1679903512
-      },
-      {
-        "city": "14-3-0",
-        "slot": 1,
-        "type": "place_token",
-        "entity": "SOO",
-        "tokener": "SOO",
-        "entity_type": "corporation",
-        "id": 709,
-        "user": 4311,
-        "created_at": 1679903519
-      },
-      {
-        "type": "run_routes",
-        "entity": "SOO",
-        "routes": [
-          {
-            "hexes": [
-              "F13",
-              "G10",
-              "H9",
-              "H11",
-              "H17",
-              "I18"
-            ],
-            "nodes": [
-              "F13-0",
-              "G10-0",
-              "H9-0",
-              "H11-0",
-              "H17-0",
-              "I18-0"
-            ],
-            "train": "6-0",
-            "revenue": 190,
-            "connections": [
-              [
-                "F13",
-                "F11",
-                "G10"
-              ],
-              [
-                "G10",
-                "H9"
-              ],
-              [
-                "H9",
-                "H11"
-              ],
-              [
-                "H11",
-                "H13",
-                "H15",
-                "H17"
-              ],
-              [
-                "H17",
-                "I18"
-              ]
-            ],
-            "revenue_str": "F13-G10-H9-H11-H17-I18"
-          }
-        ],
-        "entity_type": "corporation",
-        "id": 710,
-        "user": 4311,
-        "created_at": 1679903538
-      },
-      {
-        "kind": "payout",
-        "type": "dividend",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 711,
-        "user": 4311,
-        "created_at": 1679903540
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 712,
-        "user": 4311,
-        "created_at": 1679903551
-      },
-      {
-        "type": "undo",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 713,
-        "user": 2122,
-        "created_at": 1679913964
-      },
-      {
-        "type": "undo",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 714,
-        "user": 2122,
-        "created_at": 1679913969
-      },
-      {
-        "type": "undo",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 715,
-        "user": 2122,
-        "created_at": 1679913971
-      },
-      {
-        "type": "undo",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 716,
-        "user": 2122,
-        "created_at": 1679913972
-      },
-      {
-        "type": "undo",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 717,
-        "user": 2122,
-        "created_at": 1679913974
-      },
-      {
-        "type": "undo",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 718,
-        "user": 2122,
-        "created_at": 1679913975
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 719,
-        "user": 2122,
-        "created_at": 1679913977
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 720,
-        "user": 2122,
-        "created_at": 1679913978
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 721,
-        "user": 2122,
-        "created_at": 1679913980
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 722,
-        "user": 2122,
-        "created_at": 1679913981
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 723,
-        "user": 2122,
-        "created_at": 1679913983
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 724,
-        "user": 2122,
-        "created_at": 1679913984
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 725,
-        "user": 2122,
-        "created_at": 1679913989
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 726,
-        "user": 2122,
-        "created_at": 1679913992
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 727,
-        "user": 2122,
-        "created_at": 1679913994
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 728,
-        "user": 2122,
-        "created_at": 1679913997
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 729,
-        "user": 2122,
-        "created_at": 1679914001
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 730,
-        "user": 2122,
-        "created_at": 1679914005
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 731,
-        "user": 2122,
-        "created_at": 1679914007
-      },
-      {
-        "type": "redo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 732,
-        "user": 2122,
-        "created_at": 1679914029
-      },
-      {
-        "type": "redo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 733,
-        "user": 2122,
-        "created_at": 1679914032
-      },
-      {
-        "type": "redo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 734,
-        "user": 2122,
-        "created_at": 1679914034
-      },
-      {
-        "type": "redo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 735,
-        "user": 2122,
-        "created_at": 1679914052
-      },
-      {
-        "type": "redo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 736,
-        "user": 2122,
-        "created_at": 1679914053
-      },
-      {
-        "type": "redo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 737,
-        "user": 2122,
-        "created_at": 1679914055
-      },
-      {
-        "type": "redo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 738,
-        "user": 2122,
-        "created_at": 1679914058
-      },
-      {
-        "type": "redo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 739,
-        "user": 2122,
-        "created_at": 1679914065
-      },
-      {
-        "type": "redo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 740,
-        "user": 2122,
-        "created_at": 1679914097
-      },
-      {
-        "hex": "G18",
-        "tile": "134-0",
-        "type": "lay_tile",
-        "entity": "GN",
-        "rotation": 0,
-        "entity_type": "corporation",
-        "id": 741,
-        "user": 2122,
-        "created_at": 1679914109
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 742,
-        "user": 2122,
-        "created_at": 1679914158
-      },
-      {
-        "type": "undo",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 743,
-        "user": 2122,
-        "created_at": 1679914161
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 744,
-        "user": 2122,
-        "created_at": 1679914177
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 745,
-        "user": 2122,
-        "created_at": 1679914179
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 746,
-        "user": 2122,
-        "created_at": 1679914182
-      },
-      {
-        "type": "undo",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 747,
-        "user": 2122,
-        "created_at": 1679914186
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 749,
-        "created_at": 1679915202,
-        "hex": "J13",
-        "tile": "40-0",
-        "rotation": 1
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 750,
-        "created_at": 1679915207
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 751,
-        "created_at": 1679915216,
-        "routes": [
-          {
-            "train": "8-0",
-            "connections": [
-              [
-                "M2",
-                "L3",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ],
-              [
-                "K6",
-                "J7",
-                "J9",
-                "J11"
-              ],
-              [
-                "J11",
-                "J13",
-                "K14"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I18"
-              ]
-            ],
-            "hexes": [
+            [
               "M2",
-              "K4",
-              "K6",
-              "J11",
-              "K14",
-              "L13",
-              "I18"
-            ],
-            "revenue": 380,
-            "revenue_str": "M2-K4-K6-J11-K14-L13-I18 + Edge Token",
-            "nodes": [
-              "M2-0",
-              "K4-0",
-              "K6-0",
-              "J11-1",
-              "K14-0",
-              "L13-0",
-              "I18-0"
+              "L3",
+              "K4"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 752,
-        "created_at": 1679915217,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 753,
-        "created_at": 1679915735
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 754,
-        "created_at": 1679917697,
-        "hex": "G18",
-        "tile": "134-0",
-        "rotation": 0
-      },
-      {
-        "type": "place_token",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 755,
-        "created_at": 1679917703,
-        "city": "134-0-0",
-        "slot": 2,
-        "tokener": "GN"
-      },
-      {
-        "type": "run_routes",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 756,
-        "created_at": 1679917746,
-        "routes": [
-          {
-            "train": "8-1",
-            "connections": [
-              [
-                "G16",
-                "G18"
-              ],
-              [
-                "F15",
-                "G16"
-              ],
-              [
-                "D13",
-                "E14",
-                "F15"
-              ],
-              [
-                "D9",
-                "D11",
-                "C12",
-                "D13"
-              ],
-              [
-                "B5",
-                "C6",
-                "C8",
-                "D9"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
+          ],
+          "hexes": [
+            "J11",
+            "K6",
+            "K4",
+            "M2"
+          ],
+          "revenue": 110,
+          "revenue_str": "J11-K6-K4-M2",
+          "nodes": [
+            "K6-0",
+            "J11-1",
+            "K4-0",
+            "M2-0"
+          ]
+        }
+      ],
+      "original_id": 422
+    },
+    {
+      "type": "dividend",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 322,
+      "created_at": 1679145068,
+      "kind": "half",
+      "original_id": 423
+    },
+    {
+      "type": "par",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 323,
+      "created_at": 1679147900,
+      "corporation": "MP",
+      "share_price": "100,0,6",
+      "original_id": 424
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 324,
+      "created_at": 1679147905,
+      "original_id": 425
+    },
+    {
+      "type": "par",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 325,
+      "created_at": 1679149455,
+      "corporation": "MILW",
+      "share_price": "100,0,6",
+      "original_id": 426
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 326,
+      "created_at": 1679149487,
+      "original_id": 427
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 327,
+      "created_at": 1679222700,
+      "shares": [
+        "RI_7",
+        "RI_8"
+      ],
+      "percent": 20,
+      "original_id": 428
+    },
+    {
+      "type": "par",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 328,
+      "created_at": 1679222728,
+      "corporation": "SOO",
+      "share_price": "100,0,6",
+      "original_id": 429
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 329,
+      "created_at": 1679225788,
+      "shares": [
+        "RI_7",
+        "RI_8"
+      ],
+      "percent": 20,
+      "original_id": 430
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 330,
+      "created_at": 1679227645,
+      "shares": [
+        "MILW_1"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 431
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 331,
+      "created_at": 1679227661,
+      "original_id": 432
+    },
+    {
+      "type": "buy_shares",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 332,
+      "created_at": 1679241211,
+      "shares": [
+        "KATY_6"
+      ],
+      "percent": 10,
+      "original_id": 433
+    },
+    {
+      "type": "buy_shares",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 333,
+      "created_at": 1679250556,
+      "shares": [
+        "CBQ_2"
+      ],
+      "percent": 10,
+      "original_id": 434
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 334,
+      "created_at": 1679267228,
+      "shares": [
+        "MILW_2"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 435
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 335,
+      "created_at": 1679267251,
+      "original_id": 436
+    },
+    {
+      "type": "buy_shares",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 336,
+      "created_at": 1679269899,
+      "shares": [
+        "UP_2"
+      ],
+      "percent": 10,
+      "original_id": 439
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 337,
+      "created_at": 1679282515,
+      "shares": [
+        "MP_1"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 440
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 338,
+      "created_at": 1679282517,
+      "original_id": 441
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 339,
+      "created_at": 1679304396,
+      "shares": [
+        "MILW_3"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 442
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 340,
+      "created_at": 1679304400,
+      "original_id": 443
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 341,
+      "created_at": 1679368197,
+      "shares": [
+        "UP_8"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 446
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 342,
+      "created_at": 1679368211,
+      "original_id": 447
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 343,
+      "created_at": 1679371286,
+      "shares": [
+        "MP_2"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 448
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 344,
+      "created_at": 1679371292,
+      "original_id": 449
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 345,
+      "created_at": 1679372257,
+      "shares": [
+        "MILW_4"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 450
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 346,
+      "created_at": 1679372272,
+      "original_id": 451
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 347,
+      "created_at": 1679410504,
+      "shares": [
+        "SOO_1"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 452
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 348,
+      "created_at": 1679410655,
+      "original_id": 453
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 349,
+      "created_at": 1679436958,
+      "shares": [
+        "NP_4"
+      ],
+      "percent": 10,
+      "original_id": 454
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 350,
+      "created_at": 1679436976,
+      "shares": [
+        "UP_5"
+      ],
+      "percent": 10,
+      "original_id": 455
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 351,
+      "created_at": 1679436992,
+      "shares": [
+        "MP_3"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 456
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 352,
+      "created_at": 1679440874,
+      "shares": [
+        "NP_4"
+      ],
+      "percent": 10,
+      "original_id": 457
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 353,
+      "created_at": 1679442796,
+      "original_id": 458
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 354,
+      "created_at": 1679442870,
+      "shares": [
+        "SOO_2"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 459
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 355,
+      "created_at": 1679442917,
+      "original_id": 460
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 356,
+      "created_at": 1679444304,
+      "shares": [
+        "MP_4"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 461
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 357,
+      "created_at": 1679444306,
+      "original_id": 462
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 358,
+      "created_at": 1679485955,
+      "original_id": 463
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 359,
+      "created_at": 1679492643,
+      "shares": [
+        "SOO_3"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 464
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 360,
+      "created_at": 1679492667,
+      "original_id": 465
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 361,
+      "created_at": 1679494411,
+      "original_id": 466
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 362,
+      "created_at": 1679494668,
+      "original_id": 467
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 363,
+      "created_at": 1679525428,
+      "shares": [
+        "SOO_4"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 468
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 364,
+      "created_at": 1679525434,
+      "original_id": 469
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 365,
+      "created_at": 1679526107,
+      "original_id": 470
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 366,
+      "created_at": 1679526991,
+      "original_id": 471
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 367,
+      "created_at": 1679546479,
+      "shares": [
+        "CBQ_7"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 472
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 368,
+      "created_at": 1679546485,
+      "original_id": 473
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 369,
+      "created_at": 1679546604,
+      "original_id": 474
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 370,
+      "created_at": 1679574676,
+      "original_id": 475
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 371,
+      "created_at": 1679575430,
+      "original_id": 478
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 372,
+      "created_at": 1679575971,
+      "hex": "C12",
+      "tile": "9-13",
+      "rotation": 2,
+      "original_id": 479
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GBC",
+      "entity_type": "company",
+      "id": 373,
+      "created_at": 1679575985,
+      "hex": "D13",
+      "tile": "4-0",
+      "rotation": 2,
+      "original_id": 480
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 374,
+      "created_at": 1679575993,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "B11",
+              "C10",
+              "D9"
             ],
-            "hexes": [
-              "G18",
-              "G16",
-              "F15",
-              "D13",
-              "D9",
+            [
+              "A10",
+              "B11"
+            ]
+          ],
+          "hexes": [
+            "D9",
+            "B11",
+            "A10"
+          ],
+          "revenue": 130,
+          "revenue_str": "D9-B11-A10",
+          "nodes": [
+            "B11-0",
+            "D9-0",
+            "A10-0"
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
               "B5",
-              "A2"
+              "A6",
+              "A8",
+              "A10"
             ],
-            "revenue": 280,
-            "revenue_str": "G18-G16-F15-D13-D9-B5-A2 + Edge Token",
-            "nodes": [
-              "G16-0",
-              "G18-0",
-              "F15-0",
-              "D13-0",
-              "D9-0",
-              "B5-0",
-              "A2-0"
+            [
+              "A2",
+              "A4",
+              "B5"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 757,
-        "created_at": 1679917754,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 758,
-        "created_at": 1679917770
-      },
-      {
-        "type": "lay_tile",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 759,
-        "created_at": 1679918005,
-        "hex": "H9",
-        "tile": "5-1",
-        "rotation": 3
-      },
-      {
-        "type": "place_token",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 760,
-        "created_at": 1679918007,
-        "city": "14-3-0",
-        "slot": 1,
-        "tokener": "SOO"
-      },
-      {
-        "type": "run_routes",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 761,
-        "created_at": 1679918016,
-        "routes": [
-          {
-            "train": "6-0",
-            "connections": [
-              [
-                "F13",
-                "F11",
-                "G10"
-              ],
-              [
-                "G10",
-                "H9"
-              ],
-              [
-                "H9",
-                "H11"
-              ],
-              [
-                "H11",
-                "H13",
-                "H15",
-                "H17"
-              ],
-              [
-                "H17",
-                "I18"
-              ]
-            ],
-            "hexes": [
-              "F13",
-              "G10",
-              "H9",
-              "H11",
-              "H17",
-              "I18"
-            ],
-            "revenue": 190,
-            "revenue_str": "F13-G10-H9-H11-H17-I18",
-            "nodes": [
-              "F13-0",
-              "G10-0",
-              "H9-0",
-              "H11-0",
-              "H17-0",
-              "I18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 762,
-        "created_at": 1679918018,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 763,
-        "created_at": 1679918020
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 764,
-        "created_at": 1679918534,
-        "hex": "H17",
-        "tile": "144-0",
-        "rotation": 1
-      },
-      {
-        "type": "pass",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 765,
-        "created_at": 1679918568
-      },
-      {
-        "type": "buy_train",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 766,
-        "created_at": 1679918577,
-        "train": "10-0",
-        "price": 950,
-        "variant": "10"
-      },
-      {
-        "type": "undo",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 767,
-        "user": 2122,
-        "created_at": 1679922655
-      },
-      {
-        "type": "undo",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 768,
-        "user": 2122,
-        "created_at": 1679922659
-      },
-      {
-        "type": "undo",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 769,
-        "user": 2122,
-        "created_at": 1679922661
-      },
-      {
-        "type": "redo",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 770,
-        "user": 2122,
-        "created_at": 1679922691
-      },
-      {
-        "type": "redo",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 771,
-        "user": 2122,
-        "created_at": 1679922693
-      },
-      {
-        "type": "redo",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 772,
-        "user": 2122,
-        "created_at": 1679922699
-      },
-      {
-        "type": "lay_tile",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 773,
-        "created_at": 1679967661,
-        "hex": "J5",
-        "tile": "23-0",
-        "rotation": 2
-      },
-      {
-        "type": "run_routes",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 774,
-        "created_at": 1679967668,
-        "routes": [
-          {
-            "train": "8-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "J11"
-              ],
-              [
-                "J11",
-                "J9",
-                "J7",
-                "K6"
-              ],
-              [
-                "K6",
-                "J5",
-                "I4"
-              ],
-              [
-                "I4",
-                "H3",
-                "G2",
-                "F1"
-              ]
-            ],
-            "hexes": [
-              "K20",
+          ],
+          "hexes": [
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 200,
+          "revenue_str": "B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "A10-0",
+            "B11-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 481
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 375,
+      "created_at": 1679576036,
+      "kind": "withhold",
+      "original_id": 482
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 376,
+      "created_at": 1679576508,
+      "hex": "L13",
+      "tile": "5-0",
+      "rotation": 3,
+      "original_id": 483
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 377,
+      "created_at": 1679576659,
+      "original_id": 492
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 378,
+      "created_at": 1679576665,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
               "I18",
-              "L13",
-              "K14",
-              "J11",
-              "K6",
-              "I4",
-              "F1"
-            ],
-            "revenue": 420,
-            "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "J11-1",
-              "K6-0",
-              "I4-0",
-              "F1-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 775,
-        "created_at": 1679967673,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 776,
-        "created_at": 1679967676
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 777,
-        "created_at": 1679972291,
-        "hex": "H13",
-        "tile": "19-0",
-        "rotation": 1
-      },
-      {
-        "type": "pass",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 778,
-        "created_at": 1679972294
-      },
-      {
-        "type": "run_routes",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 779,
-        "created_at": 1679972305,
-        "routes": [
-          {
-            "train": "5-1",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J15",
-                "I16"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "L13",
-              "K14",
               "I16"
             ],
-            "revenue": 260,
-            "revenue_str": "K20-I18-L13-K14-I16",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "I16-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 780,
-        "created_at": 1679972306,
-        "kind": "withhold"
-      },
-      {
-        "type": "pass",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 781,
-        "created_at": 1679972336
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 782,
-        "created_at": 1679972358,
-        "hex": "G14",
-        "tile": "8-11",
-        "rotation": 4
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 783,
-        "created_at": 1679972361
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 784,
-        "created_at": 1679972399,
-        "routes": [
-          {
-            "train": "5-0",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "I16"
-              ],
-              [
-                "I16",
-                "J15",
-                "K14"
-              ],
-              [
-                "K14",
-                "L13"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
+            [
               "I16",
+              "J15",
+              "K14"
+            ],
+            [
+              "K14",
+              "K16",
+              "K18",
+              "K20"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "I16",
+            "K14",
+            "K20"
+          ],
+          "revenue": 150,
+          "revenue_str": "I18-I16-K14-K20",
+          "nodes": [
+            "I18-0",
+            "I16-0",
+            "K14-0",
+            "K20-0"
+          ]
+        },
+        {
+          "train": "3-5",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "H17"
+          ],
+          "revenue": 120,
+          "revenue_str": "K20-I18-H17",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "H17-0"
+          ]
+        }
+      ],
+      "original_id": 493
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 379,
+      "created_at": 1679576667,
+      "kind": "payout",
+      "original_id": 494
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 380,
+      "created_at": 1679576674,
+      "hex": "L13",
+      "tile": "14-2",
+      "rotation": 0,
+      "original_id": 495
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 381,
+      "created_at": 1679576677,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "I18",
+              "I16"
+            ],
+            [
+              "I16",
+              "J15",
+              "K14"
+            ],
+            [
+              "K14",
+              "K16",
+              "K18",
+              "K20"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "I16",
+            "K14",
+            "K20"
+          ],
+          "revenue": 150,
+          "revenue_str": "I18-I16-K14-K20",
+          "nodes": [
+            "I18-0",
+            "I16-0",
+            "K14-0",
+            "K20-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "H17"
+          ],
+          "revenue": 120,
+          "revenue_str": "K20-I18-H17",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "H17-0"
+          ]
+        }
+      ],
+      "original_id": 496
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 382,
+      "created_at": 1679576766,
+      "kind": "payout",
+      "original_id": 501
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 383,
+      "created_at": 1679577284,
+      "hex": "E14",
+      "tile": "9-14",
+      "rotation": 2,
+      "original_id": 502
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 384,
+      "created_at": 1679577296,
+      "original_id": 503
+    },
+    {
+      "type": "run_routes",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 385,
+      "created_at": 1679577303,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "B11",
+              "C10",
+              "D9"
+            ],
+            [
+              "A10",
+              "B11"
+            ]
+          ],
+          "hexes": [
+            "D9",
+            "B11",
+            "A10"
+          ],
+          "revenue": 130,
+          "revenue_str": "D9-B11-A10",
+          "nodes": [
+            "B11-0",
+            "D9-0",
+            "A10-0"
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 200,
+          "revenue_str": "B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "A10-0",
+            "B11-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 504
+    },
+    {
+      "type": "dividend",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 386,
+      "created_at": 1679577306,
+      "kind": "withhold",
+      "original_id": 505
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 387,
+      "created_at": 1679579410,
+      "hex": "K6",
+      "tile": "135-1",
+      "rotation": 2,
+      "original_id": 506
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 388,
+      "created_at": 1679579432,
+      "original_id": 507
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 389,
+      "created_at": 1679579436,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "K6",
+              "K4"
+            ],
+            [
+              "K4",
+              "L3",
+              "M2"
+            ]
+          ],
+          "hexes": [
+            "K6",
+            "K4",
+            "M2"
+          ],
+          "revenue": 160,
+          "revenue_str": "K6-K4-M2 + Edge Token",
+          "nodes": [
+            "K6-0",
+            "K4-0",
+            "M2-0"
+          ]
+        }
+      ],
+      "original_id": 508
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 390,
+      "created_at": 1679579440,
+      "kind": "payout",
+      "original_id": 509
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 391,
+      "created_at": 1679579444,
+      "original_id": 510
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 392,
+      "created_at": 1679583585,
+      "hex": "K14",
+      "tile": "63-2",
+      "rotation": 0,
+      "original_id": 511
+    },
+    {
+      "type": "place_token",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 393,
+      "created_at": 1679583595,
+      "city": "130-0-0",
+      "slot": 3,
+      "tokener": "MP",
+      "original_id": 512
+    },
+    {
+      "type": "buy_train",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 394,
+      "created_at": 1679583605,
+      "train": "5-1",
+      "price": 450,
+      "variant": "5",
+      "original_id": 513
+    },
+    {
+      "type": "buy_train",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 395,
+      "created_at": 1679583653,
+      "train": "3-2",
+      "price": 510,
+      "original_id": 514
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 396,
+      "created_at": 1679584364,
+      "hex": "G16",
+      "tile": "6-0",
+      "rotation": 2,
+      "original_id": 515
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 397,
+      "created_at": 1679584369,
+      "hex": "F15",
+      "tile": "4-1",
+      "rotation": 2,
+      "original_id": 516
+    },
+    {
+      "type": "place_token",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 398,
+      "created_at": 1679584399,
+      "city": "63-0-0",
+      "slot": 1,
+      "tokener": "MILW",
+      "original_id": 517
+    },
+    {
+      "type": "buy_train",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 399,
+      "created_at": 1679584406,
+      "train": "5-2",
+      "price": 450,
+      "variant": "5",
+      "original_id": 518
+    },
+    {
+      "type": "buy_train",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 400,
+      "created_at": 1679584529,
+      "train": "3-0",
+      "price": 380,
+      "original_id": 519
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 401,
+      "created_at": 1679632972,
+      "hex": "F13",
+      "tile": "57-2",
+      "rotation": 1,
+      "original_id": 520
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 402,
+      "created_at": 1679632977,
+      "hex": "F11",
+      "tile": "8-4",
+      "rotation": 4,
+      "original_id": 521
+    },
+    {
+      "type": "buy_train",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 403,
+      "created_at": 1679633045,
+      "train": "3-4",
+      "price": 180,
+      "original_id": 522
+    },
+    {
+      "type": "buy_train",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 404,
+      "created_at": 1679633048,
+      "train": "6-0",
+      "price": 630,
+      "variant": "6",
+      "original_id": 523
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 405,
+      "created_at": 1679633060,
+      "original_id": 524
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 406,
+      "created_at": 1679633075,
+      "hex": "J13",
+      "tile": "8-5",
+      "rotation": 5,
+      "original_id": 525
+    },
+    {
+      "type": "place_token",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 407,
+      "created_at": 1679633077,
+      "city": "130-0-0",
+      "slot": 3,
+      "tokener": "UP",
+      "original_id": 526
+    },
+    {
+      "type": "run_routes",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 408,
+      "created_at": 1679633106,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "F1",
+              "G2",
+              "H3",
+              "I4"
+            ],
+            [
+              "I4",
+              "J5",
+              "K6"
+            ],
+            [
+              "K6",
+              "K4"
+            ]
+          ],
+          "hexes": [
+            "F1",
+            "I4",
+            "K6",
+            "K4"
+          ],
+          "revenue": 190,
+          "revenue_str": "F1-I4-K6-K4 + Edge Token",
+          "nodes": [
+            "F1-0",
+            "I4-0",
+            "K6-0",
+            "K4-0"
+          ]
+        }
+      ],
+      "original_id": 527
+    },
+    {
+      "type": "dividend",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 409,
+      "created_at": 1679633110,
+      "kind": "payout",
+      "original_id": 528
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 410,
+      "created_at": 1679633114,
+      "original_id": 529
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 411,
+      "created_at": 1679634708,
+      "hex": "L13",
+      "tile": "135-2",
+      "rotation": 0,
+      "original_id": 530
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 412,
+      "created_at": 1679634716,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "I16"
+            ],
+            [
+              "I16",
+              "J15",
+              "K14"
+            ],
+            [
+              "K14",
+              "L13"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "I16",
+            "K14",
+            "L13"
+          ],
+          "revenue": 210,
+          "revenue_str": "K20-I18-I16-K14-L13",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "I16-0",
+            "K14-0",
+            "L13-0"
+          ]
+        }
+      ],
+      "original_id": 531
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 413,
+      "created_at": 1679634725,
+      "kind": "payout",
+      "original_id": 532
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 414,
+      "created_at": 1679634754,
+      "original_id": 533
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 415,
+      "created_at": 1679658004,
+      "hex": "G18",
+      "tile": "132-0",
+      "rotation": 0,
+      "original_id": 536
+    },
+    {
+      "type": "place_token",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 416,
+      "created_at": 1679658006,
+      "city": "132-0-0",
+      "slot": 1,
+      "tokener": "NP",
+      "original_id": 537
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 417,
+      "created_at": 1679658033,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 200,
+          "revenue_str": "B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "A10-0",
+            "B11-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 538
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 418,
+      "created_at": 1679658039,
+      "kind": "payout",
+      "original_id": 539
+    },
+    {
+      "type": "buy_train",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 419,
+      "created_at": 1679658051,
+      "train": "6-1",
+      "price": 630,
+      "variant": "6",
+      "original_id": 540
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 420,
+      "created_at": 1679659413,
+      "hex": "J17",
+      "tile": "9-15",
+      "rotation": 0,
+      "original_id": 541
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 421,
+      "created_at": 1679659417,
+      "original_id": 542
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 422,
+      "created_at": 1679659421,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "I18",
+              "I16"
+            ],
+            [
+              "I16",
+              "J15",
+              "K14"
+            ],
+            [
+              "K14",
+              "L13"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "I16",
+            "K14",
+            "L13"
+          ],
+          "revenue": 170,
+          "revenue_str": "I18-I16-K14-L13",
+          "nodes": [
+            "I18-0",
+            "I16-0",
+            "K14-0",
+            "L13-0"
+          ]
+        }
+      ],
+      "original_id": 543
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 423,
+      "created_at": 1679659424,
+      "kind": "payout",
+      "original_id": 544
+    },
+    {
+      "type": "buy_train",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 424,
+      "created_at": 1679659425,
+      "train": "6-2",
+      "price": 630,
+      "variant": "6",
+      "original_id": 545
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 425,
+      "created_at": 1679661202,
+      "hex": "K4",
+      "tile": "63-3",
+      "rotation": 0,
+      "original_id": 546
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 426,
+      "created_at": 1679661205,
+      "original_id": 547
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 427,
+      "created_at": 1679661244,
+      "shares": [
+        "CBQ_7"
+      ],
+      "percent": 10,
+      "original_id": 548
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 428,
+      "created_at": 1679661337,
+      "shares": [
+        "NP_7"
+      ],
+      "percent": 10,
+      "original_id": 553
+    },
+    {
+      "type": "buy_train",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 429,
+      "created_at": 1679661349,
+      "train": "8-0",
+      "price": 800,
+      "variant": "8",
+      "original_id": 554
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 430,
+      "created_at": 1679661417,
+      "shares": [
+        "CBQ_7"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 555
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 431,
+      "created_at": 1679661475,
+      "hex": "D9",
+      "tile": "138-0",
+      "rotation": 0,
+      "original_id": 556
+    },
+    {
+      "type": "buy_train",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 432,
+      "created_at": 1679661489,
+      "train": "8-1",
+      "price": 800,
+      "variant": "8",
+      "original_id": 557
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 433,
+      "created_at": 1679661501,
+      "original_id": 558
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 434,
+      "created_at": 1679662241,
+      "hex": "I18",
+      "tile": "131-0",
+      "rotation": 0,
+      "original_id": 559
+    },
+    {
+      "type": "run_routes",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 435,
+      "created_at": 1679662249,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J15",
+              "I16"
+            ],
+            [
+              "I16",
+              "I18"
+            ],
+            [
+              "I18",
+              "J19",
+              "K20"
+            ]
+          ],
+          "hexes": [
+            "L13",
+            "K14",
+            "I16",
+            "I18",
+            "K20"
+          ],
+          "revenue": 250,
+          "revenue_str": "L13-K14-I16-I18-K20",
+          "nodes": [
+            "L13-0",
+            "K14-0",
+            "I16-0",
+            "I18-0",
+            "K20-0"
+          ]
+        }
+      ],
+      "original_id": 560
+    },
+    {
+      "type": "dividend",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 436,
+      "created_at": 1679662292,
+      "kind": "withhold",
+      "original_id": 563
+    },
+    {
+      "type": "pass",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 437,
+      "created_at": 1679662293,
+      "original_id": 564
+    },
+    {
+      "type": "choose",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 438,
+      "created_at": 1679662415,
+      "choice": "Buy Mesabi Token",
+      "original_id": 565
+    },
+    {
+      "type": "choose",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 439,
+      "created_at": 1679662420,
+      "choice": "Place Edge Token",
+      "original_id": 566
+    },
+    {
+      "type": "run_routes",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 440,
+      "created_at": 1679662439,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "B11",
+              "C10",
+              "D9"
+            ],
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "D9",
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 280,
+          "revenue_str": "D9-B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "B11-0",
+            "D9-0",
+            "A10-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 567
+    },
+    {
+      "type": "dividend",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 441,
+      "created_at": 1679662446,
+      "kind": "payout",
+      "original_id": 568
+    },
+    {
+      "type": "pass",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 442,
+      "created_at": 1679662631,
+      "original_id": 569
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 443,
+      "created_at": 1679702535,
+      "hex": "F15",
+      "tile": "142-0",
+      "rotation": 2,
+      "original_id": 570
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 444,
+      "created_at": 1679702545,
+      "original_id": 571
+    },
+    {
+      "type": "run_routes",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 445,
+      "created_at": 1679702551,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "F13",
+              "F15"
+            ],
+            [
+              "F15",
+              "G16"
+            ],
+            [
+              "G16",
+              "G18"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "F15",
+            "G16",
+            "G18"
+          ],
+          "revenue": 80,
+          "revenue_str": "F13-F15-G16-G18",
+          "nodes": [
+            "F13-0",
+            "F15-0",
+            "G16-0",
+            "G18-0"
+          ]
+        }
+      ],
+      "original_id": 572
+    },
+    {
+      "type": "dividend",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 446,
+      "created_at": 1679702553,
+      "kind": "payout",
+      "original_id": 573
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 447,
+      "created_at": 1679702555,
+      "original_id": 574
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 448,
+      "created_at": 1679702580,
+      "hex": "K16",
+      "tile": "24-0",
+      "rotation": 1,
+      "original_id": 575
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 449,
+      "created_at": 1679702608,
+      "shares": [
+        "KATY_3",
+        "KATY_4",
+        "KATY_7"
+      ],
+      "percent": 30,
+      "original_id": 576
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 450,
+      "created_at": 1679702664,
+      "shares": [
+        "UP_3",
+        "UP_4"
+      ],
+      "percent": 20,
+      "original_id": 581
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 451,
+      "created_at": 1679702673,
+      "shares": [
+        "SOO_1"
+      ],
+      "percent": 10,
+      "original_id": 582
+    },
+    {
+      "type": "buy_train",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 452,
+      "created_at": 1679702677,
+      "train": "8-2",
+      "price": 800,
+      "variant": "8",
+      "original_id": 583
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 453,
+      "created_at": 1679707659,
+      "hex": "L13",
+      "tile": "138-1",
+      "rotation": 0,
+      "original_id": 584
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 454,
+      "created_at": 1679707665,
+      "original_id": 585
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 455,
+      "created_at": 1679707672,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "I16"
+            ],
+            [
+              "I16",
+              "J15",
+              "K14"
+            ],
+            [
+              "K14",
+              "L13"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "I16",
+            "K14",
+            "L13"
+          ],
+          "revenue": 260,
+          "revenue_str": "K20-I18-I16-K14-L13",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "I16-0",
+            "K14-0",
+            "L13-0"
+          ]
+        }
+      ],
+      "original_id": 586
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 456,
+      "created_at": 1679707674,
+      "kind": "payout",
+      "original_id": 587
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 457,
+      "created_at": 1679707687,
+      "original_id": 588
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 458,
+      "created_at": 1679707700,
+      "hex": "K16",
+      "tile": "47-0",
+      "rotation": 0,
+      "original_id": 589
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 459,
+      "created_at": 1679707703,
+      "original_id": 590
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 460,
+      "created_at": 1679707706,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "I16"
+            ],
+            [
+              "I16",
+              "J15",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "J11"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7",
+              "K6"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "I16",
+            "K14",
+            "J11",
+            "K6"
+          ],
+          "revenue": 260,
+          "revenue_str": "K20-I18-I16-K14-J11-K6",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "I16-0",
+            "K14-0",
+            "J11-1",
+            "K6-0"
+          ]
+        }
+      ],
+      "original_id": 591
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 461,
+      "created_at": 1679707721,
+      "kind": "payout",
+      "original_id": 592
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 462,
+      "created_at": 1679707722,
+      "original_id": 593
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 463,
+      "created_at": 1679707894,
+      "hex": "C12",
+      "tile": "27-0",
+      "rotation": 5,
+      "original_id": 594
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 464,
+      "created_at": 1679707926,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "B11",
+              "C10",
+              "D9"
+            ],
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "D9",
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 280,
+          "revenue_str": "D9-B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "B11-0",
+            "D9-0",
+            "A10-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 595
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 465,
+      "created_at": 1679707933,
+      "kind": "payout",
+      "original_id": 596
+    },
+    {
+      "type": "pass",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 466,
+      "created_at": 1679707946,
+      "original_id": 597
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 467,
+      "created_at": 1679707954,
+      "hex": "D11",
+      "tile": "8-6",
+      "rotation": 1,
+      "original_id": 598
+    },
+    {
+      "type": "pass",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 468,
+      "created_at": 1679707966,
+      "original_id": 599
+    },
+    {
+      "type": "run_routes",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 469,
+      "created_at": 1679707972,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "B11",
+              "C10",
+              "D9"
+            ],
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "D9",
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 280,
+          "revenue_str": "D9-B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "B11-0",
+            "D9-0",
+            "A10-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 600
+    },
+    {
+      "type": "dividend",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 470,
+      "created_at": 1679707976,
+      "kind": "payout",
+      "original_id": 601
+    },
+    {
+      "type": "pass",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 471,
+      "created_at": 1679707979,
+      "original_id": 602
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 472,
+      "created_at": 1679707986,
+      "hex": "C6",
+      "tile": "8-7",
+      "rotation": 2,
+      "original_id": 603
+    },
+    {
+      "type": "run_routes",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 473,
+      "created_at": 1679708011,
+      "routes": [
+        {
+          "train": "8-1",
+          "connections": [
+            [
+              "G16",
+              "G18"
+            ],
+            [
+              "F15",
+              "G16"
+            ],
+            [
+              "D13",
+              "E14",
+              "F15"
+            ],
+            [
+              "D9",
+              "D11",
+              "C12",
+              "D13"
+            ],
+            [
+              "B5",
+              "C6",
+              "C8",
+              "D9"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "G18",
+            "G16",
+            "F15",
+            "D13",
+            "D9",
+            "B5",
+            "A2"
+          ],
+          "revenue": 250,
+          "revenue_str": "G18-G16-F15-D13-D9-B5-A2 + Edge Token",
+          "nodes": [
+            "G16-0",
+            "G18-0",
+            "F15-0",
+            "D13-0",
+            "D9-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 604
+    },
+    {
+      "type": "dividend",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 474,
+      "created_at": 1679708016,
+      "kind": "payout",
+      "original_id": 605
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 475,
+      "created_at": 1679708018,
+      "original_id": 606
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 476,
+      "created_at": 1679708059,
+      "hex": "G10",
+      "tile": "4-2",
+      "rotation": 0,
+      "original_id": 607
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 477,
+      "created_at": 1679708062,
+      "original_id": 608
+    },
+    {
+      "type": "run_routes",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 478,
+      "created_at": 1679708065,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "F13",
+              "F15"
+            ],
+            [
+              "F15",
+              "G16"
+            ],
+            [
+              "G16",
+              "G18"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "F15",
+            "G16",
+            "G18"
+          ],
+          "revenue": 80,
+          "revenue_str": "F13-F15-G16-G18",
+          "nodes": [
+            "F13-0",
+            "F15-0",
+            "G16-0",
+            "G18-0"
+          ]
+        }
+      ],
+      "original_id": 609
+    },
+    {
+      "type": "dividend",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 479,
+      "created_at": 1679708066,
+      "kind": "payout",
+      "original_id": 610
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 480,
+      "created_at": 1679708069,
+      "original_id": 611
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 481,
+      "created_at": 1679708113,
+      "hex": "I6",
+      "tile": "8-8",
+      "rotation": 1,
+      "original_id": 612
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 482,
+      "created_at": 1679708119,
+      "routes": [
+        {
+          "train": "8-0",
+          "connections": [
+            [
+              "M2",
+              "L3",
+              "K4"
+            ],
+            [
+              "K4",
+              "K6"
+            ],
+            [
+              "K6",
+              "J7",
+              "J9",
+              "J11"
+            ],
+            [
+              "J11",
+              "J13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J15",
+              "I16"
+            ],
+            [
+              "I16",
+              "I18"
+            ]
+          ],
+          "hexes": [
+            "M2",
+            "K4",
+            "K6",
+            "J11",
+            "K14",
+            "I16",
+            "I18"
+          ],
+          "revenue": 330,
+          "revenue_str": "M2-K4-K6-J11-K14-I16-I18 + Edge Token",
+          "nodes": [
+            "M2-0",
+            "K4-0",
+            "K6-0",
+            "J11-1",
+            "K14-0",
+            "I16-0",
+            "I18-0"
+          ]
+        }
+      ],
+      "original_id": 613
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 483,
+      "created_at": 1679708121,
+      "kind": "payout",
+      "original_id": 614
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 484,
+      "created_at": 1679708124,
+      "original_id": 615
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 485,
+      "created_at": 1679735758,
+      "hex": "L15",
+      "tile": "8-9",
+      "rotation": 1,
+      "original_id": 616
+    },
+    {
+      "type": "pass",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 486,
+      "created_at": 1679735764,
+      "original_id": 617
+    },
+    {
+      "type": "run_routes",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 487,
+      "created_at": 1679735772,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J15",
+              "I16"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "I16"
+          ],
+          "revenue": 260,
+          "revenue_str": "K20-I18-L13-K14-I16",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "I16-0"
+          ]
+        }
+      ],
+      "original_id": 618
+    },
+    {
+      "type": "dividend",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 488,
+      "created_at": 1679735782,
+      "kind": "withhold",
+      "original_id": 619
+    },
+    {
+      "type": "pass",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 489,
+      "created_at": 1679735783,
+      "original_id": 620
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 490,
+      "created_at": 1679738720,
+      "hex": "H11",
+      "tile": "14-3",
+      "rotation": 0,
+      "original_id": 621
+    },
+    {
+      "type": "run_routes",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 491,
+      "created_at": 1679738726,
+      "routes": [
+        {
+          "train": "8-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "J11"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7",
+              "K6"
+            ],
+            [
+              "K6",
+              "J5",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3",
+              "G2",
+              "F1"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "J11",
+            "K6",
+            "I4",
+            "F1"
+          ],
+          "revenue": 420,
+          "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "J11-1",
+            "K6-0",
+            "I4-0",
+            "F1-0"
+          ]
+        }
+      ],
+      "original_id": 622
+    },
+    {
+      "type": "dividend",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 492,
+      "created_at": 1679738734,
+      "kind": "payout",
+      "original_id": 623
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 493,
+      "created_at": 1679738737,
+      "original_id": 624
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 494,
+      "created_at": 1679740955,
+      "shares": [
+        "MP_1"
+      ],
+      "percent": 10,
+      "original_id": 627
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 495,
+      "created_at": 1679740958,
+      "shares": [
+        "UP_5"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 628
+    },
+    {
+      "type": "buy_shares",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 496,
+      "created_at": 1679744705,
+      "shares": [
+        "NP_7"
+      ],
+      "percent": 10,
+      "original_id": 633
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 497,
+      "created_at": 1679746586,
+      "shares": [
+        "KATY_3"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 636
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 498,
+      "created_at": 1679746625,
+      "original_id": 637
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 499,
+      "created_at": 1679750033,
+      "original_id": 638
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 500,
+      "created_at": 1679750040,
+      "unconditional": false,
+      "indefinite": false,
+      "original_id": 639
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 501,
+      "created_at": 1679750088,
+      "shares": [
+        "CBQ_5"
+      ],
+      "percent": 10,
+      "original_id": 640
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 502,
+      "created_at": 1679750098,
+      "shares": [
+        "KATY_4"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 641
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 503,
+      "created_at": 1679753241,
+      "shares": [
+        "CBQ_8"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 642
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 504,
+      "created_at": 1679753244,
+      "shares": [
+        "CBQ_8"
+      ],
+      "percent": 10,
+      "original_id": 643
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 505,
+      "created_at": 1679753286,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1679753286,
+          "reason": "Shares were sold"
+        }
+      ],
+      "original_id": 644
+    },
+    {
+      "type": "buy_shares",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 506,
+      "created_at": 1679753871,
+      "shares": [
+        "CBQ_5"
+      ],
+      "percent": 10,
+      "original_id": 645
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 507,
+      "created_at": 1679753920,
+      "unconditional": false,
+      "indefinite": false,
+      "original_id": 646
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 508,
+      "created_at": 1679753950,
+      "original_id": 647
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 509,
+      "created_at": 1679754725,
+      "shares": [
+        "KATY_7"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 648
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 510,
+      "created_at": 1679754871,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1679754870
+        }
+      ],
+      "original_id": 649
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 511,
+      "created_at": 1679757055,
+      "original_id": 650
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 512,
+      "created_at": 1679757508,
+      "shares": [
+        "MILW_5"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 651
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 513,
+      "created_at": 1679757511,
+      "shares": [
+        "MILW_5"
+      ],
+      "percent": 10,
+      "original_id": 652
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 514,
+      "created_at": 1679757559,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1679757559,
+          "reason": "Shares were sold"
+        }
+      ],
+      "original_id": 653
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 515,
+      "created_at": 1679757651,
+      "original_id": 654
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 516,
+      "created_at": 1679757657,
+      "unconditional": false,
+      "indefinite": false,
+      "original_id": 655
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 517,
+      "created_at": 1679758295,
+      "original_id": 656
+    },
+    {
+      "type": "buy_shares",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 518,
+      "created_at": 1679795895,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1679795895,
+          "reason": "UP redeemed a share."
+        }
+      ],
+      "shares": [
+        "UP_3"
+      ],
+      "percent": 10,
+      "original_id": 657
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 519,
+      "created_at": 1679804921,
+      "original_id": 658
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 520,
+      "created_at": 1679804927,
+      "unconditional": false,
+      "indefinite": false,
+      "original_id": 659
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 521,
+      "created_at": 1679824657,
+      "original_id": 660
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 522,
+      "created_at": 1679825055,
+      "shares": [
+        "UP_4"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 663
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 523,
+      "created_at": 1679825081,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1679825081
+        }
+      ],
+      "original_id": 664
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 524,
+      "created_at": 1679825302,
+      "original_id": 665
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 525,
+      "created_at": 1679826810,
+      "shares": [
+        "SOO_5"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 666
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 526,
+      "created_at": 1679827104,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1679827103
+        }
+      ],
+      "original_id": 667
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 527,
+      "created_at": 1679827123,
+      "original_id": 668
+    },
+    {
+      "type": "buy_shares",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 528,
+      "created_at": 1679827345,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 1761,
+          "entity_type": "player",
+          "created_at": 1679827344,
+          "reason": "SOO redeemed a share."
+        }
+      ],
+      "shares": [
+        "SOO_1"
+      ],
+      "percent": 10,
+      "original_id": 669
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 529,
+      "created_at": 1679827475,
+      "original_id": 670
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 530,
+      "created_at": 1679827480,
+      "unconditional": false,
+      "indefinite": false,
+      "original_id": 671
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 531,
+      "created_at": 1679827819,
+      "original_id": 672
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 532,
+      "created_at": 1679828590,
+      "original_id": 673
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 533,
+      "created_at": 1679831892,
+      "hex": "J13",
+      "tile": "25-0",
+      "rotation": 5,
+      "original_id": 674
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 534,
+      "created_at": 1679831895,
+      "original_id": 675
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 535,
+      "created_at": 1679831928,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "I16"
+            ],
+            [
+              "I16",
+              "J15",
+              "K14"
+            ],
+            [
+              "K14",
+              "L13"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "I16",
+            "K14",
+            "L13"
+          ],
+          "revenue": 260,
+          "revenue_str": "K20-I18-I16-K14-L13",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "I16-0",
+            "K14-0",
+            "L13-0"
+          ]
+        }
+      ],
+      "original_id": 676
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 536,
+      "created_at": 1679831929,
+      "kind": "payout",
+      "original_id": 677
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 537,
+      "created_at": 1679831944,
+      "original_id": 678
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 538,
+      "created_at": 1679832394,
+      "hex": "G18",
+      "tile": "133-0",
+      "rotation": 0,
+      "original_id": 679
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 539,
+      "created_at": 1679832412,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "D9",
+              "D11",
+              "C12",
+              "D13"
+            ],
+            [
+              "B11",
+              "C10",
+              "D9"
+            ],
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "D13",
+            "D9",
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 290,
+          "revenue_str": "D13-D9-B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "D9-0",
+            "D13-0",
+            "B11-0",
+            "A10-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 680
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 540,
+      "created_at": 1679832417,
+      "kind": "payout",
+      "original_id": 681
+    },
+    {
+      "type": "buy_train",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 541,
+      "created_at": 1679832447,
+      "train": "5-2",
+      "price": 124,
+      "original_id": 682
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 542,
+      "created_at": 1679832767,
+      "hex": "I14",
+      "tile": "8-10",
+      "rotation": 0,
+      "original_id": 683
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 543,
+      "created_at": 1679832779,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "J11"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7",
+              "K6"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "J11",
+            "K6"
+          ],
+          "revenue": 310,
+          "revenue_str": "K20-I18-L13-K14-J11-K6",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "J11-1",
+            "K6-0"
+          ]
+        }
+      ],
+      "original_id": 684
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 544,
+      "created_at": 1679832783,
+      "kind": "payout",
+      "original_id": 685
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 545,
+      "created_at": 1679832849,
+      "original_id": 686
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 546,
+      "created_at": 1679915202,
+      "hex": "J13",
+      "tile": "40-0",
+      "rotation": 1,
+      "original_id": 749
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 547,
+      "created_at": 1679915207,
+      "original_id": 750
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 548,
+      "created_at": 1679915216,
+      "routes": [
+        {
+          "train": "8-0",
+          "connections": [
+            [
+              "M2",
+              "L3",
+              "K4"
+            ],
+            [
+              "K4",
+              "K6"
+            ],
+            [
+              "K6",
+              "J7",
+              "J9",
+              "J11"
+            ],
+            [
+              "J11",
+              "J13",
+              "K14"
+            ],
+            [
               "K14",
               "L13"
             ],
-            "revenue": 260,
-            "revenue_str": "K20-I18-I16-K14-L13",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "I16-0",
-              "K14-0",
-              "L13-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 785,
-        "created_at": 1679972403,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 786,
-        "created_at": 1679972410
-      },
-      {
-        "hex": "F15",
-        "tile": "145-0",
-        "type": "lay_tile",
-        "entity": "NP",
-        "rotation": 1,
-        "entity_type": "corporation",
-        "id": 787,
-        "user": 2122,
-        "created_at": 1679995587
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "routes": [
-          {
-            "hexes": [
-              "F13",
-              "F15",
-              "G16",
-              "G18",
-              "H17",
-              "I18"
-            ],
-            "nodes": [
-              "F15-0",
-              "F13-0",
-              "G16-0",
-              "G18-0",
-              "H17-0",
-              "I18-0"
-            ],
-            "train": "6-1",
-            "revenue": 230,
-            "connections": [
-              [
-                "F15",
-                "F13"
-              ],
-              [
-                "G16",
-                "F15"
-              ],
-              [
-                "G18",
-                "G16"
-              ],
-              [
-                "H17",
-                "G18"
-              ],
-              [
-                "I18",
-                "H17"
-              ]
-            ],
-            "revenue_str": "F13-F15-G16-G18-H17-I18"
-          },
-          {
-            "hexes": [
-              "D9",
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "nodes": [
-              "B11-0",
-              "D9-0",
-              "A10-0",
-              "B5-0",
-              "A2-0"
-            ],
-            "train": "5-2",
-            "revenue": 280,
-            "connections": [
-              [
-                "B11",
-                "C10",
-                "D9"
-              ],
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "revenue_str": "D9-B11-A10-B5-A2 + Edge Token"
-          }
-        ],
-        "entity_type": "corporation",
-        "id": 788,
-        "user": 2122,
-        "created_at": 1679995651
-      },
-      {
-        "kind": "payout",
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 789,
-        "user": 2122,
-        "created_at": 1679995658
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 790,
-        "user": 2122,
-        "created_at": 1679995840
-      },
-      {
-        "type": "undo",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 791,
-        "user": 2122,
-        "created_at": 1679995851
-      },
-      {
-        "type": "undo",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 792,
-        "user": 2122,
-        "created_at": 1679995858
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 793,
-        "created_at": 1679996556,
-        "hex": "G16",
-        "tile": "14-0",
-        "rotation": 1
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 794,
-        "created_at": 1679996608,
-        "routes": [
-          {
-            "train": "6-1",
-            "connections": [
-              [
-                "G18",
-                "H17"
-              ],
-              [
-                "G16",
-                "G18"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "G14",
-                "G16"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ]
-            ],
-            "hexes": [
-              "H17",
-              "G18",
-              "G16",
-              "K14",
+            [
               "L13",
+              "L15",
+              "K16",
+              "J17",
               "I18"
-            ],
-            "revenue": 300,
-            "revenue_str": "H17-G18-G16-K14-L13-I18",
-            "nodes": [
-              "G18-0",
-              "H17-0",
-              "G16-0",
-              "K14-0",
-              "L13-0",
-              "I18-0"
             ]
-          },
-          {
-            "train": "5-2",
-            "connections": [
-              [
-                "B11",
-                "C10",
-                "D9"
-              ],
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "D9",
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 280,
-            "revenue_str": "D9-B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "B11-0",
-              "D9-0",
-              "A10-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 795,
-        "created_at": 1679996614,
-        "kind": "payout"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 796,
-        "created_at": 1679997137,
-        "hex": "H17",
-        "tile": "147-0",
-        "rotation": 5
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 797,
-        "created_at": 1679997141
-      },
-      {
-        "type": "run_routes",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 798,
-        "created_at": 1679997277,
-        "routes": [
-          {
-            "train": "6-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "G14",
-                "G16"
-              ],
-              [
-                "G16",
-                "G18"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "L13",
-              "K14",
+          ],
+          "hexes": [
+            "M2",
+            "K4",
+            "K6",
+            "J11",
+            "K14",
+            "L13",
+            "I18"
+          ],
+          "revenue": 380,
+          "revenue_str": "M2-K4-K6-J11-K14-L13-I18 + Edge Token",
+          "nodes": [
+            "M2-0",
+            "K4-0",
+            "K6-0",
+            "J11-1",
+            "K14-0",
+            "L13-0",
+            "I18-0"
+          ]
+        }
+      ],
+      "original_id": 751
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 549,
+      "created_at": 1679915217,
+      "kind": "payout",
+      "original_id": 752
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 550,
+      "created_at": 1679915735,
+      "original_id": 753
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 551,
+      "created_at": 1679917697,
+      "hex": "G18",
+      "tile": "134-0",
+      "rotation": 0,
+      "original_id": 754
+    },
+    {
+      "type": "place_token",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 552,
+      "created_at": 1679917703,
+      "city": "134-0-0",
+      "slot": 2,
+      "tokener": "GN",
+      "original_id": 755
+    },
+    {
+      "type": "run_routes",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 553,
+      "created_at": 1679917746,
+      "routes": [
+        {
+          "train": "8-1",
+          "connections": [
+            [
               "G16",
               "G18"
             ],
-            "revenue": 340,
-            "revenue_str": "K20-I18-L13-K14-G16-G18",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "G16-0",
-              "G18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 799,
-        "created_at": 1679997308,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 800,
-        "created_at": 1679997313
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 801,
-        "created_at": 1680041254,
-        "hex": "F13",
-        "tile": "14-2",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 802,
-        "created_at": 1680041257
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 803,
-        "created_at": 1680041265,
-        "routes": [
-          {
-            "train": "8-0",
-            "connections": [
-              [
-                "M2",
-                "L3",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ],
-              [
-                "K6",
-                "J7",
-                "J9",
-                "J11"
-              ],
-              [
-                "J11",
-                "J13",
-                "K14"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I18"
-              ]
-            ],
-            "hexes": [
-              "M2",
-              "K4",
-              "K6",
-              "J11",
-              "K14",
-              "L13",
-              "I18"
-            ],
-            "revenue": 380,
-            "revenue_str": "M2-K4-K6-J11-K14-L13-I18 + Edge Token",
-            "nodes": [
-              "M2-0",
-              "K4-0",
-              "K6-0",
-              "J11-1",
-              "K14-0",
-              "L13-0",
-              "I18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 804,
-        "created_at": 1680041272,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 805,
-        "created_at": 1680041278
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 806,
-        "created_at": 1680045406,
-        "hex": "F15",
-        "tile": "145-0",
-        "rotation": 1
-      },
-      {
-        "type": "run_routes",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 807,
-        "created_at": 1680045470,
-        "routes": [
-          {
-            "train": "8-1",
-            "connections": [
-              [
-                "K14",
-                "K16",
-                "J17",
-                "I18"
-              ],
-              [
-                "G16",
-                "G14",
-                "H13",
-                "I14",
-                "J13",
-                "K14"
-              ],
-              [
-                "F15",
-                "G16"
-              ],
-              [
-                "D13",
-                "E14",
-                "F15"
-              ],
-              [
-                "D9",
-                "D11",
-                "C12",
-                "D13"
-              ],
-              [
-                "B5",
-                "C6",
-                "C8",
-                "D9"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "K14",
-              "G16",
+            [
               "F15",
+              "G16"
+            ],
+            [
               "D13",
+              "E14",
+              "F15"
+            ],
+            [
               "D9",
+              "D11",
+              "C12",
+              "D13"
+            ],
+            [
               "B5",
-              "A2"
+              "C6",
+              "C8",
+              "D9"
             ],
-            "revenue": 380,
-            "revenue_str": "I18-K14-G16-F15-D13-D9-B5-A2 + Edge Token",
-            "nodes": [
-              "K14-0",
-              "I18-0",
-              "G16-0",
-              "F15-0",
-              "D13-0",
-              "D9-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 808,
-        "created_at": 1680045474,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 809,
-        "created_at": 1680045543
-      },
-      {
-        "type": "lay_tile",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 810,
-        "created_at": 1680045771,
-        "hex": "H13",
-        "tile": "45-0",
-        "rotation": 1
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 811,
-        "created_at": 1680045779
-      },
-      {
-        "type": "run_routes",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 812,
-        "created_at": 1680045784,
-        "routes": [
-          {
-            "train": "6-0",
-            "connections": [
-              [
-                "H11",
-                "H13",
-                "H15",
-                "H17"
-              ],
-              [
-                "H17",
-                "G16"
-              ],
-              [
-                "G16",
-                "G14",
-                "H13",
-                "I14",
-                "J13",
-                "K14"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I18"
-              ]
-            ],
-            "hexes": [
-              "H11",
-              "H17",
-              "G16",
-              "K14",
-              "L13",
-              "I18"
-            ],
-            "revenue": 280,
-            "revenue_str": "H11-H17-G16-K14-L13-I18",
-            "nodes": [
-              "H11-0",
-              "H17-0",
-              "G16-0",
-              "K14-0",
-              "L13-0",
-              "I18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 813,
-        "created_at": 1680045785,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 814,
-        "created_at": 1680045796
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 815,
-        "created_at": 1680085010,
-        "hex": "H15",
-        "tile": "24-1",
-        "rotation": 4
-      },
-      {
-        "type": "run_routes",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 816,
-        "created_at": 1680085036,
-        "routes": [
-          {
-            "train": "10-0",
-            "connections": [
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I18"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "G16",
-                "G14",
-                "H13",
-                "I14",
-                "J13",
-                "K14"
-              ],
-              [
-                "F15",
-                "G16"
-              ],
-              [
-                "D13",
-                "E14",
-                "F15"
-              ],
-              [
-                "B11",
-                "C12",
-                "D13"
-              ],
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "L13",
-              "K14",
-              "G16",
-              "F15",
-              "D13",
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 480,
-            "revenue_str": "I18-L13-K14-G16-F15-D13-B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "L13-0",
-              "I18-0",
-              "K14-0",
-              "G16-0",
-              "F15-0",
-              "D13-0",
-              "B11-0",
-              "A10-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 817,
-        "created_at": 1680085044,
-        "kind": "withhold"
-      },
-      {
-        "type": "buy_train",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 818,
-        "created_at": 1680085231,
-        "train": "5-2",
-        "price": 428
-      },
-      {
-        "type": "lay_tile",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 819,
-        "created_at": 1680088922,
-        "hex": "H9",
-        "tile": "14-1",
-        "rotation": 0
-      },
-      {
-        "type": "run_routes",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 820,
-        "created_at": 1680088926,
-        "routes": [
-          {
-            "train": "8-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "J11"
-              ],
-              [
-                "J11",
-                "J9",
-                "J7",
-                "K6"
-              ],
-              [
-                "K6",
-                "J5",
-                "I4"
-              ],
-              [
-                "I4",
-                "H3",
-                "G2",
-                "F1"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "L13",
-              "K14",
-              "J11",
-              "K6",
-              "I4",
-              "F1"
-            ],
-            "revenue": 420,
-            "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "J11-1",
-              "K6-0",
-              "I4-0",
-              "F1-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 821,
-        "created_at": 1680088928,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 822,
-        "created_at": 1680088930
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 823,
-        "created_at": 1680091844,
-        "hex": "I16",
-        "tile": "143-0",
-        "rotation": 4
-      },
-      {
-        "type": "pass",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 824,
-        "created_at": 1680091848
-      },
-      {
-        "type": "run_routes",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 825,
-        "created_at": 1680091873,
-        "routes": [
-          {
-            "train": "5-1",
-            "connections": [
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "G14",
-                "G16"
-              ],
-              [
-                "G16",
-                "G18"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "L13",
-              "K14",
-              "G16",
-              "G18"
-            ],
-            "revenue": 290,
-            "revenue_str": "I18-L13-K14-G16-G18",
-            "nodes": [
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "G16-0",
-              "G18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 826,
-        "created_at": 1680091876,
-        "kind": "withhold"
-      },
-      {
-        "type": "buy_train",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 827,
-        "created_at": 1680091879,
-        "train": "10-1",
-        "price": 950,
-        "variant": "10"
-      },
-      {
-        "type": "lay_tile",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 828,
-        "created_at": 1680091905,
-        "hex": "I16",
-        "tile": "146-0",
-        "rotation": 3
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 829,
-        "created_at": 1680091908
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 830,
-        "created_at": 1680091914,
-        "routes": [
-          {
-            "train": "5-0",
-            "connections": [
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "G14",
-                "G16"
-              ],
-              [
-                "G16",
-                "G18"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "L13",
-              "K14",
-              "G16",
-              "G18"
-            ],
-            "revenue": 290,
-            "revenue_str": "I18-L13-K14-G16-G18",
-            "nodes": [
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "G16-0",
-              "G18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 831,
-        "created_at": 1680091915,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 832,
-        "created_at": 1680091944,
-        "train": "10-1",
-        "price": 324
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 833,
-        "created_at": 1680092812,
-        "hex": "I14",
-        "tile": "24-2",
-        "rotation": 0
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 834,
-        "created_at": 1680092855,
-        "routes": [
-          {
-            "train": "6-1",
-            "connections": [
-              [
-                "G18",
-                "H17"
-              ],
-              [
-                "G16",
-                "G18"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "G14",
-                "G16"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ]
-            ],
-            "hexes": [
-              "H17",
-              "G18",
-              "G16",
-              "K14",
-              "L13",
-              "I18"
-            ],
-            "revenue": 310,
-            "revenue_str": "H17-G18-G16-K14-L13-I18",
-            "nodes": [
-              "G18-0",
-              "H17-0",
-              "G16-0",
-              "K14-0",
-              "L13-0",
-              "I18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 835,
-        "created_at": 1680092860,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 836,
-        "created_at": 1680092995,
-        "train": "10-0",
-        "price": 784
-      },
-      {
-        "type": "lay_tile",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 837,
-        "created_at": 1680095210,
-        "hex": "J9",
-        "tile": "23-1",
-        "rotation": 4
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 838,
-        "created_at": 1680095213
-      },
-      {
-        "type": "run_routes",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 839,
-        "created_at": 1680095219,
-        "routes": [
-          {
-            "train": "6-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "G14",
-                "G16"
-              ],
-              [
-                "G16",
-                "G18"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "L13",
-              "K14",
-              "G16",
-              "G18"
-            ],
-            "revenue": 340,
-            "revenue_str": "K20-I18-L13-K14-G16-G18",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "G16-0",
-              "G18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 840,
-        "created_at": 1680095223,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 841,
-        "created_at": 1680095246
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 842,
-        "created_at": 1680098115,
-        "hex": "H7",
-        "tile": "8-12",
-        "rotation": 4
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 843,
-        "created_at": 1680098119
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 844,
-        "created_at": 1680098130,
-        "routes": [
-          {
-            "train": "8-0",
-            "connections": [
-              [
-                "M2",
-                "L3",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ],
-              [
-                "K6",
-                "J7",
-                "J9",
-                "J11"
-              ],
-              [
-                "J11",
-                "J13",
-                "K14"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I18"
-              ]
-            ],
-            "hexes": [
-              "M2",
-              "K4",
-              "K6",
-              "J11",
-              "K14",
-              "L13",
-              "I18"
-            ],
-            "revenue": 380,
-            "revenue_str": "M2-K4-K6-J11-K14-L13-I18 + Edge Token",
-            "nodes": [
-              "M2-0",
-              "K4-0",
-              "K6-0",
-              "J11-1",
-              "K14-0",
-              "L13-0",
-              "I18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 845,
-        "created_at": 1680098134,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 846,
-        "created_at": 1680098141
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 847,
-        "created_at": 1680099862,
-        "hex": "F17",
-        "tile": "8-13",
-        "rotation": 5
-      },
-      {
-        "type": "run_routes",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 848,
-        "created_at": 1680099919,
-        "routes": [
-          {
-            "train": "8-1",
-            "connections": [
-              [
-                "H17",
-                "I18"
-              ],
-              [
-                "G18",
-                "H17"
-              ],
-              [
-                "F15",
-                "F17",
-                "G18"
-              ],
-              [
-                "D13",
-                "E14",
-                "F15"
-              ],
-              [
-                "D9",
-                "D11",
-                "C12",
-                "D13"
-              ],
-              [
-                "B5",
-                "C6",
-                "C8",
-                "D9"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "H17",
-              "G18",
-              "F15",
-              "D13",
-              "D9",
-              "B5",
-              "A2"
-            ],
-            "revenue": 390,
-            "revenue_str": "I18-H17-G18-F15-D13-D9-B5-A2 + Edge Token",
-            "nodes": [
-              "H17-0",
-              "I18-0",
-              "G18-0",
-              "F15-0",
-              "D13-0",
-              "D9-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 849,
-        "created_at": 1680099929,
-        "kind": "payout"
-      },
-      {
-        "type": "buy_train",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 850,
-        "created_at": 1680100028,
-        "train": "5-2",
-        "price": 308
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 851,
-        "created_at": 1680101644
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 852,
-        "created_at": 1680101645
-      },
-      {
-        "type": "run_routes",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 853,
-        "created_at": 1680101651,
-        "routes": [
-          {
-            "train": "6-0",
-            "connections": [
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "H11"
-              ],
-              [
-                "H11",
-                "H9"
-              ],
-              [
-                "H9",
-                "H7",
-                "I6",
-                "I4"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "L13",
-              "K14",
-              "H11",
-              "H9",
-              "I4"
-            ],
-            "revenue": 290,
-            "revenue_str": "I18-L13-K14-H11-H9-I4",
-            "nodes": [
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "H11-0",
-              "H9-0",
-              "I4-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 854,
-        "created_at": 1680101656,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 855,
-        "created_at": 1680101703
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 856,
-        "created_at": 1680101723
-      },
-      {
-        "type": "run_routes",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 857,
-        "created_at": 1680101726,
-        "routes": [
-          {
-            "train": "8-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "J11"
-              ],
-              [
-                "J11",
-                "J9",
-                "J7",
-                "K6"
-              ],
-              [
-                "K6",
-                "J5",
-                "I4"
-              ],
-              [
-                "I4",
-                "H3",
-                "G2",
-                "F1"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "L13",
-              "K14",
-              "J11",
-              "K6",
-              "I4",
-              "F1"
-            ],
-            "revenue": 420,
-            "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "J11-1",
-              "K6-0",
-              "I4-0",
-              "F1-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 858,
-        "created_at": 1680101728,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 859,
-        "created_at": 1680101732
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 860,
-        "created_at": 1680101819,
-        "hex": "B3",
-        "tile": "8-14",
-        "rotation": 2
-      },
-      {
-        "type": "pass",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 861,
-        "created_at": 1680101830
-      },
-      {
-        "type": "buy_train",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 862,
-        "created_at": 1680101837,
-        "train": "12-0",
-        "price": 1100,
-        "variant": "12"
-      },
-      {
-        "type": "pass",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 863,
-        "created_at": 1680101858
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 864,
-        "created_at": 1680119011,
-        "hex": "I8",
-        "tile": "1-0",
-        "rotation": 2
-      },
-      {
-        "type": "pass",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 865,
-        "created_at": 1680119016
-      },
-      {
-        "type": "buy_train",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 866,
-        "created_at": 1680119030,
-        "train": "12-1",
-        "price": 1100,
-        "variant": "12"
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 867,
-        "created_at": 1680119050,
-        "shares": [
-          "MP_1"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 868,
-        "created_at": 1680119055
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 869,
-        "created_at": 1680131546,
-        "shares": [
-          "MP_5"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 870,
-        "created_at": 1680131556
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 871,
-        "created_at": 1680131972,
-        "shares": [
-          "GN_5"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 872,
-        "created_at": 1680132009
-      },
-      {
-        "type": "buy_shares",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 873,
-        "created_at": 1680132431,
-        "shares": [
-          "CBQ_8"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 874,
-        "created_at": 1680173579,
-        "shares": [
-          "GN_1"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 875,
-        "created_at": 1680178535,
-        "shares": [
-          "GN_6"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 876,
-        "created_at": 1680178583
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 877,
-        "created_at": 1680179446,
-        "shares": [
-          "MILW_5"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 878,
-        "created_at": 1680179449
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 879,
-        "created_at": 1680179842,
-        "shares": [
-          "GN_7"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 880,
-        "created_at": 1680179960
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 881,
-        "created_at": 1680228836,
-        "shares": [
-          "GN_8"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 882,
-        "created_at": 1680228867
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 883,
-        "created_at": 1680229273,
-        "shares": [
-          "MILW_6"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 884,
-        "created_at": 1680229278
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 885,
-        "created_at": 1680254040,
-        "shares": [
-          "MP_6"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 886,
-        "created_at": 1680254155
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 887,
-        "created_at": 1680279119,
-        "shares": [
-          "MP_7"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 888,
-        "created_at": 1680279145
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 889,
-        "created_at": 1680299492,
-        "shares": [
-          "MILW_7"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 890,
-        "created_at": 1680299497
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 891,
-        "created_at": 1680306755,
-        "shares": [
-          "MP_8"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 892,
-        "created_at": 1680306768
-      },
-      {
-        "type": "buy_shares",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 893,
-        "created_at": 1680310901,
-        "shares": [
-          "MILW_8"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 894,
-        "created_at": 1680310944
-      },
-      {
-        "type": "buy_shares",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 895,
-        "created_at": 1680311196,
-        "shares": [
-          "SOO_6"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 896,
-        "created_at": 1680311200
-      },
-      {
-        "type": "sell_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 897,
-        "created_at": 1680311619,
-        "shares": [
-          "UP_6"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 898,
-        "created_at": 1680311624,
-        "shares": [
-          "SOO_7"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "buy_shares",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 899,
-        "created_at": 1680312558,
-        "shares": [
-          "UP_6"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 900,
-        "created_at": 1680313747
-      },
-      {
-        "type": "sell_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 901,
-        "created_at": 1680349166,
-        "shares": [
-          "KATY_4"
-        ],
-        "percent": 10
-      },
-      {
-        "type": "buy_shares",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 902,
-        "created_at": 1680349170,
-        "shares": [
-          "SOO_8"
-        ],
-        "percent": 10,
-        "share_price": false
-      },
-      {
-        "type": "program_share_pass",
-        "entity": 4311,
-        "entity_type": "player",
-        "id": 903,
-        "created_at": 1680350678,
-        "auto_actions": [
-          {
-            "type": "pass",
-            "entity": 4311,
-            "entity_type": "player",
-            "created_at": 1680350676
-          }
-        ],
-        "unconditional": false,
-        "indefinite": false
-      },
-      {
-        "type": "pass",
-        "entity": 1761,
-        "entity_type": "player",
-        "id": 904,
-        "created_at": 1680351805
-      },
-      {
-        "type": "pass",
-        "entity": 2122,
-        "entity_type": "player",
-        "id": 905,
-        "created_at": 1680358429
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 906,
-        "created_at": 1680360290
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 907,
-        "created_at": 1680360337,
-        "routes": [
-          {
-            "train": "10-1",
-            "connections": [
-              [
-                "G18",
-                "H17"
-              ],
-              [
-                "H17",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "H11"
-              ],
-              [
-                "H11",
-                "H9"
-              ],
-              [
-                "H9",
-                "H7",
-                "I6",
-                "I4"
-              ],
-              [
-                "I4",
-                "J5",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ]
-            ],
-            "hexes": [
-              "G18",
-              "H17",
-              "I18",
-              "L13",
-              "K14",
-              "H11",
-              "H9",
-              "I4",
-              "K4",
-              "K6"
-            ],
-            "revenue": 460,
-            "revenue_str": "G18-H17-I18-L13-K14-H11-H9-I4-K4-K6",
-            "nodes": [
-              "G18-0",
-              "H17-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "H11-0",
-              "H9-0",
-              "I4-0",
-              "K4-0",
-              "K6-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 908,
-        "created_at": 1680360339,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 909,
-        "created_at": 1680360395
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 910,
-        "created_at": 1680360814,
-        "hex": "C12",
-        "tile": "46-0",
-        "rotation": 2
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 911,
-        "created_at": 1680360865,
-        "routes": [
-          {
-            "train": "6-1",
-            "connections": [
-              [
-                "G16",
-                "G18"
-              ],
-              [
-                "H17",
-                "G16"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H15",
-                "H17"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ]
-            ],
-            "hexes": [
-              "G18",
-              "G16",
-              "H17",
-              "K14",
-              "L13",
-              "I18"
-            ],
-            "revenue": 310,
-            "revenue_str": "G18-G16-H17-K14-L13-I18",
-            "nodes": [
-              "G16-0",
-              "G18-0",
-              "H17-0",
-              "K14-0",
-              "L13-0",
-              "I18-0"
-            ]
-          },
-          {
-            "train": "10-0",
-            "connections": [
-              [
-                "B5",
-                "B3",
-                "A2"
-              ],
-              [
-                "A10",
-                "A8",
-                "A6",
-                "B5"
-              ],
-              [
-                "B11",
-                "B9",
-                "A10"
-              ],
-              [
-                "D9",
-                "C10",
-                "B11"
-              ],
-              [
-                "D13",
-                "C12",
-                "D11",
-                "D9"
-              ],
-              [
-                "F15",
-                "E14",
-                "D13"
-              ],
-              [
-                "G18",
-                "F17",
-                "F15"
-              ],
-              [
-                "H17",
-                "G18"
-              ],
-              [
-                "I18",
-                "H17"
-              ]
-            ],
-            "hexes": [
+            [
               "A2",
-              "B5",
-              "A10",
-              "B11",
-              "D9",
-              "D13",
-              "F15",
-              "G18",
-              "H17",
-              "I18"
-            ],
-            "revenue": 490,
-            "revenue_str": "A2-B5-A10-B11-D9-D13-F15-G18-H17-I18 + Edge Token",
-            "nodes": [
-              "B5-0",
-              "A2-0",
-              "A10-0",
-              "B11-0",
-              "D9-0",
-              "D13-0",
-              "F15-0",
-              "G18-0",
-              "H17-0",
-              "I18-0"
+              "A4",
+              "B5"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 912,
-        "created_at": 1680360869,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 913,
-        "created_at": 1680361558
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 914,
-        "created_at": 1680361561
-      },
-      {
-        "type": "run_routes",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 915,
-        "created_at": 1680361576,
-        "routes": [
-          {
-            "train": "6-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "G14",
-                "G16"
-              ],
-              [
-                "G16",
-                "G18"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "L13",
-              "K14",
-              "G16",
-              "G18"
-            ],
-            "revenue": 340,
-            "revenue_str": "K20-I18-L13-K14-G16-G18",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "G16-0",
-              "G18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 916,
-        "created_at": 1680361579,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 917,
-        "created_at": 1680361583
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 918,
-        "created_at": 1680362650,
-        "hex": "F17",
-        "tile": "24-3",
-        "rotation": 5
-      },
-      {
-        "type": "run_routes",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 919,
-        "created_at": 1680362669,
-        "routes": [
-          {
-            "train": "8-1",
-            "connections": [
-              [
-                "H17",
-                "I18"
-              ],
-              [
-                "G18",
-                "H17"
-              ],
-              [
-                "F15",
-                "F17",
-                "G18"
-              ],
-              [
-                "D13",
-                "E14",
-                "F15"
-              ],
-              [
-                "D9",
-                "D11",
-                "C12",
-                "D13"
-              ],
-              [
-                "B5",
-                "C6",
-                "C8",
-                "D9"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "H17",
-              "G18",
-              "F15",
-              "D13",
-              "D9",
-              "B5",
-              "A2"
-            ],
-            "revenue": 390,
-            "revenue_str": "I18-H17-G18-F15-D13-D9-B5-A2 + Edge Token",
-            "nodes": [
-              "H17-0",
-              "I18-0",
-              "G18-0",
-              "F15-0",
-              "D13-0",
-              "D9-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 920,
-        "created_at": 1680362672,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 921,
-        "created_at": 1680362698
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 922,
-        "user": 4311,
-        "created_at": 1680367237
-      },
-      {
-        "type": "undo",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 923,
-        "user": 4311,
-        "created_at": 1680367252
-      },
-      {
-        "type": "lay_tile",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 924,
-        "created_at": 1680367279,
-        "hex": "E14",
-        "tile": "20-0",
-        "rotation": 2
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 925,
-        "created_at": 1680367282
-      },
-      {
-        "type": "run_routes",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 926,
-        "created_at": 1680367288,
-        "routes": [
-          {
-            "train": "6-0",
-            "connections": [
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "H11"
-              ],
-              [
-                "H11",
-                "H9"
-              ],
-              [
-                "H9",
-                "H7",
-                "I6",
-                "I4"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "L13",
-              "K14",
-              "H11",
-              "H9",
-              "I4"
-            ],
-            "revenue": 290,
-            "revenue_str": "I18-L13-K14-H11-H9-I4",
-            "nodes": [
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "H11-0",
-              "H9-0",
-              "I4-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 927,
-        "created_at": 1680367290,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 928,
-        "created_at": 1680367291
-      },
-      {
-        "type": "lay_tile",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 929,
-        "created_at": 1680367299,
-        "hex": "D15",
-        "tile": "8-15",
-        "rotation": 4
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 930,
-        "created_at": 1680367306
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 931,
-        "created_at": 1680367312,
-        "routes": [
-          {
-            "train": "8-0",
-            "connections": [
-              [
-                "M2",
-                "L3",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ],
-              [
-                "K6",
-                "J7",
-                "J9",
-                "J11"
-              ],
-              [
-                "J11",
-                "J13",
-                "K14"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I18"
-              ]
-            ],
-            "hexes": [
-              "M2",
-              "K4",
-              "K6",
-              "J11",
-              "K14",
-              "L13",
-              "I18"
-            ],
-            "revenue": 380,
-            "revenue_str": "M2-K4-K6-J11-K14-L13-I18 + Edge Token",
-            "nodes": [
-              "M2-0",
-              "K4-0",
-              "K6-0",
-              "J11-1",
-              "K14-0",
-              "L13-0",
-              "I18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 932,
-        "created_at": 1680367314,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 933,
-        "created_at": 1680367316
-      },
-      {
-        "type": "lay_tile",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 934,
-        "created_at": 1680367323,
-        "hex": "D17",
-        "tile": "8-16",
-        "rotation": 1
-      },
-      {
-        "type": "run_routes",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 935,
-        "created_at": 1680367327,
-        "routes": [
-          {
-            "train": "8-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "J11"
-              ],
-              [
-                "J11",
-                "J9",
-                "J7",
-                "K6"
-              ],
-              [
-                "K6",
-                "J5",
-                "I4"
-              ],
-              [
-                "I4",
-                "H3",
-                "G2",
-                "F1"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "L13",
-              "K14",
-              "J11",
-              "K6",
-              "I4",
-              "F1"
-            ],
-            "revenue": 420,
-            "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "J11-1",
-              "K6-0",
-              "I4-0",
-              "F1-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 936,
-        "created_at": 1680367329,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 937,
-        "created_at": 1680367331
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 938,
-        "created_at": 1680370854,
-        "hex": "C14",
-        "tile": "8-17",
-        "rotation": 5
-      },
-      {
-        "type": "run_routes",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 939,
-        "created_at": 1680370892,
-        "routes": [
-          {
-            "train": "12-0",
-            "connections": [
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I18"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "H17",
-                "H15",
-                "I14",
-                "J13",
-                "K14"
-              ],
-              [
-                "G16",
-                "H17"
-              ],
-              [
-                "G18",
-                "G16"
-              ],
-              [
-                "F15",
-                "F17",
-                "G18"
-              ],
-              [
-                "D13",
-                "E14",
-                "F15"
-              ],
-              [
-                "B11",
-                "C12",
-                "D13"
-              ],
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "L13",
-              "K14",
-              "H17",
-              "G16",
-              "G18",
-              "F15",
-              "D13",
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 560,
-            "revenue_str": "I18-L13-K14-H17-G16-G18-F15-D13-B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "L13-0",
-              "I18-0",
-              "K14-0",
-              "H17-0",
-              "G16-0",
-              "G18-0",
-              "F15-0",
-              "D13-0",
-              "B11-0",
-              "A10-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 940,
-        "created_at": 1680370895,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 941,
-        "created_at": 1680370901
-      },
-      {
-        "type": "pass",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 942,
-        "created_at": 1680384628
-      },
-      {
-        "type": "run_routes",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 943,
-        "created_at": 1680384666,
-        "routes": [
-          {
-            "train": "12-1",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "G14",
-                "G16"
-              ],
-              [
-                "G16",
-                "F15"
-              ],
-              [
-                "F15",
-                "F13"
-              ],
-              [
-                "F13",
-                "F11",
-                "G10"
-              ],
-              [
-                "G10",
-                "H9"
-              ],
-              [
-                "H9",
-                "H7",
-                "I6",
-                "I4"
-              ],
-              [
-                "I4",
-                "J5",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "L13",
-              "K14",
-              "G16",
-              "F15",
+          ],
+          "hexes": [
+            "G18",
+            "G16",
+            "F15",
+            "D13",
+            "D9",
+            "B5",
+            "A2"
+          ],
+          "revenue": 280,
+          "revenue_str": "G18-G16-F15-D13-D9-B5-A2 + Edge Token",
+          "nodes": [
+            "G16-0",
+            "G18-0",
+            "F15-0",
+            "D13-0",
+            "D9-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 756
+    },
+    {
+      "type": "dividend",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 554,
+      "created_at": 1679917754,
+      "kind": "payout",
+      "original_id": 757
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 555,
+      "created_at": 1679917770,
+      "original_id": 758
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 556,
+      "created_at": 1679918005,
+      "hex": "H9",
+      "tile": "5-1",
+      "rotation": 3,
+      "original_id": 759
+    },
+    {
+      "type": "place_token",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 557,
+      "created_at": 1679918007,
+      "city": "14-3-0",
+      "slot": 1,
+      "tokener": "SOO",
+      "original_id": 760
+    },
+    {
+      "type": "run_routes",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 558,
+      "created_at": 1679918016,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
               "F13",
+              "F11",
+              "G10"
+            ],
+            [
               "G10",
+              "H9"
+            ],
+            [
               "H9",
-              "I4",
-              "K4",
-              "K6"
+              "H11"
             ],
-            "revenue": 490,
-            "revenue_str": "K20-I18-L13-K14-G16-F15-F13-G10-H9-I4-K4-K6",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "G16-0",
-              "F15-0",
-              "F13-0",
-              "G10-0",
-              "H9-0",
-              "I4-0",
-              "K4-0",
-              "K6-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 944,
-        "created_at": 1680384668,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 945,
-        "created_at": 1680384715
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 946,
-        "created_at": 1680384724,
-        "routes": [
-          {
-            "train": "10-1",
-            "connections": [
-              [
-                "G18",
-                "H17"
-              ],
-              [
-                "H17",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "H11"
-              ],
-              [
-                "H11",
-                "H9"
-              ],
-              [
-                "H9",
-                "H7",
-                "I6",
-                "I4"
-              ],
-              [
-                "I4",
-                "J5",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ]
-            ],
-            "hexes": [
-              "G18",
-              "H17",
-              "I18",
-              "L13",
-              "K14",
+            [
               "H11",
-              "H9",
-              "I4",
-              "K4",
+              "H13",
+              "H15",
+              "H17"
+            ],
+            [
+              "H17",
+              "I18"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "G10",
+            "H9",
+            "H11",
+            "H17",
+            "I18"
+          ],
+          "revenue": 190,
+          "revenue_str": "F13-G10-H9-H11-H17-I18",
+          "nodes": [
+            "F13-0",
+            "G10-0",
+            "H9-0",
+            "H11-0",
+            "H17-0",
+            "I18-0"
+          ]
+        }
+      ],
+      "original_id": 761
+    },
+    {
+      "type": "dividend",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 559,
+      "created_at": 1679918018,
+      "kind": "payout",
+      "original_id": 762
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 560,
+      "created_at": 1679918020,
+      "original_id": 763
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 561,
+      "created_at": 1679918534,
+      "hex": "H17",
+      "tile": "144-0",
+      "rotation": 1,
+      "original_id": 764
+    },
+    {
+      "type": "pass",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 562,
+      "created_at": 1679918568,
+      "original_id": 765
+    },
+    {
+      "type": "buy_train",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 563,
+      "created_at": 1679918577,
+      "train": "10-0",
+      "price": 950,
+      "variant": "10",
+      "original_id": 766
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 564,
+      "created_at": 1679967661,
+      "hex": "J5",
+      "tile": "23-0",
+      "rotation": 2,
+      "original_id": 773
+    },
+    {
+      "type": "run_routes",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 565,
+      "created_at": 1679967668,
+      "routes": [
+        {
+          "train": "8-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "J11"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7",
               "K6"
             ],
-            "revenue": 460,
-            "revenue_str": "G18-H17-I18-L13-K14-H11-H9-I4-K4-K6",
-            "nodes": [
-              "G18-0",
-              "H17-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "H11-0",
-              "H9-0",
-              "I4-0",
-              "K4-0",
-              "K6-0"
+            [
+              "K6",
+              "J5",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3",
+              "G2",
+              "F1"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 947,
-        "created_at": 1680384726,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 948,
-        "created_at": 1680384727
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 949,
-        "created_at": 1680389349,
-        "hex": "D15",
-        "tile": "19-0",
-        "rotation": 2
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 950,
-        "created_at": 1680389371,
-        "routes": [
-          {
-            "train": "6-1",
-            "connections": [
-              [
-                "G16",
-                "G18"
-              ],
-              [
-                "H17",
-                "G16"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H15",
-                "H17"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ]
-            ],
-            "hexes": [
-              "G18",
-              "G16",
-              "H17",
-              "K14",
-              "L13",
-              "I18"
-            ],
-            "revenue": 310,
-            "revenue_str": "G18-G16-H17-K14-L13-I18",
-            "nodes": [
-              "G16-0",
-              "G18-0",
-              "H17-0",
-              "K14-0",
-              "L13-0",
-              "I18-0"
-            ]
-          },
-          {
-            "train": "10-0",
-            "connections": [
-              [
-                "B5",
-                "B3",
-                "A2"
-              ],
-              [
-                "A10",
-                "A8",
-                "A6",
-                "B5"
-              ],
-              [
-                "B11",
-                "B9",
-                "A10"
-              ],
-              [
-                "D9",
-                "C10",
-                "B11"
-              ],
-              [
-                "D13",
-                "C12",
-                "D11",
-                "D9"
-              ],
-              [
-                "F15",
-                "E14",
-                "D13"
-              ],
-              [
-                "G18",
-                "F17",
-                "F15"
-              ],
-              [
-                "H17",
-                "G18"
-              ],
-              [
-                "I18",
-                "H17"
-              ]
-            ],
-            "hexes": [
-              "A2",
-              "B5",
-              "A10",
-              "B11",
-              "D9",
-              "D13",
-              "F15",
-              "G18",
-              "H17",
-              "I18"
-            ],
-            "revenue": 490,
-            "revenue_str": "A2-B5-A10-B11-D9-D13-F15-G18-H17-I18 + Edge Token",
-            "nodes": [
-              "B5-0",
-              "A2-0",
-              "A10-0",
-              "B11-0",
-              "D9-0",
-              "D13-0",
-              "F15-0",
-              "G18-0",
-              "H17-0",
-              "I18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 951,
-        "created_at": 1680389375,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 952,
-        "created_at": 1680394702
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 953,
-        "user": 1761,
-        "created_at": 1680394703
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 954,
-        "user": 1761,
-        "created_at": 1680394709
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 955,
-        "created_at": 1680394723
-      },
-      {
-        "type": "run_routes",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 956,
-        "created_at": 1680394735,
-        "routes": [
-          {
-            "train": "6-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "G14",
-                "G16"
-              ],
-              [
-                "G16",
-                "G18"
-              ]
-            ],
-            "hexes": [
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "J11",
+            "K6",
+            "I4",
+            "F1"
+          ],
+          "revenue": 420,
+          "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "J11-1",
+            "K6-0",
+            "I4-0",
+            "F1-0"
+          ]
+        }
+      ],
+      "original_id": 774
+    },
+    {
+      "type": "dividend",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 566,
+      "created_at": 1679967673,
+      "kind": "payout",
+      "original_id": 775
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 567,
+      "created_at": 1679967676,
+      "original_id": 776
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 568,
+      "created_at": 1679972291,
+      "hex": "H13",
+      "tile": "19-0",
+      "rotation": 1,
+      "original_id": 777
+    },
+    {
+      "type": "pass",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 569,
+      "created_at": 1679972294,
+      "original_id": 778
+    },
+    {
+      "type": "run_routes",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 570,
+      "created_at": 1679972305,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
               "K20",
+              "J19",
+              "I18"
+            ],
+            [
               "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
               "L13",
+              "K14"
+            ],
+            [
               "K14",
+              "J15",
+              "I16"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "I16"
+          ],
+          "revenue": 260,
+          "revenue_str": "K20-I18-L13-K14-I16",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "I16-0"
+          ]
+        }
+      ],
+      "original_id": 779
+    },
+    {
+      "type": "dividend",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 571,
+      "created_at": 1679972306,
+      "kind": "withhold",
+      "original_id": 780
+    },
+    {
+      "type": "pass",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 572,
+      "created_at": 1679972336,
+      "original_id": 781
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 573,
+      "created_at": 1679972358,
+      "hex": "G14",
+      "tile": "8-11",
+      "rotation": 4,
+      "original_id": 782
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 574,
+      "created_at": 1679972361,
+      "original_id": 783
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 575,
+      "created_at": 1679972399,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "I16"
+            ],
+            [
+              "I16",
+              "J15",
+              "K14"
+            ],
+            [
+              "K14",
+              "L13"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "I16",
+            "K14",
+            "L13"
+          ],
+          "revenue": 260,
+          "revenue_str": "K20-I18-I16-K14-L13",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "I16-0",
+            "K14-0",
+            "L13-0"
+          ]
+        }
+      ],
+      "original_id": 784
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 576,
+      "created_at": 1679972403,
+      "kind": "payout",
+      "original_id": 785
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 577,
+      "created_at": 1679972410,
+      "original_id": 786
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 578,
+      "created_at": 1679996556,
+      "hex": "G16",
+      "tile": "14-0",
+      "rotation": 1,
+      "original_id": 793
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 579,
+      "created_at": 1679996608,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G18",
+              "H17"
+            ],
+            [
               "G16",
               "G18"
             ],
-            "revenue": 340,
-            "revenue_str": "K20-I18-L13-K14-G16-G18",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "G16-0",
-              "G18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 957,
-        "created_at": 1680394737,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 958,
-        "created_at": 1680394739
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 959,
-        "created_at": 1680435424,
-        "hex": "E16",
-        "tile": "9-16",
-        "rotation": 2
-      },
-      {
-        "type": "run_routes",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 960,
-        "created_at": 1680435471,
-        "routes": [
-          {
-            "train": "8-1",
-            "connections": [
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I18"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "G16",
-                "G14",
-                "H13",
-                "I14",
-                "J13",
-                "K14"
-              ],
-              [
-                "G18",
-                "G16"
-              ],
-              [
-                "D9",
-                "D11",
-                "C12",
-                "C14",
-                "D15",
-                "E16",
-                "F17",
-                "G18"
-              ],
-              [
-                "B5",
-                "C6",
-                "C8",
-                "D9"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "G14",
+              "G16"
             ],
-            "hexes": [
-              "I18",
+            [
               "L13",
-              "K14",
-              "G16",
-              "G18",
-              "D9",
-              "B5",
-              "A2"
+              "K14"
             ],
-            "revenue": 470,
-            "revenue_str": "I18-L13-K14-G16-G18-D9-B5-A2 + Edge Token",
-            "nodes": [
-              "L13-0",
-              "I18-0",
-              "K14-0",
-              "G16-0",
-              "G18-0",
-              "D9-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 961,
-        "created_at": 1680435479,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 962,
-        "created_at": 1680435486
-      },
-      {
-        "type": "lay_tile",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 963,
-        "created_at": 1680436247,
-        "hex": "C18",
-        "tile": "8-18",
-        "rotation": 4
-      },
-      {
-        "type": "choose",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 964,
-        "created_at": 1680436251,
-        "choice": "Place Edge Token"
-      },
-      {
-        "type": "run_routes",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 965,
-        "created_at": 1680436263,
-        "routes": [
-          {
-            "train": "6-0",
-            "connections": [
-              [
-                "I18",
-                "J17",
-                "K16",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "G14",
-                "G16"
-              ],
-              [
-                "G16",
-                "F15"
-              ],
-              [
-                "F15",
-                "F13"
-              ],
-              [
-                "F13",
-                "E14",
-                "D15",
-                "D17",
-                "C18",
-                "C20"
-              ]
-            ],
-            "hexes": [
+            [
               "I18",
-              "K14",
-              "G16",
-              "F15",
-              "F13",
-              "C20"
-            ],
-            "revenue": 320,
-            "revenue_str": "I18-K14-G16-F15-F13-C20 + Edge Token",
-            "nodes": [
-              "I18-0",
-              "K14-0",
-              "G16-0",
-              "F15-0",
-              "F13-0",
-              "C20-0"
+              "J17",
+              "K16",
+              "L15",
+              "L13"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 966,
-        "created_at": 1680436308,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 967,
-        "created_at": 1680436310
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 968,
-        "created_at": 1680436324
-      },
-      {
-        "type": "place_token",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 969,
-        "created_at": 1680436334,
-        "city": "14-2-0",
-        "slot": 1,
-        "tokener": "KATY"
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 970,
-        "created_at": 1680436337,
-        "routes": [
-          {
-            "train": "8-0",
-            "connections": [
-              [
-                "M2",
-                "L3",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ],
-              [
-                "K6",
-                "J7",
-                "J9",
-                "J11"
-              ],
-              [
-                "J11",
-                "J13",
-                "K14"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I18"
-              ]
+          ],
+          "hexes": [
+            "H17",
+            "G18",
+            "G16",
+            "K14",
+            "L13",
+            "I18"
+          ],
+          "revenue": 300,
+          "revenue_str": "H17-G18-G16-K14-L13-I18",
+          "nodes": [
+            "G18-0",
+            "H17-0",
+            "G16-0",
+            "K14-0",
+            "L13-0",
+            "I18-0"
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "B11",
+              "C10",
+              "D9"
             ],
-            "hexes": [
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "D9",
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 280,
+          "revenue_str": "D9-B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "B11-0",
+            "D9-0",
+            "A10-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 794
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 580,
+      "created_at": 1679996614,
+      "kind": "payout",
+      "original_id": 795
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 581,
+      "created_at": 1679997137,
+      "hex": "H17",
+      "tile": "147-0",
+      "rotation": 5,
+      "original_id": 796
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 582,
+      "created_at": 1679997141,
+      "original_id": 797
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 583,
+      "created_at": 1679997277,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "G14",
+              "G16"
+            ],
+            [
+              "G16",
+              "G18"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "G16",
+            "G18"
+          ],
+          "revenue": 340,
+          "revenue_str": "K20-I18-L13-K14-G16-G18",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "G16-0",
+            "G18-0"
+          ]
+        }
+      ],
+      "original_id": 798
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 584,
+      "created_at": 1679997308,
+      "kind": "payout",
+      "original_id": 799
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 585,
+      "created_at": 1679997313,
+      "original_id": 800
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 586,
+      "created_at": 1680041254,
+      "hex": "F13",
+      "tile": "14-2",
+      "rotation": 0,
+      "original_id": 801
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 587,
+      "created_at": 1680041257,
+      "original_id": 802
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 588,
+      "created_at": 1680041265,
+      "routes": [
+        {
+          "train": "8-0",
+          "connections": [
+            [
               "M2",
-              "K4",
-              "K6",
-              "J11",
-              "K14",
-              "L13",
-              "I18"
+              "L3",
+              "K4"
             ],
-            "revenue": 380,
-            "revenue_str": "M2-K4-K6-J11-K14-L13-I18 + Edge Token",
-            "nodes": [
-              "M2-0",
-              "K4-0",
-              "K6-0",
-              "J11-1",
-              "K14-0",
-              "L13-0",
-              "I18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 971,
-        "created_at": 1680436338,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 972,
-        "created_at": 1680436340
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 973,
-        "created_at": 1680436345
-      },
-      {
-        "type": "run_routes",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 974,
-        "created_at": 1680436353,
-        "routes": [
-          {
-            "train": "8-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "J11"
-              ],
-              [
-                "J11",
-                "J9",
-                "J7",
-                "K6"
-              ],
-              [
-                "K6",
-                "J5",
-                "I4"
-              ],
-              [
-                "I4",
-                "H3",
-                "G2",
-                "F1"
-              ]
-            ],
-            "hexes": [
-              "K20",
-              "I18",
-              "L13",
-              "K14",
-              "J11",
-              "K6",
-              "I4",
-              "F1"
-            ],
-            "revenue": 420,
-            "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "J11-1",
-              "K6-0",
-              "I4-0",
-              "F1-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 975,
-        "created_at": 1680436355,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 976,
-        "created_at": 1680436360
-      },
-      {
-        "hex": "D15",
-        "tile": "45-1",
-        "type": "lay_tile",
-        "entity": "MILW",
-        "rotation": 2,
-        "entity_type": "corporation",
-        "id": 977,
-        "user": 2122,
-        "created_at": 1680437493
-      },
-      {
-        "type": "undo",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 978,
-        "user": 2122,
-        "created_at": 1680437560
-      },
-      {
-        "type": "lay_tile",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 979,
-        "created_at": 1680437592,
-        "hex": "D15",
-        "tile": "46-1",
-        "rotation": 2
-      },
-      {
-        "type": "run_routes",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 980,
-        "created_at": 1680437620,
-        "routes": [
-          {
-            "train": "12-0",
-            "connections": [
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I18"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "H17",
-                "H15",
-                "I14",
-                "J13",
-                "K14"
-              ],
-              [
-                "G16",
-                "H17"
-              ],
-              [
-                "G18",
-                "G16"
-              ],
-              [
-                "F15",
-                "F17",
-                "G18"
-              ],
-              [
-                "D13",
-                "E14",
-                "F15"
-              ],
-              [
-                "B11",
-                "C12",
-                "D13"
-              ],
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "L13",
-              "K14",
-              "H17",
-              "G16",
-              "G18",
-              "F15",
-              "D13",
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 560,
-            "revenue_str": "I18-L13-K14-H17-G16-G18-F15-D13-B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "L13-0",
-              "I18-0",
-              "K14-0",
-              "H17-0",
-              "G16-0",
-              "G18-0",
-              "F15-0",
-              "D13-0",
-              "B11-0",
-              "A10-0",
-              "B5-0",
-              "A2-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 981,
-        "created_at": 1680437621,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 982,
-        "created_at": 1680437629
-      },
-      {
-        "type": "pass",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 983,
-        "created_at": 1680438182
-      },
-      {
-        "type": "run_routes",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 984,
-        "created_at": 1680438201,
-        "routes": [
-          {
-            "train": "12-1",
-            "connections": [
-              [
-                "G18",
-                "G16"
-              ],
-              [
-                "G16",
-                "H17"
-              ],
-              [
-                "H17",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "J11"
-              ],
-              [
-                "J11",
-                "J9",
-                "I8"
-              ],
-              [
-                "I8",
-                "H9"
-              ],
-              [
-                "H9",
-                "H7",
-                "I6",
-                "I4"
-              ],
-              [
-                "I4",
-                "J5",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ]
-            ],
-            "hexes": [
-              "G18",
-              "G16",
-              "H17",
-              "I18",
-              "L13",
-              "K14",
-              "J11",
-              "I8",
-              "H9",
-              "I4",
+            [
               "K4",
               "K6"
             ],
-            "revenue": 480,
-            "revenue_str": "G18-G16-H17-I18-L13-K14-J11-I8-H9-I4-K4-K6",
-            "nodes": [
-              "G18-0",
-              "G16-0",
-              "H17-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "J11-1",
-              "I8-0",
-              "H9-0",
-              "I4-0",
-              "K4-0",
-              "K6-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 985,
-        "created_at": 1680438204,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 986,
-        "created_at": 1680438226
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 987,
-        "created_at": 1680438255
-      },
-      {
-        "type": "run_routes",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 988,
-        "created_at": 1680438265,
-        "routes": [
-          {
-            "train": "10-1",
-            "connections": [
-              [
-                "G18",
-                "H17"
-              ],
-              [
-                "H17",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "H11"
-              ],
-              [
-                "H11",
-                "H9"
-              ],
-              [
-                "H9",
-                "H7",
-                "I6",
-                "I4"
-              ],
-              [
-                "I4",
-                "J5",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ]
+            [
+              "K6",
+              "J7",
+              "J9",
+              "J11"
             ],
-            "hexes": [
-              "G18",
-              "H17",
-              "I18",
-              "L13",
+            [
+              "J11",
+              "J13",
+              "K14"
+            ],
+            [
               "K14",
+              "L13"
+            ],
+            [
+              "L13",
+              "L15",
+              "K16",
+              "J17",
+              "I18"
+            ]
+          ],
+          "hexes": [
+            "M2",
+            "K4",
+            "K6",
+            "J11",
+            "K14",
+            "L13",
+            "I18"
+          ],
+          "revenue": 380,
+          "revenue_str": "M2-K4-K6-J11-K14-L13-I18 + Edge Token",
+          "nodes": [
+            "M2-0",
+            "K4-0",
+            "K6-0",
+            "J11-1",
+            "K14-0",
+            "L13-0",
+            "I18-0"
+          ]
+        }
+      ],
+      "original_id": 803
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 589,
+      "created_at": 1680041272,
+      "kind": "payout",
+      "original_id": 804
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 590,
+      "created_at": 1680041278,
+      "original_id": 805
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 591,
+      "created_at": 1680045406,
+      "hex": "F15",
+      "tile": "145-0",
+      "rotation": 1,
+      "original_id": 806
+    },
+    {
+      "type": "run_routes",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 592,
+      "created_at": 1680045470,
+      "routes": [
+        {
+          "train": "8-1",
+          "connections": [
+            [
+              "K14",
+              "K16",
+              "J17",
+              "I18"
+            ],
+            [
+              "G16",
+              "G14",
+              "H13",
+              "I14",
+              "J13",
+              "K14"
+            ],
+            [
+              "F15",
+              "G16"
+            ],
+            [
+              "D13",
+              "E14",
+              "F15"
+            ],
+            [
+              "D9",
+              "D11",
+              "C12",
+              "D13"
+            ],
+            [
+              "B5",
+              "C6",
+              "C8",
+              "D9"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "K14",
+            "G16",
+            "F15",
+            "D13",
+            "D9",
+            "B5",
+            "A2"
+          ],
+          "revenue": 380,
+          "revenue_str": "I18-K14-G16-F15-D13-D9-B5-A2 + Edge Token",
+          "nodes": [
+            "K14-0",
+            "I18-0",
+            "G16-0",
+            "F15-0",
+            "D13-0",
+            "D9-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 807
+    },
+    {
+      "type": "dividend",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 593,
+      "created_at": 1680045474,
+      "kind": "payout",
+      "original_id": 808
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 594,
+      "created_at": 1680045543,
+      "original_id": 809
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 595,
+      "created_at": 1680045771,
+      "hex": "H13",
+      "tile": "45-0",
+      "rotation": 1,
+      "original_id": 810
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 596,
+      "created_at": 1680045779,
+      "original_id": 811
+    },
+    {
+      "type": "run_routes",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 597,
+      "created_at": 1680045784,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
               "H11",
-              "H9",
-              "I4",
-              "K4",
+              "H13",
+              "H15",
+              "H17"
+            ],
+            [
+              "H17",
+              "G16"
+            ],
+            [
+              "G16",
+              "G14",
+              "H13",
+              "I14",
+              "J13",
+              "K14"
+            ],
+            [
+              "K14",
+              "L13"
+            ],
+            [
+              "L13",
+              "L15",
+              "K16",
+              "J17",
+              "I18"
+            ]
+          ],
+          "hexes": [
+            "H11",
+            "H17",
+            "G16",
+            "K14",
+            "L13",
+            "I18"
+          ],
+          "revenue": 280,
+          "revenue_str": "H11-H17-G16-K14-L13-I18",
+          "nodes": [
+            "H11-0",
+            "H17-0",
+            "G16-0",
+            "K14-0",
+            "L13-0",
+            "I18-0"
+          ]
+        }
+      ],
+      "original_id": 812
+    },
+    {
+      "type": "dividend",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 598,
+      "created_at": 1680045785,
+      "kind": "payout",
+      "original_id": 813
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 599,
+      "created_at": 1680045796,
+      "original_id": 814
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 600,
+      "created_at": 1680085010,
+      "hex": "H15",
+      "tile": "24-1",
+      "rotation": 4,
+      "original_id": 815
+    },
+    {
+      "type": "run_routes",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 601,
+      "created_at": 1680085036,
+      "routes": [
+        {
+          "train": "10-0",
+          "connections": [
+            [
+              "L13",
+              "L15",
+              "K16",
+              "J17",
+              "I18"
+            ],
+            [
+              "K14",
+              "L13"
+            ],
+            [
+              "G16",
+              "G14",
+              "H13",
+              "I14",
+              "J13",
+              "K14"
+            ],
+            [
+              "F15",
+              "G16"
+            ],
+            [
+              "D13",
+              "E14",
+              "F15"
+            ],
+            [
+              "B11",
+              "C12",
+              "D13"
+            ],
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "L13",
+            "K14",
+            "G16",
+            "F15",
+            "D13",
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 480,
+          "revenue_str": "I18-L13-K14-G16-F15-D13-B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "L13-0",
+            "I18-0",
+            "K14-0",
+            "G16-0",
+            "F15-0",
+            "D13-0",
+            "B11-0",
+            "A10-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 816
+    },
+    {
+      "type": "dividend",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 602,
+      "created_at": 1680085044,
+      "kind": "withhold",
+      "original_id": 817
+    },
+    {
+      "type": "buy_train",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 603,
+      "created_at": 1680085231,
+      "train": "5-2",
+      "price": 428,
+      "original_id": 818
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 604,
+      "created_at": 1680088922,
+      "hex": "H9",
+      "tile": "14-1",
+      "rotation": 0,
+      "original_id": 819
+    },
+    {
+      "type": "run_routes",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 605,
+      "created_at": 1680088926,
+      "routes": [
+        {
+          "train": "8-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "J11"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7",
               "K6"
             ],
-            "revenue": 460,
-            "revenue_str": "G18-H17-I18-L13-K14-H11-H9-I4-K4-K6",
-            "nodes": [
-              "G18-0",
-              "H17-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "H11-0",
-              "H9-0",
-              "I4-0",
-              "K4-0",
-              "K6-0"
+            [
+              "K6",
+              "J5",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3",
+              "G2",
+              "F1"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 989,
-        "created_at": 1680438267,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "RI",
-        "entity_type": "corporation",
-        "id": 990,
-        "created_at": 1680438269
-      },
-      {
-        "hex": "D19",
-        "tile": "8-19",
-        "type": "lay_tile",
-        "entity": "NP",
-        "rotation": 1,
-        "entity_type": "corporation",
-        "id": 991,
-        "user": 2122,
-        "created_at": 1680438458
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "routes": [
-          {
-            "hexes": [
-              "G18",
-              "G16",
-              "H17",
-              "K14",
-              "L13",
-              "I18"
-            ],
-            "nodes": [
-              "G16-0",
-              "G18-0",
-              "H17-0",
-              "K14-0",
-              "L13-0",
-              "I18-0"
-            ],
-            "train": "6-1",
-            "revenue": 310,
-            "connections": [
-              [
-                "G16",
-                "G18"
-              ],
-              [
-                "H17",
-                "G16"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H15",
-                "H17"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ]
-            ],
-            "revenue_str": "G18-G16-H17-K14-L13-I18"
-          },
-          {
-            "hexes": [
-              "A2",
-              "B5",
-              "A10",
-              "B11",
-              "D9",
-              "D13",
-              "F15",
-              "G18",
-              "H17",
-              "I18"
-            ],
-            "nodes": [
-              "B5-0",
-              "A2-0",
-              "A10-0",
-              "B11-0",
-              "D9-0",
-              "D13-0",
-              "F15-0",
-              "G18-0",
-              "H17-0",
-              "I18-0"
-            ],
-            "train": "10-0",
-            "revenue": 490,
-            "connections": [
-              [
-                "B5",
-                "B3",
-                "A2"
-              ],
-              [
-                "A10",
-                "A8",
-                "A6",
-                "B5"
-              ],
-              [
-                "B11",
-                "B9",
-                "A10"
-              ],
-              [
-                "D9",
-                "C10",
-                "B11"
-              ],
-              [
-                "D13",
-                "C12",
-                "D11",
-                "D9"
-              ],
-              [
-                "F15",
-                "E14",
-                "D13"
-              ],
-              [
-                "G18",
-                "F17",
-                "F15"
-              ],
-              [
-                "H17",
-                "G18"
-              ],
-              [
-                "I18",
-                "H17"
-              ]
-            ],
-            "revenue_str": "A2-B5-A10-B11-D9-D13-F15-G18-H17-I18 + Edge Token"
-          }
-        ],
-        "entity_type": "corporation",
-        "id": 992,
-        "user": 2122,
-        "created_at": 1680438484
-      },
-      {
-        "kind": "payout",
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 993,
-        "user": 2122,
-        "created_at": 1680438489
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 994,
-        "user": 2122,
-        "created_at": 1680438820
-      },
-      {
-        "type": "undo",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 995,
-        "user": 2122,
-        "created_at": 1680438824
-      },
-      {
-        "type": "undo",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 996,
-        "user": 2122,
-        "created_at": 1680438827
-      },
-      {
-        "hex": "D19",
-        "tile": "9-17",
-        "type": "lay_tile",
-        "entity": "NP",
-        "rotation": 0,
-        "entity_type": "corporation",
-        "id": 997,
-        "user": 2122,
-        "created_at": 1680438835
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "routes": [
-          {
-            "hexes": [
-              "G18",
-              "G16",
-              "H17",
-              "K14",
-              "L13",
-              "I18"
-            ],
-            "nodes": [
-              "G16-0",
-              "G18-0",
-              "H17-0",
-              "K14-0",
-              "L13-0",
-              "I18-0"
-            ],
-            "train": "6-1",
-            "revenue": 310,
-            "connections": [
-              [
-                "G16",
-                "G18"
-              ],
-              [
-                "H17",
-                "G16"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H15",
-                "H17"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ]
-            ],
-            "revenue_str": "G18-G16-H17-K14-L13-I18"
-          },
-          {
-            "hexes": [
-              "A2",
-              "B5",
-              "A10",
-              "B11",
-              "D9",
-              "D13",
-              "F15",
-              "G18",
-              "H17",
-              "I18"
-            ],
-            "nodes": [
-              "B5-0",
-              "A2-0",
-              "A10-0",
-              "B11-0",
-              "D9-0",
-              "D13-0",
-              "F15-0",
-              "G18-0",
-              "H17-0",
-              "I18-0"
-            ],
-            "train": "10-0",
-            "revenue": 490,
-            "connections": [
-              [
-                "B5",
-                "B3",
-                "A2"
-              ],
-              [
-                "A10",
-                "A8",
-                "A6",
-                "B5"
-              ],
-              [
-                "B11",
-                "B9",
-                "A10"
-              ],
-              [
-                "D9",
-                "C10",
-                "B11"
-              ],
-              [
-                "D13",
-                "C12",
-                "D11",
-                "D9"
-              ],
-              [
-                "F15",
-                "E14",
-                "D13"
-              ],
-              [
-                "G18",
-                "F17",
-                "F15"
-              ],
-              [
-                "H17",
-                "G18"
-              ],
-              [
-                "I18",
-                "H17"
-              ]
-            ],
-            "revenue_str": "A2-B5-A10-B11-D9-D13-F15-G18-H17-I18 + Edge Token"
-          }
-        ],
-        "entity_type": "corporation",
-        "id": 998,
-        "user": 2122,
-        "created_at": 1680438841
-      },
-      {
-        "kind": "payout",
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 999,
-        "user": 2122,
-        "created_at": 1680438843
-      },
-      {
-        "type": "undo",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 1000,
-        "user": 2122,
-        "created_at": 1680439291
-      },
-      {
-        "type": "undo",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 1001,
-        "user": 2122,
-        "created_at": 1680439295
-      },
-      {
-        "type": "undo",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 1002,
-        "user": 2122,
-        "created_at": 1680439298
-      },
-      {
-        "type": "lay_tile",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 1003,
-        "created_at": 1680439312,
-        "hex": "F17",
-        "tile": "42-0",
-        "rotation": 2
-      },
-      {
-        "type": "run_routes",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 1004,
-        "created_at": 1680439318,
-        "routes": [
-          {
-            "train": "6-1",
-            "connections": [
-              [
-                "G16",
-                "G18"
-              ],
-              [
-                "H17",
-                "G16"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H15",
-                "H17"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ]
-            ],
-            "hexes": [
-              "G18",
-              "G16",
-              "H17",
-              "K14",
-              "L13",
-              "I18"
-            ],
-            "revenue": 310,
-            "revenue_str": "G18-G16-H17-K14-L13-I18",
-            "nodes": [
-              "G16-0",
-              "G18-0",
-              "H17-0",
-              "K14-0",
-              "L13-0",
-              "I18-0"
-            ]
-          },
-          {
-            "train": "10-0",
-            "connections": [
-              [
-                "B5",
-                "B3",
-                "A2"
-              ],
-              [
-                "A10",
-                "A8",
-                "A6",
-                "B5"
-              ],
-              [
-                "B11",
-                "B9",
-                "A10"
-              ],
-              [
-                "D9",
-                "C10",
-                "B11"
-              ],
-              [
-                "D13",
-                "C12",
-                "D11",
-                "D9"
-              ],
-              [
-                "F15",
-                "E14",
-                "D13"
-              ],
-              [
-                "G18",
-                "F17",
-                "F15"
-              ],
-              [
-                "H17",
-                "G18"
-              ],
-              [
-                "I18",
-                "H17"
-              ]
-            ],
-            "hexes": [
-              "A2",
-              "B5",
-              "A10",
-              "B11",
-              "D9",
-              "D13",
-              "F15",
-              "G18",
-              "H17",
-              "I18"
-            ],
-            "revenue": 490,
-            "revenue_str": "A2-B5-A10-B11-D9-D13-F15-G18-H17-I18 + Edge Token",
-            "nodes": [
-              "B5-0",
-              "A2-0",
-              "A10-0",
-              "B11-0",
-              "D9-0",
-              "D13-0",
-              "F15-0",
-              "G18-0",
-              "H17-0",
-              "I18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "NP",
-        "entity_type": "corporation",
-        "id": 1005,
-        "created_at": 1680439322,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 1006,
-        "created_at": 1680439496
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 1007,
-        "created_at": 1680439498
-      },
-      {
-        "type": "run_routes",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 1008,
-        "created_at": 1680439508,
-        "routes": [
-          {
-            "train": "6-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "G14",
-                "G16"
-              ],
-              [
-                "G16",
-                "G18"
-              ]
-            ],
-            "hexes": [
-              "K20",
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "J11",
+            "K6",
+            "I4",
+            "F1"
+          ],
+          "revenue": 420,
+          "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "J11-1",
+            "K6-0",
+            "I4-0",
+            "F1-0"
+          ]
+        }
+      ],
+      "original_id": 820
+    },
+    {
+      "type": "dividend",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 606,
+      "created_at": 1680088928,
+      "kind": "payout",
+      "original_id": 821
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 607,
+      "created_at": 1680088930,
+      "original_id": 822
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 608,
+      "created_at": 1680091844,
+      "hex": "I16",
+      "tile": "143-0",
+      "rotation": 4,
+      "original_id": 823
+    },
+    {
+      "type": "pass",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 609,
+      "created_at": 1680091848,
+      "original_id": 824
+    },
+    {
+      "type": "run_routes",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 610,
+      "created_at": 1680091873,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
               "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
               "L13",
+              "K14"
+            ],
+            [
               "K14",
+              "J13",
+              "I14",
+              "H13",
+              "G14",
+              "G16"
+            ],
+            [
+              "G16",
+              "G18"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "L13",
+            "K14",
+            "G16",
+            "G18"
+          ],
+          "revenue": 290,
+          "revenue_str": "I18-L13-K14-G16-G18",
+          "nodes": [
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "G16-0",
+            "G18-0"
+          ]
+        }
+      ],
+      "original_id": 825
+    },
+    {
+      "type": "dividend",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 611,
+      "created_at": 1680091876,
+      "kind": "withhold",
+      "original_id": 826
+    },
+    {
+      "type": "buy_train",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 612,
+      "created_at": 1680091879,
+      "train": "10-1",
+      "price": 950,
+      "variant": "10",
+      "original_id": 827
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 613,
+      "created_at": 1680091905,
+      "hex": "I16",
+      "tile": "146-0",
+      "rotation": 3,
+      "original_id": 828
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 614,
+      "created_at": 1680091908,
+      "original_id": 829
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 615,
+      "created_at": 1680091914,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "G14",
+              "G16"
+            ],
+            [
+              "G16",
+              "G18"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "L13",
+            "K14",
+            "G16",
+            "G18"
+          ],
+          "revenue": 290,
+          "revenue_str": "I18-L13-K14-G16-G18",
+          "nodes": [
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "G16-0",
+            "G18-0"
+          ]
+        }
+      ],
+      "original_id": 830
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 616,
+      "created_at": 1680091915,
+      "kind": "payout",
+      "original_id": 831
+    },
+    {
+      "type": "buy_train",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 617,
+      "created_at": 1680091944,
+      "train": "10-1",
+      "price": 324,
+      "original_id": 832
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 618,
+      "created_at": 1680092812,
+      "hex": "I14",
+      "tile": "24-2",
+      "rotation": 0,
+      "original_id": 833
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 619,
+      "created_at": 1680092855,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G18",
+              "H17"
+            ],
+            [
               "G16",
               "G18"
             ],
-            "revenue": 340,
-            "revenue_str": "K20-I18-L13-K14-G16-G18",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "G16-0",
-              "G18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 1009,
-        "created_at": 1680439510,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "CBQ",
-        "entity_type": "corporation",
-        "id": 1010,
-        "created_at": 1680439511
-      },
-      {
-        "type": "lay_tile",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 1011,
-        "created_at": 1680439602,
-        "hex": "J17",
-        "tile": "24-0",
-        "rotation": 0
-      },
-      {
-        "type": "run_routes",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 1012,
-        "created_at": 1680439622,
-        "routes": [
-          {
-            "train": "8-1",
-            "connections": [
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I18"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "G16",
-                "G14",
-                "H13",
-                "I14",
-                "J13",
-                "K14"
-              ],
-              [
-                "G18",
-                "G16"
-              ],
-              [
-                "D9",
-                "D11",
-                "C12",
-                "C14",
-                "D15",
-                "E16",
-                "F17",
-                "G18"
-              ],
-              [
-                "B5",
-                "C6",
-                "C8",
-                "D9"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "G14",
+              "G16"
             ],
-            "hexes": [
+            [
+              "L13",
+              "K14"
+            ],
+            [
               "I18",
-              "L13",
-              "K14",
-              "G16",
-              "G18",
-              "D9",
-              "B5",
-              "A2"
-            ],
-            "revenue": 470,
-            "revenue_str": "I18-L13-K14-G16-G18-D9-B5-A2 + Edge Token",
-            "nodes": [
-              "L13-0",
-              "I18-0",
-              "K14-0",
-              "G16-0",
-              "G18-0",
-              "D9-0",
-              "B5-0",
-              "A2-0"
+              "J17",
+              "K16",
+              "L15",
+              "L13"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 1013,
-        "created_at": 1680439624,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "GN",
-        "entity_type": "corporation",
-        "id": 1014,
-        "created_at": 1680439655
-      },
-      {
-        "type": "lay_tile",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 1015,
-        "created_at": 1680440339,
-        "hex": "G12",
-        "tile": "9-17",
-        "rotation": 0
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 1016,
-        "created_at": 1680440346
-      },
-      {
-        "type": "run_routes",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 1017,
-        "created_at": 1680440358,
-        "routes": [
-          {
-            "train": "6-0",
-            "connections": [
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "I14",
-                "H13",
-                "H11"
-              ],
-              [
-                "H11",
-                "G12",
-                "F13"
-              ],
-              [
-                "F13",
-                "E14",
-                "D15",
-                "D17",
-                "C18",
-                "C20"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "L13",
-              "K14",
-              "H11",
-              "F13",
-              "C20"
-            ],
-            "revenue": 360,
-            "revenue_str": "I18-L13-K14-H11-F13-C20 + Edge Token",
-            "nodes": [
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "H11-0",
-              "F13-0",
-              "C20-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 1018,
-        "created_at": 1680440361,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "SOO",
-        "entity_type": "corporation",
-        "id": 1019,
-        "created_at": 1680440371
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 1020,
-        "created_at": 1680440390
-      },
-      {
-        "type": "run_routes",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 1021,
-        "created_at": 1680440409,
-        "routes": [
-          {
-            "train": "8-0",
-            "connections": [
-              [
-                "M2",
-                "L3",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ],
-              [
-                "K6",
-                "J7",
-                "J9",
-                "J11"
-              ],
-              [
-                "J11",
-                "J13",
-                "K14"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I16"
-              ],
-              [
-                "I16",
-                "I18"
-              ]
-            ],
-            "hexes": [
-              "M2",
-              "K4",
-              "K6",
-              "J11",
-              "K14",
-              "L13",
-              "I16",
+          ],
+          "hexes": [
+            "H17",
+            "G18",
+            "G16",
+            "K14",
+            "L13",
+            "I18"
+          ],
+          "revenue": 310,
+          "revenue_str": "H17-G18-G16-K14-L13-I18",
+          "nodes": [
+            "G18-0",
+            "H17-0",
+            "G16-0",
+            "K14-0",
+            "L13-0",
+            "I18-0"
+          ]
+        }
+      ],
+      "original_id": 834
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 620,
+      "created_at": 1680092860,
+      "kind": "payout",
+      "original_id": 835
+    },
+    {
+      "type": "buy_train",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 621,
+      "created_at": 1680092995,
+      "train": "10-0",
+      "price": 784,
+      "original_id": 836
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 622,
+      "created_at": 1680095210,
+      "hex": "J9",
+      "tile": "23-1",
+      "rotation": 4,
+      "original_id": 837
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 623,
+      "created_at": 1680095213,
+      "original_id": 838
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 624,
+      "created_at": 1680095219,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
               "I18"
             ],
-            "revenue": 400,
-            "revenue_str": "M2-K4-K6-J11-K14-L13-I16-I18 + Edge Token",
-            "nodes": [
-              "M2-0",
-              "K4-0",
-              "K6-0",
-              "J11-1",
-              "K14-0",
-              "L13-0",
-              "I16-0",
-              "I18-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 1022,
-        "created_at": 1680440411,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "KATY",
-        "entity_type": "corporation",
-        "id": 1023,
-        "created_at": 1680440412
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 1024,
-        "created_at": 1680440432
-      },
-      {
-        "type": "run_routes",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 1025,
-        "created_at": 1680440451,
-        "routes": [
-          {
-            "train": "8-2",
-            "connections": [
-              [
-                "K20",
-                "J19",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "J11"
-              ],
-              [
-                "J11",
-                "J9",
-                "J7",
-                "K6"
-              ],
-              [
-                "K6",
-                "J5",
-                "I4"
-              ],
-              [
-                "I4",
-                "H3",
-                "G2",
-                "F1"
-              ]
-            ],
-            "hexes": [
-              "K20",
+            [
               "I18",
-              "L13",
-              "K14",
-              "J11",
-              "K6",
-              "I4",
-              "F1"
+              "J17",
+              "K16",
+              "L15",
+              "L13"
             ],
-            "revenue": 420,
-            "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
-            "nodes": [
-              "K20-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "J11-1",
-              "K6-0",
-              "I4-0",
-              "F1-0"
-            ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 1026,
-        "created_at": 1680440455,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "UP",
-        "entity_type": "corporation",
-        "id": 1027,
-        "created_at": 1680440562
-      },
-      {
-        "type": "pass",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 1028,
-        "created_at": 1680441076
-      },
-      {
-        "type": "run_routes",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 1029,
-        "created_at": 1680441122,
-        "routes": [
-          {
-            "train": "12-0",
-            "connections": [
-              [
-                "I16",
-                "I18"
-              ],
-              [
-                "L13",
-                "L15",
-                "K16",
-                "J17",
-                "I16"
-              ],
-              [
-                "K14",
-                "L13"
-              ],
-              [
-                "H17",
-                "H15",
-                "I14",
-                "J13",
-                "K14"
-              ],
-              [
-                "G18",
-                "H17"
-              ],
-              [
-                "G16",
-                "G18"
-              ],
-              [
-                "F15",
-                "G16"
-              ],
-              [
-                "B11",
-                "C12",
-                "C14",
-                "D15",
-                "E16",
-                "F17",
-                "F15"
-              ],
-              [
-                "A10",
-                "B9",
-                "B11"
-              ],
-              [
-                "B5",
-                "A6",
-                "A8",
-                "A10"
-              ],
-              [
-                "A2",
-                "A4",
-                "B5"
-              ]
-            ],
-            "hexes": [
-              "I18",
-              "I16",
+            [
               "L13",
+              "K14"
+            ],
+            [
               "K14",
-              "H17",
-              "G18",
+              "J13",
+              "I14",
+              "H13",
+              "G14",
+              "G16"
+            ],
+            [
               "G16",
-              "F15",
-              "B11",
-              "A10",
-              "B5",
-              "A2"
-            ],
-            "revenue": 570,
-            "revenue_str": "I18-I16-L13-K14-H17-G18-G16-F15-B11-A10-B5-A2 + Edge Token",
-            "nodes": [
-              "I16-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "H17-0",
-              "G18-0",
-              "G16-0",
-              "F15-0",
-              "B11-0",
-              "A10-0",
-              "B5-0",
-              "A2-0"
+              "G18"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 1030,
-        "created_at": 1680441127,
-        "kind": "payout"
-      },
-      {
-        "type": "pass",
-        "entity": "MILW",
-        "entity_type": "corporation",
-        "id": 1031,
-        "created_at": 1680441130
-      },
-      {
-        "type": "pass",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 1032,
-        "created_at": 1680441609
-      },
-      {
-        "type": "run_routes",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 1033,
-        "created_at": 1680441612,
-        "routes": [
-          {
-            "train": "12-1",
-            "connections": [
-              [
-                "G18",
-                "G16"
-              ],
-              [
-                "G16",
-                "H17"
-              ],
-              [
-                "H17",
-                "I18"
-              ],
-              [
-                "I18",
-                "J17",
-                "K16",
-                "L15",
-                "L13"
-              ],
-              [
-                "L13",
-                "K14"
-              ],
-              [
-                "K14",
-                "J13",
-                "J11"
-              ],
-              [
-                "J11",
-                "J9",
-                "I8"
-              ],
-              [
-                "I8",
-                "H9"
-              ],
-              [
-                "H9",
-                "H7",
-                "I6",
-                "I4"
-              ],
-              [
-                "I4",
-                "J5",
-                "K4"
-              ],
-              [
-                "K4",
-                "K6"
-              ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "G16",
+            "G18"
+          ],
+          "revenue": 340,
+          "revenue_str": "K20-I18-L13-K14-G16-G18",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "G16-0",
+            "G18-0"
+          ]
+        }
+      ],
+      "original_id": 839
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 625,
+      "created_at": 1680095223,
+      "kind": "payout",
+      "original_id": 840
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 626,
+      "created_at": 1680095246,
+      "original_id": 841
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 627,
+      "created_at": 1680098115,
+      "hex": "H7",
+      "tile": "8-12",
+      "rotation": 4,
+      "original_id": 842
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 628,
+      "created_at": 1680098119,
+      "original_id": 843
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 629,
+      "created_at": 1680098130,
+      "routes": [
+        {
+          "train": "8-0",
+          "connections": [
+            [
+              "M2",
+              "L3",
+              "K4"
             ],
-            "hexes": [
-              "G18",
-              "G16",
-              "H17",
-              "I18",
-              "L13",
-              "K14",
-              "J11",
-              "I8",
-              "H9",
-              "I4",
+            [
               "K4",
               "K6"
             ],
-            "revenue": 480,
-            "revenue_str": "G18-G16-H17-I18-L13-K14-J11-I8-H9-I4-K4-K6",
-            "nodes": [
-              "G18-0",
-              "G16-0",
-              "H17-0",
-              "I18-0",
-              "L13-0",
-              "K14-0",
-              "J11-1",
-              "I8-0",
-              "H9-0",
-              "I4-0",
-              "K4-0",
-              "K6-0"
+            [
+              "K6",
+              "J7",
+              "J9",
+              "J11"
+            ],
+            [
+              "J11",
+              "J13",
+              "K14"
+            ],
+            [
+              "K14",
+              "L13"
+            ],
+            [
+              "L13",
+              "L15",
+              "K16",
+              "J17",
+              "I18"
             ]
-          }
-        ]
-      },
-      {
-        "type": "dividend",
-        "entity": "MP",
-        "entity_type": "corporation",
-        "id": 1034,
-        "created_at": 1680441614,
-        "kind": "payout"
-      }
-    ],
-    "loaded": true,
-    "created_at": 1678093279,
-    "updated_at": 1680441831,
-    "finished_at": 1680441831
-  }
+          ],
+          "hexes": [
+            "M2",
+            "K4",
+            "K6",
+            "J11",
+            "K14",
+            "L13",
+            "I18"
+          ],
+          "revenue": 380,
+          "revenue_str": "M2-K4-K6-J11-K14-L13-I18 + Edge Token",
+          "nodes": [
+            "M2-0",
+            "K4-0",
+            "K6-0",
+            "J11-1",
+            "K14-0",
+            "L13-0",
+            "I18-0"
+          ]
+        }
+      ],
+      "original_id": 844
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 630,
+      "created_at": 1680098134,
+      "kind": "payout",
+      "original_id": 845
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 631,
+      "created_at": 1680098141,
+      "original_id": 846
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 632,
+      "created_at": 1680099862,
+      "hex": "F17",
+      "tile": "8-13",
+      "rotation": 5,
+      "original_id": 847
+    },
+    {
+      "type": "run_routes",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 633,
+      "created_at": 1680099919,
+      "routes": [
+        {
+          "train": "8-1",
+          "connections": [
+            [
+              "H17",
+              "I18"
+            ],
+            [
+              "G18",
+              "H17"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18"
+            ],
+            [
+              "D13",
+              "E14",
+              "F15"
+            ],
+            [
+              "D9",
+              "D11",
+              "C12",
+              "D13"
+            ],
+            [
+              "B5",
+              "C6",
+              "C8",
+              "D9"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "H17",
+            "G18",
+            "F15",
+            "D13",
+            "D9",
+            "B5",
+            "A2"
+          ],
+          "revenue": 390,
+          "revenue_str": "I18-H17-G18-F15-D13-D9-B5-A2 + Edge Token",
+          "nodes": [
+            "H17-0",
+            "I18-0",
+            "G18-0",
+            "F15-0",
+            "D13-0",
+            "D9-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 848
+    },
+    {
+      "type": "dividend",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 634,
+      "created_at": 1680099929,
+      "kind": "payout",
+      "original_id": 849
+    },
+    {
+      "type": "buy_train",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 635,
+      "created_at": 1680100028,
+      "train": "5-2",
+      "price": 308,
+      "original_id": 850
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 636,
+      "created_at": 1680101644,
+      "original_id": 851
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 637,
+      "created_at": 1680101645,
+      "original_id": 852
+    },
+    {
+      "type": "run_routes",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 638,
+      "created_at": 1680101651,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "H11"
+            ],
+            [
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "H7",
+              "I6",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "L13",
+            "K14",
+            "H11",
+            "H9",
+            "I4"
+          ],
+          "revenue": 290,
+          "revenue_str": "I18-L13-K14-H11-H9-I4",
+          "nodes": [
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "H11-0",
+            "H9-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "original_id": 853
+    },
+    {
+      "type": "dividend",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 639,
+      "created_at": 1680101656,
+      "kind": "payout",
+      "original_id": 854
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 640,
+      "created_at": 1680101703,
+      "original_id": 855
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 641,
+      "created_at": 1680101723,
+      "original_id": 856
+    },
+    {
+      "type": "run_routes",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 642,
+      "created_at": 1680101726,
+      "routes": [
+        {
+          "train": "8-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "J11"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7",
+              "K6"
+            ],
+            [
+              "K6",
+              "J5",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3",
+              "G2",
+              "F1"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "J11",
+            "K6",
+            "I4",
+            "F1"
+          ],
+          "revenue": 420,
+          "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "J11-1",
+            "K6-0",
+            "I4-0",
+            "F1-0"
+          ]
+        }
+      ],
+      "original_id": 857
+    },
+    {
+      "type": "dividend",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 643,
+      "created_at": 1680101728,
+      "kind": "payout",
+      "original_id": 858
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 644,
+      "created_at": 1680101732,
+      "original_id": 859
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 645,
+      "created_at": 1680101819,
+      "hex": "B3",
+      "tile": "8-14",
+      "rotation": 2,
+      "original_id": 860
+    },
+    {
+      "type": "pass",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 646,
+      "created_at": 1680101830,
+      "original_id": 861
+    },
+    {
+      "type": "buy_train",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 647,
+      "created_at": 1680101837,
+      "train": "12-0",
+      "price": 1100,
+      "variant": "12",
+      "original_id": 862
+    },
+    {
+      "type": "pass",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 648,
+      "created_at": 1680101858,
+      "original_id": 863
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 649,
+      "created_at": 1680119011,
+      "hex": "I8",
+      "tile": "1-0",
+      "rotation": 2,
+      "original_id": 864
+    },
+    {
+      "type": "pass",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 650,
+      "created_at": 1680119016,
+      "original_id": 865
+    },
+    {
+      "type": "buy_train",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 651,
+      "created_at": 1680119030,
+      "train": "12-1",
+      "price": 1100,
+      "variant": "12",
+      "original_id": 866
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 652,
+      "created_at": 1680119050,
+      "shares": [
+        "MP_1"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 867
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 653,
+      "created_at": 1680119055,
+      "original_id": 868
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 654,
+      "created_at": 1680131546,
+      "shares": [
+        "MP_5"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 869
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 655,
+      "created_at": 1680131556,
+      "original_id": 870
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 656,
+      "created_at": 1680131972,
+      "shares": [
+        "GN_5"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 871
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 657,
+      "created_at": 1680132009,
+      "original_id": 872
+    },
+    {
+      "type": "buy_shares",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 658,
+      "created_at": 1680132431,
+      "shares": [
+        "CBQ_8"
+      ],
+      "percent": 10,
+      "original_id": 873
+    },
+    {
+      "type": "buy_shares",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 659,
+      "created_at": 1680173579,
+      "shares": [
+        "GN_1"
+      ],
+      "percent": 10,
+      "original_id": 874
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 660,
+      "created_at": 1680178535,
+      "shares": [
+        "GN_6"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 875
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 661,
+      "created_at": 1680178583,
+      "original_id": 876
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 662,
+      "created_at": 1680179446,
+      "shares": [
+        "MILW_5"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 877
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 663,
+      "created_at": 1680179449,
+      "original_id": 878
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 664,
+      "created_at": 1680179842,
+      "shares": [
+        "GN_7"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 879
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 665,
+      "created_at": 1680179960,
+      "original_id": 880
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 666,
+      "created_at": 1680228836,
+      "shares": [
+        "GN_8"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 881
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 667,
+      "created_at": 1680228867,
+      "original_id": 882
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 668,
+      "created_at": 1680229273,
+      "shares": [
+        "MILW_6"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 883
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 669,
+      "created_at": 1680229278,
+      "original_id": 884
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 670,
+      "created_at": 1680254040,
+      "shares": [
+        "MP_6"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 885
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 671,
+      "created_at": 1680254155,
+      "original_id": 886
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 672,
+      "created_at": 1680279119,
+      "shares": [
+        "MP_7"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 887
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 673,
+      "created_at": 1680279145,
+      "original_id": 888
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 674,
+      "created_at": 1680299492,
+      "shares": [
+        "MILW_7"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 889
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 675,
+      "created_at": 1680299497,
+      "original_id": 890
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 676,
+      "created_at": 1680306755,
+      "shares": [
+        "MP_8"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 891
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 677,
+      "created_at": 1680306768,
+      "original_id": 892
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 678,
+      "created_at": 1680310901,
+      "shares": [
+        "MILW_8"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 893
+    },
+    {
+      "type": "pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 679,
+      "created_at": 1680310944,
+      "original_id": 894
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 680,
+      "created_at": 1680311196,
+      "shares": [
+        "SOO_6"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 895
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 681,
+      "created_at": 1680311200,
+      "original_id": 896
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 682,
+      "created_at": 1680311619,
+      "shares": [
+        "UP_6"
+      ],
+      "percent": 10,
+      "original_id": 897
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 683,
+      "created_at": 1680311624,
+      "shares": [
+        "SOO_7"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 898
+    },
+    {
+      "type": "buy_shares",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 684,
+      "created_at": 1680312558,
+      "shares": [
+        "UP_6"
+      ],
+      "percent": 10,
+      "original_id": 899
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 685,
+      "created_at": 1680313747,
+      "original_id": 900
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 686,
+      "created_at": 1680349166,
+      "shares": [
+        "KATY_4"
+      ],
+      "percent": 10,
+      "original_id": 901
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 687,
+      "created_at": 1680349170,
+      "shares": [
+        "SOO_8"
+      ],
+      "percent": 10,
+      "share_price": false,
+      "original_id": 902
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 4311,
+      "entity_type": "player",
+      "id": 688,
+      "created_at": 1680350678,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 4311,
+          "entity_type": "player",
+          "created_at": 1680350676
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false,
+      "original_id": 903
+    },
+    {
+      "type": "pass",
+      "entity": 1761,
+      "entity_type": "player",
+      "id": 689,
+      "created_at": 1680351805,
+      "original_id": 904
+    },
+    {
+      "type": "pass",
+      "entity": 2122,
+      "entity_type": "player",
+      "id": 690,
+      "created_at": 1680358429,
+      "original_id": 905
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 691,
+      "created_at": 1680360290,
+      "original_id": 906
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 692,
+      "created_at": 1680360337,
+      "routes": [
+        {
+          "train": "10-1",
+          "connections": [
+            [
+              "G18",
+              "H17"
+            ],
+            [
+              "H17",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "H11"
+            ],
+            [
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "H7",
+              "I6",
+              "I4"
+            ],
+            [
+              "I4",
+              "J5",
+              "K4"
+            ],
+            [
+              "K4",
+              "K6"
+            ]
+          ],
+          "hexes": [
+            "G18",
+            "H17",
+            "I18",
+            "L13",
+            "K14",
+            "H11",
+            "H9",
+            "I4",
+            "K4",
+            "K6"
+          ],
+          "revenue": 460,
+          "revenue_str": "G18-H17-I18-L13-K14-H11-H9-I4-K4-K6",
+          "nodes": [
+            "G18-0",
+            "H17-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "H11-0",
+            "H9-0",
+            "I4-0",
+            "K4-0",
+            "K6-0"
+          ]
+        }
+      ],
+      "original_id": 907
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 693,
+      "created_at": 1680360339,
+      "kind": "payout",
+      "original_id": 908
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 694,
+      "created_at": 1680360395,
+      "original_id": 909
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 695,
+      "created_at": 1680360814,
+      "hex": "C12",
+      "tile": "46-0",
+      "rotation": 2,
+      "original_id": 910
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 696,
+      "created_at": 1680360865,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G16",
+              "G18"
+            ],
+            [
+              "H17",
+              "G16"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H15",
+              "H17"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ]
+          ],
+          "hexes": [
+            "G18",
+            "G16",
+            "H17",
+            "K14",
+            "L13",
+            "I18"
+          ],
+          "revenue": 310,
+          "revenue_str": "G18-G16-H17-K14-L13-I18",
+          "nodes": [
+            "G16-0",
+            "G18-0",
+            "H17-0",
+            "K14-0",
+            "L13-0",
+            "I18-0"
+          ]
+        },
+        {
+          "train": "10-0",
+          "connections": [
+            [
+              "B5",
+              "B3",
+              "A2"
+            ],
+            [
+              "A10",
+              "A8",
+              "A6",
+              "B5"
+            ],
+            [
+              "B11",
+              "B9",
+              "A10"
+            ],
+            [
+              "D9",
+              "C10",
+              "B11"
+            ],
+            [
+              "D13",
+              "C12",
+              "D11",
+              "D9"
+            ],
+            [
+              "F15",
+              "E14",
+              "D13"
+            ],
+            [
+              "G18",
+              "F17",
+              "F15"
+            ],
+            [
+              "H17",
+              "G18"
+            ],
+            [
+              "I18",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "A2",
+            "B5",
+            "A10",
+            "B11",
+            "D9",
+            "D13",
+            "F15",
+            "G18",
+            "H17",
+            "I18"
+          ],
+          "revenue": 490,
+          "revenue_str": "A2-B5-A10-B11-D9-D13-F15-G18-H17-I18 + Edge Token",
+          "nodes": [
+            "B5-0",
+            "A2-0",
+            "A10-0",
+            "B11-0",
+            "D9-0",
+            "D13-0",
+            "F15-0",
+            "G18-0",
+            "H17-0",
+            "I18-0"
+          ]
+        }
+      ],
+      "original_id": 911
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 697,
+      "created_at": 1680360869,
+      "kind": "payout",
+      "original_id": 912
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 698,
+      "created_at": 1680361558,
+      "original_id": 913
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 699,
+      "created_at": 1680361561,
+      "original_id": 914
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 700,
+      "created_at": 1680361576,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "G14",
+              "G16"
+            ],
+            [
+              "G16",
+              "G18"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "G16",
+            "G18"
+          ],
+          "revenue": 340,
+          "revenue_str": "K20-I18-L13-K14-G16-G18",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "G16-0",
+            "G18-0"
+          ]
+        }
+      ],
+      "original_id": 915
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 701,
+      "created_at": 1680361579,
+      "kind": "payout",
+      "original_id": 916
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 702,
+      "created_at": 1680361583,
+      "original_id": 917
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 703,
+      "created_at": 1680362650,
+      "hex": "F17",
+      "tile": "24-3",
+      "rotation": 5,
+      "original_id": 918
+    },
+    {
+      "type": "run_routes",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 704,
+      "created_at": 1680362669,
+      "routes": [
+        {
+          "train": "8-1",
+          "connections": [
+            [
+              "H17",
+              "I18"
+            ],
+            [
+              "G18",
+              "H17"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18"
+            ],
+            [
+              "D13",
+              "E14",
+              "F15"
+            ],
+            [
+              "D9",
+              "D11",
+              "C12",
+              "D13"
+            ],
+            [
+              "B5",
+              "C6",
+              "C8",
+              "D9"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "H17",
+            "G18",
+            "F15",
+            "D13",
+            "D9",
+            "B5",
+            "A2"
+          ],
+          "revenue": 390,
+          "revenue_str": "I18-H17-G18-F15-D13-D9-B5-A2 + Edge Token",
+          "nodes": [
+            "H17-0",
+            "I18-0",
+            "G18-0",
+            "F15-0",
+            "D13-0",
+            "D9-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 919
+    },
+    {
+      "type": "dividend",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 705,
+      "created_at": 1680362672,
+      "kind": "payout",
+      "original_id": 920
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 706,
+      "created_at": 1680362698,
+      "original_id": 921
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 707,
+      "created_at": 1680367279,
+      "hex": "E14",
+      "tile": "20-0",
+      "rotation": 2,
+      "original_id": 924
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 708,
+      "created_at": 1680367282,
+      "original_id": 925
+    },
+    {
+      "type": "run_routes",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 709,
+      "created_at": 1680367288,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "H11"
+            ],
+            [
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "H7",
+              "I6",
+              "I4"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "L13",
+            "K14",
+            "H11",
+            "H9",
+            "I4"
+          ],
+          "revenue": 290,
+          "revenue_str": "I18-L13-K14-H11-H9-I4",
+          "nodes": [
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "H11-0",
+            "H9-0",
+            "I4-0"
+          ]
+        }
+      ],
+      "original_id": 926
+    },
+    {
+      "type": "dividend",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 710,
+      "created_at": 1680367290,
+      "kind": "payout",
+      "original_id": 927
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 711,
+      "created_at": 1680367291,
+      "original_id": 928
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 712,
+      "created_at": 1680367299,
+      "hex": "D15",
+      "tile": "8-15",
+      "rotation": 4,
+      "original_id": 929
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 713,
+      "created_at": 1680367306,
+      "original_id": 930
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 714,
+      "created_at": 1680367312,
+      "routes": [
+        {
+          "train": "8-0",
+          "connections": [
+            [
+              "M2",
+              "L3",
+              "K4"
+            ],
+            [
+              "K4",
+              "K6"
+            ],
+            [
+              "K6",
+              "J7",
+              "J9",
+              "J11"
+            ],
+            [
+              "J11",
+              "J13",
+              "K14"
+            ],
+            [
+              "K14",
+              "L13"
+            ],
+            [
+              "L13",
+              "L15",
+              "K16",
+              "J17",
+              "I18"
+            ]
+          ],
+          "hexes": [
+            "M2",
+            "K4",
+            "K6",
+            "J11",
+            "K14",
+            "L13",
+            "I18"
+          ],
+          "revenue": 380,
+          "revenue_str": "M2-K4-K6-J11-K14-L13-I18 + Edge Token",
+          "nodes": [
+            "M2-0",
+            "K4-0",
+            "K6-0",
+            "J11-1",
+            "K14-0",
+            "L13-0",
+            "I18-0"
+          ]
+        }
+      ],
+      "original_id": 931
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 715,
+      "created_at": 1680367314,
+      "kind": "payout",
+      "original_id": 932
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 716,
+      "created_at": 1680367316,
+      "original_id": 933
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 717,
+      "created_at": 1680367323,
+      "hex": "D17",
+      "tile": "8-16",
+      "rotation": 1,
+      "original_id": 934
+    },
+    {
+      "type": "run_routes",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 718,
+      "created_at": 1680367327,
+      "routes": [
+        {
+          "train": "8-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "J11"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7",
+              "K6"
+            ],
+            [
+              "K6",
+              "J5",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3",
+              "G2",
+              "F1"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "J11",
+            "K6",
+            "I4",
+            "F1"
+          ],
+          "revenue": 420,
+          "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "J11-1",
+            "K6-0",
+            "I4-0",
+            "F1-0"
+          ]
+        }
+      ],
+      "original_id": 935
+    },
+    {
+      "type": "dividend",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 719,
+      "created_at": 1680367329,
+      "kind": "payout",
+      "original_id": 936
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 720,
+      "created_at": 1680367331,
+      "original_id": 937
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 721,
+      "created_at": 1680370854,
+      "hex": "C14",
+      "tile": "8-17",
+      "rotation": 5,
+      "original_id": 938
+    },
+    {
+      "type": "run_routes",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 722,
+      "created_at": 1680370892,
+      "routes": [
+        {
+          "train": "12-0",
+          "connections": [
+            [
+              "L13",
+              "L15",
+              "K16",
+              "J17",
+              "I18"
+            ],
+            [
+              "K14",
+              "L13"
+            ],
+            [
+              "H17",
+              "H15",
+              "I14",
+              "J13",
+              "K14"
+            ],
+            [
+              "G16",
+              "H17"
+            ],
+            [
+              "G18",
+              "G16"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18"
+            ],
+            [
+              "D13",
+              "E14",
+              "F15"
+            ],
+            [
+              "B11",
+              "C12",
+              "D13"
+            ],
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "L13",
+            "K14",
+            "H17",
+            "G16",
+            "G18",
+            "F15",
+            "D13",
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 560,
+          "revenue_str": "I18-L13-K14-H17-G16-G18-F15-D13-B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "L13-0",
+            "I18-0",
+            "K14-0",
+            "H17-0",
+            "G16-0",
+            "G18-0",
+            "F15-0",
+            "D13-0",
+            "B11-0",
+            "A10-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 939
+    },
+    {
+      "type": "dividend",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 723,
+      "created_at": 1680370895,
+      "kind": "payout",
+      "original_id": 940
+    },
+    {
+      "type": "pass",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 724,
+      "created_at": 1680370901,
+      "original_id": 941
+    },
+    {
+      "type": "pass",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 725,
+      "created_at": 1680384628,
+      "original_id": 942
+    },
+    {
+      "type": "run_routes",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 726,
+      "created_at": 1680384666,
+      "routes": [
+        {
+          "train": "12-1",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "G14",
+              "G16"
+            ],
+            [
+              "G16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13"
+            ],
+            [
+              "F13",
+              "F11",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ],
+            [
+              "H9",
+              "H7",
+              "I6",
+              "I4"
+            ],
+            [
+              "I4",
+              "J5",
+              "K4"
+            ],
+            [
+              "K4",
+              "K6"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "G16",
+            "F15",
+            "F13",
+            "G10",
+            "H9",
+            "I4",
+            "K4",
+            "K6"
+          ],
+          "revenue": 490,
+          "revenue_str": "K20-I18-L13-K14-G16-F15-F13-G10-H9-I4-K4-K6",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "G16-0",
+            "F15-0",
+            "F13-0",
+            "G10-0",
+            "H9-0",
+            "I4-0",
+            "K4-0",
+            "K6-0"
+          ]
+        }
+      ],
+      "original_id": 943
+    },
+    {
+      "type": "dividend",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 727,
+      "created_at": 1680384668,
+      "kind": "payout",
+      "original_id": 944
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 728,
+      "created_at": 1680384715,
+      "original_id": 945
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 729,
+      "created_at": 1680384724,
+      "routes": [
+        {
+          "train": "10-1",
+          "connections": [
+            [
+              "G18",
+              "H17"
+            ],
+            [
+              "H17",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "H11"
+            ],
+            [
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "H7",
+              "I6",
+              "I4"
+            ],
+            [
+              "I4",
+              "J5",
+              "K4"
+            ],
+            [
+              "K4",
+              "K6"
+            ]
+          ],
+          "hexes": [
+            "G18",
+            "H17",
+            "I18",
+            "L13",
+            "K14",
+            "H11",
+            "H9",
+            "I4",
+            "K4",
+            "K6"
+          ],
+          "revenue": 460,
+          "revenue_str": "G18-H17-I18-L13-K14-H11-H9-I4-K4-K6",
+          "nodes": [
+            "G18-0",
+            "H17-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "H11-0",
+            "H9-0",
+            "I4-0",
+            "K4-0",
+            "K6-0"
+          ]
+        }
+      ],
+      "original_id": 946
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 730,
+      "created_at": 1680384726,
+      "kind": "payout",
+      "original_id": 947
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 731,
+      "created_at": 1680384727,
+      "original_id": 948
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 732,
+      "created_at": 1680389349,
+      "hex": "D15",
+      "tile": "19-0",
+      "rotation": 2,
+      "original_id": 949
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 733,
+      "created_at": 1680389371,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G16",
+              "G18"
+            ],
+            [
+              "H17",
+              "G16"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H15",
+              "H17"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ]
+          ],
+          "hexes": [
+            "G18",
+            "G16",
+            "H17",
+            "K14",
+            "L13",
+            "I18"
+          ],
+          "revenue": 310,
+          "revenue_str": "G18-G16-H17-K14-L13-I18",
+          "nodes": [
+            "G16-0",
+            "G18-0",
+            "H17-0",
+            "K14-0",
+            "L13-0",
+            "I18-0"
+          ]
+        },
+        {
+          "train": "10-0",
+          "connections": [
+            [
+              "B5",
+              "B3",
+              "A2"
+            ],
+            [
+              "A10",
+              "A8",
+              "A6",
+              "B5"
+            ],
+            [
+              "B11",
+              "B9",
+              "A10"
+            ],
+            [
+              "D9",
+              "C10",
+              "B11"
+            ],
+            [
+              "D13",
+              "C12",
+              "D11",
+              "D9"
+            ],
+            [
+              "F15",
+              "E14",
+              "D13"
+            ],
+            [
+              "G18",
+              "F17",
+              "F15"
+            ],
+            [
+              "H17",
+              "G18"
+            ],
+            [
+              "I18",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "A2",
+            "B5",
+            "A10",
+            "B11",
+            "D9",
+            "D13",
+            "F15",
+            "G18",
+            "H17",
+            "I18"
+          ],
+          "revenue": 490,
+          "revenue_str": "A2-B5-A10-B11-D9-D13-F15-G18-H17-I18 + Edge Token",
+          "nodes": [
+            "B5-0",
+            "A2-0",
+            "A10-0",
+            "B11-0",
+            "D9-0",
+            "D13-0",
+            "F15-0",
+            "G18-0",
+            "H17-0",
+            "I18-0"
+          ]
+        }
+      ],
+      "original_id": 950
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 734,
+      "created_at": 1680389375,
+      "kind": "payout",
+      "original_id": 951
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 735,
+      "created_at": 1680394702,
+      "original_id": 952
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 736,
+      "created_at": 1680394723,
+      "original_id": 955
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 737,
+      "created_at": 1680394735,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "G14",
+              "G16"
+            ],
+            [
+              "G16",
+              "G18"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "G16",
+            "G18"
+          ],
+          "revenue": 340,
+          "revenue_str": "K20-I18-L13-K14-G16-G18",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "G16-0",
+            "G18-0"
+          ]
+        }
+      ],
+      "original_id": 956
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 738,
+      "created_at": 1680394737,
+      "kind": "payout",
+      "original_id": 957
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 739,
+      "created_at": 1680394739,
+      "original_id": 958
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 740,
+      "created_at": 1680435424,
+      "hex": "E16",
+      "tile": "9-16",
+      "rotation": 2,
+      "original_id": 959
+    },
+    {
+      "type": "run_routes",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 741,
+      "created_at": 1680435471,
+      "routes": [
+        {
+          "train": "8-1",
+          "connections": [
+            [
+              "L13",
+              "L15",
+              "K16",
+              "J17",
+              "I18"
+            ],
+            [
+              "K14",
+              "L13"
+            ],
+            [
+              "G16",
+              "G14",
+              "H13",
+              "I14",
+              "J13",
+              "K14"
+            ],
+            [
+              "G18",
+              "G16"
+            ],
+            [
+              "D9",
+              "D11",
+              "C12",
+              "C14",
+              "D15",
+              "E16",
+              "F17",
+              "G18"
+            ],
+            [
+              "B5",
+              "C6",
+              "C8",
+              "D9"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "L13",
+            "K14",
+            "G16",
+            "G18",
+            "D9",
+            "B5",
+            "A2"
+          ],
+          "revenue": 470,
+          "revenue_str": "I18-L13-K14-G16-G18-D9-B5-A2 + Edge Token",
+          "nodes": [
+            "L13-0",
+            "I18-0",
+            "K14-0",
+            "G16-0",
+            "G18-0",
+            "D9-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 960
+    },
+    {
+      "type": "dividend",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 742,
+      "created_at": 1680435479,
+      "kind": "payout",
+      "original_id": 961
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 743,
+      "created_at": 1680435486,
+      "original_id": 962
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 744,
+      "created_at": 1680436247,
+      "hex": "C18",
+      "tile": "8-18",
+      "rotation": 4,
+      "original_id": 963
+    },
+    {
+      "type": "choose",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 745,
+      "created_at": 1680436251,
+      "choice": "Place Edge Token",
+      "original_id": 964
+    },
+    {
+      "type": "run_routes",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 746,
+      "created_at": 1680436263,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "I18",
+              "J17",
+              "K16",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "G14",
+              "G16"
+            ],
+            [
+              "G16",
+              "F15"
+            ],
+            [
+              "F15",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "D15",
+              "D17",
+              "C18",
+              "C20"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "K14",
+            "G16",
+            "F15",
+            "F13",
+            "C20"
+          ],
+          "revenue": 320,
+          "revenue_str": "I18-K14-G16-F15-F13-C20 + Edge Token",
+          "nodes": [
+            "I18-0",
+            "K14-0",
+            "G16-0",
+            "F15-0",
+            "F13-0",
+            "C20-0"
+          ]
+        }
+      ],
+      "original_id": 965
+    },
+    {
+      "type": "dividend",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 747,
+      "created_at": 1680436308,
+      "kind": "payout",
+      "original_id": 966
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 748,
+      "created_at": 1680436310,
+      "original_id": 967
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 749,
+      "created_at": 1680436324,
+      "original_id": 968
+    },
+    {
+      "type": "place_token",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 750,
+      "created_at": 1680436334,
+      "city": "14-2-0",
+      "slot": 1,
+      "tokener": "KATY",
+      "original_id": 969
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 751,
+      "created_at": 1680436337,
+      "routes": [
+        {
+          "train": "8-0",
+          "connections": [
+            [
+              "M2",
+              "L3",
+              "K4"
+            ],
+            [
+              "K4",
+              "K6"
+            ],
+            [
+              "K6",
+              "J7",
+              "J9",
+              "J11"
+            ],
+            [
+              "J11",
+              "J13",
+              "K14"
+            ],
+            [
+              "K14",
+              "L13"
+            ],
+            [
+              "L13",
+              "L15",
+              "K16",
+              "J17",
+              "I18"
+            ]
+          ],
+          "hexes": [
+            "M2",
+            "K4",
+            "K6",
+            "J11",
+            "K14",
+            "L13",
+            "I18"
+          ],
+          "revenue": 380,
+          "revenue_str": "M2-K4-K6-J11-K14-L13-I18 + Edge Token",
+          "nodes": [
+            "M2-0",
+            "K4-0",
+            "K6-0",
+            "J11-1",
+            "K14-0",
+            "L13-0",
+            "I18-0"
+          ]
+        }
+      ],
+      "original_id": 970
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 752,
+      "created_at": 1680436338,
+      "kind": "payout",
+      "original_id": 971
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 753,
+      "created_at": 1680436340,
+      "original_id": 972
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 754,
+      "created_at": 1680436345,
+      "original_id": 973
+    },
+    {
+      "type": "run_routes",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 755,
+      "created_at": 1680436353,
+      "routes": [
+        {
+          "train": "8-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "J11"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7",
+              "K6"
+            ],
+            [
+              "K6",
+              "J5",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3",
+              "G2",
+              "F1"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "J11",
+            "K6",
+            "I4",
+            "F1"
+          ],
+          "revenue": 420,
+          "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "J11-1",
+            "K6-0",
+            "I4-0",
+            "F1-0"
+          ]
+        }
+      ],
+      "original_id": 974
+    },
+    {
+      "type": "dividend",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 756,
+      "created_at": 1680436355,
+      "kind": "payout",
+      "original_id": 975
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 757,
+      "created_at": 1680436360,
+      "original_id": 976
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 758,
+      "created_at": 1680437592,
+      "hex": "D15",
+      "tile": "46-1",
+      "rotation": 2,
+      "original_id": 979
+    },
+    {
+      "type": "run_routes",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 759,
+      "created_at": 1680437620,
+      "routes": [
+        {
+          "train": "12-0",
+          "connections": [
+            [
+              "L13",
+              "L15",
+              "K16",
+              "J17",
+              "I18"
+            ],
+            [
+              "K14",
+              "L13"
+            ],
+            [
+              "H17",
+              "H15",
+              "I14",
+              "J13",
+              "K14"
+            ],
+            [
+              "G16",
+              "H17"
+            ],
+            [
+              "G18",
+              "G16"
+            ],
+            [
+              "F15",
+              "F17",
+              "G18"
+            ],
+            [
+              "D13",
+              "E14",
+              "F15"
+            ],
+            [
+              "B11",
+              "C12",
+              "D13"
+            ],
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "L13",
+            "K14",
+            "H17",
+            "G16",
+            "G18",
+            "F15",
+            "D13",
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 560,
+          "revenue_str": "I18-L13-K14-H17-G16-G18-F15-D13-B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "L13-0",
+            "I18-0",
+            "K14-0",
+            "H17-0",
+            "G16-0",
+            "G18-0",
+            "F15-0",
+            "D13-0",
+            "B11-0",
+            "A10-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 980
+    },
+    {
+      "type": "dividend",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 760,
+      "created_at": 1680437621,
+      "kind": "payout",
+      "original_id": 981
+    },
+    {
+      "type": "pass",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 761,
+      "created_at": 1680437629,
+      "original_id": 982
+    },
+    {
+      "type": "pass",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 762,
+      "created_at": 1680438182,
+      "original_id": 983
+    },
+    {
+      "type": "run_routes",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 763,
+      "created_at": 1680438201,
+      "routes": [
+        {
+          "train": "12-1",
+          "connections": [
+            [
+              "G18",
+              "G16"
+            ],
+            [
+              "G16",
+              "H17"
+            ],
+            [
+              "H17",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "J11"
+            ],
+            [
+              "J11",
+              "J9",
+              "I8"
+            ],
+            [
+              "I8",
+              "H9"
+            ],
+            [
+              "H9",
+              "H7",
+              "I6",
+              "I4"
+            ],
+            [
+              "I4",
+              "J5",
+              "K4"
+            ],
+            [
+              "K4",
+              "K6"
+            ]
+          ],
+          "hexes": [
+            "G18",
+            "G16",
+            "H17",
+            "I18",
+            "L13",
+            "K14",
+            "J11",
+            "I8",
+            "H9",
+            "I4",
+            "K4",
+            "K6"
+          ],
+          "revenue": 480,
+          "revenue_str": "G18-G16-H17-I18-L13-K14-J11-I8-H9-I4-K4-K6",
+          "nodes": [
+            "G18-0",
+            "G16-0",
+            "H17-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "J11-1",
+            "I8-0",
+            "H9-0",
+            "I4-0",
+            "K4-0",
+            "K6-0"
+          ]
+        }
+      ],
+      "original_id": 984
+    },
+    {
+      "type": "dividend",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 764,
+      "created_at": 1680438204,
+      "kind": "payout",
+      "original_id": 985
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 765,
+      "created_at": 1680438226,
+      "original_id": 986
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 766,
+      "created_at": 1680438255,
+      "original_id": 987
+    },
+    {
+      "type": "run_routes",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 767,
+      "created_at": 1680438265,
+      "routes": [
+        {
+          "train": "10-1",
+          "connections": [
+            [
+              "G18",
+              "H17"
+            ],
+            [
+              "H17",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "H11"
+            ],
+            [
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "H7",
+              "I6",
+              "I4"
+            ],
+            [
+              "I4",
+              "J5",
+              "K4"
+            ],
+            [
+              "K4",
+              "K6"
+            ]
+          ],
+          "hexes": [
+            "G18",
+            "H17",
+            "I18",
+            "L13",
+            "K14",
+            "H11",
+            "H9",
+            "I4",
+            "K4",
+            "K6"
+          ],
+          "revenue": 460,
+          "revenue_str": "G18-H17-I18-L13-K14-H11-H9-I4-K4-K6",
+          "nodes": [
+            "G18-0",
+            "H17-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "H11-0",
+            "H9-0",
+            "I4-0",
+            "K4-0",
+            "K6-0"
+          ]
+        }
+      ],
+      "original_id": 988
+    },
+    {
+      "type": "dividend",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 768,
+      "created_at": 1680438267,
+      "kind": "payout",
+      "original_id": 989
+    },
+    {
+      "type": "pass",
+      "entity": "RI",
+      "entity_type": "corporation",
+      "id": 769,
+      "created_at": 1680438269,
+      "original_id": 990
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 770,
+      "created_at": 1680439312,
+      "hex": "F17",
+      "tile": "42-0",
+      "rotation": 2,
+      "original_id": 1003
+    },
+    {
+      "type": "run_routes",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 771,
+      "created_at": 1680439318,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G16",
+              "G18"
+            ],
+            [
+              "H17",
+              "G16"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H15",
+              "H17"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ]
+          ],
+          "hexes": [
+            "G18",
+            "G16",
+            "H17",
+            "K14",
+            "L13",
+            "I18"
+          ],
+          "revenue": 310,
+          "revenue_str": "G18-G16-H17-K14-L13-I18",
+          "nodes": [
+            "G16-0",
+            "G18-0",
+            "H17-0",
+            "K14-0",
+            "L13-0",
+            "I18-0"
+          ]
+        },
+        {
+          "train": "10-0",
+          "connections": [
+            [
+              "B5",
+              "B3",
+              "A2"
+            ],
+            [
+              "A10",
+              "A8",
+              "A6",
+              "B5"
+            ],
+            [
+              "B11",
+              "B9",
+              "A10"
+            ],
+            [
+              "D9",
+              "C10",
+              "B11"
+            ],
+            [
+              "D13",
+              "C12",
+              "D11",
+              "D9"
+            ],
+            [
+              "F15",
+              "E14",
+              "D13"
+            ],
+            [
+              "G18",
+              "F17",
+              "F15"
+            ],
+            [
+              "H17",
+              "G18"
+            ],
+            [
+              "I18",
+              "H17"
+            ]
+          ],
+          "hexes": [
+            "A2",
+            "B5",
+            "A10",
+            "B11",
+            "D9",
+            "D13",
+            "F15",
+            "G18",
+            "H17",
+            "I18"
+          ],
+          "revenue": 490,
+          "revenue_str": "A2-B5-A10-B11-D9-D13-F15-G18-H17-I18 + Edge Token",
+          "nodes": [
+            "B5-0",
+            "A2-0",
+            "A10-0",
+            "B11-0",
+            "D9-0",
+            "D13-0",
+            "F15-0",
+            "G18-0",
+            "H17-0",
+            "I18-0"
+          ]
+        }
+      ],
+      "original_id": 1004
+    },
+    {
+      "type": "dividend",
+      "entity": "NP",
+      "entity_type": "corporation",
+      "id": 772,
+      "created_at": 1680439322,
+      "kind": "payout",
+      "original_id": 1005
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 773,
+      "created_at": 1680439496,
+      "original_id": 1006
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 774,
+      "created_at": 1680439498,
+      "original_id": 1007
+    },
+    {
+      "type": "run_routes",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 775,
+      "created_at": 1680439508,
+      "routes": [
+        {
+          "train": "6-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "G14",
+              "G16"
+            ],
+            [
+              "G16",
+              "G18"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "G16",
+            "G18"
+          ],
+          "revenue": 340,
+          "revenue_str": "K20-I18-L13-K14-G16-G18",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "G16-0",
+            "G18-0"
+          ]
+        }
+      ],
+      "original_id": 1008
+    },
+    {
+      "type": "dividend",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 776,
+      "created_at": 1680439510,
+      "kind": "payout",
+      "original_id": 1009
+    },
+    {
+      "type": "pass",
+      "entity": "CBQ",
+      "entity_type": "corporation",
+      "id": 777,
+      "created_at": 1680439511,
+      "original_id": 1010
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 778,
+      "created_at": 1680439602,
+      "hex": "J17",
+      "tile": "24-0",
+      "rotation": 0,
+      "original_id": 1011
+    },
+    {
+      "type": "run_routes",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 779,
+      "created_at": 1680439622,
+      "routes": [
+        {
+          "train": "8-1",
+          "connections": [
+            [
+              "L13",
+              "L15",
+              "K16",
+              "J17",
+              "I18"
+            ],
+            [
+              "K14",
+              "L13"
+            ],
+            [
+              "G16",
+              "G14",
+              "H13",
+              "I14",
+              "J13",
+              "K14"
+            ],
+            [
+              "G18",
+              "G16"
+            ],
+            [
+              "D9",
+              "D11",
+              "C12",
+              "C14",
+              "D15",
+              "E16",
+              "F17",
+              "G18"
+            ],
+            [
+              "B5",
+              "C6",
+              "C8",
+              "D9"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "L13",
+            "K14",
+            "G16",
+            "G18",
+            "D9",
+            "B5",
+            "A2"
+          ],
+          "revenue": 470,
+          "revenue_str": "I18-L13-K14-G16-G18-D9-B5-A2 + Edge Token",
+          "nodes": [
+            "L13-0",
+            "I18-0",
+            "K14-0",
+            "G16-0",
+            "G18-0",
+            "D9-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 1012
+    },
+    {
+      "type": "dividend",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 780,
+      "created_at": 1680439624,
+      "kind": "payout",
+      "original_id": 1013
+    },
+    {
+      "type": "pass",
+      "entity": "GN",
+      "entity_type": "corporation",
+      "id": 781,
+      "created_at": 1680439655,
+      "original_id": 1014
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 782,
+      "created_at": 1680440339,
+      "hex": "G12",
+      "tile": "9-17",
+      "rotation": 0,
+      "original_id": 1015
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 783,
+      "created_at": 1680440346,
+      "original_id": 1016
+    },
+    {
+      "type": "run_routes",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 784,
+      "created_at": 1680440358,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "I14",
+              "H13",
+              "H11"
+            ],
+            [
+              "H11",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "D15",
+              "D17",
+              "C18",
+              "C20"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "L13",
+            "K14",
+            "H11",
+            "F13",
+            "C20"
+          ],
+          "revenue": 360,
+          "revenue_str": "I18-L13-K14-H11-F13-C20 + Edge Token",
+          "nodes": [
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "H11-0",
+            "F13-0",
+            "C20-0"
+          ]
+        }
+      ],
+      "original_id": 1017
+    },
+    {
+      "type": "dividend",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 785,
+      "created_at": 1680440361,
+      "kind": "payout",
+      "original_id": 1018
+    },
+    {
+      "type": "pass",
+      "entity": "SOO",
+      "entity_type": "corporation",
+      "id": 786,
+      "created_at": 1680440371,
+      "original_id": 1019
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 787,
+      "created_at": 1680440390,
+      "original_id": 1020
+    },
+    {
+      "type": "run_routes",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 788,
+      "created_at": 1680440409,
+      "routes": [
+        {
+          "train": "8-0",
+          "connections": [
+            [
+              "M2",
+              "L3",
+              "K4"
+            ],
+            [
+              "K4",
+              "K6"
+            ],
+            [
+              "K6",
+              "J7",
+              "J9",
+              "J11"
+            ],
+            [
+              "J11",
+              "J13",
+              "K14"
+            ],
+            [
+              "K14",
+              "L13"
+            ],
+            [
+              "L13",
+              "L15",
+              "K16",
+              "J17",
+              "I16"
+            ],
+            [
+              "I16",
+              "I18"
+            ]
+          ],
+          "hexes": [
+            "M2",
+            "K4",
+            "K6",
+            "J11",
+            "K14",
+            "L13",
+            "I16",
+            "I18"
+          ],
+          "revenue": 400,
+          "revenue_str": "M2-K4-K6-J11-K14-L13-I16-I18 + Edge Token",
+          "nodes": [
+            "M2-0",
+            "K4-0",
+            "K6-0",
+            "J11-1",
+            "K14-0",
+            "L13-0",
+            "I16-0",
+            "I18-0"
+          ]
+        }
+      ],
+      "original_id": 1021
+    },
+    {
+      "type": "dividend",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 789,
+      "created_at": 1680440411,
+      "kind": "payout",
+      "original_id": 1022
+    },
+    {
+      "type": "pass",
+      "entity": "KATY",
+      "entity_type": "corporation",
+      "id": 790,
+      "created_at": 1680440412,
+      "original_id": 1023
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 791,
+      "created_at": 1680440432,
+      "original_id": 1024
+    },
+    {
+      "type": "run_routes",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 792,
+      "created_at": 1680440451,
+      "routes": [
+        {
+          "train": "8-2",
+          "connections": [
+            [
+              "K20",
+              "J19",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "J11"
+            ],
+            [
+              "J11",
+              "J9",
+              "J7",
+              "K6"
+            ],
+            [
+              "K6",
+              "J5",
+              "I4"
+            ],
+            [
+              "I4",
+              "H3",
+              "G2",
+              "F1"
+            ]
+          ],
+          "hexes": [
+            "K20",
+            "I18",
+            "L13",
+            "K14",
+            "J11",
+            "K6",
+            "I4",
+            "F1"
+          ],
+          "revenue": 420,
+          "revenue_str": "K20-I18-L13-K14-J11-K6-I4-F1 + Edge Token",
+          "nodes": [
+            "K20-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "J11-1",
+            "K6-0",
+            "I4-0",
+            "F1-0"
+          ]
+        }
+      ],
+      "original_id": 1025
+    },
+    {
+      "type": "dividend",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 793,
+      "created_at": 1680440455,
+      "kind": "payout",
+      "original_id": 1026
+    },
+    {
+      "type": "pass",
+      "entity": "UP",
+      "entity_type": "corporation",
+      "id": 794,
+      "created_at": 1680440562,
+      "original_id": 1027
+    },
+    {
+      "type": "pass",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 795,
+      "created_at": 1680441076,
+      "original_id": 1028
+    },
+    {
+      "type": "run_routes",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 796,
+      "created_at": 1680441122,
+      "routes": [
+        {
+          "train": "12-0",
+          "connections": [
+            [
+              "I16",
+              "I18"
+            ],
+            [
+              "L13",
+              "L15",
+              "K16",
+              "J17",
+              "I16"
+            ],
+            [
+              "K14",
+              "L13"
+            ],
+            [
+              "H17",
+              "H15",
+              "I14",
+              "J13",
+              "K14"
+            ],
+            [
+              "G18",
+              "H17"
+            ],
+            [
+              "G16",
+              "G18"
+            ],
+            [
+              "F15",
+              "G16"
+            ],
+            [
+              "B11",
+              "C12",
+              "C14",
+              "D15",
+              "E16",
+              "F17",
+              "F15"
+            ],
+            [
+              "A10",
+              "B9",
+              "B11"
+            ],
+            [
+              "B5",
+              "A6",
+              "A8",
+              "A10"
+            ],
+            [
+              "A2",
+              "A4",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "I18",
+            "I16",
+            "L13",
+            "K14",
+            "H17",
+            "G18",
+            "G16",
+            "F15",
+            "B11",
+            "A10",
+            "B5",
+            "A2"
+          ],
+          "revenue": 570,
+          "revenue_str": "I18-I16-L13-K14-H17-G18-G16-F15-B11-A10-B5-A2 + Edge Token",
+          "nodes": [
+            "I16-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "H17-0",
+            "G18-0",
+            "G16-0",
+            "F15-0",
+            "B11-0",
+            "A10-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "original_id": 1029
+    },
+    {
+      "type": "dividend",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 797,
+      "created_at": 1680441127,
+      "kind": "payout",
+      "original_id": 1030
+    },
+    {
+      "type": "pass",
+      "entity": "MILW",
+      "entity_type": "corporation",
+      "id": 798,
+      "created_at": 1680441130,
+      "original_id": 1031
+    },
+    {
+      "type": "pass",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 799,
+      "created_at": 1680441609,
+      "original_id": 1032
+    },
+    {
+      "type": "run_routes",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 800,
+      "created_at": 1680441612,
+      "routes": [
+        {
+          "train": "12-1",
+          "connections": [
+            [
+              "G18",
+              "G16"
+            ],
+            [
+              "G16",
+              "H17"
+            ],
+            [
+              "H17",
+              "I18"
+            ],
+            [
+              "I18",
+              "J17",
+              "K16",
+              "L15",
+              "L13"
+            ],
+            [
+              "L13",
+              "K14"
+            ],
+            [
+              "K14",
+              "J13",
+              "J11"
+            ],
+            [
+              "J11",
+              "J9",
+              "I8"
+            ],
+            [
+              "I8",
+              "H9"
+            ],
+            [
+              "H9",
+              "H7",
+              "I6",
+              "I4"
+            ],
+            [
+              "I4",
+              "J5",
+              "K4"
+            ],
+            [
+              "K4",
+              "K6"
+            ]
+          ],
+          "hexes": [
+            "G18",
+            "G16",
+            "H17",
+            "I18",
+            "L13",
+            "K14",
+            "J11",
+            "I8",
+            "H9",
+            "I4",
+            "K4",
+            "K6"
+          ],
+          "revenue": 480,
+          "revenue_str": "G18-G16-H17-I18-L13-K14-J11-I8-H9-I4-K4-K6",
+          "nodes": [
+            "G18-0",
+            "G16-0",
+            "H17-0",
+            "I18-0",
+            "L13-0",
+            "K14-0",
+            "J11-1",
+            "I8-0",
+            "H9-0",
+            "I4-0",
+            "K4-0",
+            "K6-0"
+          ]
+        }
+      ],
+      "original_id": 1033
+    },
+    {
+      "type": "dividend",
+      "entity": "MP",
+      "entity_type": "corporation",
+      "id": 801,
+      "created_at": 1680441614,
+      "kind": "payout",
+      "original_id": 1034
+    }
+  ],
+  "loaded": true,
+  "created_at": 1678093279,
+  "updated_at": 1680441831,
+  "finished_at": 1680441831
+}


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

**Explanation of Change**

Per 1850 rules a president can use price protection even if he already sold shares in the company. 
![photo_2023-11-29 13 59 35](https://github.com/tobymao/18xx/assets/576786/31ebc32a-18ff-475d-827d-6a3f80b45569)
This is different from 1870 rules, so this fix is needed. 

**Any Assumptions / Hacks**
* I've decided to not allow president to use price protection to buy the shares he sold himself, otherwise it leads to possible infinite SRs.
* Migrate script was able to repair the fixture, so most possibly pins won't be needed, only migration of existing games as they are easily fixable by adding a pass.