### PR TITLE
[18EU] Fix problem exchanging minor for market shares when it has trains

### DIFF
--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -402,6 +402,8 @@ module Engine
         end
 
         def maybe_discard_pullman(entity)
+          return if entity == @depot
+
           pullman = owns_pullman?(entity)
           return unless pullman
 


### PR DESCRIPTION
Fixes #9805

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- N/A Add the `pins` label if this change will break existing games
    I don't think this needs pins because the case where it makes a difference was previously an exception, so there should be no actions broken by this.
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
    This bug comes from the code trying to decide if the Depot needs to discard its Pullman trains.  This code is called during the final exchange round when you both: exchange for a market share AND your minor has trains.  If either of those conditions is not met, the game will progress.  i.e. if your minor doesn't have any trains, the market exchange works fine.

* **Screenshots**

* **Any Assumptions / Hacks**
