### PR TITLE
update rules links

### DIFF
--- a/lib/engine/game/g_1822_pnw/meta.rb
+++ b/lib/engine/game/g_1822_pnw/meta.rb
@@ -17,7 +17,7 @@ module Engine
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1822PNW'.freeze
         GAME_LOCATION = 'Pacific Northwest'.freeze
         GAME_PUBLISHER = :all_aboard_games
-        GAME_RULES_URL = 'https://boardgamegeek.com/thread/2890404/1822pnw-public-rules-review'.freeze
+        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/269597/1822pnw-rules'.freeze
         GAME_TITLE = '1822PNW'.freeze
 
         PLAYER_RANGE = [3, 5].freeze

--- a/lib/engine/game/g_18_gb/meta.rb
+++ b/lib/engine/game/g_18_gb/meta.rb
@@ -16,7 +16,7 @@ module Engine
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18GB'
         GAME_LOCATION = 'Great Britain'
         GAME_PUBLISHER = :all_aboard_games
-        GAME_RULES_URL = 'https://www.dropbox.com/s/uilbrqw8qyo3ves/18GB%20Rules.pdf?dl=0'
+        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/269595/18gb-rules'
 
         PLAYER_RANGE = [2, 6].freeze
         OPTIONAL_RULES = [

--- a/lib/engine/game/g_18_ny/meta.rb
+++ b/lib/engine/game/g_18_ny/meta.rb
@@ -14,7 +14,7 @@ module Engine
         GAME_PUBLISHER = :all_aboard_games
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18NY'
         GAME_LOCATION = 'New York, USA'
-        GAME_RULES_URL = 'https://www.dropbox.com/s/837djjcwbm1mt0x/18NY%20Rules.pdf?dl=0'
+        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/269593/18ny-rules'
         GAME_TITLE = '18NY'
         GAME_VARIANTS = [
           {

--- a/lib/engine/game/g_18_sj/meta.rb
+++ b/lib/engine/game/g_18_sj/meta.rb
@@ -16,7 +16,7 @@ module Engine
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18SJ'
         GAME_LOCATION = 'Sweden'
         GAME_PUBLISHER = :all_aboard_games
-        GAME_RULES_URL = 'https://www.dropbox.com/s/2iaubghicswpz3c/18SJ%20Rules.pdf?dl=0'
+        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/269594/18sj-rules'
 
         PLAYER_RANGE = [2, 6].freeze
         OPTIONAL_RULES = [

--- a/lib/engine/game/g_18_texas/meta.rb
+++ b/lib/engine/game/g_18_texas/meta.rb
@@ -15,7 +15,7 @@ module Engine
         GAME_DESIGNER = 'Scott Petersen'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Texas'
         GAME_PUBLISHER = :all_aboard_games
-        GAME_RULES_URL = 'https://docs.google.com/document/d/1WxUVRZ6uHu32fpaAaRa8z8lXGQLyGqZws3Ce0yDrFNY'
+        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/269592'
 
         PLAYER_RANGE = [3, 5].freeze
       end


### PR DESCRIPTION
Fixes #9982

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Adds new updated rules links for 18NY, 18GB, 18Texas, 1822PNW, and 18SJ
