### PR TITLE
[18Mag] fix int conversion issue w/ Opal

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1427,7 +1427,7 @@ module Engine
         # in a city/town/offboard slot.
         distance = distance.sort_by { |types, _| types.size }
 
-        max_num_stops = [distance.sum { |h| h['pay'] }, visits.size].min
+        max_num_stops = [distance.sum { |h| h['pay'].to_i }, visits.size].min
 
         max_num_stops.downto(1) do |num_stops|
           # to_i to work around Opal bug

--- a/public/fixtures/18Mag/plus_train_power.json
+++ b/public/fixtures/18Mag/plus_train_power.json
@@ -1,0 +1,1037 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 1090,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1702050277,
+      "company": "KK",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 11205,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1702052002,
+      "company": "FJ",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 4217,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1702060706,
+      "company": "MA",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1702062446,
+      "minor": "1",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 11205,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1702064650,
+      "minor": "7",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 4217,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1702072565,
+      "corporation": "SKEV",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1702073163,
+      "minor": "3",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 1090,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1702074277,
+      "minor": "4",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 4217,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1702077070,
+      "minor": "11",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1702079669,
+      "corporation": "LdStEG",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 1090,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1702102265,
+      "corporation": "G&C",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 11205,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1702102512,
+      "minor": "8",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1702105283,
+      "minor": "2",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 1090,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1702107737,
+      "minor": "9",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 11205,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1702107993,
+      "minor": "13",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 4217,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1702110424,
+      "minor": "5",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 1090,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1702123096,
+      "minor": "10",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 11205,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1702127727,
+      "corporation": "SIK",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 4217,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1702140504,
+      "minor": "12",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1702142120,
+      "company": "GSvS",
+      "price": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 21,
+      "created_at": 1702142129,
+      "hex": "E12",
+      "tile": "L33-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 22,
+      "created_at": 1702142175,
+      "hex": "D13",
+      "tile": "58-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 23,
+      "created_at": 1702142178
+    },
+    {
+      "cost": 10,
+      "type": "special_buy",
+      "entity": "1",
+      "description": "Plus Train Upgrade [G&C]",
+      "entity_type": "minor",
+      "id": 24,
+      "user": 3864,
+      "created_at": 1702142200
+    },
+    {
+      "type": "undo",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 25,
+      "user": 3864,
+      "created_at": 1702142204
+    },
+    {
+      "type": "run_routes",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 26,
+      "created_at": 1702142209,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "E12",
+              "D13"
+            ]
+          ],
+          "hexes": [
+            "D13",
+            "E12"
+          ],
+          "revenue": 40,
+          "revenue_str": "D13-E12",
+          "subsidy": 0,
+          "nodes": [
+            "E12-0",
+            "D13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "pass",
+      "entity": "1",
+      "entity_type": "minor",
+      "id": 27,
+      "created_at": 1702142213
+    },
+    {
+      "type": "lay_tile",
+      "entity": "2",
+      "entity_type": "minor",
+      "id": 28,
+      "created_at": 1702142226,
+      "hex": "D19",
+      "tile": "L32-0",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "2",
+      "entity_type": "minor",
+      "id": 29,
+      "created_at": 1702142230,
+      "hex": "D17",
+      "tile": "4-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "2",
+      "entity_type": "minor",
+      "id": 30,
+      "created_at": 1702142235
+    },
+    {
+      "type": "run_routes",
+      "entity": "2",
+      "entity_type": "minor",
+      "id": 31,
+      "created_at": 1702142244,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "D19",
+              "D17"
+            ]
+          ],
+          "hexes": [
+            "D17",
+            "D19"
+          ],
+          "revenue": 40,
+          "revenue_str": "D17-D19",
+          "subsidy": 0,
+          "nodes": [
+            "D19-0",
+            "D17-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "pass",
+      "entity": "2",
+      "entity_type": "minor",
+      "id": 32,
+      "created_at": 1702142246
+    },
+    {
+      "type": "lay_tile",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 33,
+      "created_at": 1702142308,
+      "hex": "E10",
+      "tile": "5-0",
+      "rotation": 5
+    },
+    {
+      "hex": "F9",
+      "tile": "8-0",
+      "type": "lay_tile",
+      "entity": "3",
+      "rotation": 1,
+      "entity_type": "minor",
+      "id": 34,
+      "user": 3864,
+      "created_at": 1702142314
+    },
+    {
+      "type": "undo",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 35,
+      "user": 3864,
+      "created_at": 1702142318
+    },
+    {
+      "type": "lay_tile",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 36,
+      "created_at": 1702142325,
+      "hex": "F11",
+      "tile": "7-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 37,
+      "created_at": 1702142330
+    },
+    {
+      "type": "run_routes",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 38,
+      "created_at": 1702142364,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "E10",
+              "F11",
+              "E12"
+            ]
+          ],
+          "hexes": [
+            "E12",
+            "E10"
+          ],
+          "revenue": 50,
+          "revenue_str": "E12-E10",
+          "subsidy": 0,
+          "nodes": [
+            "E10-0",
+            "E12-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "pass",
+      "entity": "3",
+      "entity_type": "minor",
+      "id": 39,
+      "created_at": 1702142374
+    },
+    {
+      "type": "lay_tile",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 40,
+      "created_at": 1702145562,
+      "hex": "G14",
+      "tile": "L32-1",
+      "rotation": 0
+    },
+    {
+      "hex": "F13",
+      "tile": "57-1",
+      "type": "lay_tile",
+      "entity": "4",
+      "rotation": 2,
+      "entity_type": "minor",
+      "id": 41,
+      "user": 1090,
+      "created_at": 1702145567
+    },
+    {
+      "type": "undo",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 42,
+      "user": 1090,
+      "created_at": 1702145589
+    },
+    {
+      "type": "pass",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 43,
+      "user": 1090,
+      "created_at": 1702145596
+    },
+    {
+      "type": "undo",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 44,
+      "user": 1090,
+      "created_at": 1702145606
+    },
+    {
+      "type": "lay_tile",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 45,
+      "created_at": 1702145613,
+      "hex": "F13",
+      "tile": "57-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 46,
+      "created_at": 1702145660
+    },
+    {
+      "type": "pass",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 47,
+      "created_at": 1702145666
+    },
+    {
+      "type": "run_routes",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 48,
+      "created_at": 1702145678,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "G14",
+              "F13"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "G14"
+          ],
+          "revenue": 50,
+          "revenue_str": "F13-G14",
+          "subsidy": 0,
+          "nodes": [
+            "G14-0",
+            "F13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "pass",
+      "entity": "4",
+      "entity_type": "minor",
+      "id": 49,
+      "created_at": 1702145730
+    },
+    {
+      "type": "lay_tile",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 50,
+      "created_at": 1702153963,
+      "hex": "H27",
+      "tile": "57-2",
+      "rotation": 0
+    },
+    {
+      "type": "special_buy",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 51,
+      "created_at": 1702153966,
+      "description": "Use Terrain Token",
+      "cost": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 52,
+      "created_at": 1702153987,
+      "hex": "G28",
+      "tile": "8-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 53,
+      "created_at": 1702154022
+    },
+    {
+      "type": "run_routes",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 54,
+      "created_at": 1702154043,
+      "routes": [
+        {
+          "train": "2-9",
+          "connections": [
+            [
+              "H27",
+              "I26"
+            ]
+          ],
+          "hexes": [
+            "H27",
+            "I26"
+          ],
+          "revenue": 40,
+          "revenue_str": "H27-I26",
+          "subsidy": 0,
+          "nodes": [
+            "H27-0",
+            "I26-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "pass",
+      "entity": "5",
+      "entity_type": "minor",
+      "id": 55,
+      "created_at": 1702154048
+    },
+    {
+      "type": "lay_tile",
+      "entity": "7",
+      "entity_type": "minor",
+      "id": 56,
+      "created_at": 1702154460,
+      "hex": "G10",
+      "tile": "L32-2",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "7",
+      "entity_type": "minor",
+      "id": 57,
+      "created_at": 1702154464,
+      "hex": "G8",
+      "tile": "8-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "7",
+      "entity_type": "minor",
+      "id": 58,
+      "created_at": 1702154468
+    },
+    {
+      "type": "pass",
+      "entity": "7",
+      "entity_type": "minor",
+      "id": 59,
+      "created_at": 1702154473
+    },
+    {
+      "type": "lay_tile",
+      "entity": "8",
+      "entity_type": "minor",
+      "id": 60,
+      "created_at": 1702154483,
+      "hex": "H5",
+      "tile": "6-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "8",
+      "entity_type": "minor",
+      "id": 61,
+      "created_at": 1702154486,
+      "hex": "H3",
+      "tile": "9-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "8",
+      "entity_type": "minor",
+      "id": 62,
+      "created_at": 1702154489
+    },
+    {
+      "type": "special_buy",
+      "entity": "8",
+      "entity_type": "minor",
+      "id": 63,
+      "created_at": 1702154501,
+      "description": "+20 Offboard Bonus [RABA]",
+      "cost": 10
+    },
+    {
+      "type": "run_routes",
+      "entity": "8",
+      "entity_type": "minor",
+      "id": 64,
+      "created_at": 1702154508,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "H5",
+              "H3",
+              "H1"
+            ]
+          ],
+          "hexes": [
+            "H5",
+            "H1"
+          ],
+          "revenue": 60,
+          "revenue_str": "H5-H1 (RABA)",
+          "subsidy": 0,
+          "nodes": [
+            "H5-0",
+            "H1-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "pass",
+      "entity": "8",
+      "entity_type": "minor",
+      "id": 65,
+      "created_at": 1702154511
+    },
+    {
+      "type": "lay_tile",
+      "entity": "9",
+      "entity_type": "minor",
+      "id": 66,
+      "created_at": 1702155806,
+      "hex": "I14",
+      "tile": "L32-3",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "9",
+      "entity_type": "minor",
+      "id": 67,
+      "created_at": 1702155821,
+      "hex": "H13",
+      "tile": "58-2",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "9",
+      "entity_type": "minor",
+      "id": 68,
+      "created_at": 1702155832
+    },
+    {
+      "type": "run_routes",
+      "entity": "9",
+      "entity_type": "minor",
+      "id": 69,
+      "created_at": 1702155850,
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "I14",
+              "H13"
+            ]
+          ],
+          "hexes": [
+            "H13",
+            "I14"
+          ],
+          "revenue": 40,
+          "revenue_str": "H13-I14",
+          "subsidy": 0,
+          "nodes": [
+            "I14-0",
+            "H13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "pass",
+      "entity": "9",
+      "entity_type": "minor",
+      "id": 70,
+      "created_at": 1702155886
+    },
+    {
+      "type": "lay_tile",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 71,
+      "created_at": 1702155921,
+      "hex": "H17",
+      "tile": "57-3",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 72,
+      "created_at": 1702155931,
+      "hex": "G18",
+      "tile": "58-3",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 73,
+      "created_at": 1702155938
+    },
+    {
+      "type": "run_routes",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 74,
+      "created_at": 1702155946,
+      "routes": [
+        {
+          "train": "2-10",
+          "connections": [
+            [
+              "H17",
+              "G18"
+            ]
+          ],
+          "hexes": [
+            "G18",
+            "H17"
+          ],
+          "revenue": 30,
+          "revenue_str": "G18-H17",
+          "subsidy": 0,
+          "nodes": [
+            "H17-0",
+            "G18-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "pass",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 75,
+      "created_at": 1702155977
+    },
+    {
+      "hex": "D7",
+      "tile": "6-1",
+      "type": "lay_tile",
+      "entity": "11",
+      "rotation": 2,
+      "entity_type": "minor",
+      "id": 76,
+      "user": 4217,
+      "created_at": 1702159207
+    },
+    {
+      "type": "pass",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 77,
+      "user": 4217,
+      "created_at": 1702159608
+    },
+    {
+      "type": "undo",
+      "entity": "11",
+      "action_id": 75,
+      "entity_type": "minor",
+      "id": 78,
+      "user": 4217,
+      "created_at": 1702159631
+    },
+    {
+      "type": "lay_tile",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 79,
+      "created_at": 1702159637,
+      "hex": "D7",
+      "tile": "6-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 80,
+      "created_at": 1702159643,
+      "hex": "E6",
+      "tile": "58-4",
+      "rotation": 3
+    },
+    {
+      "type": "choose_ability",
+      "entity": "MA",
+      "entity_type": "company",
+      "id": 81,
+      "created_at": 1702159649,
+      "choice": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 82,
+      "created_at": 1702159654
+    },
+    {
+      "type": "undo",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 85,
+      "user": 4217,
+      "created_at": 1702162940
+    },
+    {
+      "type": "redo",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 86,
+      "user": 4217,
+      "created_at": 1702162955
+    },
+    {
+      "type": "undo",
+      "entity": "11",
+      "action_id": 75,
+      "entity_type": "minor",
+      "id": 89,
+      "user": 4217,
+      "created_at": 1702275662
+    },
+    {
+      "type": "undo",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 90,
+      "user": 4217,
+      "created_at": 1702275676
+    },
+    {
+      "type": "redo",
+      "entity": "10",
+      "entity_type": "minor",
+      "id": 91,
+      "user": 4217,
+      "created_at": 1702275679
+    },
+    {
+      "type": "redo",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 92,
+      "user": 4217,
+      "created_at": 1702275682
+    },
+    {
+      "type": "run_routes",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 93,
+      "created_at": 1702315118,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "C6",
+              "D7"
+            ],
+            [
+              "D7",
+              "E6"
+            ]
+          ],
+          "hexes": [
+            "C6",
+            "D7",
+            "E6"
+          ],
+          "revenue": 60,
+          "revenue_str": "C6-D7-E6",
+          "subsidy": 0,
+          "nodes": [
+            "C6-0",
+            "D7-0",
+            "E6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "end_game",
+      "entity": "11",
+      "entity_type": "minor",
+      "id": 94,
+      "created_at": 1702347453
+    }
+  ],
+  "id": "hs_ivrwgdko_144021",
+  "players": [
+    {
+      "id": 1090,
+      "name": "Guido65"
+    },
+    {
+      "id": 11205,
+      "name": "Szhveronika"
+    },
+    {
+      "id": 4217,
+      "name": "queroscia"
+    },
+    {
+      "id": 3864,
+      "name": "Michal(UTC)"
+    }
+  ],
+  "title": "18Mag",
+  "description": "EU fast async",
+  "min_players": 2,
+  "max_players": 4,
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "settings": {
+    "seed": 967221989,
+    "is_async": true,
+    "unlisted": false,
+    "auto_routing": true,
+    "player_order": null,
+    "optional_rules": [
+      "standard_divs",
+      "new_major",
+      "supporters"
+    ]
+  },
+  "user_settings": null,
+  "turn": 1,
+  "round": "Operating Round",
+  "acting": [
+    4217
+  ],
+  "result": {"1090":140, "11205":95, "3864":135, "4217":125},
+  "loaded": true,
+  "created_at": "2023-12-11",
+  "updated_at": 1702347453,
+  "finished_at": null,
+  "manually_ended": true,
+  "mode": "hotseat"
+}


### PR DESCRIPTION
Fixes #9996

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Explicitely convert the number of paying stops to an int 

This seems to be an issue w/ Opal, as there have been other patches (including in the line below this one) that fix similar issues

Includes a fixture to test this fix

* **Screenshots**

* **Any Assumptions / Hacks**
