### PR TITLE
[multiple] Adjust CSS to not add extra bar under minor companies.

### DIFF
--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -104,6 +104,7 @@ module View
             fontSize: '80%',
             textAlign: 'left',
             fontWeight: 'normal',
+            whiteSpace: 'pre-line',
           }
 
           value_style = {

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -836,7 +836,7 @@ module Engine
         end
 
         def empty_auction_slot
-          @empty_auction_slot ||= Engine::Company.new(sym: '', name: '', value: nil, revenue: nil, desc: '', color: 'LightGrey')
+          @empty_auction_slot ||= Engine::Company.new(sym: '', name: '', value: nil, revenue: nil, desc: "\n"*3, color: 'LightGrey')
         end
 
         def company_header(company)

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -836,7 +836,8 @@ module Engine
         end
 
         def empty_auction_slot
-          @empty_auction_slot ||= Engine::Company.new(sym: '', name: '', value: nil, revenue: nil, desc: "\n"*3, color: 'LightGrey')
+          @empty_auction_slot ||= Engine::Company.new(sym: '', name: '', value: nil, revenue: nil, desc: "\n" * 3,
+                                                      color: 'LightGrey')
         end
 
         def company_header(company)

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -344,7 +344,6 @@ text.number {
   border: 1px solid gainsboro;
   border-radius: 0.7rem;
   align-self: start;
-  min-height: 100px;
 }
 .game.card {
   margin: 0 0.5rem 0.5rem 0;


### PR DESCRIPTION
<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

    In fbcd3ed `min-height:100px` was added to the `.card` css to ensure that the empty slots in the 1817 auction were not too short (my assumption).  In other games, this adds tiny bars to some of the minor corp cards that don't have much info.  This change reverts the `min-height` and replaces it with a description of a few newlines for those empty slot companies.  To allow this to work, the description style now has the `whiteSpace: 'pre-line',` property, which is identical to `normal` except that it preserves newlines.  I didn't see any newlines in any other company descriptions.

* **Screenshots**

    #### 18EU & 1880
    | Old      | New |
    | ----------- | ----------- |
    | ![image](https://github.com/tobymao/18xx/assets/5263073/3182d8ff-e05c-4581-b7aa-ef7938023a44) | ![image](https://github.com/tobymao/18xx/assets/5263073/ec845d68-998c-49a5-88e6-9f4b4549b4de) |

    #### 1817 Empty Slot (Changes practically invisible, Empty Slot Card is bigger)
    | Old      | New |
    | ----------- | ----------- |
    | ![image](https://github.com/tobymao/18xx/assets/5263073/005fdcec-c730-411e-8075-1f9a698d3153) | ![image](https://github.com/tobymao/18xx/assets/5263073/dd50be2f-f8da-487f-b561-470a859e6ab0)  |

* **Any Assumptions / Hacks**
    My assumption is that 1817 is the only place where cards need to be inflated like this.
