### PR TITLE
[18EU] show bidders on corporation cards

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -166,7 +166,7 @@ module View
             textAlign: 'center',
             fontWeight: 'bold',
             padding: '0.5rem',
-          }
+          },
         }
 
         rows = @bids

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -13,6 +13,7 @@ module View
       include Lib::Settings
 
       needs :user, default: nil, store: true
+      needs :bids, default: nil
       needs :corporation
       needs :selected_company, default: nil, store: true
       needs :selected_corporation, default: nil, store: true
@@ -80,6 +81,7 @@ module View
         end
         abilities_to_display = @corporation.all_abilities.select(&:description)
         children << render_abilities(abilities_to_display) if abilities_to_display.any?
+        children << render_bidders if @bids&.any?
 
         extras = []
         if @game.corporation_show_loans?(@corporation)
@@ -145,6 +147,56 @@ module View
         end
 
         h('div.corp.card', { style: card_style, on: { click: select_corporation } }, children)
+      end
+
+      def render_bidders
+        table_props = {
+          style: {
+            margin: '0 auto',
+            borderSpacing: '0 1px',
+            fontWeight: 'normal',
+          },
+        }
+
+        header_props = {
+          style: {
+            textAlign: 'center',
+            fontWeight: 'bold',
+            padding: '0.5rem',
+          }
+        }
+
+        rows = @bids
+          .sort_by(&:price)
+          .reverse.map.with_index do |bid, i|
+            bg_color =
+              if setting_for(:show_player_colors, @game)
+                player_colors(@game.players)[bid.entity]
+              elsif @user && bid.entity.name == @user['name']
+                color_for(i.zero? ? :green : :yellow)
+              else
+                color_for(:bg)
+              end
+            props = {
+              style: {
+                backgroundColor: bg_color,
+                color: contrast_on(bg_color),
+              },
+            }
+            h(:tr, props, [
+              h('td.left', bid.entity.name.truncate(20)),
+              h('td.right', bid.price >= 0 ? @game.format_currency(bid.price) : '--'),
+            ])
+          end
+
+        h(:div, header_props, [
+           h(:label, 'Bidders:'),
+           h(:table, table_props, [
+             h(:tbody, [
+               *rows,
+             ]),
+           ]),
+        ])
       end
 
       def render_title(bg = nil)

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -158,8 +158,11 @@ module View
           },
         }
 
+        # almost identical to render_bidders in view/game/company
+        # except for  minor CSS tweaks for padding/text alignment
         header_props = {
           style: {
+            clear: 'both',
             textAlign: 'center',
             fontWeight: 'bold',
             padding: '0.5rem',

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -273,7 +273,7 @@ module View
           }
 
           @step.available.select(&:minor?).map do |minor|
-            children = [h(Corporation, corporation: minor)]
+            children = [h(Corporation, corporation: minor, bids: @step&.bids[minor])]
             children << render_minor_input(minor) if @selected_corporation == minor
             h(:div, props, children)
           end

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -273,7 +273,7 @@ module View
           }
 
           @step.available.select(&:minor?).map do |minor|
-            children = [h(Corporation, corporation: minor, bids: @step&.bids[minor])]
+            children = [h(Corporation, corporation: minor, bids: @step&.bids&.dig(minor))]
             children << render_minor_input(minor) if @selected_corporation == minor
             h(:div, props, children)
           end

--- a/lib/engine/game/g_18_eu/step/modified_dutch_auction.rb
+++ b/lib/engine/game/g_18_eu/step/modified_dutch_auction.rb
@@ -91,6 +91,9 @@ module Engine
 
           def remove_from_auction(entity)
             @active_bidders.delete(entity)
+            @bids[@auctioning]&.reject! do |bid|
+              bid.entity == entity
+            end
             resolve_bids
           end
 


### PR DESCRIPTION
<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

    Noticed while looking at #9945, because that minor does have bids on it, but they're not shown, so it's tough to tell.

    In an `Auction` round, if minors are being displayed, show bids if there are any for that minor.  Most applicable for 18EU.  I couldn't find another game with the right set of criteria to benefit from this.  Some don't use actual minors, just corporations with the type "minor", and some use other rounds that don't inherit from Auction.

* **Screenshots**


    #### 18EU
    | Old      | New |
    | ----------- | ----------- |
    | ![image](https://github.com/tobymao/18xx/assets/5263073/7675cf9d-073a-4473-bd22-c9cb982884e2) | ![image](https://github.com/tobymao/18xx/assets/5263073/01c38ae0-1918-4e36-bff8-49a6c5640601) |

* **Any Assumptions / Hacks**
