### PR TITLE
1850jr init commit and to alpha

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -17,7 +17,9 @@ module View
 
     def render_notification
       message = <<~MESSAGE
-        <p><a href="https://github.com/tobymao/18xx/wiki/1868%20Wyoming">1868 Wyoming</a> and <a href="https://github.com/tobymao/18xx/wiki/18NL">18NL</a> are in beta.</p>
+        <p><a href="https://github.com/tobymao/18xx/wiki/1850Jr">1850jr</a> is in alpha,
+        <a href="https://github.com/tobymao/18xx/wiki/1868%20Wyoming">1868 Wyoming</a> and
+        <a href="https://github.com/tobymao/18xx/wiki/18NL">18NL</a> are in beta.</p>
         <p>Learn how to get <a href='https://github.com/tobymao/18xx/wiki/Notifications'>notifications</a> by email, Slack, Discord, and Telegram.</p>
         <p>Please submit problem reports and make suggestions for improvements on
         <a href='https://github.com/tobymao/18xx/issues'>GitHub</a>. Join the

--- a/lib/engine/game/g_1850_jr.rb
+++ b/lib/engine/game/g_1850_jr.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1850Jr
+    end
+  end
+end

--- a/lib/engine/game/g_1850_jr/entities.rb
+++ b/lib/engine/game/g_1850_jr/entities.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1850Jr
+      module Entities
+        COMPANIES = [
+          {
+            name: 'Trenino Corleone-Monreale',
+            sym: 'TCM',
+            value: 40,
+            revenue: 10,
+            desc: 'A corporation owning the TCM may lay a tile on D4 without cost, even if this hex is not connected'\
+                  " to the corporation's track. This free tile placement is in addition to the corporation's normal tile"\
+                  ' placement. Blocks D4 while owned by a player.',
+            abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['D4'] },
+                        {
+                          type: 'tile_lay',
+                          owner_type: 'corporation',
+                          hexes: ['D4'],
+                          free: true,
+                          tiles: %w[7 8 9],
+                          when: 'owning_corp_or_turn',
+                          count: 1,
+                        }],
+            color: nil,
+          },
+          {
+            name: 'Ferrovia Siracusana Marittima',
+            sym: 'FSM',
+            value: 110,
+            revenue: 20,
+            desc: 'A player owning the MH may exchange it for a 10% share of the SFA if they do not already hold 60%'\
+                  ' of the SFA and there is SFA stock available in the Bank or the Pool. The exchange may be made during'\
+                  " the player's turn of a stock round or between the turns of other players or corporations in either "\
+                  'stock or operating rounds. This action closes the private company. Blocks G9 while owned by a player.',
+            abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['G9'] },
+                        {
+                          type: 'exchange',
+                          corporations: ['SFA'],
+                          owner_type: 'player',
+                          when: 'any',
+                          from: %w[ipo market],
+                        }],
+            color: nil,
+          },
+          {
+            name: 'Strada di Ferro Trinacria',
+            sym: 'SFT',
+            value: 220,
+            revenue: 30,
+            desc: "The owner of this private company immediately receives the President's certificate of the"\
+                  ' IFT without further payment. This private company may not be sold to any corporation, and does'\
+                  ' not exchange hands if the owning player loses the Presidency of the IFT.'\
+                  ' When the IFT purchases its first train the private company is closed.'\
+                  ' Blocks F6 & G5 while owned by a player.',
+            abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: %w[F6 G5] },
+                        { type: 'close', when: 'bought_train', corporation: 'IFT' },
+                        { type: 'no_buy' },
+                        { type: 'shares', shares: 'IFT_0' }],
+            color: nil,
+          },
+        ].freeze
+
+        CORPORATIONS = [
+          {
+            float_percent: 60,
+            sym: 'IFT',
+            name: 'Impresa Ferroviaria Trinacria',
+            logo: '1849/IFT',
+            simple_logo: '1849/IFT.alt',
+            tokens: [0, 40, 100],
+            coordinates: 'G5',
+            color: '#0189d1',
+          },
+          {
+            float_percent: 60,
+            sym: 'SFA',
+            name: 'Società Ferroviaria Akragas',
+            logo: '1849/SFA',
+            simple_logo: '1849/SFA.alt',
+            tokens: [0, 40, 100, 100],
+            coordinates: 'D6',
+            color: :pink,
+            text_color: 'black',
+          },
+          {
+            float_percent: 60,
+            sym: 'CTL',
+            name: 'Compagnia Transporti Lilibeo',
+            logo: '1849/CTL',
+            simple_logo: '1849/CTL.alt',
+            tokens: [0, 40, 100],
+            coordinates: 'B4',
+            color: :'#FFF500',
+            text_color: 'black',
+          },
+          {
+            float_percent: 60,
+            sym: 'RCS',
+            name: 'Rete Centrale Sicula',
+            logo: '1849/RCS',
+            simple_logo: '1849/RCS.alt',
+            tokens: [0, 40],
+            coordinates: 'D2',
+            city: 1,
+            color: '#f48221',
+          },
+        ].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1850_jr/game.rb
+++ b/lib/engine/game/g_1850_jr/game.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require_relative 'entities'
+require_relative 'map'
+require_relative 'meta'
+require_relative '../base'
+
+module Engine
+  module Game
+    module G1850Jr
+      class Game < Game::Base
+        include_meta(G1850Jr::Meta)
+        include Entities
+        include Map
+
+        register_colors(orange: '#f58121',
+                        black: '#110a0c',
+                        blue: '#025aaa',
+                        yellow: '#ffe600',
+                        green: '#32763f')
+        TRACK_RESTRICTION = :permissive
+        SELL_BUY_ORDER = :sell_buy_sell
+        TILE_RESERVATION_BLOCKS_OTHERS = :always
+        CURRENCY_FORMAT_STR = 'L.%s'
+
+        BANK_CASH = 6000
+
+        CERT_LIMIT = { 3 => 10, 4 => 8, 5 => 6, 6 => 5 }.freeze
+
+        STARTING_CASH = { 3 => 680, 4 => 510, 5 => 408, 6 => 340 }.freeze
+
+        MARKET = [
+          %w[60y 67 71 76 82 90 100p 112 126 142 160 180 200 225 250 275 300 325 350],
+          %w[53y 60y 66 70 76 82 90p 100 112 126 142 160 180 200 220 240 260 280 300],
+          %w[46y 55y 60y 65 70 76 82p 90 100 111 125 140 155 170 185 200],
+          %w[39o 48y 54y 60y 66 71 76p 82 90 100 110 120 130],
+          %w[32o 41o 48y 55y 62 67 71p 76 82 90 100],
+          %w[25b 34o 42o 50y 58y 65 67p 71 75 80],
+          %w[18b 27b 36o 45o 54y 63 67 69 70],
+          %w[10b 20b 30b 40o 50y 60y 67 68],
+          ['', '10b', '20b', '30b', '40o', '50y', '60y'],
+          ['', '', '10b', '20b', '30b', '40o', '50y'],
+          ['', '', '', '10b', '20b', '30b', '40o'],
+        ].freeze
+
+        PHASES = [{
+          name: '2',
+          train_limit: 4,
+          tiles: [:yellow],
+          operating_rounds: 1,
+          status: ['limited_train_buy'],
+        },
+                  {
+                    name: '3',
+                    on: '3',
+                    train_limit: 4,
+                    tiles: %i[yellow green],
+                    operating_rounds: 2,
+                    status: %w[can_buy_companies limited_train_buy],
+                  },
+                  {
+                    name: '4',
+                    on: '4',
+                    train_limit: 3,
+                    tiles: %i[yellow green],
+                    operating_rounds: 2,
+                    status: %w[can_buy_companies limited_train_buy],
+                  },
+                  {
+                    name: '5',
+                    on: '5',
+                    train_limit: 2,
+                    tiles: %i[yellow green brown],
+                    operating_rounds: 3,
+                    status: ['limited_train_buy'],
+                  },
+                  {
+                    name: '6',
+                    on: '6',
+                    train_limit: 2,
+                    tiles: %i[yellow green brown],
+                    operating_rounds: 3,
+                    status: ['limited_train_buy'],
+                  },
+                  {
+                    name: 'D',
+                    on: 'D',
+                    train_limit: 2,
+                    tiles: %i[yellow green brown],
+                    operating_rounds: 3,
+                    status: ['limited_train_buy'],
+                  }].freeze
+
+        TRAINS = [{ name: '2', distance: 2, price: 80, rusts_on: '4', num: 3 },
+                  { name: '3', distance: 3, price: 180, rusts_on: '6', num: 3 },
+                  { name: '4', distance: 4, price: 300, rusts_on: 'D', num: 2 },
+                  {
+                    name: '5',
+                    distance: 5,
+                    price: 450,
+                    num: 1,
+                    events: [{ 'type' => 'close_companies' }],
+                  },
+                  { name: '6', distance: 6, price: 630, num: 1 },
+                  {
+                    name: 'D',
+                    distance: 999,
+                    price: 1100,
+                    num: 4,
+                    discount: { '4' => 300, '5' => 300, '6' => 300 },
+                  }].freeze
+
+        def operating_round(round_num)
+          Round::Operating.new(self, [
+            Engine::Step::Bankrupt,
+            Engine::Step::Exchange,
+            Engine::Step::SpecialTrack,
+            Engine::Step::BuyCompany,
+            Engine::Step::HomeToken,
+            Engine::Step::Track,
+            Engine::Step::Token,
+            Engine::Step::Route,
+            Engine::Step::Dividend,
+            Engine::Step::DiscardTrain,
+            Engine::Step::SingleDepotTrainBuy,
+            [Engine::Step::BuyCompany, { blocks: true }],
+          ], round_num: round_num)
+        end
+
+        STATUS_TEXT = Base::STATUS_TEXT.merge(Engine::Step::SingleDepotTrainBuy::STATUS_TEXT).freeze
+
+        def revenue_for(route, stops)
+          revenue = super
+
+          port = stops.find { |stop| stop.groups.include?('port') }
+
+          if port
+            raise GameError, "#{port.tile.location_name} must contain 2 other stops" if stops.size < 3
+
+            revenue += (revenue / 2).floor(-1)
+          end
+
+          revenue
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1850_jr/map.rb
+++ b/lib/engine/game/g_1850_jr/map.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1850Jr
+      module Map
+        TILES = {
+          # yellow
+          '1' => 1,
+          '2' => 1,
+          '3' => 2,
+          '4' => 2,
+          '7' => 4,
+          '8' => 8,
+          '9' => 7,
+          '55' => 1,
+          '56' => 1,
+          '57' => 4,
+          '58' => 2,
+          '69' => 1,
+          # green
+          '14' => 3,
+          '15' => 2,
+          '16' => 1,
+          '18' => 1,
+          '19' => 1,
+          '20' => 1,
+          '23' => 3,
+          '24' => 3,
+          '25' => 1,
+          '26' => 1,
+          '27' => 1,
+          '28' => 1,
+          '29' => 1,
+          '53' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:50;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0;label=C',
+          },
+          '54' =>
+          {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:60;city=revenue:60;path=a:0,b:_0;path=a:5,b:_0;path=a:1,b:_1;path=a:2,b:_1;label=P',
+          },
+          '59' => 1,
+          # brown
+          '39' => 1,
+          '40' => 1,
+          '41' => 2,
+          '42' => 2,
+          '43' => 2,
+          '44' => 1,
+          '45' => 2,
+          '46' => 2,
+          '47' => 1,
+          '61' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:60;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:1,b:_0;label=C',
+          },
+          '62' =>
+          {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:80,slots:2;city=revenue:80,slots:2;path=a:0,b:_0;'\
+                      'path=a:5,b:_0;path=a:1,b:_1;path=a:2,b:_1;label=P',
+          },
+          '63' => 2,
+          '64' => 1,
+          '65' => 1,
+          '66' => 1,
+          '67' => 1,
+          '68' => 1,
+          '70' => 1,
+        }.freeze
+
+        LOCATION_NAMES = {
+          'A5' => 'Tunisia',
+          'B4' => 'Trapani & Marsala',
+          'C1' => 'Genova',
+          'C3' => 'Partinico & Alcamo',
+          'D2' => 'Palermo',
+          'D6' => 'Girgenti',
+          'E5' => 'Caltanissetta',
+          'E9' => 'Malta',
+          'F2' => 'San Stefano',
+          'F6' => 'Caltagirone',
+          'F8' => 'Terranova',
+          'G5' => 'Catania',
+          'H0' => 'Napoli',
+          'H2' => 'Messina',
+          'H8' => 'Siracusa',
+          'I1' => 'Villa San Giovanni',
+          'I3' => 'Taranto',
+        }.freeze
+
+        HEXES = {
+          blue: {
+            %w[A5 E9] => 'offboard=revenue:yellow_0,groups:port,route:never;path=a:4,b:_0;icon=image:port;',
+            ['C1'] => 'offboard=revenue:yellow_0,groups:port,route:never;path=a:5,b:_0;icon=image:port;'\
+                      'border=edge:0,type:impassable',
+            ['H0'] => 'offboard=revenue:yellow_0,groups:port,route:never;path=a:0,b:_0;icon=image:port',
+            ['I1'] => 'offboard=revenue:yellow_0,groups:port,route:never;path=a:1,b:_0;icon=image:port',
+            ['I3'] => 'offboard=revenue:yellow_0,groups:port,route:never;path=a:2,b:_0;icon=image:port',
+          },
+          white: {
+            %w[B2 E3 E7 G9 H4] => '',
+            %w[C5 D4 F4 G7] => 'upgrade=cost:120,terrain:mountain',
+            %w[D6 F8 H2] => 'city=revenue:0',
+            %w[F2 F6] => 'town=revenue:0;upgrade=cost:120,terrain:mountain',
+            ['G3'] => 'upgrade=cost:120,terrain:mountain;border=edge:0,type:impassable',
+            ['C3'] => 'town=revenue:0;town=revenue:0;border=edge:3,type:impassable',
+            ['E5'] => 'city=revenue:0;upgrade=cost:120,terrain:mountain',
+          },
+          yellow: {
+            ['B4'] => 'city=revenue:0;city=revenue:0;label=OO',
+            ['D2'] => 'city=revenue:40;city=revenue:40;path=a:2,b:_0;path=a:5,b:_1;label=P',
+            ['G5'] => 'city=revenue:30;path=a:0,b:_0;path=a:4,b:_0;border=edge:3,type:impassable;label=C',
+          },
+          gray: {
+            ['A3'] => 'path=a:4,b:5',
+            ['G1'] => 'path=a:1,b:5',
+            ['H6'] => 'path=a:0,b:1',
+            ['H8'] => 'city=revenue:30;path=a:1,b:_0;path=a:3,b:_0',
+          },
+        }.freeze
+
+        LAYOUT = :flat
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1850_jr/meta.rb
+++ b/lib/engine/game/g_1850_jr/meta.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../meta'
+
+module Engine
+  module Game
+    module G1850Jr
+      module Meta
+        include Game::Meta
+
+        DEV_STAGE = :alpha
+
+        GAME_DESIGNER = 'Gabriele Callari, Fabio Pellegrino'
+        GAME_LOCATION = 'Sicily'
+        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/268508/rules-english'
+        GAME_INFO_URL = ''
+
+        PLAYER_RANGE = [3, 6].freeze
+      end
+    end
+  end
+end

--- a/public/fixtures/1850Jr/hotseat.json
+++ b/public/fixtures/1850Jr/hotseat.json
@@ -1,0 +1,4572 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1702604690,
+      "company": "FSM",
+      "price": 115
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1702604692,
+      "company": "FSM",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1702604698,
+      "company": "TCM",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1702604700,
+      "company": "FSM",
+      "price": 125
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1702604701
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1702604704
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1702604706,
+      "company": "SFT",
+      "price": 220
+    },
+    {
+      "type": "par",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1702604707,
+      "corporation": "IFT",
+      "share_price": "100,0,6"
+    },
+    {
+      "type": "par",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1702604719,
+      "corporation": "SFA",
+      "share_price": "100,0,6"
+    },
+    {
+      "type": "par",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1702604723,
+      "corporation": "RCS",
+      "share_price": "90,1,6"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1702604725,
+      "shares": [
+        "IFT_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1702604726,
+      "shares": [
+        "SFA_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1702604727,
+      "shares": [
+        "RCS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1702604729,
+      "shares": [
+        "IFT_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1702604730,
+      "shares": [
+        "SFA_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1702604731,
+      "shares": [
+        "RCS_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1702604732,
+      "shares": [
+        "IFT_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1702604733,
+      "shares": [
+        "SFA_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1702604734,
+      "shares": [
+        "RCS_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1702604737,
+      "shares": [
+        "IFT_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1702604738,
+      "shares": [
+        "SFA_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1702604740,
+      "shares": [
+        "RCS_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 23,
+      "created_at": 1702604759,
+      "hex": "G7",
+      "tile": "7-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 24,
+      "created_at": 1702604764
+    },
+    {
+      "type": "buy_train",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 25,
+      "created_at": 1702604766,
+      "train": "2-0",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 26,
+      "created_at": 1702604780,
+      "hex": "D6",
+      "tile": "57-0",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 27,
+      "created_at": 1702604788,
+      "train": "2-1",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "undo",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 28,
+      "created_at": 1702604800
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 29,
+      "created_at": 1702604803
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 30,
+      "created_at": 1702604822,
+      "hex": "E3",
+      "tile": "8-0",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 31,
+      "created_at": 1702604824,
+      "train": "2-1",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 32,
+      "created_at": 1702604842
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 33,
+      "created_at": 1702604850,
+      "shares": [
+        "RCS_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1702604852
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1702604853
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1702604855
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 37,
+      "created_at": 1702604855
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 38,
+      "created_at": 1702604861,
+      "hex": "H4",
+      "tile": "8-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 39,
+      "created_at": 1702604862
+    },
+    {
+      "type": "run_routes",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 40,
+      "created_at": 1702604864,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "G5",
+              "G7",
+              "H6",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G5",
+            "H8"
+          ],
+          "revenue": 60,
+          "revenue_str": "G5-H8",
+          "nodes": [
+            "G5-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 41,
+      "created_at": 1702604866,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 42,
+      "created_at": 1702604869,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "undo",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 43,
+      "created_at": 1702604877
+    },
+    {
+      "type": "pass",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 44,
+      "created_at": 1702604879
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 45,
+      "created_at": 1702604886,
+      "hex": "E7",
+      "tile": "7-1",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 46,
+      "created_at": 1702604891,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 47,
+      "created_at": 1702604901
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 48,
+      "created_at": 1702604905,
+      "hex": "E5",
+      "tile": "57-1",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 49,
+      "created_at": 1702604908,
+      "city": "57-1-0",
+      "slot": 0,
+      "tokener": "RCS"
+    },
+    {
+      "type": "run_routes",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 50,
+      "created_at": 1702604912,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "D2",
+              "E3",
+              "E5"
+            ]
+          ],
+          "hexes": [
+            "D2",
+            "E5"
+          ],
+          "revenue": 60,
+          "revenue_str": "D2-E5",
+          "nodes": [
+            "D2-1",
+            "E5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 51,
+      "created_at": 1702604912,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 52,
+      "created_at": 1702604914,
+      "train": "3-0",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "buy_company",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 53,
+      "created_at": 1702604919,
+      "company": "FSM",
+      "price": 220
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 54,
+      "created_at": 1702604921
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 55,
+      "created_at": 1702604922
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 56,
+      "created_at": 1702604932
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 57,
+      "created_at": 1702604936,
+      "shares": [
+        "RCS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "undo",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 58,
+      "created_at": 1702604943
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 59,
+      "created_at": 1702604956,
+      "shares": [
+        "IFT_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 60,
+      "created_at": 1702604958
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 61,
+      "created_at": 1702604961
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 62,
+      "created_at": 1702604962
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 63,
+      "created_at": 1702604965,
+      "shares": [
+        "SFA_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 64,
+      "created_at": 1702604978,
+      "shares": [
+        "RCS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 65,
+      "created_at": 1702604982
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 66,
+      "created_at": 1702604984
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 67,
+      "created_at": 1702604993
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 68,
+      "created_at": 1702604995,
+      "shares": [
+        "IFT_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 69,
+      "created_at": 1702604997
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 70,
+      "created_at": 1702604998
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 71,
+      "created_at": 1702604998
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 72,
+      "created_at": 1702605001,
+      "shares": [
+        "IFT_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 73,
+      "created_at": 1702605002
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 74,
+      "created_at": 1702605003
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 75,
+      "created_at": 1702605003
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 76,
+      "created_at": 1702605003
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 77,
+      "created_at": 1702605014,
+      "hex": "G5",
+      "tile": "53-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 78,
+      "created_at": 1702605016
+    },
+    {
+      "type": "run_routes",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 79,
+      "created_at": 1702605018,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "G5",
+              "G7",
+              "H6",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G5",
+            "H8"
+          ],
+          "revenue": 80,
+          "revenue_str": "G5-H8",
+          "nodes": [
+            "G5-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 80,
+      "created_at": 1702605019,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 81,
+      "created_at": 1702605020,
+      "train": "3-1",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 82,
+      "created_at": 1702605023
+    },
+    {
+      "type": "pass",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 83,
+      "created_at": 1702605025
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 84,
+      "created_at": 1702605033,
+      "hex": "D2",
+      "tile": "54-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 85,
+      "created_at": 1702605043,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "E5",
+              "E7",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "E5",
+            "D6"
+          ],
+          "revenue": 40,
+          "revenue_str": "E5-D6",
+          "nodes": [
+            "E5-0",
+            "D6-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "D2",
+              "E3",
+              "E5"
+            ]
+          ],
+          "hexes": [
+            "D2",
+            "E5"
+          ],
+          "revenue": 80,
+          "revenue_str": "D2-E5",
+          "nodes": [
+            "D2-0",
+            "E5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 86,
+      "created_at": 1702605044,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 87,
+      "created_at": 1702605049
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 88,
+      "created_at": 1702605052
+    },
+    {
+      "type": "buy_company",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 89,
+      "created_at": 1702605061,
+      "company": "TCM",
+      "price": 80
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TCM",
+      "entity_type": "company",
+      "id": 90,
+      "created_at": 1702605068,
+      "hex": "D4",
+      "tile": "9-0",
+      "rotation": 0
+    },
+    {
+      "type": "undo",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 91,
+      "created_at": 1702605073
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TCM",
+      "entity_type": "company",
+      "id": 92,
+      "created_at": 1702605239,
+      "hex": "D4",
+      "tile": "9-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 93,
+      "created_at": 1702605243,
+      "hex": "D6",
+      "tile": "15-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 94,
+      "created_at": 1702605248,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "D6",
+              "D4",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "D2"
+          ],
+          "revenue": 90,
+          "revenue_str": "D6-D2",
+          "nodes": [
+            "D6-0",
+            "D2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 95,
+      "created_at": 1702605251,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 96,
+      "created_at": 1702605254,
+      "train": "3-2",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 97,
+      "created_at": 1702605257
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 98,
+      "created_at": 1702605262,
+      "hex": "H2",
+      "tile": "57-2",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 99,
+      "created_at": 1702605268,
+      "city": "57-2-0",
+      "slot": 0,
+      "tokener": "IFT"
+    },
+    {
+      "type": "run_routes",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 100,
+      "created_at": 1702605273,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "G5",
+              "H4",
+              "H2"
+            ],
+            [
+              "H2",
+              "H0"
+            ]
+          ],
+          "hexes": [
+            "G5",
+            "H2",
+            "H0"
+          ],
+          "revenue": 100,
+          "revenue_str": "G5-H2-H0",
+          "nodes": [
+            "G5-0",
+            "H2-0",
+            "H0-0"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "G5",
+              "G7",
+              "H6",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G5",
+            "H8"
+          ],
+          "revenue": 80,
+          "revenue_str": "G5-H8",
+          "nodes": [
+            "G5-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 101,
+      "created_at": 1702605282,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 102,
+      "created_at": 1702605296,
+      "train": "4-0",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 103,
+      "created_at": 1702605298
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 104,
+      "created_at": 1702605310,
+      "hex": "E5",
+      "tile": "14-0",
+      "rotation": 0
+    },
+    {
+      "type": "undo",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 105,
+      "created_at": 1702605324,
+      "action_id": 103
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 106,
+      "created_at": 1702605328,
+      "hex": "D4",
+      "tile": "26-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 107,
+      "created_at": 1702605334,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "E5",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "D4",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "E5",
+            "D2",
+            "D6"
+          ],
+          "revenue": 110,
+          "revenue_str": "E5-D2-D6",
+          "nodes": [
+            "E5-0",
+            "D2-0",
+            "D6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 108,
+      "created_at": 1702605335,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 109,
+      "created_at": 1702605338,
+      "train": "4-1",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 110,
+      "created_at": 1702605340
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 111,
+      "created_at": 1702605349,
+      "hex": "E5",
+      "tile": "15-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 112,
+      "created_at": 1702605357
+    },
+    {
+      "type": "run_routes",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 113,
+      "created_at": 1702605364,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "D2",
+              "D4",
+              "D6"
+            ],
+            [
+              "D6",
+              "E7",
+              "E5"
+            ]
+          ],
+          "hexes": [
+            "D2",
+            "D6",
+            "E5"
+          ],
+          "revenue": 120,
+          "revenue_str": "D2-D6-E5",
+          "nodes": [
+            "D2-0",
+            "D6-0",
+            "E5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 114,
+      "created_at": 1702605365,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 115,
+      "created_at": 1702605366,
+      "train": "5-0",
+      "price": 450,
+      "variant": "5"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 116,
+      "created_at": 1702605400,
+      "shares": [
+        "IFT_1",
+        "IFT_2",
+        "IFT_3",
+        "IFT_4",
+        "IFT_0"
+      ],
+      "percent": 50
+    },
+    {
+      "type": "undo",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 117,
+      "created_at": 1702605408
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 118,
+      "created_at": 1702605411,
+      "shares": [
+        "IFT_1",
+        "IFT_2",
+        "IFT_3",
+        "IFT_4"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "par",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 119,
+      "created_at": 1702605426,
+      "corporation": "CTL",
+      "share_price": "100,0,6"
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 120,
+      "created_at": 1702605430
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 121,
+      "created_at": 1702605456,
+      "shares": [
+        "IFT_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 122,
+      "created_at": 1702605461
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 123,
+      "created_at": 1702605467,
+      "shares": [
+        "IFT_7",
+        "IFT_0"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 124,
+      "created_at": 1702605472,
+      "shares": [
+        "RCS_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 125,
+      "created_at": 1702605477
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 126,
+      "created_at": 1702605478,
+      "shares": [
+        "CTL_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 127,
+      "created_at": 1702605482
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 128,
+      "created_at": 1702605495,
+      "shares": [
+        "RCS_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 129,
+      "created_at": 1702605496
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 130,
+      "created_at": 1702605504,
+      "shares": [
+        "SFA_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 131,
+      "created_at": 1702605508
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 132,
+      "created_at": 1702605511,
+      "shares": [
+        "CTL_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 133,
+      "created_at": 1702605513
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 134,
+      "created_at": 1702605526,
+      "shares": [
+        "CTL_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 135,
+      "created_at": 1702605527
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 136,
+      "created_at": 1702605533,
+      "shares": [
+        "SFA_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 137,
+      "created_at": 1702605534
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 138,
+      "created_at": 1702605536,
+      "shares": [
+        "CTL_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 139,
+      "created_at": 1702605537
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 140,
+      "created_at": 1702605538
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 141,
+      "created_at": 1702605549
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 142,
+      "created_at": 1702605559,
+      "shares": [
+        "SFA_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 143,
+      "created_at": 1702605561
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 144,
+      "created_at": 1702605561
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 145,
+      "created_at": 1702605562
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 146,
+      "created_at": 1702605565,
+      "shares": [
+        "CTL_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 147,
+      "created_at": 1702605566
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 148,
+      "created_at": 1702605566
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 149,
+      "created_at": 1702605567
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 150,
+      "created_at": 1702605568
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 151,
+      "created_at": 1702605594,
+      "hex": "C3",
+      "tile": "55-0",
+      "rotation": 1
+    },
+    {
+      "type": "undo",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 152,
+      "created_at": 1702605598
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 153,
+      "created_at": 1702605601,
+      "hex": "D2",
+      "tile": "62-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 154,
+      "created_at": 1702605607,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D2",
+              "D4",
+              "D6"
+            ],
+            [
+              "D6",
+              "E7",
+              "E5"
+            ]
+          ],
+          "hexes": [
+            "D2",
+            "D6",
+            "E5"
+          ],
+          "revenue": 140,
+          "revenue_str": "D2-D6-E5",
+          "nodes": [
+            "D2-0",
+            "D6-0",
+            "E5-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "D2",
+              "E3",
+              "E5"
+            ],
+            [
+              "E5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "D2",
+            "E5",
+            "D6"
+          ],
+          "revenue": 140,
+          "revenue_str": "D2-E5-D6",
+          "nodes": [
+            "D2-0",
+            "E5-0",
+            "D6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 155,
+      "created_at": 1702605608,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 156,
+      "created_at": 1702605644,
+      "hex": "C5",
+      "tile": "8-2",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 157,
+      "created_at": 1702605646
+    },
+    {
+      "type": "undo",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 158,
+      "created_at": 1702605653
+    },
+    {
+      "type": "place_token",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 159,
+      "created_at": 1702605655,
+      "city": "15-1-0",
+      "slot": 1,
+      "tokener": "SFA"
+    },
+    {
+      "type": "run_routes",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 160,
+      "created_at": 1702605658,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "D6",
+              "E7",
+              "E5"
+            ],
+            [
+              "E5",
+              "E3",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "E5",
+            "D2"
+          ],
+          "revenue": 140,
+          "revenue_str": "D6-E5-D2",
+          "nodes": [
+            "D6-0",
+            "E5-0",
+            "D2-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E5",
+              "D6"
+            ],
+            [
+              "D6",
+              "D4",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "E5",
+            "D6",
+            "D2"
+          ],
+          "revenue": 140,
+          "revenue_str": "E5-D6-D2",
+          "nodes": [
+            "E5-0",
+            "D6-0",
+            "D2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 161,
+      "created_at": 1702605659,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 162,
+      "created_at": 1702605666,
+      "hex": "B4",
+      "tile": "59-0",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 163,
+      "created_at": 1702605688,
+      "city": "59-0-0",
+      "slot": 0,
+      "tokener": "CTL"
+    },
+    {
+      "type": "undo",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 164,
+      "created_at": 1702605718
+    },
+    {
+      "type": "place_token",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 165,
+      "created_at": 1702605720,
+      "city": "59-0-1",
+      "slot": 0,
+      "tokener": "CTL"
+    },
+    {
+      "type": "buy_train",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 166,
+      "created_at": 1702605726,
+      "train": "6-0",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 167,
+      "created_at": 1702605730
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 168,
+      "created_at": 1702605742,
+      "hex": "F4",
+      "tile": "9-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 169,
+      "created_at": 1702605745
+    },
+    {
+      "type": "run_routes",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 170,
+      "created_at": 1702605750,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "H0",
+              "H2"
+            ],
+            [
+              "H2",
+              "H4",
+              "G5"
+            ],
+            [
+              "G5",
+              "G7",
+              "H6",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "H0",
+            "H2",
+            "G5",
+            "H8"
+          ],
+          "revenue": 150,
+          "revenue_str": "H0-H2-G5-H8",
+          "nodes": [
+            "H0-0",
+            "H2-0",
+            "G5-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 171,
+      "created_at": 1702605751,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 172,
+      "created_at": 1702605753
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 173,
+      "created_at": 1702605776,
+      "hex": "C3",
+      "tile": "69-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 174,
+      "created_at": 1702605788,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "C1",
+              "D2"
+            ],
+            [
+              "D2",
+              "C3"
+            ],
+            [
+              "C3",
+              "C5",
+              "D6"
+            ],
+            [
+              "D6",
+              "D4",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "C1",
+            "D2",
+            "C3",
+            "D6",
+            "D2"
+          ],
+          "revenue": 300,
+          "revenue_str": "C1-D2-C3-D6-D2",
+          "nodes": [
+            "C1-0",
+            "D2-1",
+            "C3-1",
+            "D6-0",
+            "D2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 175,
+      "created_at": 1702605796,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 176,
+      "created_at": 1702605798
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 177,
+      "created_at": 1702605806,
+      "hex": "E5",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 178,
+      "created_at": 1702605809,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D2",
+              "D4",
+              "D6"
+            ],
+            [
+              "D6",
+              "C5",
+              "C3"
+            ],
+            [
+              "C3",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "D2",
+            "D6",
+            "C3",
+            "D2"
+          ],
+          "revenue": 200,
+          "revenue_str": "D2-D6-C3-D2",
+          "nodes": [
+            "D2-0",
+            "D6-0",
+            "C3-1",
+            "D2-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 179,
+      "created_at": 1702605810,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 180,
+      "created_at": 1702605813
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 181,
+      "created_at": 1702605829,
+      "hex": "B4",
+      "tile": "68-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 182,
+      "created_at": 1702605840
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 183,
+      "created_at": 1702605846,
+      "hex": "E3",
+      "tile": "23-0",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 184,
+      "created_at": 1702605851,
+      "city": "62-0-0",
+      "slot": 1,
+      "tokener": "IFT"
+    },
+    {
+      "type": "undo",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 185,
+      "created_at": 1702605857
+    },
+    {
+      "type": "place_token",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 186,
+      "created_at": 1702605859,
+      "city": "15-0-0",
+      "slot": 1,
+      "tokener": "IFT"
+    },
+    {
+      "type": "run_routes",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 187,
+      "created_at": 1702605874,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "H0",
+              "H2"
+            ],
+            [
+              "H2",
+              "H4",
+              "G5"
+            ],
+            [
+              "G5",
+              "F4",
+              "E3",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "H0",
+            "H2",
+            "G5",
+            "D2"
+          ],
+          "revenue": 220,
+          "revenue_str": "H0-H2-G5-D2",
+          "nodes": [
+            "H0-0",
+            "H2-0",
+            "G5-0",
+            "D2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 188,
+      "created_at": 1702605875,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 189,
+      "created_at": 1702605880,
+      "train": "6-0",
+      "price": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 190,
+      "created_at": 1702605892,
+      "hex": "E3",
+      "tile": "45-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 191,
+      "created_at": 1702605897,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "C1",
+              "D2"
+            ],
+            [
+              "D2",
+              "C3"
+            ],
+            [
+              "C3",
+              "C5",
+              "D6"
+            ],
+            [
+              "D6",
+              "D4",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "C1",
+            "D2",
+            "C3",
+            "D6",
+            "D2"
+          ],
+          "revenue": 300,
+          "revenue_str": "C1-D2-C3-D6-D2",
+          "nodes": [
+            "C1-0",
+            "D2-1",
+            "C3-1",
+            "D6-0",
+            "D2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 192,
+      "created_at": 1702605898,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 193,
+      "created_at": 1702605899
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 194,
+      "created_at": 1702605900
+    },
+    {
+      "type": "run_routes",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 195,
+      "created_at": 1702605904,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D6",
+              "E7",
+              "E5"
+            ],
+            [
+              "E5",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "D4",
+              "C3"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "E5",
+            "D2",
+            "C3"
+          ],
+          "revenue": 160,
+          "revenue_str": "D6-E5-D2-C3",
+          "nodes": [
+            "D6-0",
+            "E5-0",
+            "D2-0",
+            "C3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "undo",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 196,
+      "created_at": 1702605909,
+      "action_id": 193
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 197,
+      "created_at": 1702605912,
+      "hex": "B2",
+      "tile": "8-3",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 198,
+      "created_at": 1702605916,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "B4",
+              "A3",
+              "B2",
+              "C3"
+            ],
+            [
+              "C3",
+              "D4",
+              "D2"
+            ],
+            [
+              "D2",
+              "E3",
+              "F4",
+              "G5"
+            ]
+          ],
+          "hexes": [
+            "B4",
+            "C3",
+            "D2",
+            "G5"
+          ],
+          "revenue": 190,
+          "revenue_str": "B4-C3-D2-G5",
+          "nodes": [
+            "B4-1",
+            "C3-0",
+            "D2-0",
+            "G5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 199,
+      "created_at": 1702605917,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 200,
+      "created_at": 1702605919
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 201,
+      "created_at": 1702605921
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 202,
+      "created_at": 1702605923
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 203,
+      "created_at": 1702605931,
+      "hex": "G5",
+      "tile": "61-0",
+      "rotation": 2
+    },
+    {
+      "type": "undo",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 204,
+      "created_at": 1702605967
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 205,
+      "created_at": 1702605977,
+      "hex": "G5",
+      "tile": "61-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 206,
+      "created_at": 1702605982,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G5",
+              "F4",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "D4",
+              "D6"
+            ],
+            [
+              "D6",
+              "C5",
+              "C3"
+            ],
+            [
+              "C3",
+              "D2"
+            ],
+            [
+              "D2",
+              "C1"
+            ]
+          ],
+          "hexes": [
+            "G5",
+            "D2",
+            "D6",
+            "C3",
+            "D2",
+            "C1"
+          ],
+          "revenue": 390,
+          "revenue_str": "G5-D2-D6-C3-D2-C1",
+          "nodes": [
+            "G5-0",
+            "D2-0",
+            "D6-0",
+            "C3-1",
+            "D2-1",
+            "C1-0"
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "H0",
+              "H2"
+            ],
+            [
+              "H2",
+              "H4",
+              "G5"
+            ],
+            [
+              "G5",
+              "G7",
+              "H6",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "H0",
+            "H2",
+            "G5",
+            "H8"
+          ],
+          "revenue": 160,
+          "revenue_str": "H0-H2-G5-H8",
+          "nodes": [
+            "H0-0",
+            "H2-0",
+            "G5-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 207,
+      "created_at": 1702605985,
+      "kind": "payout"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 208,
+      "created_at": 1702606002,
+      "shares": [
+        "CTL_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 209,
+      "created_at": 1702606007,
+      "shares": [
+        "RCS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 210,
+      "created_at": 1702606023
+    },
+    {
+      "type": "undo",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 211,
+      "created_at": 1702606035
+    },
+    {
+      "type": "undo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 212,
+      "created_at": 1702606037
+    },
+    {
+      "type": "undo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 213,
+      "created_at": 1702606039
+    },
+    {
+      "type": "undo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 214,
+      "created_at": 1702606040
+    },
+    {
+      "type": "undo",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 215,
+      "created_at": 1702606043
+    },
+    {
+      "type": "undo",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 216,
+      "created_at": 1702606044,
+      "action_id": 202
+    },
+    {
+      "type": "undo",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 217,
+      "created_at": 1702606046
+    },
+    {
+      "type": "redo",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 218,
+      "created_at": 1702606059
+    },
+    {
+      "type": "redo",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 219,
+      "created_at": 1702606060
+    },
+    {
+      "type": "redo",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 220,
+      "created_at": 1702606061
+    },
+    {
+      "type": "redo",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 221,
+      "created_at": 1702606061
+    },
+    {
+      "type": "redo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 222,
+      "created_at": 1702606061
+    },
+    {
+      "type": "redo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 223,
+      "created_at": 1702606063
+    },
+    {
+      "type": "redo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 224,
+      "created_at": 1702606063
+    },
+    {
+      "type": "undo",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 225,
+      "created_at": 1702606088,
+      "action_id": 207
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 226,
+      "created_at": 1702606112,
+      "shares": [
+        "IFT_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 227,
+      "created_at": 1702606113
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 228,
+      "created_at": 1702606118,
+      "shares": [
+        "IFT_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 229,
+      "created_at": 1702606119
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 230,
+      "created_at": 1702606121,
+      "shares": [
+        "IFT_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 231,
+      "created_at": 1702606122
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 232,
+      "created_at": 1702606123,
+      "shares": [
+        "IFT_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 233,
+      "created_at": 1702606125
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 234,
+      "created_at": 1702606150,
+      "shares": [
+        "RCS_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 235,
+      "created_at": 1702606151,
+      "shares": [
+        "IFT_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 236,
+      "created_at": 1702606160
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 237,
+      "created_at": 1702606164,
+      "shares": [
+        "IFT_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 238,
+      "created_at": 1702606167
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 239,
+      "created_at": 1702606169,
+      "shares": [
+        "CTL_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 240,
+      "created_at": 1702606184
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 241,
+      "created_at": 1702606191
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 242,
+      "created_at": 1702606194
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 243,
+      "created_at": 1702606195
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 244,
+      "created_at": 1702606201,
+      "hex": "C5",
+      "tile": "23-1",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 245,
+      "created_at": 1702606207,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "C1",
+              "D2"
+            ],
+            [
+              "D2",
+              "C3"
+            ],
+            [
+              "C3",
+              "C5",
+              "D6"
+            ],
+            [
+              "D6",
+              "D4",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "C1",
+            "D2",
+            "C3",
+            "D6",
+            "D2"
+          ],
+          "revenue": 300,
+          "revenue_str": "C1-D2-C3-D6-D2",
+          "nodes": [
+            "C1-0",
+            "D2-1",
+            "C3-1",
+            "D6-0",
+            "D2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 246,
+      "created_at": 1702606208,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 247,
+      "created_at": 1702606209
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 248,
+      "created_at": 1702606220
+    },
+    {
+      "type": "run_routes",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 249,
+      "created_at": 1702606227,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G5",
+              "F4",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "D4",
+              "C3"
+            ],
+            [
+              "C3",
+              "B2",
+              "A3",
+              "B4"
+            ]
+          ],
+          "hexes": [
+            "G5",
+            "D2",
+            "C3",
+            "B4"
+          ],
+          "revenue": 200,
+          "revenue_str": "G5-D2-C3-B4",
+          "nodes": [
+            "G5-0",
+            "D2-0",
+            "C3-0",
+            "B4-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 250,
+      "created_at": 1702606228,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 251,
+      "created_at": 1702606229
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 252,
+      "created_at": 1702606235,
+      "hex": "G9",
+      "tile": "8-4",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 253,
+      "created_at": 1702606241,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G5",
+              "F4",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "D4",
+              "D6"
+            ],
+            [
+              "D6",
+              "C5",
+              "C3"
+            ],
+            [
+              "C3",
+              "D2"
+            ],
+            [
+              "D2",
+              "C1"
+            ]
+          ],
+          "hexes": [
+            "G5",
+            "D2",
+            "D6",
+            "C3",
+            "D2",
+            "C1"
+          ],
+          "revenue": 390,
+          "revenue_str": "G5-D2-D6-C3-D2-C1",
+          "nodes": [
+            "G5-0",
+            "D2-0",
+            "D6-0",
+            "C3-1",
+            "D2-1",
+            "C1-0"
+          ]
+        },
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "H0",
+              "H2"
+            ],
+            [
+              "H2",
+              "H4",
+              "G5"
+            ],
+            [
+              "G5",
+              "G7",
+              "H6",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "H0",
+            "H2",
+            "G5",
+            "H8"
+          ],
+          "revenue": 160,
+          "revenue_str": "H0-H2-G5-H8",
+          "nodes": [
+            "H0-0",
+            "H2-0",
+            "G5-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 254,
+      "created_at": 1702606244,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 255,
+      "created_at": 1702606250
+    },
+    {
+      "type": "buy_train",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 256,
+      "created_at": 1702606258,
+      "train": "6-0",
+      "price": 371
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 257,
+      "created_at": 1702606268
+    },
+    {
+      "type": "run_routes",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 258,
+      "created_at": 1702606270,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "C1",
+              "D2"
+            ],
+            [
+              "D2",
+              "C3"
+            ],
+            [
+              "C3",
+              "C5",
+              "D6"
+            ],
+            [
+              "D6",
+              "D4",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "C1",
+            "D2",
+            "C3",
+            "D6",
+            "D2"
+          ],
+          "revenue": 300,
+          "revenue_str": "C1-D2-C3-D6-D2",
+          "nodes": [
+            "C1-0",
+            "D2-1",
+            "C3-1",
+            "D6-0",
+            "D2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 259,
+      "created_at": 1702606271,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 260,
+      "created_at": 1702606272
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 261,
+      "created_at": 1702606278,
+      "hex": "E7",
+      "tile": "27-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 262,
+      "created_at": 1702606282,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G5",
+              "F4",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "D4",
+              "C3"
+            ],
+            [
+              "C3",
+              "B2",
+              "A3",
+              "B4"
+            ]
+          ],
+          "hexes": [
+            "G5",
+            "D2",
+            "C3",
+            "B4"
+          ],
+          "revenue": 200,
+          "revenue_str": "G5-D2-C3-B4",
+          "nodes": [
+            "G5-0",
+            "D2-0",
+            "C3-0",
+            "B4-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 263,
+      "created_at": 1702606283,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 264,
+      "created_at": 1702606284
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 265,
+      "created_at": 1702606290,
+      "hex": "F8",
+      "tile": "57-3",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 266,
+      "created_at": 1702606293,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "H0",
+              "H2"
+            ],
+            [
+              "H2",
+              "H4",
+              "G5"
+            ],
+            [
+              "G5",
+              "F4",
+              "E3",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "H0",
+            "H2",
+            "G5",
+            "D2"
+          ],
+          "revenue": 240,
+          "revenue_str": "H0-H2-G5-D2",
+          "nodes": [
+            "H0-0",
+            "H2-0",
+            "G5-0",
+            "D2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 267,
+      "created_at": 1702606294,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 268,
+      "created_at": 1702606296,
+      "train": "D-0",
+      "price": 800,
+      "variant": "D",
+      "exchange": "4-0"
+    },
+    {
+      "type": "pass",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 269,
+      "created_at": 1702606299
+    },
+    {
+      "type": "undo",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 270,
+      "created_at": 1702606304
+    },
+    {
+      "type": "buy_train",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 271,
+      "created_at": 1702606307,
+      "train": "6-0",
+      "price": 1
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 272,
+      "created_at": 1702606309
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 273,
+      "created_at": 1702606309
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 274,
+      "created_at": 1702606317,
+      "hex": "F8",
+      "tile": "14-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 275,
+      "created_at": 1702606320,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E9",
+              "F8"
+            ],
+            [
+              "F8",
+              "E7",
+              "D6"
+            ],
+            [
+              "D6",
+              "D4",
+              "D2"
+            ],
+            [
+              "D2",
+              "E3",
+              "F4",
+              "G5"
+            ]
+          ],
+          "hexes": [
+            "E9",
+            "F8",
+            "D6",
+            "D2",
+            "G5"
+          ],
+          "revenue": 300,
+          "revenue_str": "E9-F8-D6-D2-G5",
+          "nodes": [
+            "E9-0",
+            "F8-0",
+            "D6-0",
+            "D2-0",
+            "G5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 276,
+      "created_at": 1702606324,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 277,
+      "created_at": 1702606326
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 278,
+      "created_at": 1702606331
+    },
+    {
+      "type": "buy_train",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 279,
+      "created_at": 1702606336,
+      "train": "D-1",
+      "price": 1100,
+      "variant": "D"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 280,
+      "created_at": 1702606341,
+      "hex": "H2",
+      "tile": "14-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 281,
+      "created_at": 1702606347,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "I1",
+              "H2"
+            ],
+            [
+              "H2",
+              "H4",
+              "G5"
+            ],
+            [
+              "G5",
+              "G7",
+              "H6",
+              "H8"
+            ],
+            [
+              "H8",
+              "G9",
+              "F8"
+            ],
+            [
+              "F8",
+              "E7",
+              "D6"
+            ],
+            [
+              "D6",
+              "E5"
+            ]
+          ],
+          "hexes": [
+            "I1",
+            "H2",
+            "G5",
+            "H8",
+            "F8",
+            "D6",
+            "E5"
+          ],
+          "revenue": 330,
+          "revenue_str": "I1-H2-G5-H8-F8-D6-E5",
+          "nodes": [
+            "I1-0",
+            "H2-0",
+            "G5-0",
+            "H8-0",
+            "F8-0",
+            "D6-0",
+            "E5-0"
+          ]
+        },
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G5",
+              "F4",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "D4",
+              "D6"
+            ],
+            [
+              "D6",
+              "C5",
+              "C3"
+            ],
+            [
+              "C3",
+              "D2"
+            ],
+            [
+              "D2",
+              "C1"
+            ]
+          ],
+          "hexes": [
+            "G5",
+            "D2",
+            "D6",
+            "C3",
+            "D2",
+            "C1"
+          ],
+          "revenue": 390,
+          "revenue_str": "G5-D2-D6-C3-D2-C1",
+          "nodes": [
+            "G5-0",
+            "D2-0",
+            "D6-0",
+            "C3-1",
+            "D2-1",
+            "C1-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 282,
+      "created_at": 1702606348,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 283,
+      "created_at": 1702606350
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 284,
+      "created_at": 1702606359
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 285,
+      "created_at": 1702606368
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 286,
+      "created_at": 1702606374,
+      "shares": [
+        "RCS_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 287,
+      "created_at": 1702606375
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 288,
+      "created_at": 1702606379,
+      "shares": [
+        "RCS_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 289,
+      "created_at": 1702606381
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 290,
+      "created_at": 1702606383
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 291,
+      "created_at": 1702606388,
+      "shares": [
+        "RCS_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 292,
+      "created_at": 1702606390
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 293,
+      "created_at": 1702606392
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 294,
+      "created_at": 1702606393
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 295,
+      "created_at": 1702606393
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 296,
+      "created_at": 1702606395
+    },
+    {
+      "type": "run_routes",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 297,
+      "created_at": 1702606398,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E9",
+              "F8"
+            ],
+            [
+              "F8",
+              "E7",
+              "D6"
+            ],
+            [
+              "D6",
+              "D4",
+              "D2"
+            ],
+            [
+              "D2",
+              "E3",
+              "F4",
+              "G5"
+            ]
+          ],
+          "hexes": [
+            "E9",
+            "F8",
+            "D6",
+            "D2",
+            "G5"
+          ],
+          "revenue": 300,
+          "revenue_str": "E9-F8-D6-D2-G5",
+          "nodes": [
+            "E9-0",
+            "F8-0",
+            "D6-0",
+            "D2-0",
+            "G5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 298,
+      "created_at": 1702606399,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 299,
+      "created_at": 1702606401
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 300,
+      "created_at": 1702606403
+    },
+    {
+      "type": "undo",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 301,
+      "created_at": 1702606408
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 302,
+      "created_at": 1702606411,
+      "hex": "E7",
+      "tile": "41-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 303,
+      "created_at": 1702606420,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "E9",
+              "F8"
+            ],
+            [
+              "F8",
+              "E7",
+              "E5"
+            ],
+            [
+              "E5",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "D4",
+              "C3"
+            ],
+            [
+              "C3",
+              "B2",
+              "A3",
+              "B4"
+            ],
+            [
+              "B4",
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "E9",
+            "F8",
+            "E5",
+            "D2",
+            "C3",
+            "B4",
+            "D6"
+          ],
+          "revenue": 360,
+          "revenue_str": "E9-F8-E5-D2-C3-B4-D6",
+          "nodes": [
+            "E9-0",
+            "F8-0",
+            "E5-0",
+            "D2-0",
+            "C3-0",
+            "B4-1",
+            "D6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 304,
+      "created_at": 1702606421,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 305,
+      "created_at": 1702606427,
+      "hex": "H2",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 306,
+      "created_at": 1702606429,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "I1",
+              "H2"
+            ],
+            [
+              "H2",
+              "H4",
+              "G5"
+            ],
+            [
+              "G5",
+              "G7",
+              "H6",
+              "H8"
+            ],
+            [
+              "H8",
+              "G9",
+              "F8"
+            ],
+            [
+              "F8",
+              "E7",
+              "D6"
+            ],
+            [
+              "D6",
+              "E5"
+            ]
+          ],
+          "hexes": [
+            "I1",
+            "H2",
+            "G5",
+            "H8",
+            "F8",
+            "D6",
+            "E5"
+          ],
+          "revenue": 340,
+          "revenue_str": "I1-H2-G5-H8-F8-D6-E5",
+          "nodes": [
+            "I1-0",
+            "H2-0",
+            "G5-0",
+            "H8-0",
+            "F8-0",
+            "D6-0",
+            "E5-0"
+          ]
+        },
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G5",
+              "F4",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "D4",
+              "D6"
+            ],
+            [
+              "D6",
+              "C5",
+              "C3"
+            ],
+            [
+              "C3",
+              "D2"
+            ],
+            [
+              "D2",
+              "C1"
+            ]
+          ],
+          "hexes": [
+            "G5",
+            "D2",
+            "D6",
+            "C3",
+            "D2",
+            "C1"
+          ],
+          "revenue": 390,
+          "revenue_str": "G5-D2-D6-C3-D2-C1",
+          "nodes": [
+            "G5-0",
+            "D2-0",
+            "D6-0",
+            "C3-1",
+            "D2-1",
+            "C1-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 307,
+      "created_at": 1702606430,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 308,
+      "created_at": 1702606431
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 309,
+      "created_at": 1702606432
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 310,
+      "created_at": 1702606432
+    },
+    {
+      "type": "run_routes",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 311,
+      "created_at": 1702606433,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E9",
+              "F8"
+            ],
+            [
+              "F8",
+              "E7",
+              "D6"
+            ],
+            [
+              "D6",
+              "D4",
+              "D2"
+            ],
+            [
+              "D2",
+              "E3",
+              "F4",
+              "G5"
+            ]
+          ],
+          "hexes": [
+            "E9",
+            "F8",
+            "D6",
+            "D2",
+            "G5"
+          ],
+          "revenue": 300,
+          "revenue_str": "E9-F8-D6-D2-G5",
+          "nodes": [
+            "E9-0",
+            "F8-0",
+            "D6-0",
+            "D2-0",
+            "G5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 312,
+      "created_at": 1702606434,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 313,
+      "created_at": 1702606435
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 314,
+      "created_at": 1702606437
+    },
+    {
+      "type": "run_routes",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 315,
+      "created_at": 1702606438,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "E9",
+              "F8"
+            ],
+            [
+              "F8",
+              "E7",
+              "E5"
+            ],
+            [
+              "E5",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "D4",
+              "C3"
+            ],
+            [
+              "C3",
+              "B2",
+              "A3",
+              "B4"
+            ],
+            [
+              "B4",
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "E9",
+            "F8",
+            "E5",
+            "D2",
+            "C3",
+            "B4",
+            "D6"
+          ],
+          "revenue": 360,
+          "revenue_str": "E9-F8-E5-D2-C3-B4-D6",
+          "nodes": [
+            "E9-0",
+            "F8-0",
+            "E5-0",
+            "D2-0",
+            "C3-0",
+            "B4-1",
+            "D6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 316,
+      "created_at": 1702606439,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 317,
+      "created_at": 1702606439
+    },
+    {
+      "type": "run_routes",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 318,
+      "created_at": 1702606440,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "I1",
+              "H2"
+            ],
+            [
+              "H2",
+              "H4",
+              "G5"
+            ],
+            [
+              "G5",
+              "G7",
+              "H6",
+              "H8"
+            ],
+            [
+              "H8",
+              "G9",
+              "F8"
+            ],
+            [
+              "F8",
+              "E7",
+              "D6"
+            ],
+            [
+              "D6",
+              "E5"
+            ]
+          ],
+          "hexes": [
+            "I1",
+            "H2",
+            "G5",
+            "H8",
+            "F8",
+            "D6",
+            "E5"
+          ],
+          "revenue": 340,
+          "revenue_str": "I1-H2-G5-H8-F8-D6-E5",
+          "nodes": [
+            "I1-0",
+            "H2-0",
+            "G5-0",
+            "H8-0",
+            "F8-0",
+            "D6-0",
+            "E5-0"
+          ]
+        },
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G5",
+              "F4",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "D4",
+              "D6"
+            ],
+            [
+              "D6",
+              "C5",
+              "C3"
+            ],
+            [
+              "C3",
+              "D2"
+            ],
+            [
+              "D2",
+              "C1"
+            ]
+          ],
+          "hexes": [
+            "G5",
+            "D2",
+            "D6",
+            "C3",
+            "D2",
+            "C1"
+          ],
+          "revenue": 390,
+          "revenue_str": "G5-D2-D6-C3-D2-C1",
+          "nodes": [
+            "G5-0",
+            "D2-0",
+            "D6-0",
+            "C3-1",
+            "D2-1",
+            "C1-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 319,
+      "created_at": 1702606441,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 320,
+      "created_at": 1702606442
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 321,
+      "created_at": 1702606444
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 322,
+      "created_at": 1702606446
+    },
+    {
+      "type": "run_routes",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 323,
+      "created_at": 1702606447,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "E9",
+              "F8"
+            ],
+            [
+              "F8",
+              "E7",
+              "D6"
+            ],
+            [
+              "D6",
+              "D4",
+              "D2"
+            ],
+            [
+              "D2",
+              "E3",
+              "F4",
+              "G5"
+            ]
+          ],
+          "hexes": [
+            "E9",
+            "F8",
+            "D6",
+            "D2",
+            "G5"
+          ],
+          "revenue": 300,
+          "revenue_str": "E9-F8-D6-D2-G5",
+          "nodes": [
+            "E9-0",
+            "F8-0",
+            "D6-0",
+            "D2-0",
+            "G5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 324,
+      "created_at": 1702606448,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SFA",
+      "entity_type": "corporation",
+      "id": 325,
+      "created_at": 1702606451
+    },
+    {
+      "type": "pass",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 326,
+      "created_at": 1702606451
+    },
+    {
+      "type": "run_routes",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 327,
+      "created_at": 1702606452,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "E9",
+              "F8"
+            ],
+            [
+              "F8",
+              "E7",
+              "E5"
+            ],
+            [
+              "E5",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "D4",
+              "C3"
+            ],
+            [
+              "C3",
+              "B2",
+              "A3",
+              "B4"
+            ],
+            [
+              "B4",
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "E9",
+            "F8",
+            "E5",
+            "D2",
+            "C3",
+            "B4",
+            "D6"
+          ],
+          "revenue": 360,
+          "revenue_str": "E9-F8-E5-D2-C3-B4-D6",
+          "nodes": [
+            "E9-0",
+            "F8-0",
+            "E5-0",
+            "D2-0",
+            "C3-0",
+            "B4-1",
+            "D6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "RCS",
+      "entity_type": "corporation",
+      "id": 328,
+      "created_at": 1702606453,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 329,
+      "created_at": 1702606454
+    },
+    {
+      "type": "run_routes",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 330,
+      "created_at": 1702606455,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "I1",
+              "H2"
+            ],
+            [
+              "H2",
+              "H4",
+              "G5"
+            ],
+            [
+              "G5",
+              "G7",
+              "H6",
+              "H8"
+            ],
+            [
+              "H8",
+              "G9",
+              "F8"
+            ],
+            [
+              "F8",
+              "E7",
+              "D6"
+            ],
+            [
+              "D6",
+              "E5"
+            ]
+          ],
+          "hexes": [
+            "I1",
+            "H2",
+            "G5",
+            "H8",
+            "F8",
+            "D6",
+            "E5"
+          ],
+          "revenue": 340,
+          "revenue_str": "I1-H2-G5-H8-F8-D6-E5",
+          "nodes": [
+            "I1-0",
+            "H2-0",
+            "G5-0",
+            "H8-0",
+            "F8-0",
+            "D6-0",
+            "E5-0"
+          ]
+        },
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G5",
+              "F4",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "D4",
+              "D6"
+            ],
+            [
+              "D6",
+              "C5",
+              "C3"
+            ],
+            [
+              "C3",
+              "D2"
+            ],
+            [
+              "D2",
+              "C1"
+            ]
+          ],
+          "hexes": [
+            "G5",
+            "D2",
+            "D6",
+            "C3",
+            "D2",
+            "C1"
+          ],
+          "revenue": 390,
+          "revenue_str": "G5-D2-D6-C3-D2-C1",
+          "nodes": [
+            "G5-0",
+            "D2-0",
+            "D6-0",
+            "C3-1",
+            "D2-1",
+            "C1-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IFT",
+      "entity_type": "corporation",
+      "id": 331,
+      "created_at": 1702606456,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 332,
+      "created_at": 1702606458
+    },
+    {
+      "type": "pass",
+      "entity": "CTL",
+      "entity_type": "corporation",
+      "id": 333,
+      "created_at": 1702606459
+    }
+  ],
+  "id": "hs_bmgpssmr_1702604684",
+  "players": [
+    {
+      "name": "Player 1",
+      "id": 0
+    },
+    {
+      "name": "Player 2",
+      "id": 1
+    },
+    {
+      "name": "Player 3",
+      "id": 2
+    }
+  ],
+  "title": "1850Jr",
+  "description": "",
+  "min_players": "3",
+  "max_players": "3",
+  "settings": {
+    "optional_rules": [],
+    "seed": ""
+  },
+  "mode": "hotseat",
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "created_at": "2023-12-14",
+  "loaded": true,
+  "result": {
+    "0" : 4792,
+    "1": 3895,
+    "2": 5583
+  },
+  "manually_ended": false,
+  "turn": 6,
+  "round": "Operating Round",
+  "acting": [
+    2,
+    0,
+    1
+  ],
+  "updated_at": 1702606459
+}


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Implements 1850jr, a small 1830 clone from 1995 that was originally published in an Italian fanzine. [BGG link](https://boardgamegeek.com/boardgameexpansion/154473/1850jr). I reached out to the designer via BGG and got his permission. Screenshot of geekmail below. 

Maybe just a curiosity of a game, but I played a couple of hotseat games and there were at least a few interesting moments.

* **Screenshots**
![image](https://github.com/tobymao/18xx/assets/26125362/3912fee4-682d-4f02-8455-df194d57f330)


* **Any Assumptions / Hacks**
