### PR TITLE
[18EU] Allow holdings above limit when corporation hasn't operated yet.

### DIFF
--- a/lib/engine/game/g_18_eu/corporation.rb
+++ b/lib/engine/game/g_18_eu/corporation.rb
@@ -9,7 +9,8 @@ module Engine
         def holding_ok?(share_holder, extra_percent = 0)
           # Per the rules, it's OK to temporarily hold over the per-corp limit
           # if the company hasn't operated yet.
-          return true unless self.operated?
+          return true unless operated?
+
           super
         end
       end

--- a/lib/engine/game/g_18_eu/corporation.rb
+++ b/lib/engine/game/g_18_eu/corporation.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative '../../corporation'
+
+module Engine
+  module Game
+    module G18EU
+      class Corporation < Engine::Corporation
+        def holding_ok?(share_holder, extra_percent = 0)
+          return true unless self.operated?
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_eu/corporation.rb
+++ b/lib/engine/game/g_18_eu/corporation.rb
@@ -7,8 +7,8 @@ module Engine
     module G18EU
       class Corporation < Engine::Corporation
         def holding_ok?(share_holder, extra_percent = 0)
-          # per the rules, it's OK to hold over the limit until the company operates
-          # but then you must sell at the next opportunity.
+          # Per the rules, it's OK to temporarily hold over the per-corp limit
+          # if the company hasn't operated yet.
           return true unless self.operated?
           super
         end

--- a/lib/engine/game/g_18_eu/corporation.rb
+++ b/lib/engine/game/g_18_eu/corporation.rb
@@ -7,6 +7,8 @@ module Engine
     module G18EU
       class Corporation < Engine::Corporation
         def holding_ok?(share_holder, extra_percent = 0)
+          # per the rules, it's OK to hold over the limit until the company operates
+          # but then you must sell at the next opportunity.
           return true unless self.operated?
           super
         end

--- a/lib/engine/game/g_18_eu/game.rb
+++ b/lib/engine/game/g_18_eu/game.rb
@@ -3,6 +3,7 @@
 require_relative 'meta'
 require_relative 'map'
 require_relative 'entities'
+require_relative 'corporation'
 require_relative 'market'
 require_relative 'trains'
 require_relative '../base'
@@ -31,6 +32,7 @@ module Engine
 
         BIDDING_BOX_MINOR_COLOR = '#c6e9af'
 
+        CORPORATION_CLASS = G18EU::Corporation
         BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
         GAME_END_CHECK = { bankrupt: :immediate, bank: :full_or }.freeze
 

--- a/public/fixtures/18EU/can_hold_70_percent_before_operates.json
+++ b/public/fixtures/18EU/can_hold_70_percent_before_operates.json
@@ -1,0 +1,7667 @@
+{
+    "status": "finished",
+    "actions": [
+        {
+            "type": "bid",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 1,
+            "created_at": 1700604733,
+            "minor": "10",
+            "price": 0
+        },
+        {
+            "type": "program_auction_bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 2,
+            "created_at": 1700606358,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700606358
+                }
+            ],
+            "bid_target": "10",
+            "enable_maximum_bid": false,
+            "maximum_bid": "100",
+            "enable_buy_price": true,
+            "buy_price": "70",
+            "auto_pass_after": false
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 3,
+            "created_at": 1700614555
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 4,
+            "created_at": 1700625916
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 5,
+            "created_at": 1700635543,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700635542
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 6,
+            "created_at": 1700670474
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 7,
+            "created_at": 1700674745
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 8,
+            "created_at": 1700675119,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700675119
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 9,
+            "created_at": 1700675566
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 10,
+            "created_at": 1700675663
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 11,
+            "created_at": 1700675770,
+            "auto_actions": [
+                {
+                    "type": "bid",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700675769,
+                    "minor": "10",
+                    "price": 70
+                },
+                {
+                    "type": "program_disable",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700675769,
+                    "reason": "10 is owned by toddvp"
+                }
+            ]
+        },
+        {
+            "type": "bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 12,
+            "created_at": 1700678607,
+            "minor": "5",
+            "price": 0
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 13,
+            "created_at": 1700678644
+        },
+        {
+            "type": "program_auction_bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 14,
+            "created_at": 1700678824,
+            "bid_target": "5",
+            "enable_maximum_bid": false,
+            "maximum_bid": "100",
+            "enable_buy_price": true,
+            "buy_price": "70",
+            "auto_pass_after": false
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 15,
+            "created_at": 1700680100
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 16,
+            "created_at": 1700684877,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700684876
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 17,
+            "created_at": 1700684911
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 18,
+            "created_at": 1700686667
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 19,
+            "created_at": 1700688725,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700688724
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 20,
+            "created_at": 1700689841
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 21,
+            "created_at": 1700690619
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 22,
+            "created_at": 1700693340,
+            "auto_actions": [
+                {
+                    "type": "bid",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700693340,
+                    "minor": "5",
+                    "price": 70
+                }
+            ]
+        },
+        {
+            "type": "bid",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 23,
+            "created_at": 1700694357,
+            "minor": "3",
+            "price": 0
+        },
+        {
+            "type": "bid",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 24,
+            "created_at": 1700722851,
+            "minor": "3",
+            "price": 100
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 25,
+            "created_at": 1700726870,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700726870,
+                    "reason": "5 is owned by toddvp"
+                }
+            ]
+        },
+        {
+            "type": "program_auction_bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 26,
+            "created_at": 1700753888,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700753891,
+                    "reason": "Bids submitted for 3"
+                }
+            ],
+            "bid_target": "3",
+            "enable_maximum_bid": false,
+            "maximum_bid": "105",
+            "enable_buy_price": true,
+            "buy_price": "60",
+            "auto_pass_after": false
+        },
+        {
+            "type": "program_auction_bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 27,
+            "created_at": 1700753938,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700753941,
+                    "reason": "Bids submitted for 3"
+                }
+            ],
+            "bid_target": "3",
+            "enable_maximum_bid": false,
+            "maximum_bid": "105",
+            "enable_buy_price": true,
+            "buy_price": "60",
+            "auto_pass_after": false
+        },
+        {
+            "type": "pass",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 28,
+            "created_at": 1700753966
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 29,
+            "created_at": 1700773043
+        },
+        {
+            "type": "bid",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 30,
+            "created_at": 1700773357,
+            "minor": "2",
+            "price": 100
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 31,
+            "created_at": 1700774827
+        },
+        {
+            "type": "pass",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 32,
+            "created_at": 1700782289
+        },
+        {
+            "type": "bid",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 33,
+            "created_at": 1700785119,
+            "minor": "2",
+            "price": 105
+        },
+        {
+            "type": "bid",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 34,
+            "created_at": 1700799656,
+            "minor": "2",
+            "price": 110
+        },
+        {
+            "type": "bid",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 35,
+            "created_at": 1700800238,
+            "minor": "2",
+            "price": 115
+        },
+        {
+            "type": "bid",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 36,
+            "created_at": 1700803905,
+            "minor": "2",
+            "price": 120
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 37,
+            "created_at": 1700835857
+        },
+        {
+            "type": "bid",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 38,
+            "created_at": 1700838600,
+            "minor": "6",
+            "price": 0
+        },
+        {
+            "type": "program_auction_bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 39,
+            "created_at": 1700844553,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700844556
+                }
+            ],
+            "bid_target": "6",
+            "enable_maximum_bid": false,
+            "maximum_bid": "100",
+            "enable_buy_price": true,
+            "buy_price": "70",
+            "auto_pass_after": false
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 40,
+            "created_at": 1700877029
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 41,
+            "created_at": 1700913913
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 42,
+            "created_at": 1700913937,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700913936
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 43,
+            "created_at": 1700925691
+        },
+        {
+            "type": "program_auction_bid",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 44,
+            "created_at": 1700925710,
+            "bid_target": "6",
+            "enable_maximum_bid": true,
+            "maximum_bid": "60",
+            "enable_buy_price": true,
+            "buy_price": "60",
+            "auto_pass_after": false
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 45,
+            "created_at": 1700925726
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 46,
+            "created_at": 1700926725,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700926725
+                },
+                {
+                    "type": "program_disable",
+                    "entity": 253,
+                    "entity_type": "player",
+                    "created_at": 1700926725,
+                    "reason": "Price for 6 exceeded maximum bid"
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 47,
+            "created_at": 1700926987
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 48,
+            "created_at": 1700927981
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 49,
+            "created_at": 1700929096,
+            "auto_actions": [
+                {
+                    "type": "bid",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700929095,
+                    "minor": "6",
+                    "price": 70
+                },
+                {
+                    "type": "program_disable",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700929095,
+                    "reason": "6 is owned by toddvp"
+                }
+            ]
+        },
+        {
+            "type": "bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 50,
+            "created_at": 1700931490,
+            "minor": "11",
+            "price": 0
+        },
+        {
+            "type": "program_auction_bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 51,
+            "created_at": 1700931548,
+            "bid_target": "11",
+            "enable_maximum_bid": false,
+            "maximum_bid": "100",
+            "enable_buy_price": true,
+            "buy_price": "60",
+            "auto_pass_after": false
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 52,
+            "created_at": 1700969351
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 53,
+            "created_at": 1700988395
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 54,
+            "created_at": 1700994095,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1700994094
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 55,
+            "created_at": 1701014588
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 56,
+            "created_at": 1701014614
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 57,
+            "created_at": 1701016277,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701016277
+                }
+            ]
+        },
+        {
+            "type": "bid",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 58,
+            "created_at": 1701038044,
+            "minor": "11",
+            "price": 80
+        },
+        {
+            "type": "bid",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 59,
+            "created_at": 1701038057,
+            "minor": "13",
+            "price": 0
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 60,
+            "created_at": 1701058520
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 61,
+            "created_at": 1701079287,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701079287,
+                    "reason": "11 is owned by Joshua6"
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 62,
+            "created_at": 1701113983
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 63,
+            "created_at": 1701114061
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 64,
+            "created_at": 1701114176
+        },
+        {
+            "type": "bid",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 65,
+            "created_at": 1701115062,
+            "minor": "13",
+            "price": 90
+        },
+        {
+            "type": "bid",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 66,
+            "created_at": 1701115902,
+            "minor": "12",
+            "price": 0
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 67,
+            "created_at": 1701116789
+        },
+        {
+            "type": "program_auction_bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 68,
+            "created_at": 1701122423,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701122422
+                }
+            ],
+            "bid_target": "12",
+            "enable_maximum_bid": false,
+            "maximum_bid": "100",
+            "enable_buy_price": true,
+            "buy_price": "80",
+            "auto_pass_after": false
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 69,
+            "created_at": 1701122636
+        },
+        {
+            "type": "bid",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 70,
+            "created_at": 1701144705,
+            "minor": "12",
+            "price": 90
+        },
+        {
+            "type": "bid",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 71,
+            "created_at": 1701160785,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701160785,
+                    "reason": "12 is owned by l33twash0r"
+                }
+            ],
+            "minor": "7",
+            "price": 0
+        },
+        {
+            "type": "program_auction_bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 72,
+            "created_at": 1701196512,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701196512
+                }
+            ],
+            "bid_target": "7",
+            "enable_maximum_bid": false,
+            "maximum_bid": "100",
+            "enable_buy_price": true,
+            "buy_price": "60",
+            "auto_pass_after": false
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 73,
+            "created_at": 1701199002
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 74,
+            "created_at": 1701200865,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701200864
+                }
+            ]
+        },
+        {
+            "type": "bid",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 75,
+            "created_at": 1701202527,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701202526,
+                    "reason": "7 is owned by Joshua6"
+                }
+            ],
+            "minor": "7",
+            "price": 90
+        },
+        {
+            "type": "bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 76,
+            "created_at": 1701207743,
+            "minor": "8",
+            "price": 0
+        },
+        {
+            "type": "program_auction_bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 77,
+            "created_at": 1701207789,
+            "bid_target": "8",
+            "enable_maximum_bid": false,
+            "maximum_bid": "100",
+            "enable_buy_price": true,
+            "buy_price": "80",
+            "auto_pass_after": false
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 78,
+            "created_at": 1701208300
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 79,
+            "created_at": 1701208371,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701208370
+                }
+            ]
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 80,
+            "created_at": 1701208832
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 81,
+            "created_at": 1701209124,
+            "auto_actions": [
+                {
+                    "type": "bid",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701209124,
+                    "minor": "8",
+                    "price": 80
+                }
+            ]
+        },
+        {
+            "type": "bid",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 83,
+            "created_at": 1701209547,
+            "minor": "14",
+            "price": 0
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 84,
+            "created_at": 1701210681
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 85,
+            "created_at": 1701210922
+        },
+        {
+            "type": "bid",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 86,
+            "created_at": 1701211522,
+            "minor": "14",
+            "price": 90
+        },
+        {
+            "type": "bid",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 87,
+            "created_at": 1701243300,
+            "minor": "1",
+            "price": 0
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 88,
+            "created_at": 1701249132
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 89,
+            "created_at": 1701274208
+        },
+        {
+            "type": "bid",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 90,
+            "created_at": 1701274965,
+            "minor": "1",
+            "price": 90
+        },
+        {
+            "type": "bid",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 91,
+            "created_at": 1701274988,
+            "minor": "9",
+            "price": 0
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 92,
+            "created_at": 1701275049
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 93,
+            "user": 253,
+            "created_at": 1701275061
+        },
+        {
+            "type": "undo",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 94,
+            "user": 253,
+            "created_at": 1701275067
+        },
+        {
+            "type": "bid",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 95,
+            "created_at": 1701275069,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701275068,
+                    "reason": "8 is owned by toddvp"
+                }
+            ],
+            "minor": "9",
+            "price": 90
+        },
+        {
+            "type": "bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 96,
+            "created_at": 1701276077,
+            "minor": "4",
+            "price": 0
+        },
+        {
+            "type": "program_auction_bid",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 97,
+            "created_at": 1701276108,
+            "bid_target": "4",
+            "enable_maximum_bid": false,
+            "maximum_bid": "90",
+            "enable_buy_price": true,
+            "buy_price": "60",
+            "auto_pass_after": false
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 98,
+            "created_at": 1701276164
+        },
+        {
+            "type": "bid",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 99,
+            "created_at": 1701276175,
+            "minor": "4",
+            "price": 80
+        },
+        {
+            "type": "bid",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 100,
+            "created_at": 1701276181,
+            "minor": "15",
+            "price": 0
+        },
+        {
+            "type": "bid",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 101,
+            "created_at": 1701276569,
+            "minor": "15",
+            "price": 80
+        },
+        {
+            "type": "lay_tile",
+            "entity": "1",
+            "entity_type": "minor",
+            "id": 102,
+            "created_at": 1701276585,
+            "hex": "B9",
+            "tile": "8-0",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "1",
+            "entity_type": "minor",
+            "id": 103,
+            "created_at": 1701276588,
+            "hex": "B7",
+            "tile": "58-0",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "1",
+            "entity_type": "minor",
+            "id": 104,
+            "created_at": 1701276591,
+            "routes": [
+                {
+                    "train": "2-0",
+                    "connections": [
+                        [
+                            "A10",
+                            "B9",
+                            "B7"
+                        ],
+                        [
+                            "B7",
+                            "A6"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B7",
+                        "A6"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "A10-B7-A6",
+                    "nodes": [
+                        "A10-0",
+                        "B7-0",
+                        "A6-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "1",
+            "entity_type": "minor",
+            "id": 105,
+            "created_at": 1701276594
+        },
+        {
+            "type": "lay_tile",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 106,
+            "created_at": 1701280786,
+            "hex": "C8",
+            "tile": "202-0",
+            "rotation": 3
+        },
+        {
+            "type": "lay_tile",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 107,
+            "created_at": 1701280789,
+            "hex": "C6",
+            "tile": "4-0",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 108,
+            "created_at": 1701280790,
+            "routes": [
+                {
+                    "train": "2-1",
+                    "connections": [
+                        [
+                            "C8",
+                            "C6"
+                        ]
+                    ],
+                    "hexes": [
+                        "C8",
+                        "C6"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "C8-C6",
+                    "nodes": [
+                        "C8-0",
+                        "C6-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 109,
+            "created_at": 1701280794
+        },
+        {
+            "type": "lay_tile",
+            "entity": "3",
+            "entity_type": "minor",
+            "id": 110,
+            "created_at": 1701280797,
+            "hex": "B11",
+            "tile": "8-1",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "3",
+            "entity_type": "minor",
+            "id": 111,
+            "created_at": 1701280800,
+            "hex": "B13",
+            "tile": "4-1",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "3",
+            "entity_type": "minor",
+            "id": 112,
+            "created_at": 1701280801,
+            "routes": [
+                {
+                    "train": "2-2",
+                    "connections": [
+                        [
+                            "A10",
+                            "B11",
+                            "B13"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B13"
+                    ],
+                    "revenue": 50,
+                    "revenue_str": "A10-B13",
+                    "nodes": [
+                        "A10-1",
+                        "B13-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "3",
+            "entity_type": "minor",
+            "id": 113,
+            "created_at": 1701280802
+        },
+        {
+            "hex": "J7",
+            "tile": "201-0",
+            "type": "lay_tile",
+            "entity": "4",
+            "rotation": 3,
+            "entity_type": "minor",
+            "id": 114,
+            "user": 253,
+            "created_at": 1701285988
+        },
+        {
+            "hex": "K6",
+            "tile": "9-0",
+            "type": "lay_tile",
+            "entity": "4",
+            "rotation": 1,
+            "entity_type": "minor",
+            "id": 115,
+            "user": 253,
+            "created_at": 1701285992
+        },
+        {
+            "type": "undo",
+            "entity": "5",
+            "action_id": 113,
+            "entity_type": "minor",
+            "id": 116,
+            "user": 253,
+            "created_at": 1701285994
+        },
+        {
+            "hex": "J7",
+            "tile": "202-1",
+            "type": "lay_tile",
+            "entity": "4",
+            "rotation": 2,
+            "entity_type": "minor",
+            "id": 117,
+            "user": 253,
+            "created_at": 1701286016
+        },
+        {
+            "hex": "I6",
+            "tile": "7-0",
+            "type": "lay_tile",
+            "entity": "4",
+            "rotation": 4,
+            "entity_type": "minor",
+            "id": 118,
+            "user": 253,
+            "created_at": 1701286019
+        },
+        {
+            "type": "undo",
+            "entity": "4",
+            "action_id": 113,
+            "entity_type": "minor",
+            "id": 119,
+            "user": 253,
+            "created_at": 1701286021
+        },
+        {
+            "type": "lay_tile",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 120,
+            "created_at": 1701286032,
+            "hex": "J7",
+            "tile": "201-0",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 121,
+            "created_at": 1701286041,
+            "hex": "I8",
+            "tile": "58-1",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 122,
+            "created_at": 1701286073,
+            "routes": [
+                {
+                    "train": "2-3",
+                    "connections": [
+                        [
+                            "J7",
+                            "I8"
+                        ]
+                    ],
+                    "hexes": [
+                        "J7",
+                        "I8"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "J7-I8",
+                    "nodes": [
+                        "J7-0",
+                        "I8-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 123,
+            "created_at": 1701286075
+        },
+        {
+            "type": "lay_tile",
+            "entity": "5",
+            "entity_type": "minor",
+            "id": 124,
+            "created_at": 1701287675,
+            "hex": "H19",
+            "tile": "201-1",
+            "rotation": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "5",
+            "entity_type": "minor",
+            "id": 125,
+            "created_at": 1701287684,
+            "hex": "H21",
+            "tile": "8-2",
+            "rotation": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "5",
+            "entity_type": "minor",
+            "id": 126,
+            "created_at": 1701287699,
+            "routes": [
+                {
+                    "train": "2-4",
+                    "connections": [
+                        [
+                            "H19",
+                            "H21",
+                            "G22"
+                        ]
+                    ],
+                    "hexes": [
+                        "H19",
+                        "G22"
+                    ],
+                    "revenue": 60,
+                    "revenue_str": "H19-G22",
+                    "nodes": [
+                        "H19-0",
+                        "G22-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "5",
+            "entity_type": "minor",
+            "id": 127,
+            "created_at": 1701287708
+        },
+        {
+            "type": "lay_tile",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 128,
+            "created_at": 1701287730,
+            "hex": "K12",
+            "tile": "3-0",
+            "rotation": 5
+        },
+        {
+            "type": "lay_tile",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 129,
+            "created_at": 1701287769,
+            "hex": "L13",
+            "tile": "9-0",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 130,
+            "created_at": 1701287781,
+            "routes": [
+                {
+                    "train": "2-5",
+                    "connections": [
+                        [
+                            "K14",
+                            "K12"
+                        ]
+                    ],
+                    "hexes": [
+                        "K14",
+                        "K12"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "K14-K12",
+                    "nodes": [
+                        "K14-1",
+                        "K12-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 131,
+            "created_at": 1701287786
+        },
+        {
+            "hex": "I6",
+            "tile": "9-1",
+            "type": "lay_tile",
+            "entity": "7",
+            "rotation": 1,
+            "entity_type": "minor",
+            "id": 132,
+            "user": 253,
+            "created_at": 1701288911
+        },
+        {
+            "hex": "H7",
+            "tile": "3-1",
+            "type": "lay_tile",
+            "entity": "7",
+            "rotation": 4,
+            "entity_type": "minor",
+            "id": 133,
+            "user": 253,
+            "created_at": 1701288915
+        },
+        {
+            "type": "undo",
+            "entity": "7",
+            "action_id": 131,
+            "entity_type": "minor",
+            "id": 134,
+            "user": 253,
+            "created_at": 1701288926
+        },
+        {
+            "type": "lay_tile",
+            "entity": "7",
+            "entity_type": "minor",
+            "id": 135,
+            "created_at": 1701288933,
+            "hex": "I6",
+            "tile": "7-0",
+            "rotation": 4
+        },
+        {
+            "type": "pass",
+            "entity": "7",
+            "entity_type": "minor",
+            "id": 136,
+            "created_at": 1701289043
+        },
+        {
+            "type": "run_routes",
+            "entity": "7",
+            "entity_type": "minor",
+            "id": 137,
+            "created_at": 1701289051,
+            "routes": [
+                {
+                    "train": "2-6",
+                    "connections": [
+                        [
+                            "J5",
+                            "I6",
+                            "J7"
+                        ]
+                    ],
+                    "hexes": [
+                        "J5",
+                        "J7"
+                    ],
+                    "revenue": 60,
+                    "revenue_str": "J5-J7",
+                    "nodes": [
+                        "J5-1",
+                        "J7-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "7",
+            "entity_type": "minor",
+            "id": 138,
+            "created_at": 1701289052
+        },
+        {
+            "type": "lay_tile",
+            "entity": "8",
+            "entity_type": "minor",
+            "id": 139,
+            "created_at": 1701291169,
+            "hex": "M16",
+            "tile": "202-1",
+            "rotation": 3
+        },
+        {
+            "type": "lay_tile",
+            "entity": "8",
+            "entity_type": "minor",
+            "id": 140,
+            "created_at": 1701291176,
+            "hex": "M14",
+            "tile": "8-3",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "8",
+            "entity_type": "minor",
+            "id": 141,
+            "created_at": 1701291186,
+            "routes": [
+                {
+                    "train": "2-7",
+                    "connections": [
+                        [
+                            "N17",
+                            "M16"
+                        ],
+                        [
+                            "M16",
+                            "M14",
+                            "L13",
+                            "K12"
+                        ]
+                    ],
+                    "hexes": [
+                        "N17",
+                        "M16",
+                        "K12"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "N17-M16-K12",
+                    "nodes": [
+                        "N17-0",
+                        "M16-0",
+                        "K12-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "minor",
+            "id": 142,
+            "created_at": 1701291191
+        },
+        {
+            "type": "lay_tile",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 143,
+            "created_at": 1701293982,
+            "hex": "K4",
+            "tile": "58-2",
+            "rotation": 5
+        },
+        {
+            "type": "lay_tile",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 144,
+            "created_at": 1701293985,
+            "hex": "L5",
+            "tile": "4-2",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 145,
+            "created_at": 1701293987,
+            "routes": [
+                {
+                    "train": "2-8",
+                    "connections": [
+                        [
+                            "J5",
+                            "K4"
+                        ],
+                        [
+                            "K4",
+                            "L5"
+                        ]
+                    ],
+                    "hexes": [
+                        "J5",
+                        "K4",
+                        "L5"
+                    ],
+                    "revenue": 50,
+                    "revenue_str": "J5-K4-L5",
+                    "nodes": [
+                        "J5-0",
+                        "K4-0",
+                        "L5-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 146,
+            "created_at": 1701293992
+        },
+        {
+            "type": "lay_tile",
+            "entity": "10",
+            "entity_type": "minor",
+            "id": 147,
+            "created_at": 1701294039,
+            "hex": "E18",
+            "tile": "201-2",
+            "rotation": 5
+        },
+        {
+            "type": "lay_tile",
+            "entity": "10",
+            "entity_type": "minor",
+            "id": 148,
+            "created_at": 1701294046,
+            "hex": "E20",
+            "tile": "57-0",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "10",
+            "entity_type": "minor",
+            "id": 149,
+            "created_at": 1701294059,
+            "routes": [
+                {
+                    "train": "2-9",
+                    "connections": [
+                        [
+                            "E18",
+                            "E20"
+                        ],
+                        [
+                            "E20",
+                            "E22"
+                        ]
+                    ],
+                    "hexes": [
+                        "E18",
+                        "E20",
+                        "E22"
+                    ],
+                    "revenue": 60,
+                    "revenue_str": "E18-E20-E22",
+                    "nodes": [
+                        "E18-0",
+                        "E20-0",
+                        "E22-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "10",
+            "entity_type": "minor",
+            "id": 150,
+            "created_at": 1701294064
+        },
+        {
+            "type": "lay_tile",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 151,
+            "created_at": 1701295753,
+            "hex": "J17",
+            "tile": "9-1",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 152,
+            "created_at": 1701295755,
+            "hex": "I18",
+            "tile": "57-1",
+            "rotation": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 153,
+            "created_at": 1701295759,
+            "routes": [
+                {
+                    "train": "2-10",
+                    "connections": [
+                        [
+                            "K14",
+                            "K16",
+                            "J17",
+                            "I18"
+                        ]
+                    ],
+                    "hexes": [
+                        "K14",
+                        "I18"
+                    ],
+                    "revenue": 50,
+                    "revenue_str": "K14-I18",
+                    "nodes": [
+                        "K14-0",
+                        "I18-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 154,
+            "created_at": 1701295764
+        },
+        {
+            "type": "lay_tile",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 155,
+            "created_at": 1701298342,
+            "hex": "D3",
+            "tile": "202-2",
+            "rotation": 1
+        },
+        {
+            "type": "lay_tile",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 156,
+            "created_at": 1701298344,
+            "hex": "C4",
+            "tile": "58-3",
+            "rotation": 4
+        },
+        {
+            "type": "run_routes",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 157,
+            "created_at": 1701298351,
+            "routes": [
+                {
+                    "train": "2-11",
+                    "connections": [
+                        [
+                            "C8",
+                            "C6"
+                        ],
+                        [
+                            "C6",
+                            "C4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ],
+                        [
+                            "D3",
+                            "D1"
+                        ]
+                    ],
+                    "hexes": [
+                        "C8",
+                        "C6",
+                        "C4",
+                        "D3",
+                        "D1"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "C8-C6-C4-D3-D1",
+                    "nodes": [
+                        "C8-0",
+                        "C6-0",
+                        "C4-0",
+                        "D3-0",
+                        "D1-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 158,
+            "created_at": 1701298352
+        },
+        {
+            "type": "lay_tile",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 159,
+            "created_at": 1701329047,
+            "hex": "G12",
+            "tile": "201-3",
+            "rotation": 2
+        },
+        {
+            "type": "lay_tile",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 160,
+            "created_at": 1701329052,
+            "hex": "F11",
+            "tile": "58-4",
+            "rotation": 5
+        },
+        {
+            "type": "run_routes",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 161,
+            "created_at": 1701329054,
+            "routes": [
+                {
+                    "train": "2-12",
+                    "connections": [
+                        [
+                            "G12",
+                            "F11"
+                        ]
+                    ],
+                    "hexes": [
+                        "G12",
+                        "F11"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "G12-F11",
+                    "nodes": [
+                        "G12-0",
+                        "F11-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 162,
+            "created_at": 1701329056
+        },
+        {
+            "type": "lay_tile",
+            "entity": "14",
+            "entity_type": "minor",
+            "id": 163,
+            "created_at": 1701329065,
+            "hex": "D13",
+            "tile": "202-3",
+            "rotation": 4
+        },
+        {
+            "type": "lay_tile",
+            "entity": "14",
+            "entity_type": "minor",
+            "id": 164,
+            "created_at": 1701329068,
+            "hex": "D15",
+            "tile": "58-5",
+            "rotation": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "14",
+            "entity_type": "minor",
+            "id": 165,
+            "created_at": 1701329070,
+            "routes": [
+                {
+                    "train": "2-13",
+                    "connections": [
+                        [
+                            "D13",
+                            "D15"
+                        ]
+                    ],
+                    "hexes": [
+                        "D13",
+                        "D15"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "D13-D15",
+                    "nodes": [
+                        "D13-0",
+                        "D15-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "14",
+            "entity_type": "minor",
+            "id": 166,
+            "created_at": 1701329071
+        },
+        {
+            "type": "lay_tile",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 167,
+            "created_at": 1701329078,
+            "hex": "B17",
+            "tile": "202-4",
+            "rotation": 4
+        },
+        {
+            "type": "lay_tile",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 168,
+            "created_at": 1701329080,
+            "hex": "C16",
+            "tile": "4-3",
+            "rotation": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 169,
+            "created_at": 1701329083,
+            "routes": [
+                {
+                    "train": "2-14",
+                    "connections": [
+                        [
+                            "B17",
+                            "C16"
+                        ],
+                        [
+                            "C16",
+                            "D15"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "B17",
+                        "C16",
+                        "D15",
+                        "D13"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "B17-C16-D15-D13",
+                    "nodes": [
+                        "B17-0",
+                        "C16-0",
+                        "D15-0",
+                        "D13-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 170,
+            "created_at": 1701329085
+        },
+        {
+            "type": "pass",
+            "entity": "1",
+            "entity_type": "minor",
+            "id": 171,
+            "created_at": 1701329088
+        },
+        {
+            "type": "run_routes",
+            "entity": "1",
+            "entity_type": "minor",
+            "id": 172,
+            "created_at": 1701329091,
+            "routes": [
+                {
+                    "train": "2-0",
+                    "connections": [
+                        [
+                            "A10",
+                            "B9",
+                            "B7"
+                        ],
+                        [
+                            "B7",
+                            "A6"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B7",
+                        "A6"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "A10-B7-A6",
+                    "nodes": [
+                        "A10-0",
+                        "B7-0",
+                        "A6-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "1",
+            "entity_type": "minor",
+            "id": 173,
+            "created_at": 1701329094
+        },
+        {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 174,
+            "created_at": 1701329161
+        },
+        {
+            "type": "run_routes",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 175,
+            "created_at": 1701329163,
+            "routes": [
+                {
+                    "train": "2-1",
+                    "connections": [
+                        [
+                            "C8",
+                            "C6"
+                        ],
+                        [
+                            "C6",
+                            "C4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ]
+                    ],
+                    "hexes": [
+                        "C8",
+                        "C6",
+                        "C4",
+                        "D3"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "C8-C6-C4-D3",
+                    "nodes": [
+                        "C8-0",
+                        "C6-0",
+                        "C4-0",
+                        "D3-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 176,
+            "created_at": 1701329164
+        },
+        {
+            "type": "lay_tile",
+            "entity": "3",
+            "entity_type": "minor",
+            "id": 177,
+            "created_at": 1701329177,
+            "hex": "B15",
+            "tile": "9-2",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "3",
+            "entity_type": "minor",
+            "id": 178,
+            "created_at": 1701329181,
+            "routes": [
+                {
+                    "train": "2-2",
+                    "connections": [
+                        [
+                            "A10",
+                            "B11",
+                            "B13"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B13"
+                    ],
+                    "revenue": 50,
+                    "revenue_str": "A10-B13",
+                    "nodes": [
+                        "A10-1",
+                        "B13-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "3",
+            "entity_type": "minor",
+            "id": 179,
+            "created_at": 1701329181
+        },
+        {
+            "type": "lay_tile",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 180,
+            "created_at": 1701360769,
+            "hex": "H7",
+            "tile": "4-4",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 181,
+            "created_at": 1701360778,
+            "routes": [
+                {
+                    "train": "2-3",
+                    "connections": [
+                        [
+                            "J5",
+                            "I6",
+                            "J7"
+                        ],
+                        [
+                            "J7",
+                            "I8"
+                        ],
+                        [
+                            "I8",
+                            "H7"
+                        ]
+                    ],
+                    "hexes": [
+                        "J5",
+                        "J7",
+                        "I8",
+                        "H7"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "J5-J7-I8-H7",
+                    "nodes": [
+                        "J5-1",
+                        "J7-0",
+                        "I8-0",
+                        "H7-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 182,
+            "created_at": 1701360786
+        },
+        {
+            "type": "lay_tile",
+            "entity": "5",
+            "entity_type": "minor",
+            "id": 183,
+            "created_at": 1701362937,
+            "hex": "G20",
+            "tile": "58-6",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "5",
+            "entity_type": "minor",
+            "id": 184,
+            "created_at": 1701362951,
+            "routes": [
+                {
+                    "train": "2-4",
+                    "connections": [
+                        [
+                            "G22",
+                            "H21",
+                            "H19"
+                        ],
+                        [
+                            "H19",
+                            "G20"
+                        ]
+                    ],
+                    "hexes": [
+                        "G22",
+                        "H19",
+                        "G20"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "G22-H19-G20",
+                    "nodes": [
+                        "G22-0",
+                        "H19-0",
+                        "G20-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "5",
+            "entity_type": "minor",
+            "id": 185,
+            "created_at": 1701362956
+        },
+        {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 186,
+            "created_at": 1701362966
+        },
+        {
+            "type": "run_routes",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 187,
+            "created_at": 1701362995,
+            "routes": [
+                {
+                    "train": "2-5",
+                    "connections": [
+                        [
+                            "K14",
+                            "K12"
+                        ],
+                        [
+                            "K12",
+                            "L13",
+                            "M14",
+                            "M16"
+                        ]
+                    ],
+                    "hexes": [
+                        "K14",
+                        "K12",
+                        "M16"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "K14-K12-M16",
+                    "nodes": [
+                        "K14-1",
+                        "K12-0",
+                        "M16-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 188,
+            "created_at": 1701363000
+        },
+        {
+            "type": "pass",
+            "entity": "7",
+            "entity_type": "minor",
+            "id": 189,
+            "created_at": 1701363224
+        },
+        {
+            "type": "run_routes",
+            "entity": "7",
+            "entity_type": "minor",
+            "id": 190,
+            "created_at": 1701363226,
+            "routes": [
+                {
+                    "train": "2-6",
+                    "connections": [
+                        [
+                            "J5",
+                            "I6",
+                            "J7"
+                        ]
+                    ],
+                    "hexes": [
+                        "J5",
+                        "J7"
+                    ],
+                    "revenue": 60,
+                    "revenue_str": "J5-J7",
+                    "nodes": [
+                        "J5-1",
+                        "J7-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "7",
+            "entity_type": "minor",
+            "id": 191,
+            "created_at": 1701363236
+        },
+        {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "minor",
+            "id": 192,
+            "created_at": 1701364280
+        },
+        {
+            "type": "run_routes",
+            "entity": "8",
+            "entity_type": "minor",
+            "id": 193,
+            "created_at": 1701364290,
+            "routes": [
+                {
+                    "train": "2-7",
+                    "connections": [
+                        [
+                            "N17",
+                            "M16"
+                        ],
+                        [
+                            "M16",
+                            "M14",
+                            "L13",
+                            "K12"
+                        ]
+                    ],
+                    "hexes": [
+                        "N17",
+                        "M16",
+                        "K12"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "N17-M16-K12",
+                    "nodes": [
+                        "N17-0",
+                        "M16-0",
+                        "K12-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "minor",
+            "id": 194,
+            "created_at": 1701364301
+        },
+        {
+            "type": "lay_tile",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 195,
+            "created_at": 1701365028,
+            "hex": "M6",
+            "tile": "8-4",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 196,
+            "created_at": 1701365034,
+            "routes": [
+                {
+                    "train": "2-8",
+                    "connections": [
+                        [
+                            "J5",
+                            "K4"
+                        ],
+                        [
+                            "K4",
+                            "L5"
+                        ],
+                        [
+                            "L5",
+                            "M6",
+                            "N5"
+                        ]
+                    ],
+                    "hexes": [
+                        "J5",
+                        "K4",
+                        "L5",
+                        "N5"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "J5-K4-L5-N5",
+                    "nodes": [
+                        "J5-0",
+                        "K4-0",
+                        "L5-0",
+                        "N5-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 197,
+            "created_at": 1701365043
+        },
+        {
+            "type": "lay_tile",
+            "entity": "10",
+            "entity_type": "minor",
+            "id": 198,
+            "created_at": 1701365504,
+            "hex": "F19",
+            "tile": "9-3",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "10",
+            "entity_type": "minor",
+            "id": 199,
+            "created_at": 1701365594,
+            "routes": [
+                {
+                    "train": "2-9",
+                    "connections": [
+                        [
+                            "G20",
+                            "F19",
+                            "E18"
+                        ],
+                        [
+                            "E18",
+                            "E20"
+                        ],
+                        [
+                            "E20",
+                            "E22"
+                        ]
+                    ],
+                    "hexes": [
+                        "G20",
+                        "E18",
+                        "E20",
+                        "E22"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "G20-E18-E20-E22",
+                    "nodes": [
+                        "G20-0",
+                        "E18-0",
+                        "E20-0",
+                        "E22-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "10",
+            "entity_type": "minor",
+            "id": 200,
+            "created_at": 1701365609
+        },
+        {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 201,
+            "created_at": 1701365756
+        },
+        {
+            "type": "run_routes",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 202,
+            "created_at": 1701365764,
+            "routes": [
+                {
+                    "train": "2-10",
+                    "connections": [
+                        [
+                            "K14",
+                            "K16",
+                            "J17",
+                            "I18"
+                        ]
+                    ],
+                    "hexes": [
+                        "K14",
+                        "I18"
+                    ],
+                    "revenue": 50,
+                    "revenue_str": "K14-I18",
+                    "nodes": [
+                        "K14-0",
+                        "I18-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 203,
+            "created_at": 1701365766
+        },
+        {
+            "type": "pass",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 204,
+            "created_at": 1701365875
+        },
+        {
+            "type": "run_routes",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 205,
+            "created_at": 1701365876,
+            "routes": [
+                {
+                    "train": "2-11",
+                    "connections": [
+                        [
+                            "C8",
+                            "C6"
+                        ],
+                        [
+                            "C6",
+                            "C4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ],
+                        [
+                            "D3",
+                            "D1"
+                        ]
+                    ],
+                    "hexes": [
+                        "C8",
+                        "C6",
+                        "C4",
+                        "D3",
+                        "D1"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "C8-C6-C4-D3-D1",
+                    "nodes": [
+                        "C8-0",
+                        "C6-0",
+                        "C4-0",
+                        "D3-0",
+                        "D1-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 206,
+            "created_at": 1701365877
+        },
+        {
+            "hex": "G10",
+            "tile": "58-7",
+            "type": "lay_tile",
+            "entity": "13",
+            "rotation": 0,
+            "entity_type": "minor",
+            "id": 207,
+            "user": 2394,
+            "created_at": 1701366297
+        },
+        {
+            "type": "run_routes",
+            "entity": "13",
+            "routes": [
+                {
+                    "hexes": [
+                        "F11",
+                        "G12",
+                        "G10"
+                    ],
+                    "nodes": [
+                        "F11-0",
+                        "G12-0",
+                        "G10-0"
+                    ],
+                    "train": "2-12",
+                    "revenue": 50,
+                    "connections": [
+                        [
+                            "F11",
+                            "G12"
+                        ],
+                        [
+                            "G12",
+                            "G10"
+                        ]
+                    ],
+                    "revenue_str": "F11-G12-G10"
+                }
+            ],
+            "entity_type": "minor",
+            "extra_revenue": 0,
+            "id": 208,
+            "user": 2394,
+            "created_at": 1701366304
+        },
+        {
+            "type": "undo",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 209,
+            "user": 2394,
+            "created_at": 1701366310
+        },
+        {
+            "type": "undo",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 210,
+            "user": 2394,
+            "created_at": 1701366312
+        },
+        {
+            "type": "lay_tile",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 211,
+            "created_at": 1701366316,
+            "hex": "E12",
+            "tile": "4-5",
+            "rotation": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 212,
+            "created_at": 1701366319,
+            "routes": [
+                {
+                    "train": "2-12",
+                    "connections": [
+                        [
+                            "G12",
+                            "F11"
+                        ],
+                        [
+                            "F11",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "D13"
+                        ]
+                    ],
+                    "hexes": [
+                        "G12",
+                        "F11",
+                        "E12",
+                        "D13"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "G12-F11-E12-D13",
+                    "nodes": [
+                        "G12-0",
+                        "F11-0",
+                        "E12-0",
+                        "D13-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 213,
+            "created_at": 1701366322
+        },
+        {
+            "type": "pass",
+            "entity": "14",
+            "entity_type": "minor",
+            "id": 214,
+            "created_at": 1701366326
+        },
+        {
+            "type": "run_routes",
+            "entity": "14",
+            "entity_type": "minor",
+            "id": 215,
+            "created_at": 1701366328,
+            "routes": [
+                {
+                    "train": "2-13",
+                    "connections": [
+                        [
+                            "B17",
+                            "C16"
+                        ],
+                        [
+                            "C16",
+                            "D15"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ],
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ]
+                    ],
+                    "hexes": [
+                        "B17",
+                        "C16",
+                        "D15",
+                        "D13",
+                        "E12",
+                        "F11"
+                    ],
+                    "revenue": 100,
+                    "revenue_str": "B17-C16-D15-D13-E12-F11",
+                    "nodes": [
+                        "B17-0",
+                        "C16-0",
+                        "D15-0",
+                        "D13-0",
+                        "E12-0",
+                        "F11-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "14",
+            "entity_type": "minor",
+            "id": 216,
+            "created_at": 1701366330
+        },
+        {
+            "type": "lay_tile",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 217,
+            "created_at": 1701366334,
+            "hex": "B19",
+            "tile": "57-2",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 218,
+            "created_at": 1701366338,
+            "routes": [
+                {
+                    "train": "2-14",
+                    "connections": [
+                        [
+                            "D15",
+                            "C16"
+                        ],
+                        [
+                            "C16",
+                            "B17"
+                        ],
+                        [
+                            "B17",
+                            "B19"
+                        ],
+                        [
+                            "B19",
+                            "B21"
+                        ]
+                    ],
+                    "hexes": [
+                        "D15",
+                        "C16",
+                        "B17",
+                        "B19",
+                        "B21"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "D15-C16-B17-B19-B21",
+                    "nodes": [
+                        "D15-0",
+                        "C16-0",
+                        "B17-0",
+                        "B19-0",
+                        "B21-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 219,
+            "created_at": 1701366344
+        },
+        {
+            "type": "pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 220,
+            "created_at": 1701371413
+        },
+        {
+            "type": "par",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 221,
+            "created_at": 1701373409,
+            "corporation": "SNCF",
+            "share_price": "75,4,3"
+        },
+        {
+            "city": "A10-0-0",
+            "slot": 0,
+            "type": "place_token",
+            "entity": "SNCF",
+            "tokener": "SNCF",
+            "entity_type": "corporation",
+            "id": 222,
+            "user": 2394,
+            "created_at": 1701373415
+        },
+        {
+            "type": "par",
+            "entity": 7046,
+            "corporation": "FS",
+            "entity_type": "player",
+            "share_price": "75,4,3",
+            "id": 223,
+            "user": 7046,
+            "created_at": 1701374026
+        },
+        {
+            "type": "undo",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 224,
+            "user": 7046,
+            "created_at": 1701374069
+        },
+        {
+            "type": "undo",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 225,
+            "user": 7046,
+            "created_at": 1701374116
+        },
+        {
+            "type": "place_token",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 226,
+            "created_at": 1701375838,
+            "city": "A10-0-0",
+            "slot": 0,
+            "tokener": "SNCF"
+        },
+        {
+            "type": "par",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 227,
+            "created_at": 1701384031,
+            "corporation": "BNR",
+            "share_price": "75,4,3"
+        },
+        {
+            "type": "place_token",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 228,
+            "created_at": 1701384048,
+            "city": "201-2-0",
+            "slot": 0,
+            "tokener": "BNR"
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 229,
+            "created_at": 1701384606
+        },
+        {
+            "type": "par",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 230,
+            "created_at": 1701403600,
+            "corporation": "FS",
+            "share_price": "75,4,3"
+        },
+        {
+            "type": "place_token",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 231,
+            "created_at": 1701403610,
+            "city": "A10-0-1",
+            "slot": 0,
+            "tokener": "FS"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 232,
+            "created_at": 1701414860,
+            "shares": [
+                "SNCF_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": "5",
+            "entity_type": "minor",
+            "id": 233,
+            "created_at": 1701453099,
+            "shares": [
+                "BNR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "place_token",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 234,
+            "created_at": 1701453135,
+            "city": "201-1-0",
+            "slot": 0,
+            "tokener": "BNR"
+        },
+        {
+            "type": "undo",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 235,
+            "user": 2394,
+            "created_at": 1701455085
+        },
+        {
+            "type": "redo",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 236,
+            "user": 2394,
+            "created_at": 1701455086
+        },
+        {
+            "type": "par",
+            "entity": 253,
+            "corporation": "RPR",
+            "entity_type": "player",
+            "share_price": "100,2,4",
+            "id": 237,
+            "user": 253,
+            "created_at": 1701455363
+        },
+        {
+            "type": "undo",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 238,
+            "user": 253,
+            "created_at": 1701455371
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 239,
+            "created_at": 1701455794
+        },
+        {
+            "type": "buy_shares",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 240,
+            "created_at": 1701455838,
+            "shares": [
+                "FS_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 241,
+            "created_at": 1701456852,
+            "shares": [
+                "SNCF_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 242,
+            "created_at": 1701456862,
+            "unconditional": false,
+            "indefinite": false
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 243,
+            "created_at": 1701471734,
+            "shares": [
+                "BNR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 244,
+            "created_at": 1701473853,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701473853
+                },
+                {
+                    "type": "pass",
+                    "entity": 2394,
+                    "entity_type": "player",
+                    "created_at": 1701473853
+                }
+            ],
+            "shares": [
+                "SNCF_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 245,
+            "created_at": 1701474519,
+            "shares": [
+                "BNR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 246,
+            "created_at": 1701475319,
+            "unconditional": false,
+            "indefinite": false
+        },
+        {
+            "type": "buy_shares",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 247,
+            "created_at": 1701476011,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701476012
+                },
+                {
+                    "type": "pass",
+                    "entity": 2394,
+                    "entity_type": "player",
+                    "created_at": 1701476012
+                },
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701476012
+                }
+            ],
+            "shares": [
+                "BNR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 253,
+            "shares": [
+                "FS_3"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 173,
+                    "created_at": 1701476019,
+                    "entity_type": "player"
+                },
+                {
+                    "type": "pass",
+                    "entity": 2394,
+                    "created_at": 1701476019,
+                    "entity_type": "player"
+                },
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "created_at": 1701476019,
+                    "entity_type": "player"
+                },
+                {
+                    "type": "pass",
+                    "entity": 253,
+                    "created_at": 1701476019,
+                    "entity_type": "player"
+                }
+            ],
+            "id": 248,
+            "user": 253,
+            "created_at": 1701476019
+        },
+        {
+            "type": "undo",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 249,
+            "user": 253,
+            "created_at": 1701476024
+        },
+        {
+            "type": "buy_shares",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 250,
+            "created_at": 1701476040,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701476041
+                },
+                {
+                    "type": "pass",
+                    "entity": 2394,
+                    "entity_type": "player",
+                    "created_at": 1701476041
+                },
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701476041
+                },
+                {
+                    "type": "pass",
+                    "entity": 253,
+                    "entity_type": "player",
+                    "created_at": 1701476041
+                }
+            ],
+            "shares": [
+                "FS_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 251,
+            "user": 173,
+            "created_at": 1701513229
+        },
+        {
+            "type": "undo",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 252,
+            "user": 173,
+            "created_at": 1701513236
+        },
+        {
+            "type": "lay_tile",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 253,
+            "created_at": 1701513249,
+            "hex": "D9",
+            "tile": "9-4",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 254,
+            "created_at": 1701513250,
+            "routes": [
+                {
+                    "train": "2-1",
+                    "connections": [
+                        [
+                            "C8",
+                            "C6"
+                        ],
+                        [
+                            "C6",
+                            "C4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ]
+                    ],
+                    "hexes": [
+                        "C8",
+                        "C6",
+                        "C4",
+                        "D3"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "C8-C6-C4-D3",
+                    "nodes": [
+                        "C8-0",
+                        "C6-0",
+                        "C4-0",
+                        "D3-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 255,
+            "created_at": 1701513253
+        },
+        {
+            "type": "lay_tile",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 256,
+            "created_at": 1701529367,
+            "hex": "G6",
+            "tile": "58-7",
+            "rotation": 3
+        },
+        {
+            "type": "run_routes",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 257,
+            "created_at": 1701529371,
+            "routes": [
+                {
+                    "train": "2-3",
+                    "connections": [
+                        [
+                            "J5",
+                            "I6",
+                            "J7"
+                        ],
+                        [
+                            "J7",
+                            "I8"
+                        ],
+                        [
+                            "I8",
+                            "H7"
+                        ],
+                        [
+                            "H7",
+                            "G6"
+                        ]
+                    ],
+                    "hexes": [
+                        "J5",
+                        "J7",
+                        "I8",
+                        "H7",
+                        "G6"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "J5-J7-I8-H7-G6",
+                    "nodes": [
+                        "J5-1",
+                        "J7-0",
+                        "I8-0",
+                        "H7-0",
+                        "G6-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 258,
+            "created_at": 1701529386
+        },
+        {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 259,
+            "created_at": 1701541418
+        },
+        {
+            "type": "run_routes",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 260,
+            "created_at": 1701541424,
+            "routes": [
+                {
+                    "train": "2-5",
+                    "connections": [
+                        [
+                            "K14",
+                            "K12"
+                        ],
+                        [
+                            "K12",
+                            "L13",
+                            "M14",
+                            "M16"
+                        ]
+                    ],
+                    "hexes": [
+                        "K14",
+                        "K12",
+                        "M16"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "K14-K12-M16",
+                    "nodes": [
+                        "K14-1",
+                        "K12-0",
+                        "M16-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 261,
+            "created_at": 1701541569
+        },
+        {
+            "type": "pass",
+            "entity": "7",
+            "entity_type": "minor",
+            "id": 262,
+            "created_at": 1701541700
+        },
+        {
+            "type": "run_routes",
+            "entity": "7",
+            "entity_type": "minor",
+            "id": 263,
+            "created_at": 1701541701,
+            "routes": [
+                {
+                    "train": "2-6",
+                    "connections": [
+                        [
+                            "J5",
+                            "I6",
+                            "J7"
+                        ]
+                    ],
+                    "hexes": [
+                        "J5",
+                        "J7"
+                    ],
+                    "revenue": 60,
+                    "revenue_str": "J5-J7",
+                    "nodes": [
+                        "J5-1",
+                        "J7-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "7",
+            "entity_type": "minor",
+            "id": 264,
+            "created_at": 1701541710
+        },
+        {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "minor",
+            "id": 265,
+            "created_at": 1701542107
+        },
+        {
+            "type": "run_routes",
+            "entity": "8",
+            "entity_type": "minor",
+            "id": 266,
+            "created_at": 1701542111,
+            "routes": [
+                {
+                    "train": "2-7",
+                    "connections": [
+                        [
+                            "N17",
+                            "M16"
+                        ],
+                        [
+                            "M16",
+                            "M14",
+                            "L13",
+                            "K12"
+                        ]
+                    ],
+                    "hexes": [
+                        "N17",
+                        "M16",
+                        "K12"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "N17-M16-K12",
+                    "nodes": [
+                        "N17-0",
+                        "M16-0",
+                        "K12-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "minor",
+            "id": 267,
+            "created_at": 1701542186
+        },
+        {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 268,
+            "created_at": 1701544677
+        },
+        {
+            "type": "run_routes",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 269,
+            "created_at": 1701544680,
+            "routes": [
+                {
+                    "train": "2-8",
+                    "connections": [
+                        [
+                            "J5",
+                            "K4"
+                        ],
+                        [
+                            "K4",
+                            "L5"
+                        ],
+                        [
+                            "L5",
+                            "M6",
+                            "N5"
+                        ]
+                    ],
+                    "hexes": [
+                        "J5",
+                        "K4",
+                        "L5",
+                        "N5"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "J5-K4-L5-N5",
+                    "nodes": [
+                        "J5-0",
+                        "K4-0",
+                        "L5-0",
+                        "N5-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 270,
+            "created_at": 1701544692
+        },
+        {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 271,
+            "created_at": 1701544716
+        },
+        {
+            "type": "run_routes",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 272,
+            "created_at": 1701544717,
+            "routes": [
+                {
+                    "train": "2-10",
+                    "connections": [
+                        [
+                            "K14",
+                            "K16",
+                            "J17",
+                            "I18"
+                        ]
+                    ],
+                    "hexes": [
+                        "K14",
+                        "I18"
+                    ],
+                    "revenue": 50,
+                    "revenue_str": "K14-I18",
+                    "nodes": [
+                        "K14-0",
+                        "I18-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 273,
+            "created_at": 1701544719
+        },
+        {
+            "type": "undo",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 274,
+            "user": 2394,
+            "created_at": 1701605955
+        },
+        {
+            "type": "redo",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 275,
+            "user": 2394,
+            "created_at": 1701605956
+        },
+        {
+            "type": "pass",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 276,
+            "created_at": 1701606007
+        },
+        {
+            "type": "run_routes",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 277,
+            "created_at": 1701606009,
+            "routes": [
+                {
+                    "train": "2-11",
+                    "connections": [
+                        [
+                            "C8",
+                            "C6"
+                        ],
+                        [
+                            "C6",
+                            "C4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ],
+                        [
+                            "D3",
+                            "D1"
+                        ]
+                    ],
+                    "hexes": [
+                        "C8",
+                        "C6",
+                        "C4",
+                        "D3",
+                        "D1"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "C8-C6-C4-D3-D1",
+                    "nodes": [
+                        "C8-0",
+                        "C6-0",
+                        "C4-0",
+                        "D3-0",
+                        "D1-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 278,
+            "created_at": 1701606010
+        },
+        {
+            "type": "lay_tile",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 279,
+            "created_at": 1701606219,
+            "hex": "G10",
+            "tile": "58-8",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 280,
+            "created_at": 1701606223,
+            "routes": [
+                {
+                    "train": "2-12",
+                    "connections": [
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "F11",
+                            "G12"
+                        ],
+                        [
+                            "G12",
+                            "G10"
+                        ]
+                    ],
+                    "hexes": [
+                        "D13",
+                        "E12",
+                        "F11",
+                        "G12",
+                        "G10"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "D13-E12-F11-G12-G10",
+                    "nodes": [
+                        "D13-0",
+                        "E12-0",
+                        "F11-0",
+                        "G12-0",
+                        "G10-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 281,
+            "created_at": 1701606240
+        },
+        {
+            "type": "pass",
+            "entity": "14",
+            "entity_type": "minor",
+            "id": 282,
+            "created_at": 1701606243
+        },
+        {
+            "type": "run_routes",
+            "entity": "14",
+            "entity_type": "minor",
+            "id": 283,
+            "created_at": 1701606246,
+            "routes": [
+                {
+                    "train": "2-13",
+                    "connections": [
+                        [
+                            "B17",
+                            "C16"
+                        ],
+                        [
+                            "C16",
+                            "D15"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ],
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ]
+                    ],
+                    "hexes": [
+                        "B17",
+                        "C16",
+                        "D15",
+                        "D13",
+                        "E12",
+                        "F11"
+                    ],
+                    "revenue": 100,
+                    "revenue_str": "B17-C16-D15-D13-E12-F11",
+                    "nodes": [
+                        "B17-0",
+                        "C16-0",
+                        "D15-0",
+                        "D13-0",
+                        "E12-0",
+                        "F11-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "14",
+            "entity_type": "minor",
+            "id": 284,
+            "created_at": 1701606268,
+            "train": "2-12",
+            "price": 100
+        },
+        {
+            "type": "pass",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 285,
+            "created_at": 1701606272
+        },
+        {
+            "type": "run_routes",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 286,
+            "created_at": 1701606275,
+            "routes": [
+                {
+                    "train": "2-14",
+                    "connections": [
+                        [
+                            "D15",
+                            "C16"
+                        ],
+                        [
+                            "C16",
+                            "B17"
+                        ],
+                        [
+                            "B17",
+                            "B19"
+                        ],
+                        [
+                            "B19",
+                            "B21"
+                        ]
+                    ],
+                    "hexes": [
+                        "D15",
+                        "C16",
+                        "B17",
+                        "B19",
+                        "B21"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "D15-C16-B17-B19-B21",
+                    "nodes": [
+                        "D15-0",
+                        "C16-0",
+                        "B17-0",
+                        "B19-0",
+                        "B21-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 287,
+            "created_at": 1701606285
+        },
+        {
+            "type": "pass",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 288,
+            "created_at": 1701606426
+        },
+        {
+            "type": "run_routes",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 289,
+            "created_at": 1701606429,
+            "routes": [
+                {
+                    "train": "2-0",
+                    "connections": [
+                        [
+                            "A10",
+                            "B9",
+                            "B7"
+                        ],
+                        [
+                            "B7",
+                            "A6"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B7",
+                        "A6"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "A10-B7-A6",
+                    "nodes": [
+                        "A10-0",
+                        "B7-0",
+                        "A6-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 290,
+            "created_at": 1701606432,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 291,
+            "user": 2394,
+            "created_at": 1701606440
+        },
+        {
+            "type": "undo",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 292,
+            "user": 2394,
+            "created_at": 1701606460
+        },
+        {
+            "type": "buy_train",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 293,
+            "created_at": 1701606472,
+            "train": "2-14",
+            "price": 80
+        },
+        {
+            "type": "pass",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 294,
+            "created_at": 1701606474
+        },
+        {
+            "type": "pass",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 295,
+            "created_at": 1701621644
+        },
+        {
+            "type": "pass",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 296,
+            "created_at": 1701621656
+        },
+        {
+            "type": "run_routes",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 297,
+            "created_at": 1701621678,
+            "routes": [
+                {
+                    "train": "2-4",
+                    "connections": [
+                        [
+                            "G22",
+                            "H21",
+                            "H19"
+                        ],
+                        [
+                            "H19",
+                            "G20"
+                        ]
+                    ],
+                    "hexes": [
+                        "G22",
+                        "H19",
+                        "G20"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "G22-H19-G20",
+                    "nodes": [
+                        "G22-0",
+                        "H19-0",
+                        "G20-0"
+                    ]
+                },
+                {
+                    "train": "2-9",
+                    "connections": [
+                        [
+                            "G20",
+                            "F19",
+                            "E18"
+                        ],
+                        [
+                            "E18",
+                            "E20"
+                        ],
+                        [
+                            "E20",
+                            "E22"
+                        ]
+                    ],
+                    "hexes": [
+                        "G20",
+                        "E18",
+                        "E20",
+                        "E22"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "G20-E18-E20-E22",
+                    "nodes": [
+                        "G20-0",
+                        "E18-0",
+                        "E20-0",
+                        "E22-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 298,
+            "created_at": 1701621686,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 299,
+            "created_at": 1701621703,
+            "train": "3-0",
+            "price": 200,
+            "variant": "3"
+        },
+        {
+            "type": "buy_train",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 300,
+            "created_at": 1701621704,
+            "train": "3-1",
+            "price": 200,
+            "variant": "3"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 301,
+            "created_at": 1701621744,
+            "hex": "B17",
+            "tile": "576-0",
+            "rotation": 3
+        },
+        {
+            "type": "run_routes",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 302,
+            "created_at": 1701621747,
+            "routes": [
+                {
+                    "train": "2-2",
+                    "connections": [
+                        [
+                            "A10",
+                            "B11",
+                            "B13"
+                        ],
+                        [
+                            "B13",
+                            "B15",
+                            "B17"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B13",
+                        "B17"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "A10-B13-B17",
+                    "nodes": [
+                        "A10-1",
+                        "B13-0",
+                        "B17-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 303,
+            "created_at": 1701621747,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 304,
+            "created_at": 1701621751,
+            "train": "3-2",
+            "price": 200,
+            "variant": "3"
+        },
+        {
+            "type": "pass",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 305,
+            "created_at": 1701621752
+        },
+        {
+            "type": "lay_tile",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 306,
+            "created_at": 1701621756,
+            "hex": "E10",
+            "tile": "8-5",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 307,
+            "created_at": 1701621757,
+            "routes": [
+                {
+                    "train": "2-1",
+                    "connections": [
+                        [
+                            "C8",
+                            "C6"
+                        ],
+                        [
+                            "C6",
+                            "C4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ]
+                    ],
+                    "hexes": [
+                        "C8",
+                        "C6",
+                        "C4",
+                        "D3"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "C8-C6-C4-D3",
+                    "nodes": [
+                        "C8-0",
+                        "C6-0",
+                        "C4-0",
+                        "D3-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 308,
+            "created_at": 1701621761
+        },
+        {
+            "type": "lay_tile",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 309,
+            "created_at": 1701642150,
+            "hex": "G4",
+            "tile": "9-5",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 310,
+            "created_at": 1701642161,
+            "routes": [
+                {
+                    "train": "2-3",
+                    "connections": [
+                        [
+                            "J5",
+                            "I6",
+                            "J7"
+                        ],
+                        [
+                            "J7",
+                            "I8"
+                        ],
+                        [
+                            "I8",
+                            "H7"
+                        ],
+                        [
+                            "H7",
+                            "G6"
+                        ]
+                    ],
+                    "hexes": [
+                        "J5",
+                        "J7",
+                        "I8",
+                        "H7",
+                        "G6"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "J5-J7-I8-H7-G6",
+                    "nodes": [
+                        "J5-1",
+                        "J7-0",
+                        "I8-0",
+                        "H7-0",
+                        "G6-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "buy_train",
+            "price": 110,
+            "train": "2-6",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 311,
+            "user": 253,
+            "created_at": 1701642293
+        },
+        {
+            "type": "undo",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 312,
+            "user": 253,
+            "created_at": 1701642297
+        },
+        {
+            "type": "buy_train",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 313,
+            "created_at": 1701642326,
+            "train": "2-6",
+            "price": 110
+        },
+        {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 314,
+            "created_at": 1701643456
+        },
+        {
+            "type": "run_routes",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 315,
+            "created_at": 1701643462,
+            "routes": [
+                {
+                    "train": "2-5",
+                    "connections": [
+                        [
+                            "K14",
+                            "K12"
+                        ],
+                        [
+                            "K12",
+                            "L13",
+                            "M14",
+                            "M16"
+                        ]
+                    ],
+                    "hexes": [
+                        "K14",
+                        "K12",
+                        "M16"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "K14-K12-M16",
+                    "nodes": [
+                        "K14-1",
+                        "K12-0",
+                        "M16-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 316,
+            "created_at": 1701643472
+        },
+        {
+            "type": "pass",
+            "entity": "7",
+            "entity_type": "minor",
+            "id": 317,
+            "created_at": 1701648790
+        },
+        {
+            "type": "buy_train",
+            "entity": "7",
+            "entity_type": "minor",
+            "id": 318,
+            "created_at": 1701648792,
+            "train": "3-3",
+            "price": 200,
+            "variant": "3"
+        },
+        {
+            "type": "pass",
+            "entity": "8",
+            "entity_type": "minor",
+            "id": 319,
+            "created_at": 1701649606
+        },
+        {
+            "type": "run_routes",
+            "entity": "8",
+            "entity_type": "minor",
+            "id": 320,
+            "created_at": 1701649612,
+            "routes": [
+                {
+                    "train": "2-7",
+                    "connections": [
+                        [
+                            "N17",
+                            "M16"
+                        ],
+                        [
+                            "M16",
+                            "M14",
+                            "L13",
+                            "K12"
+                        ]
+                    ],
+                    "hexes": [
+                        "N17",
+                        "M16",
+                        "K12"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "N17-M16-K12",
+                    "nodes": [
+                        "N17-0",
+                        "M16-0",
+                        "K12-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "8",
+            "entity_type": "minor",
+            "id": 321,
+            "created_at": 1701649635,
+            "train": "3-0",
+            "price": 140
+        },
+        {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 322,
+            "created_at": 1701649976
+        },
+        {
+            "type": "run_routes",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 323,
+            "created_at": 1701649979,
+            "routes": [
+                {
+                    "train": "2-8",
+                    "connections": [
+                        [
+                            "J5",
+                            "K4"
+                        ],
+                        [
+                            "K4",
+                            "L5"
+                        ],
+                        [
+                            "L5",
+                            "M6",
+                            "N5"
+                        ]
+                    ],
+                    "hexes": [
+                        "J5",
+                        "K4",
+                        "L5",
+                        "N5"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "J5-K4-L5-N5",
+                    "nodes": [
+                        "J5-0",
+                        "K4-0",
+                        "L5-0",
+                        "N5-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 324,
+            "created_at": 1701649988
+        },
+        {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 325,
+            "created_at": 1701649996
+        },
+        {
+            "type": "run_routes",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 326,
+            "created_at": 1701649997,
+            "routes": [
+                {
+                    "train": "2-10",
+                    "connections": [
+                        [
+                            "K14",
+                            "K16",
+                            "J17",
+                            "I18"
+                        ]
+                    ],
+                    "hexes": [
+                        "K14",
+                        "I18"
+                    ],
+                    "revenue": 50,
+                    "revenue_str": "K14-I18",
+                    "nodes": [
+                        "K14-0",
+                        "I18-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 327,
+            "user": 253,
+            "created_at": 1701649999
+        },
+        {
+            "type": "undo",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 328,
+            "user": 253,
+            "created_at": 1701650004
+        },
+        {
+            "type": "buy_train",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 329,
+            "created_at": 1701650020,
+            "train": "2-3",
+            "price": 100
+        },
+        {
+            "type": "pass",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 330,
+            "created_at": 1701663048
+        },
+        {
+            "type": "run_routes",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 331,
+            "created_at": 1701663049,
+            "routes": [
+                {
+                    "train": "2-11",
+                    "connections": [
+                        [
+                            "C8",
+                            "C6"
+                        ],
+                        [
+                            "C6",
+                            "C4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ],
+                        [
+                            "D3",
+                            "D1"
+                        ]
+                    ],
+                    "hexes": [
+                        "C8",
+                        "C6",
+                        "C4",
+                        "D3",
+                        "D1"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "C8-C6-C4-D3-D1",
+                    "nodes": [
+                        "C8-0",
+                        "C6-0",
+                        "C4-0",
+                        "D3-0",
+                        "D1-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 332,
+            "created_at": 1701663056
+        },
+        {
+            "type": "lay_tile",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 333,
+            "created_at": 1701672559,
+            "hex": "F9",
+            "tile": "57-3",
+            "rotation": 2
+        },
+        {
+            "type": "buy_train",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 334,
+            "created_at": 1701672566,
+            "train": "3-4",
+            "price": 200,
+            "variant": "3"
+        },
+        {
+            "type": "pass",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 335,
+            "created_at": 1701672568
+        },
+        {
+            "type": "pass",
+            "entity": "14",
+            "entity_type": "minor",
+            "id": 336,
+            "created_at": 1701672574
+        },
+        {
+            "type": "run_routes",
+            "entity": "14",
+            "routes": [
+                {
+                    "hexes": [
+                        "D13",
+                        "E12",
+                        "F11",
+                        "G12"
+                    ],
+                    "nodes": [
+                        "D13-0",
+                        "E12-0",
+                        "F11-0",
+                        "G12-0"
+                    ],
+                    "train": "2-12",
+                    "revenue": 80,
+                    "connections": [
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "F11",
+                            "G12"
+                        ]
+                    ],
+                    "revenue_str": "D13-E12-F11-G12"
+                },
+                {
+                    "hexes": [
+                        "D13",
+                        "D15",
+                        "C16",
+                        "B17"
+                    ],
+                    "nodes": [
+                        "D13-0",
+                        "D15-0",
+                        "C16-0",
+                        "B17-0"
+                    ],
+                    "train": "2-13",
+                    "revenue": 90,
+                    "connections": [
+                        [
+                            "D13",
+                            "D15"
+                        ],
+                        [
+                            "D15",
+                            "C16"
+                        ],
+                        [
+                            "C16",
+                            "B17"
+                        ]
+                    ],
+                    "revenue_str": "D13-D15-C16-B17"
+                }
+            ],
+            "entity_type": "minor",
+            "extra_revenue": 0,
+            "id": 337,
+            "user": 2394,
+            "created_at": 1701672580
+        },
+        {
+            "type": "pass",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 338,
+            "user": 2394,
+            "created_at": 1701672584
+        },
+        {
+            "type": "buy_train",
+            "price": 200,
+            "train": "3-5",
+            "entity": "15",
+            "variant": "3",
+            "entity_type": "minor",
+            "id": 339,
+            "user": 2394,
+            "created_at": 1701672596
+        },
+        {
+            "hex": "A10",
+            "tile": "580-0",
+            "type": "lay_tile",
+            "entity": "SNCF",
+            "rotation": 3,
+            "entity_type": "corporation",
+            "id": 340,
+            "user": 2394,
+            "created_at": 1701672604
+        },
+        {
+            "type": "undo",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 341,
+            "user": 2394,
+            "created_at": 1701672617
+        },
+        {
+            "type": "undo",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 342,
+            "user": 2394,
+            "created_at": 1701672619
+        },
+        {
+            "type": "undo",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 343,
+            "user": 2394,
+            "created_at": 1701672621
+        },
+        {
+            "type": "undo",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 344,
+            "user": 2394,
+            "created_at": 1701672623
+        },
+        {
+            "type": "run_routes",
+            "entity": "14",
+            "entity_type": "minor",
+            "id": 345,
+            "created_at": 1701672628,
+            "routes": [
+                {
+                    "train": "2-12",
+                    "connections": [
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "F11",
+                            "G12"
+                        ]
+                    ],
+                    "hexes": [
+                        "D13",
+                        "E12",
+                        "F11",
+                        "G12"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "D13-E12-F11-G12",
+                    "nodes": [
+                        "D13-0",
+                        "E12-0",
+                        "F11-0",
+                        "G12-0"
+                    ]
+                },
+                {
+                    "train": "2-13",
+                    "connections": [
+                        [
+                            "D13",
+                            "D15"
+                        ],
+                        [
+                            "D15",
+                            "C16"
+                        ],
+                        [
+                            "C16",
+                            "B17"
+                        ]
+                    ],
+                    "hexes": [
+                        "D13",
+                        "D15",
+                        "C16",
+                        "B17"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "D13-D15-C16-B17",
+                    "nodes": [
+                        "D13-0",
+                        "D15-0",
+                        "C16-0",
+                        "B17-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "pass",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 346,
+            "created_at": 1701672635
+        },
+        {
+            "type": "buy_train",
+            "entity": "15",
+            "entity_type": "minor",
+            "id": 347,
+            "created_at": 1701672663,
+            "train": "2-0",
+            "price": 200
+        },
+        {
+            "type": "lay_tile",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 348,
+            "created_at": 1701672669,
+            "hex": "A10",
+            "tile": "580-0",
+            "rotation": 3
+        },
+        {
+            "type": "run_routes",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 349,
+            "created_at": 1701672686,
+            "routes": [
+                {
+                    "train": "2-14",
+                    "connections": [
+                        [
+                            "A10",
+                            "B9",
+                            "B7"
+                        ],
+                        [
+                            "B7",
+                            "A6"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B7",
+                        "A6"
+                    ],
+                    "revenue": 110,
+                    "revenue_str": "A10-B7-A6",
+                    "nodes": [
+                        "A10-0",
+                        "B7-0",
+                        "A6-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 350,
+            "created_at": 1701672690,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 351,
+            "created_at": 1701672734,
+            "train": "2-12",
+            "price": 100
+        },
+        {
+            "type": "pass",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 352,
+            "created_at": 1701672736
+        },
+        {
+            "type": "pass",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 353,
+            "created_at": 1701672752
+        },
+        {
+            "type": "lay_tile",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 354,
+            "created_at": 1701710516,
+            "hex": "H19",
+            "tile": "577-0",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 355,
+            "created_at": 1701710581
+        },
+        {
+            "type": "run_routes",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 356,
+            "created_at": 1701710610,
+            "routes": [
+                {
+                    "train": "3-1",
+                    "connections": [
+                        [
+                            "H19",
+                            "I18"
+                        ],
+                        [
+                            "I18",
+                            "J17",
+                            "K16",
+                            "K14"
+                        ]
+                    ],
+                    "hexes": [
+                        "H19",
+                        "I18",
+                        "K14"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "H19-I18-K14",
+                    "nodes": [
+                        "H19-0",
+                        "I18-0",
+                        "K14-0"
+                    ]
+                },
+                {
+                    "train": "2-4",
+                    "connections": [
+                        [
+                            "G20",
+                            "F19",
+                            "E18"
+                        ],
+                        [
+                            "E18",
+                            "E20"
+                        ],
+                        [
+                            "E20",
+                            "E22"
+                        ]
+                    ],
+                    "hexes": [
+                        "G20",
+                        "E18",
+                        "E20",
+                        "E22"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "G20-E18-E20-E22",
+                    "nodes": [
+                        "G20-0",
+                        "E18-0",
+                        "E20-0",
+                        "E22-0"
+                    ]
+                },
+                {
+                    "train": "2-9",
+                    "connections": [
+                        [
+                            "G22",
+                            "H21",
+                            "H19"
+                        ],
+                        [
+                            "H19",
+                            "G20"
+                        ]
+                    ],
+                    "hexes": [
+                        "G22",
+                        "H19",
+                        "G20"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "G22-H19-G20",
+                    "nodes": [
+                        "G22-0",
+                        "H19-0",
+                        "G20-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 357,
+            "created_at": 1701710659,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 358,
+            "created_at": 1701710665,
+            "train": "3-5",
+            "price": 200,
+            "variant": "3"
+        },
+        {
+            "type": "pass",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 359,
+            "created_at": 1701710689
+        },
+        {
+            "type": "undo",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 360,
+            "user": 2394,
+            "created_at": 1701717204
+        },
+        {
+            "type": "redo",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 361,
+            "user": 2394,
+            "created_at": 1701717205
+        },
+        {
+            "type": "lay_tile",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 362,
+            "created_at": 1701720040,
+            "hex": "B11",
+            "tile": "83-0",
+            "rotation": 3
+        },
+        {
+            "type": "run_routes",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 363,
+            "created_at": 1701720050,
+            "routes": [
+                {
+                    "train": "3-2",
+                    "connections": [
+                        [
+                            "A10",
+                            "B11",
+                            "B13"
+                        ],
+                        [
+                            "B13",
+                            "B15",
+                            "B17"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B13",
+                        "B17"
+                    ],
+                    "revenue": 110,
+                    "revenue_str": "A10-B13-B17",
+                    "nodes": [
+                        "A10-1",
+                        "B13-0",
+                        "B17-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 364,
+            "created_at": 1701720052,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 365,
+            "created_at": 1701720056
+        },
+        {
+            "type": "pass",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 366,
+            "created_at": 1701720058
+        },
+        {
+            "type": "buy_shares",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 367,
+            "created_at": 1701720063,
+            "shares": [
+                "BNR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "par",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 368,
+            "created_at": 1701722196,
+            "corporation": "GSR",
+            "share_price": "100,2,4"
+        },
+        {
+            "type": "place_token",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 369,
+            "created_at": 1701722204,
+            "city": "576-0-0",
+            "slot": 0,
+            "tokener": "GSR"
+        },
+        {
+            "type": "par",
+            "entity": 7046,
+            "corporation": "RPR",
+            "entity_type": "player",
+            "share_price": "100,2,4",
+            "id": 370,
+            "user": 7046,
+            "created_at": 1701722357
+        },
+        {
+            "city": "202-1-0",
+            "slot": 0,
+            "type": "place_token",
+            "entity": "RPR",
+            "tokener": "RPR",
+            "entity_type": "corporation",
+            "id": 371,
+            "user": 7046,
+            "created_at": 1701722367
+        },
+        {
+            "type": "undo",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 372,
+            "user": 7046,
+            "created_at": 1701722407
+        },
+        {
+            "type": "undo",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 373,
+            "user": 7046,
+            "created_at": 1701722419
+        },
+        {
+            "type": "par",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 374,
+            "created_at": 1701722462,
+            "corporation": "RPR",
+            "share_price": "90,3,4"
+        },
+        {
+            "type": "place_token",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 375,
+            "created_at": 1701722469,
+            "city": "202-1-0",
+            "slot": 0,
+            "tokener": "RPR"
+        },
+        {
+            "type": "par",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 376,
+            "created_at": 1701722994,
+            "corporation": "RBSR",
+            "share_price": "100,2,4"
+        },
+        {
+            "type": "place_token",
+            "entity": "RBSR",
+            "entity_type": "corporation",
+            "id": 377,
+            "created_at": 1701722999,
+            "city": "J5-0-1",
+            "slot": 0,
+            "tokener": "RBSR"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 378,
+            "created_at": 1701723041,
+            "shares": [
+                "FS_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 379,
+            "created_at": 1701723055,
+            "unconditional": false,
+            "indefinite": false
+        },
+        {
+            "type": "buy_shares",
+            "entity": "14",
+            "entity_type": "minor",
+            "id": 380,
+            "created_at": 1701723907,
+            "shares": [
+                "GSR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "place_token",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 381,
+            "created_at": 1701723911,
+            "city": "202-3-0",
+            "slot": 0,
+            "tokener": "GSR"
+        },
+        {
+            "type": "buy_shares",
+            "entity": "6",
+            "entity_type": "minor",
+            "id": 382,
+            "created_at": 1701724255,
+            "shares": [
+                "RPR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "place_token",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 383,
+            "created_at": 1701724261,
+            "city": "K14-0-1",
+            "slot": 0,
+            "tokener": "RPR"
+        },
+        {
+            "type": "buy_shares",
+            "entity": "11",
+            "entity_type": "minor",
+            "id": 384,
+            "created_at": 1701724660,
+            "shares": [
+                "RPR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "discard_train",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 385,
+            "created_at": 1701729289,
+            "train": "2-3"
+        },
+        {
+            "type": "pass",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 386,
+            "created_at": 1701729374,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701729373
+                }
+            ]
+        },
+        {
+            "type": "buy_shares",
+            "entity": "13",
+            "entity_type": "minor",
+            "id": 387,
+            "created_at": 1701776201,
+            "shares": [
+                "GSR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "place_token",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 388,
+            "created_at": 1701776203,
+            "city": "201-3-0",
+            "slot": 0,
+            "tokener": "GSR"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 389,
+            "created_at": 1701804122,
+            "shares": [
+                "RPR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 390,
+            "created_at": 1701804150,
+            "unconditional": false,
+            "indefinite": false
+        },
+        {
+            "type": "buy_shares",
+            "entity": "4",
+            "entity_type": "minor",
+            "id": 391,
+            "created_at": 1701806631,
+            "shares": [
+                "RBSR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "place_token",
+            "entity": "RBSR",
+            "entity_type": "corporation",
+            "id": 392,
+            "created_at": 1701806635,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701806632
+                }
+            ],
+            "city": "201-0-0",
+            "slot": 0,
+            "tokener": "RBSR"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 393,
+            "created_at": 1701806689,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701806688
+                }
+            ],
+            "shares": [
+                "GSR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 394,
+            "created_at": 1701806700,
+            "unconditional": false,
+            "indefinite": false
+        },
+        {
+            "type": "buy_shares",
+            "entity": "9",
+            "entity_type": "minor",
+            "id": 395,
+            "created_at": 1701807201,
+            "shares": [
+                "RBSR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "place_token",
+            "entity": "RBSR",
+            "entity_type": "corporation",
+            "id": 396,
+            "created_at": 1701807202,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701807200
+                },
+                {
+                    "type": "pass",
+                    "entity": 2394,
+                    "entity_type": "player",
+                    "created_at": 1701807200
+                },
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701807200
+                }
+            ],
+            "city": "J5-0-0",
+            "slot": 0,
+            "tokener": "RBSR"
+        },
+        {
+            "type": "buy_shares",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 397,
+            "created_at": 1701807211,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701807208
+                },
+                {
+                    "type": "pass",
+                    "entity": 2394,
+                    "entity_type": "player",
+                    "created_at": 1701807208
+                },
+                {
+                    "type": "pass",
+                    "entity": 7046,
+                    "entity_type": "player",
+                    "created_at": 1701807208
+                }
+            ],
+            "shares": [
+                "GSR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 398,
+            "created_at": 1701807214
+        },
+        {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 399,
+            "created_at": 1701807338
+        },
+        {
+            "type": "run_routes",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 400,
+            "created_at": 1701807343,
+            "routes": [
+                {
+                    "train": "2-1",
+                    "connections": [
+                        [
+                            "C8",
+                            "C6"
+                        ],
+                        [
+                            "C6",
+                            "C4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ]
+                    ],
+                    "hexes": [
+                        "C8",
+                        "C6",
+                        "C4",
+                        "D3"
+                    ],
+                    "revenue": 80,
+                    "revenue_str": "C8-C6-C4-D3",
+                    "nodes": [
+                        "C8-0",
+                        "C6-0",
+                        "C4-0",
+                        "D3-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "buy_train",
+            "price": 100,
+            "train": "P-0",
+            "entity": "2",
+            "variant": "P",
+            "entity_type": "minor",
+            "id": 401,
+            "user": 173,
+            "created_at": 1701807413
+        },
+        {
+            "type": "pass",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 402,
+            "user": 173,
+            "created_at": 1701807417
+        },
+        {
+            "type": "undo",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 403,
+            "user": 173,
+            "created_at": 1701807423
+        },
+        {
+            "type": "undo",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 404,
+            "user": 173,
+            "created_at": 1701807424
+        },
+        {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 405,
+            "created_at": 1701807427
+        },
+        {
+            "type": "pass",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 406,
+            "created_at": 1701807428
+        },
+        {
+            "type": "run_routes",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 407,
+            "created_at": 1701807430,
+            "routes": [
+                {
+                    "train": "2-11",
+                    "connections": [
+                        [
+                            "C8",
+                            "C6"
+                        ],
+                        [
+                            "C6",
+                            "C4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ],
+                        [
+                            "D3",
+                            "D1"
+                        ]
+                    ],
+                    "hexes": [
+                        "C8",
+                        "C6",
+                        "C4",
+                        "D3",
+                        "D1"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "C8-C6-C4-D3-D1",
+                    "nodes": [
+                        "C8-0",
+                        "C6-0",
+                        "C4-0",
+                        "D3-0",
+                        "D1-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 408,
+            "created_at": 1701807434,
+            "train": "3-6",
+            "price": 200,
+            "variant": "3"
+        },
+        {
+            "type": "lay_tile",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 409,
+            "created_at": 1701807528,
+            "hex": "E8",
+            "tile": "9-6",
+            "rotation": 2
+        },
+        {
+            "type": "pass",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 410,
+            "created_at": 1701807554
+        },
+        {
+            "type": "run_routes",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 411,
+            "created_at": 1701807674,
+            "routes": [
+                {
+                    "train": "3-4",
+                    "connections": [
+                        [
+                            "B17",
+                            "C16"
+                        ],
+                        [
+                            "C16",
+                            "D15"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ],
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "F11",
+                            "G12"
+                        ],
+                        [
+                            "G12",
+                            "G10"
+                        ]
+                    ],
+                    "hexes": [
+                        "B17",
+                        "C16",
+                        "D15",
+                        "D13",
+                        "E12",
+                        "F11",
+                        "G12",
+                        "G10"
+                    ],
+                    "revenue": 150,
+                    "revenue_str": "B17-C16-D15-D13-E12-F11-G12-G10",
+                    "nodes": [
+                        "B17-0",
+                        "C16-0",
+                        "D15-0",
+                        "D13-0",
+                        "E12-0",
+                        "F11-0",
+                        "G12-0",
+                        "G10-0"
+                    ]
+                },
+                {
+                    "train": "2-13",
+                    "connections": [
+                        [
+                            "B17",
+                            "B19"
+                        ],
+                        [
+                            "B19",
+                            "B21"
+                        ]
+                    ],
+                    "hexes": [
+                        "B17",
+                        "B19",
+                        "B21"
+                    ],
+                    "revenue": 70,
+                    "revenue_str": "B17-B19-B21",
+                    "nodes": [
+                        "B17-0",
+                        "B19-0",
+                        "B21-0"
+                    ]
+                },
+                {
+                    "train": "2-0",
+                    "connections": [
+                        [
+                            "B17",
+                            "B15",
+                            "B13"
+                        ],
+                        [
+                            "B13",
+                            "B11",
+                            "A10"
+                        ]
+                    ],
+                    "hexes": [
+                        "B17",
+                        "B13",
+                        "A10"
+                    ],
+                    "revenue": 110,
+                    "revenue_str": "B17-B13-A10",
+                    "nodes": [
+                        "B17-0",
+                        "B13-0",
+                        "A10-1"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 412,
+            "created_at": 1701807677,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 413,
+            "created_at": 1701807687,
+            "train": "4-0",
+            "price": 300,
+            "variant": "4"
+        },
+        {
+            "type": "pass",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 414,
+            "created_at": 1701807689
+        },
+        {
+            "hex": "J5",
+            "tile": "581-0",
+            "type": "lay_tile",
+            "entity": "RBSR",
+            "rotation": 1,
+            "entity_type": "corporation",
+            "id": 415,
+            "user": 253,
+            "created_at": 1701807884
+        },
+        {
+            "type": "undo",
+            "entity": "RBSR",
+            "action_id": 414,
+            "entity_type": "corporation",
+            "id": 416,
+            "user": 253,
+            "created_at": 1701807899
+        },
+        {
+            "hex": "F3",
+            "tile": "4-6",
+            "type": "lay_tile",
+            "entity": "RBSR",
+            "rotation": 1,
+            "entity_type": "corporation",
+            "id": 417,
+            "user": 253,
+            "created_at": 1701807904
+        },
+        {
+            "type": "undo",
+            "entity": "RBSR",
+            "action_id": 414,
+            "entity_type": "corporation",
+            "id": 418,
+            "user": 253,
+            "created_at": 1701807910
+        },
+        {
+            "type": "lay_tile",
+            "entity": "RBSR",
+            "entity_type": "corporation",
+            "id": 419,
+            "created_at": 1701807920,
+            "hex": "J5",
+            "tile": "581-0",
+            "rotation": 3
+        },
+        {
+            "type": "run_routes",
+            "entity": "RBSR",
+            "entity_type": "corporation",
+            "id": 420,
+            "created_at": 1701807932,
+            "routes": [
+                {
+                    "train": "3-3",
+                    "connections": [
+                        [
+                            "J5",
+                            "I6",
+                            "J7"
+                        ],
+                        [
+                            "J7",
+                            "I8"
+                        ],
+                        [
+                            "I8",
+                            "H7"
+                        ],
+                        [
+                            "H7",
+                            "G6"
+                        ],
+                        [
+                            "G6",
+                            "G4",
+                            "G2"
+                        ]
+                    ],
+                    "hexes": [
+                        "J5",
+                        "J7",
+                        "I8",
+                        "H7",
+                        "G6",
+                        "G2"
+                    ],
+                    "revenue": 140,
+                    "revenue_str": "J5-J7-I8-H7-G6-G2",
+                    "nodes": [
+                        "J5-2",
+                        "J7-0",
+                        "I8-0",
+                        "H7-0",
+                        "G6-0",
+                        "G2-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "RBSR",
+            "entity_type": "corporation",
+            "id": 421,
+            "created_at": 1701807934,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "RBSR",
+            "entity_type": "corporation",
+            "id": 422,
+            "created_at": 1701807939,
+            "train": "4-1",
+            "price": 300,
+            "variant": "4"
+        },
+        {
+            "type": "pass",
+            "entity": "RBSR",
+            "entity_type": "corporation",
+            "id": 423,
+            "created_at": 1701807957
+        },
+        {
+            "type": "lay_tile",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 424,
+            "created_at": 1701808021,
+            "hex": "B9",
+            "tile": "81-0",
+            "rotation": 1
+        },
+        {
+            "type": "buy_train",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 425,
+            "created_at": 1701808024,
+            "train": "4-2",
+            "price": 300,
+            "variant": "4"
+        },
+        {
+            "type": "pass",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 426,
+            "created_at": 1701808025
+        },
+        {
+            "type": "pass",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 427,
+            "created_at": 1701808037
+        },
+        {
+            "type": "lay_tile",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 428,
+            "created_at": 1701809042,
+            "hex": "K14",
+            "tile": "581-1",
+            "rotation": 1
+        },
+        {
+            "type": "place_token",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 429,
+            "created_at": 1701809052,
+            "city": "581-1-2",
+            "slot": 0,
+            "tokener": "BNR"
+        },
+        {
+            "type": "run_routes",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 430,
+            "created_at": 1701809078,
+            "routes": [
+                {
+                    "train": "3-5",
+                    "connections": [
+                        [
+                            "K14",
+                            "K16",
+                            "J17",
+                            "I18"
+                        ],
+                        [
+                            "I18",
+                            "H19"
+                        ]
+                    ],
+                    "hexes": [
+                        "K14",
+                        "I18",
+                        "H19"
+                    ],
+                    "revenue": 110,
+                    "revenue_str": "K14-I18-H19",
+                    "nodes": [
+                        "K14-2",
+                        "I18-0",
+                        "H19-0"
+                    ]
+                },
+                {
+                    "train": "3-1",
+                    "connections": [
+                        [
+                            "E18",
+                            "F19",
+                            "G20"
+                        ],
+                        [
+                            "G20",
+                            "H19"
+                        ],
+                        [
+                            "H19",
+                            "H21",
+                            "G22"
+                        ]
+                    ],
+                    "hexes": [
+                        "E18",
+                        "G20",
+                        "H19",
+                        "G22"
+                    ],
+                    "revenue": 110,
+                    "revenue_str": "E18-G20-H19-G22",
+                    "nodes": [
+                        "E18-0",
+                        "G20-0",
+                        "H19-0",
+                        "G22-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 431,
+            "created_at": 1701809086,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 432,
+            "created_at": 1701809133
+        },
+        {
+            "type": "pass",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 433,
+            "created_at": 1701809138
+        },
+        {
+            "type": "lay_tile",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 434,
+            "created_at": 1701809163,
+            "hex": "B15",
+            "tile": "83-1",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 435,
+            "created_at": 1701809169,
+            "routes": [
+                {
+                    "train": "3-2",
+                    "connections": [
+                        [
+                            "A10",
+                            "B11",
+                            "B13"
+                        ],
+                        [
+                            "B13",
+                            "B15",
+                            "B17"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B13",
+                        "B17"
+                    ],
+                    "revenue": 110,
+                    "revenue_str": "A10-B13-B17",
+                    "nodes": [
+                        "A10-1",
+                        "B13-0",
+                        "B17-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 436,
+            "created_at": 1701809171,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 437,
+            "created_at": 1701809177
+        },
+        {
+            "type": "pass",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 438,
+            "created_at": 1701809180
+        },
+        {
+            "type": "lay_tile",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 439,
+            "created_at": 1701809464,
+            "hex": "M16",
+            "tile": "576-1",
+            "rotation": 2
+        },
+        {
+            "type": "run_routes",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 440,
+            "created_at": 1701809480,
+            "routes": [
+                {
+                    "train": "3-0",
+                    "connections": [
+                        [
+                            "K14",
+                            "K12"
+                        ],
+                        [
+                            "K12",
+                            "L13",
+                            "M14",
+                            "M16"
+                        ],
+                        [
+                            "M16",
+                            "N17"
+                        ]
+                    ],
+                    "hexes": [
+                        "K14",
+                        "K12",
+                        "M16",
+                        "N17"
+                    ],
+                    "revenue": 130,
+                    "revenue_str": "K14-K12-M16-N17",
+                    "nodes": [
+                        "K14-1",
+                        "K12-0",
+                        "M16-0",
+                        "N17-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 441,
+            "created_at": 1701809486,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 442,
+            "created_at": 1701809557
+        },
+        {
+            "type": "pass",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 443,
+            "created_at": 1701809749
+        },
+        {
+            "type": "buy_train",
+            "entity": "2",
+            "entity_type": "minor",
+            "id": 444,
+            "created_at": 1701809769,
+            "train": "3-2",
+            "price": 119
+        },
+        {
+            "type": "pass",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 445,
+            "created_at": 1701809773
+        },
+        {
+            "type": "run_routes",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 446,
+            "created_at": 1701809776,
+            "routes": [
+                {
+                    "train": "3-6",
+                    "connections": [
+                        [
+                            "C8",
+                            "C6"
+                        ],
+                        [
+                            "C6",
+                            "C4"
+                        ],
+                        [
+                            "C4",
+                            "D3"
+                        ],
+                        [
+                            "D3",
+                            "D1"
+                        ]
+                    ],
+                    "hexes": [
+                        "C8",
+                        "C6",
+                        "C4",
+                        "D3",
+                        "D1"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "C8-C6-C4-D3-D1",
+                    "nodes": [
+                        "C8-0",
+                        "C6-0",
+                        "C4-0",
+                        "D3-0",
+                        "D1-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "lay_tile",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 447,
+            "created_at": 1701811967,
+            "hex": "C16",
+            "tile": "142-0",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 448,
+            "created_at": 1701811969
+        },
+        {
+            "type": "run_routes",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 449,
+            "created_at": 1701811981,
+            "routes": [
+                {
+                    "train": "4-0",
+                    "connections": [
+                        [
+                            "B17",
+                            "C16"
+                        ],
+                        [
+                            "C16",
+                            "D15"
+                        ],
+                        [
+                            "D15",
+                            "D13"
+                        ],
+                        [
+                            "D13",
+                            "E12"
+                        ],
+                        [
+                            "E12",
+                            "F11"
+                        ],
+                        [
+                            "F11",
+                            "G12"
+                        ],
+                        [
+                            "G12",
+                            "G10"
+                        ],
+                        [
+                            "G10",
+                            "F9"
+                        ]
+                    ],
+                    "hexes": [
+                        "B17",
+                        "C16",
+                        "D15",
+                        "D13",
+                        "E12",
+                        "F11",
+                        "G12",
+                        "G10",
+                        "F9"
+                    ],
+                    "revenue": 170,
+                    "revenue_str": "B17-C16-D15-D13-E12-F11-G12-G10-F9",
+                    "nodes": [
+                        "B17-0",
+                        "C16-0",
+                        "D15-0",
+                        "D13-0",
+                        "E12-0",
+                        "F11-0",
+                        "G12-0",
+                        "G10-0",
+                        "F9-0"
+                    ]
+                },
+                {
+                    "train": "3-4",
+                    "connections": [
+                        [
+                            "A10",
+                            "B11",
+                            "B13"
+                        ],
+                        [
+                            "B13",
+                            "B15",
+                            "B17"
+                        ],
+                        [
+                            "B17",
+                            "B19"
+                        ],
+                        [
+                            "B19",
+                            "B21"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B13",
+                        "B17",
+                        "B19",
+                        "B21"
+                    ],
+                    "revenue": 140,
+                    "revenue_str": "A10-B13-B17-B19-B21",
+                    "nodes": [
+                        "A10-1",
+                        "B13-0",
+                        "B17-0",
+                        "B19-0",
+                        "B21-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 450,
+            "created_at": 1701811983,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 451,
+            "created_at": 1701811988
+        },
+        {
+            "type": "pass",
+            "entity": "GSR",
+            "entity_type": "corporation",
+            "id": 452,
+            "created_at": 1701811990
+        },
+        {
+            "type": "lay_tile",
+            "entity": "RBSR",
+            "entity_type": "corporation",
+            "id": 453,
+            "created_at": 1701813112,
+            "hex": "F3",
+            "tile": "4-6",
+            "rotation": 1
+        },
+        {
+            "type": "run_routes",
+            "entity": "RBSR",
+            "entity_type": "corporation",
+            "id": 454,
+            "created_at": 1701813164,
+            "routes": [
+                {
+                    "train": "4-1",
+                    "connections": [
+                        [
+                            "J5",
+                            "K4"
+                        ],
+                        [
+                            "K4",
+                            "L5"
+                        ],
+                        [
+                            "L5",
+                            "M6",
+                            "N5"
+                        ]
+                    ],
+                    "hexes": [
+                        "J5",
+                        "K4",
+                        "L5",
+                        "N5"
+                    ],
+                    "revenue": 90,
+                    "revenue_str": "J5-K4-L5-N5",
+                    "nodes": [
+                        "J5-0",
+                        "K4-0",
+                        "L5-0",
+                        "N5-0"
+                    ]
+                },
+                {
+                    "train": "3-3",
+                    "connections": [
+                        [
+                            "J5",
+                            "I6",
+                            "J7"
+                        ],
+                        [
+                            "J7",
+                            "I8"
+                        ],
+                        [
+                            "I8",
+                            "H7"
+                        ],
+                        [
+                            "H7",
+                            "G6"
+                        ],
+                        [
+                            "G6",
+                            "G4",
+                            "G2"
+                        ],
+                        [
+                            "G2",
+                            "F3"
+                        ]
+                    ],
+                    "hexes": [
+                        "J5",
+                        "J7",
+                        "I8",
+                        "H7",
+                        "G6",
+                        "G2",
+                        "F3"
+                    ],
+                    "revenue": 150,
+                    "revenue_str": "J5-J7-I8-H7-G6-G2-F3",
+                    "nodes": [
+                        "J5-2",
+                        "J7-0",
+                        "I8-0",
+                        "H7-0",
+                        "G6-0",
+                        "G2-0",
+                        "F3-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "RBSR",
+            "entity_type": "corporation",
+            "id": 455,
+            "created_at": 1701813168,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "RBSR",
+            "entity_type": "corporation",
+            "id": 456,
+            "created_at": 1701813191
+        },
+        {
+            "type": "pass",
+            "entity": "RBSR",
+            "entity_type": "corporation",
+            "id": 457,
+            "created_at": 1701813199
+        },
+        {
+            "type": "lay_tile",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 458,
+            "created_at": 1701817209,
+            "hex": "L15",
+            "tile": "4-7",
+            "rotation": 2
+        },
+        {
+            "type": "pass",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 459,
+            "created_at": 1701817230
+        },
+        {
+            "type": "run_routes",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 460,
+            "created_at": 1701817268,
+            "routes": [
+                {
+                    "train": "3-5",
+                    "connections": [
+                        [
+                            "E18",
+                            "F19",
+                            "G20"
+                        ],
+                        [
+                            "G20",
+                            "H19"
+                        ],
+                        [
+                            "H19",
+                            "H21",
+                            "G22"
+                        ]
+                    ],
+                    "hexes": [
+                        "E18",
+                        "G20",
+                        "H19",
+                        "G22"
+                    ],
+                    "revenue": 110,
+                    "revenue_str": "E18-G20-H19-G22",
+                    "nodes": [
+                        "E18-0",
+                        "G20-0",
+                        "H19-0",
+                        "G22-0"
+                    ]
+                },
+                {
+                    "train": "3-1",
+                    "connections": [
+                        [
+                            "M16",
+                            "L15"
+                        ],
+                        [
+                            "L15",
+                            "K14"
+                        ],
+                        [
+                            "K14",
+                            "K16",
+                            "J17",
+                            "I18"
+                        ]
+                    ],
+                    "hexes": [
+                        "M16",
+                        "L15",
+                        "K14",
+                        "I18"
+                    ],
+                    "revenue": 120,
+                    "revenue_str": "M16-L15-K14-I18",
+                    "nodes": [
+                        "M16-0",
+                        "L15-0",
+                        "K14-2",
+                        "I18-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 461,
+            "created_at": 1701817271,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 462,
+            "created_at": 1701817289
+        },
+        {
+            "type": "sell_shares",
+            "entity": "BNR",
+            "entity_type": "corporation",
+            "id": 463,
+            "created_at": 1701817633,
+            "shares": [
+                "BNR_7",
+                "BNR_8"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "lay_tile",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 464,
+            "created_at": 1701817664,
+            "hex": "B13",
+            "tile": "142-1",
+            "rotation": 0
+        },
+        {
+            "type": "buy_train",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 465,
+            "created_at": 1701817666,
+            "train": "4-3",
+            "price": 300,
+            "variant": "4"
+        },
+        {
+            "type": "pass",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 466,
+            "created_at": 1701817677
+        },
+        {
+            "type": "pass",
+            "entity": "FS",
+            "entity_type": "corporation",
+            "id": 467,
+            "created_at": 1701817679
+        },
+        {
+            "type": "lay_tile",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 468,
+            "created_at": 1701817788,
+            "hex": "L15",
+            "tile": "141-0",
+            "rotation": 5
+        },
+        {
+            "type": "run_routes",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 469,
+            "created_at": 1701817833,
+            "routes": [
+                {
+                    "train": "3-0",
+                    "connections": [
+                        [
+                            "K14",
+                            "K12"
+                        ],
+                        [
+                            "K12",
+                            "L13",
+                            "M14",
+                            "M16"
+                        ],
+                        [
+                            "M16",
+                            "N17"
+                        ]
+                    ],
+                    "hexes": [
+                        "K14",
+                        "K12",
+                        "M16",
+                        "N17"
+                    ],
+                    "revenue": 130,
+                    "revenue_str": "K14-K12-M16-N17",
+                    "nodes": [
+                        "K14-1",
+                        "K12-0",
+                        "M16-0",
+                        "N17-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 470,
+            "created_at": 1701817875,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 471,
+            "created_at": 1701818263
+        },
+        {
+            "type": "sell_shares",
+            "entity": "RPR",
+            "entity_type": "corporation",
+            "id": 472,
+            "created_at": 1701818294,
+            "shares": [
+                "RPR_5",
+                "RPR_6"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "lay_tile",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 473,
+            "created_at": 1701855452,
+            "hex": "B7",
+            "tile": "144-0",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "SNCF",
+            "routes": [
+                {
+                    "hexes": [
+                        "A10",
+                        "B7",
+                        "A6"
+                    ],
+                    "nodes": [
+                        "A10-0",
+                        "B7-0",
+                        "A6-0"
+                    ],
+                    "train": "4-2",
+                    "revenue": 110,
+                    "connections": [
+                        [
+                            "A10",
+                            "B9",
+                            "B7"
+                        ],
+                        [
+                            "B7",
+                            "A6"
+                        ]
+                    ],
+                    "revenue_str": "A10-B7-A6"
+                }
+            ],
+            "entity_type": "corporation",
+            "extra_revenue": 0,
+            "id": 474,
+            "user": 2394,
+            "created_at": 1701855455
+        },
+        {
+            "kind": "payout",
+            "type": "dividend",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 475,
+            "user": 2394,
+            "created_at": 1701855459
+        },
+        {
+            "type": "pass",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 476,
+            "user": 2394,
+            "created_at": 1701855467
+        },
+        {
+            "type": "pass",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 477,
+            "user": 2394,
+            "created_at": 1701855470
+        },
+        {
+            "type": "undo",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 478,
+            "user": 2394,
+            "created_at": 1701855510
+        },
+        {
+            "type": "undo",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 479,
+            "user": 2394,
+            "created_at": 1701855513
+        },
+        {
+            "type": "redo",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 480,
+            "user": 173,
+            "created_at": 1701855514
+        },
+        {
+            "type": "undo",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 481,
+            "user": 2394,
+            "created_at": 1701855515
+        },
+        {
+            "type": "undo",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 482,
+            "user": 2394,
+            "created_at": 1701855523
+        },
+        {
+            "type": "undo",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 483,
+            "user": 2394,
+            "created_at": 1701855529
+        },
+        {
+            "type": "run_routes",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 484,
+            "created_at": 1701855548,
+            "routes": [
+                {
+                    "train": "4-2",
+                    "connections": [
+                        [
+                            "A10",
+                            "B9",
+                            "B7"
+                        ],
+                        [
+                            "B7",
+                            "A6"
+                        ]
+                    ],
+                    "hexes": [
+                        "A10",
+                        "B7",
+                        "A6"
+                    ],
+                    "revenue": 110,
+                    "revenue_str": "A10-B7-A6",
+                    "nodes": [
+                        "A10-0",
+                        "B7-0",
+                        "A6-0"
+                    ]
+                }
+            ],
+            "extra_revenue": 0
+        },
+        {
+            "type": "dividend",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 485,
+            "created_at": 1701855550,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 486,
+            "created_at": 1701855551
+        },
+        {
+            "type": "pass",
+            "entity": "SNCF",
+            "entity_type": "corporation",
+            "id": 487,
+            "created_at": 1701855552
+        },
+        {
+            "type": "sell_shares",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 488,
+            "created_at": 1701871540,
+            "shares": [
+                "BNR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "par",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 489,
+            "created_at": 1701871543,
+            "corporation": "AIRS",
+            "share_price": "82,3,3"
+        },
+        {
+            "type": "place_token",
+            "entity": "AIRS",
+            "entity_type": "corporation",
+            "id": 490,
+            "created_at": 1701871550,
+            "city": "202-0-0",
+            "slot": 0,
+            "tokener": "AIRS"
+        },
+        {
+            "type": "program_buy_shares",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 491,
+            "created_at": 1701871557,
+            "corporation": "AIRS",
+            "until_condition": "float",
+            "from_market": false,
+            "auto_pass_after": false
+        },
+        {
+            "type": "program_buy_shares",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 492,
+            "created_at": 1701871565,
+            "corporation": "AIRS",
+            "until_condition": 5,
+            "from_market": false,
+            "auto_pass_after": false
+        },
+        {
+            "type": "program_buy_shares",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 493,
+            "created_at": 1701871566,
+            "corporation": "AIRS",
+            "until_condition": 5,
+            "from_market": false,
+            "auto_pass_after": true
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 494,
+            "created_at": 1701879681,
+            "shares": [
+                "SNCF_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 495,
+            "created_at": 1701880781,
+            "shares": [
+                "SNCF_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 496,
+            "created_at": 1701880845,
+            "auto_actions": [
+                {
+                    "type": "buy_shares",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701880844,
+                    "shares": [
+                        "AIRS_2"
+                    ],
+                    "percent": 10
+                }
+            ],
+            "shares": [
+                "RBSR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 497,
+            "created_at": 1701881445,
+            "shares": [
+                "RPR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 498,
+            "created_at": 1701882572,
+            "shares": [
+                "SNCF_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 499,
+            "created_at": 1701882996,
+            "auto_actions": [
+                {
+                    "type": "buy_shares",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701882996,
+                    "shares": [
+                        "AIRS_3"
+                    ],
+                    "percent": 10
+                }
+            ],
+            "shares": [
+                "SNCF_8"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 500,
+            "created_at": 1701884986,
+            "shares": [
+                "BNR_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 501,
+            "created_at": 1701887957,
+            "shares": [
+                "GSR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 502,
+            "created_at": 1701887997,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701887996,
+                    "reason": "5 share(s) bought in AIRS, end condition met"
+                },
+                {
+                    "type": "program_share_pass",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701887996,
+                    "unconditional": false,
+                    "indefinite": false
+                },
+                {
+                    "type": "pass",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701887996
+                }
+            ],
+            "shares": [
+                "AIRS_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 503,
+            "created_at": 1701888205,
+            "shares": [
+                "RBSR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 504,
+            "created_at": 1701888991,
+            "shares": [
+                "RBSR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 253,
+            "shares": [
+                "AIRS_5"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 173,
+                    "created_at": 1701889388,
+                    "entity_type": "player"
+                }
+            ],
+            "id": 505,
+            "user": 253,
+            "created_at": 1701889389
+        },
+        {
+            "type": "undo",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 506,
+            "user": 253,
+            "created_at": 1701889394
+        },
+        {
+            "type": "buy_shares",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 507,
+            "created_at": 1701889416,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701889415
+                }
+            ],
+            "shares": [
+                "AIRS_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 508,
+            "created_at": 1701890137
+        },
+        {
+            "type": "sell_shares",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 509,
+            "created_at": 1701890372,
+            "shares": [
+                "GSR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "sell_shares",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 510,
+            "created_at": 1701890416,
+            "shares": [
+                "BNR_1",
+                "BNR_2"
+            ],
+            "percent": 20
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7046,
+            "shares": [
+                "RPR_6"
+            ],
+            "percent": 10,
+            "entity_type": "player",
+            "id": 511,
+            "user": 7046,
+            "created_at": 1701890435
+        },
+        {
+            "type": "undo",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 512,
+            "user": 7046,
+            "created_at": 1701890468
+        },
+        {
+            "type": "sell_shares",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 513,
+            "created_at": 1701890515,
+            "shares": [
+                "RBSR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 514,
+            "created_at": 1701890538,
+            "shares": [
+                "RPR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 515,
+            "created_at": 1701891385,
+            "auto_actions": [
+                {
+                    "type": "program_disable",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1701891385,
+                    "reason": "Shares were sold"
+                }
+            ]
+        },
+        {
+            "type": "buy_shares",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 516,
+            "created_at": 1701891829,
+            "shares": [
+                "AIRS_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "sell_shares",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 517,
+            "created_at": 1701891917,
+            "shares": [
+                "RPR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 518,
+            "created_at": 1701891919,
+            "shares": [
+                "BNR_8"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 519,
+            "created_at": 1701893683,
+            "shares": [
+                "FS_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 520,
+            "created_at": 1701898189
+        },
+        {
+            "type": "buy_shares",
+            "entity": "12",
+            "entity_type": "minor",
+            "id": 521,
+            "created_at": 1701921987,
+            "shares": [
+                "AIRS_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "place_token",
+            "entity": "AIRS",
+            "entity_type": "corporation",
+            "id": 522,
+            "created_at": 1701921993,
+            "city": "202-2-0",
+            "slot": 0,
+            "tokener": "AIRS"
+        },
+        {
+            "type": "program_share_pass",
+            "entity": 173,
+            "entity_type": "player",
+            "id": 523,
+            "created_at": 1701922005,
+            "unconditional": true,
+            "indefinite": false
+        },
+        {
+            "type": "sell_shares",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 524,
+            "created_at": 1701940115,
+            "shares": [
+                "GSR_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 525,
+            "created_at": 1701940117,
+            "shares": [
+                "BNR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": 7046,
+            "entity_type": "player",
+            "id": 526,
+            "created_at": 1701963248,
+            "shares": [
+                "FS_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": 253,
+            "entity_type": "player",
+            "id": 527,
+            "created_at": 1702692255,
+            "auto_actions": [
+                {
+                    "type": "pass",
+                    "entity": 173,
+                    "entity_type": "player",
+                    "created_at": 1702692255
+                }
+            ]
+        },
+        {
+            "type": "end_game",
+            "entity": 2394,
+            "entity_type": "player",
+            "id": 528,
+            "created_at": 1702692302
+        }
+    ],
+    "id": "hs_qtqacxob_141991",
+    "players": [
+        {
+            "id": 2394,
+            "name": "NuttyH"
+        },
+        {
+            "id": 7046,
+            "name": "toddvp"
+        },
+        {
+            "id": 253,
+            "name": "Joshua6"
+        },
+        {
+            "id": 173,
+            "name": "l33twash0r"
+        }
+    ],
+    "title": "18EU",
+    "description": "Cloned from game 141991",
+    "min_players": 4,
+    "max_players": 4,
+    "user": {
+        "id": 0,
+        "name": "You"
+    },
+    "settings": {
+        "seed": 496725000,
+        "is_async": true,
+        "unlisted": false,
+        "auto_routing": true,
+        "player_order": null,
+        "optional_rules": [
+            "extra_three_train",
+            "second_extra_three_train"
+        ]
+    },
+    "user_settings": null,
+    "turn": 4,
+    "round": "Stock Round",
+    "acting": [
+        2394
+    ],
+    "result": {
+        "7046": 1723,
+        "2394": 1557,
+        "253": 1428,
+        "173": 1039
+    },
+    "loaded": true,
+    "created_at": "2023-12-15",
+    "updated_at": 1702692302,
+    "finished_at": null,
+    "mode": "hotseat",
+    "manually_ended": true
+}


### PR DESCRIPTION
Fixes #9987 
<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

    This is a mismatch between `must_sell?`, `can_sell_anything?` and `holding_ok?`.  The game processes that you can sell something (FS), and you must sell something (over 60% cert limit in AIRS), but it doesn't know that you can't sell the thing you're over the limit in, so it keeps telling you to sell until you can't sell anything any longer.

    This change adds a `holding_ok?` to the 18EU corp so that holding is ok if the corp hasn't operated yet.

* **Screenshots**


    #### 18EU
    | Old      | New |
    | ----------- | ----------- |
    | ![image](https://github.com/tobymao/18xx/assets/5263073/6908a49b-fe94-4471-a060-b4fb91ae3261) | ![image](https://github.com/tobymao/18xx/assets/5263073/1b83407a-31ac-4b1b-9a70-2ba967c3fdd9) |

* **Any Assumptions / Hacks**
