### PR TITLE
[1822] fix for full_or_turn SELL_AFTER case.

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1069,7 +1069,7 @@ module Engine
         when :p_any_operate
           corporation.operated? || corporation.president?(entity)
         when :full_or_turn
-          if @round.operating? && corporation.president?(entity)
+          if @round.operating? && corporation == @round.current_operator
             corporation.operating_history.size > 1
           else
             corporation.operated?


### PR DESCRIPTION
Fixes #10026 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
The code previously didn't take into account that it would prevent you from selling stock in another corp which had operated only once if you were also the president of that corp. This should fix that by also checking if the bundle.corporation is the @round.current_operator.

I ran a couple of tests, but given its failure the first time, I'd appreciate it if someone else can't take a look and make sure I got it right this time.

* **Screenshots**

* **Any Assumptions / Hacks**
