### PR TITLE
[1871] Call player.unpass! in process_split

### DIFF
--- a/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
+++ b/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
@@ -167,6 +167,7 @@ module Engine
             entity = action.entity
             raise GameError, "#{corporation.name} cannot be split" unless @game.can_split?(corporation, entity)
 
+            entity.unpass!
             # Set data needed for splitting
             @round.split_start(corporation)
 


### PR DESCRIPTION
The player's pass flag was not being cleared on a split action. This could result in a stock round ending early: if a player had passed, then split a corporation on their next action, and all others then passed, the stock round will end without the splitter getting another action.

Fixes #10038 and #8568.

This might break a few games. It's a fairly weird set of actions that could trigger this bug, but there might be some games that are broken by this fix and will need pinning or archiving.

@kelsin: can you please review this fix? Github isn't letting me add you as a reviewer.