### PR TITLE
[1830] adds 3rd 6-train option

### DIFF
--- a/lib/engine/game/g_1830/game.rb
+++ b/lib/engine/game/g_1830/game.rb
@@ -158,7 +158,7 @@ module Engine
                     num: 3,
                     events: [{ 'type' => 'close_companies' }],
                   },
-                  { name: '6', distance: 6, price: 630, num: 2 },
+                  { name: '6', distance: 6, price: 630 },
                   {
                     name: 'D',
                     distance: 999,
@@ -188,6 +188,16 @@ module Engine
 
         def multiple_buy_only_from_market?
           !optional_rules&.include?(:multiple_brown_from_ipo)
+        end
+
+        def num_trains(train)
+          return train[:num] unless train[:name] == '6'
+
+          optional_6_train ? 3 : 2
+        end
+
+        def optional_6_train
+          @optional_rules&.include?(:optional_6_train)
         end
       end
     end

--- a/lib/engine/game/g_1830/meta.rb
+++ b/lib/engine/game/g_1830/meta.rb
@@ -24,6 +24,11 @@ module Engine
             short_name: 'Buy Multiple Brown Shares From IPO',
             desc: 'Multiple brown shares may be bought from IPO as well as from pool',
           },
+          {
+            sym: :optional_6_train,
+            short_name: 'Optional extra 6-Train',
+            desc: 'Adds a 3rd 6-train',
+          },
         ].freeze
       end
     end


### PR DESCRIPTION
Fixes #10046


### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
The Avalon Hill rules did include an option to add a 3rd 6-train. This is also referenced in the Mayfair rules:

![image](https://github.com/tobymao/18xx/assets/26125362/33988bd1-49a7-482e-9411-3b1fc7ebfba6)

