### PR TITLE
[1868WY] fix Ames double share protection

### DIFF
--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -1979,6 +1979,10 @@ module Engine
           net_sold = before[:num_shares] - num_buyable
           share_price = @stock_market.find_relative_share_price(before[:share_price], bundle.corporation, [:up] * net_sold)
 
+          # if UP was ledged before being dumped, the new price after protection
+          # can't be higher than the pre-dump price
+          share_price = before[:share_price] if share_price.price > before[:share_price].price
+
           after = {
             president: president,
             num_buyable: num_buyable,

--- a/lib/engine/game/g_1868_wy/step/double_share_protection.rb
+++ b/lib/engine/game/g_1868_wy/step/double_share_protection.rb
@@ -120,7 +120,7 @@ module Engine
               @game.swap_up_double_share_and_presidency!
               @log << "#{player.name} swaps the Ames Brothers 20% share for the UP president's certificate"
             else
-              old_price = @game.union_pacific.share_price.price
+              old_price = @game.union_pacific.share_price
 
               swap = @game.up_protection_player_bundle
 


### PR DESCRIPTION
* don't increase price past original sale price when new president buys shares to protect their Ames double share
* fix error when logging price change

Fixes #10028
