### PR TITLE
[1868WY] fix Big Boy [+1 +1] token with double-headed trains

### DIFF
--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -54,8 +54,8 @@ module Engine
         include StubsAreRestricted
         include SwapColorAndStripes
 
-        attr_accessor :big_boy_first_chance, :double_headed_trains, :dpr_first_home_status,
-                      :placed_oil_dt_count, :up_double_share_protection
+        attr_accessor :big_boy_first_chance, :big_boy_train_dh_original, :double_headed_trains,
+                      :dpr_first_home_status, :placed_oil_dt_count, :up_double_share_protection
         attr_reader :big_boy_train, :big_boy_train_original, :tile_groups, :unused_tiles,
                     :busters
 
@@ -1828,7 +1828,7 @@ module Engine
           update_cache(:trains)
         end
 
-        def attach_big_boy(train, entity)
+        def attach_big_boy(train, entity = nil, log: true)
           detached = detach_big_boy(log: false)
 
           @big_boy_train_original = train.dup
@@ -1848,14 +1848,16 @@ module Engine
           ]
           @big_boy_train = train
 
-          @log <<
-            if detached
-              "#{entity.name} moves the [+1+1] token from a #{detached.name} "\
-                "train to a #{@big_boy_train_original.name} train, forming a #{train.name} train"
-            else
-              "#{entity.name} attaches the [+1+1] token to a #{@big_boy_train_original.name} "\
-                "train, forming a #{train.name} train"
-            end
+          if log
+            @log <<
+              if detached
+                "#{entity&.name} moves the [+1+1] token from a #{detached.name} "\
+                  "train to a #{@big_boy_train_original.name} train, forming a #{train.name} train"
+              else
+                "#{entity&.name} attaches the [+1+1] token to a #{@big_boy_train_original.name} "\
+                  "train, forming a #{train.name} train"
+              end
+          end
 
           @big_boy_train
         end

--- a/lib/engine/game/g_1868_wy/step/dividend.rb
+++ b/lib/engine/game/g_1868_wy/step/dividend.rb
@@ -27,6 +27,8 @@ module Engine
 
           def rust_obsolete_trains!(entity, log: false)
             super(entity, log: false)
+
+            @game.attach_big_boy(@game.big_boy_train_dh_original, log: false) if @game.big_boy_train_dh_original
           end
 
           def process_dividend(action)

--- a/lib/engine/game/g_1868_wy/step/double_head_trains.rb
+++ b/lib/engine/game/g_1868_wy/step/double_head_trains.rb
@@ -70,6 +70,11 @@ module Engine
             # route auto-selector can use its previous route
             sym = trains.map(&:id).sort.join('_')
 
+            if (big_boy_train = trains.find { |t| t == @game.big_boy_train })
+              @game.detach_big_boy
+              @game.big_boy_train_dh_original = big_boy_train
+            end
+
             if (train = @game.train_by_id("#{sym}-0"))
               # refresh double-headed train that ran previously
               train.operated = false
@@ -93,6 +98,8 @@ module Engine
               @game.remove_train(train)
             end
 
+            @game.attach_big_boy(train, log: false) if big_boy_train
+
             # run train this OR, then remove it from company automatically via
             # base logic for obsolete trains
             train.obsolete = true
@@ -101,26 +108,17 @@ module Engine
           end
 
           def combined_distance_and_name(trains)
-            big_boy_train = false
-
             cities, towns = trains.each_with_object([0, 0]) do |train, c_t|
               c, t = @game.distance(train)
               c_t[0] += c
               c_t[1] += t
-
-              big_boy_train ||= (train == @game.big_boy_train)
             end
 
             distance = [
               { 'nodes' => ['town'], 'pay' => towns, 'visit' => towns },
               { 'nodes' => %w[city offboard town], 'pay' => cities, 'visit' => cities },
             ]
-            name =
-              if big_boy_train
-                "[#{cities}+#{towns}]"
-              else
-                "#{cities}+#{towns}"
-              end
+            name = "#{cities}+#{towns}"
 
             [distance, name]
           end


### PR DESCRIPTION
When double-heading trains, first detach the token, and re-attach it to the double-headed train, re-attaching it to the original train when the double-headed train is "rusted" in the divdend step for being obsolete.

Fixes #10040