### PR TITLE
[1822CA] Allow icons to be rendered in city slots; use for destinations

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -46,6 +46,8 @@ module View
           6 => 2.0,
         }.freeze
 
+        ICON_RADIUS = 16
+
         def render_part
           color = ((@reservation&.corporation? || @reservation&.minor?) &&
                     @reservation&.reservation_color) ||
@@ -78,6 +80,7 @@ module View
           children << reservation if @reservation && !@token
           children << render_boom if @city&.boom
           children << h(Token, token: @token, radius: radius, game: @game) if @token
+          children << render_slot_icon if @city&.slot_icons&.[](@slot_index)
 
           props = {
             on: { click: ->(event) { on_click(event) } },
@@ -209,6 +212,19 @@ module View
               r: @boom_radius ||= 10 * (radius_addend + (route_prop(0, :width).to_i / 40)),
               'stroke-width': 2,
               'stroke-dasharray': 6,
+            })
+        end
+
+        def render_slot_icon
+          icon = @city&.slot_icons&.[](@slot_index)
+
+          h(:image,
+            attrs: {
+              href: icon.image,
+              x: -ICON_RADIUS,
+              y: -ICON_RADIUS,
+              width: "#{ICON_RADIUS * 2}px",
+              height: "#{ICON_RADIUS * 2}px",
             })
         end
       end

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2076,8 +2076,13 @@ module Engine
             c.tokens << Engine::Token.new(c, logo: "../#{c.destination_icon}.svg",
                                              simple_logo: "../#{c.destination_icon}.svg",
                                              type: :destination)
-
-            dest_hex.tile.icons << Part::Icon.new("../#{c.destination_icon}", "#{c.id}_destination", loc: c.destination_loc)
+            icon = Part::Icon.new("../#{c.destination_icon}", "#{c.id}_destination", owner: c, loc: c.destination_loc)
+            if c.destination_icon_in_city_slot
+              city, slot = c.destination_icon_in_city_slot
+              dest_hex.tile.cities[city].slot_icons[slot] = icon
+            else
+              dest_hex.tile.icons << icon
+            end
 
             next unless c.id == self.class::TWO_HOME_CORPORATION
 

--- a/lib/engine/game/g_1822_ca/entities.rb
+++ b/lib/engine/game/g_1822_ca/entities.rb
@@ -1605,6 +1605,7 @@ module Engine
             text_color: 'black',
             destination_coordinates: 'C15',
             destination_icon: '1822_ca/CNoR_DEST',
+            destination_icon_in_city_slot: [0, 3],
           },
           {
             sym: 'CPR',
@@ -1620,6 +1621,7 @@ module Engine
             color: '#ed242a',
             destination_coordinates: 'C15',
             destination_icon: '1822_ca/CPR_DEST',
+            destination_icon_in_city_slot: [0, 2],
           },
           {
             sym: 'GNWR',
@@ -1635,6 +1637,7 @@ module Engine
             destination_coordinates: 'N16',
             destination_exits: [3],
             destination_icon: '1822_ca/GNWR_DEST',
+            destination_icon_in_city_slot: [1, 0],
           },
           {
             sym: 'GT',
@@ -1650,6 +1653,7 @@ module Engine
             destination_coordinates: 'AF12',
             destination_exits: [0],
             destination_icon: '1822_ca/GT_DEST',
+            destination_icon_in_city_slot: [0, 1],
           },
           {
             sym: 'GTP',
@@ -1693,6 +1697,7 @@ module Engine
             destination_loc: '3.5',
             destination_exits: [0, 1, 2, 3, 4, 5],
             destination_icon: '1822_ca/ICR_DEST',
+            destination_icon_in_city_slot: [2, 0],
           },
           {
             sym: 'NTR',
@@ -1707,6 +1712,7 @@ module Engine
             destination_coordinates: 'N16',
             destination_exits: [5],
             destination_icon: '1822_ca/NTR_DEST',
+            destination_icon_in_city_slot: [3, 0],
           },
           {
             sym: 'PGE',

--- a/lib/engine/game/g_1822_ca_ers/entities.rb
+++ b/lib/engine/game/g_1822_ca_ers/entities.rb
@@ -19,8 +19,8 @@ module Engine
                                    CPR GT GWR ICR NTR QMOO].freeze
 
         STARTING_CORPORATIONS_OVERRIDE = {
-          'CPR' => { destination_coordinates: 'T12' },
-          'NTR' => { destination_coordinates: 'T14' },
+          'CPR' => { destination_coordinates: 'T12', destination_icon_in_city_slot: [0, 0] },
+          'NTR' => { destination_coordinates: 'T14', destination_icon_in_city_slot: [0, 2] },
         }.freeze
       end
     end

--- a/lib/engine/operator.rb
+++ b/lib/engine/operator.rb
@@ -10,7 +10,7 @@ module Engine
     attr_reader :city, :loans, :logo, :logo_filename, :simple_logo,
                 :operating_history, :tokens, :trains, :destination_icon,
                 :destination_coordinates, :destination_exits, :destination_loc,
-                :share_price
+                :share_price, :destination_icon_in_city_slot
 
     def init_operator(opts)
       @cash = 0
@@ -29,6 +29,7 @@ module Engine
       @destination_exits = opts[:destination_exits]
       @destination_icon = opts[:destination_icon] ? "/icons/#{opts[:destination_icon]}" : ''
       @destination_loc = opts[:destination_loc]
+      @destination_icon_in_city_slot = opts[:destination_icon_in_city_slot]
     end
 
     def operator?

--- a/lib/engine/part/city.rb
+++ b/lib/engine/part/city.rb
@@ -6,7 +6,7 @@ require_relative 'revenue_center'
 module Engine
   module Part
     class City < RevenueCenter
-      attr_accessor :reservations
+      attr_accessor :reservations, :slot_icons
       attr_reader :tokens, :extra_tokens, :boom
 
       def initialize(revenue, **opts)
@@ -17,6 +17,7 @@ module Engine
         @extra_tokens = []
         @reservations = []
         @boom = opts[:boom]
+        @slot_icons = {}
       end
 
       def slots(all: false)
@@ -50,7 +51,8 @@ module Engine
       end
 
       def find_reservation(corporation)
-        @reservations.find_index { |r| r && [r, r.owner].include?(corporation) }
+        @reservations.find_index { |r| r && [r, r.owner].include?(corporation) } ||
+          @slot_icons.find { |_, icon| icon&.owner == corporation }
       end
 
       def reserved_by?(corporation)
@@ -119,7 +121,7 @@ module Engine
       def get_slot(corporation, cheater: false)
         reservation = find_reservation(corporation)
         open_slot = @tokens.find_index.with_index do |t, i|
-          t.nil? && @reservations[i].nil?
+          t.nil? && @reservations[i].nil? && @slot_icons[i].nil?
         end
         return open_slot || @tokens.size if cheater
 


### PR DESCRIPTION
1822CA introduces destination tokens that are specific to cities and slots, rather than just the hexes, as seen in other 1822 games.

This will make it clear which city needs to be hit for the destination to be complete. Icons in city slots also count as reservations, meaning other corporations may not token there.

[#9376]
