### PR TITLE
rysnc the pinned directory on deploy, clean unused pins in queue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ prod_rack_up_b_d : prod_link data_dir ensure_prod_env
 # remotely deploy latest master in prod
 prod_deploy : clean
 	$(CONTAINER_COMPOSE) run rack rake precompile && \
-		rsync --verbose --checksum public/assets/*.js public/assets/*.js.gz public/assets/version.json deploy@18xx:~/18xx/public/assets/ && \
+		rsync --verbose --checksum public/assets/*.js public/assets/*.js.gz public/assets/version.json public/pinned/*.js.gz deploy@18xx:~/18xx/public/assets/ && \
 		ssh -l deploy 18xx "source ~/.profile && cd ~/18xx/ && git pull && make prod_rack_up_b_d"
 
 style:

--- a/queue.rb
+++ b/queue.rb
@@ -3,6 +3,7 @@
 require 'logger'
 require 'rufus-scheduler'
 require 'require_all'
+require 'sequel'
 require_relative 'models'
 require_rel './models'
 require_relative 'lib/assets'
@@ -10,6 +11,8 @@ require_relative 'lib/bus'
 require_relative 'lib/hooks'
 require_relative 'lib/mail'
 require_relative 'lib/user_stats'
+
+Sequel.extension :pg_json_ops
 
 PRODUCTION = ENV['RACK_ENV'] == 'production'
 
@@ -20,6 +23,8 @@ Bus.configure
 ASSETS = Assets.new(precompiled: PRODUCTION)
 
 scheduler = Rufus::Scheduler.new
+
+PINS_TO_KEEP = 3
 
 def days_ago(days)
   Time.now - (86_400 * days)
@@ -39,6 +44,22 @@ scheduler.cron '00 09 * * *' do
   Game.where(
     Sequel.lit(filter, finished: days_ago(365), active: days_ago(90))
   ).all.each(&:archive!)
+
+  # clean up unused pins, except for the newest few
+  PINS_DIR = File.join(File.dirname(__FILE__), '..', 'public', 'pinned')
+  pins = Dir.glob("#{PINS_DIR}/*.js.gz")
+           .sort_by{ |f| File.mtime(f) }[0..-(1 + PINS_TO_KEEP)]
+           .map { |f| f.split(/[.\/]/)[-3] }
+  pins.each do |pin|
+    where_kwargs = {
+      Sequel.pg_jsonb_op(:settings).get_text('pin') => pin,
+      status: %w[active finished],
+    }
+    if Game.where(**where_kwargs).count.zero?
+      file = "#{PINS_DIR}/#{pin}.js.gz"
+      FileUtils.rm(file)
+    end
+  end
 
   Game.where(status: 'new').all.each do |game|
     if game.settings['unlisted']

--- a/queue.rb
+++ b/queue.rb
@@ -25,7 +25,7 @@ ASSETS = Assets.new(precompiled: PRODUCTION)
 scheduler = Rufus::Scheduler.new
 
 # give latest pins a chance to be used before they get cleaned up
-UNUSED_RECENT_PINS_TO_KEEP = 3
+UNUSED_RECENT_PINS_TO_KEEP = 2
 PINS_DIR = File.join(File.dirname(__FILE__), '..', 'public', 'pinned')
 
 def days_ago(days)


### PR DESCRIPTION
* rsync `public/pinned` on deployment so the current release always shows up in pins directory, simplifying the process to pin games
* clean up unused pin files daily in `queue.rb` * keep the newest few around so that just-deployed pins aren't cleaned up before they can be used
