### PR TITLE
18GB: Prevent special token powers being used illegally

### DIFF
--- a/lib/engine/game/g_18_gb/step/special_token.rb
+++ b/lib/engine/game/g_18_gb/step/special_token.rb
@@ -13,6 +13,20 @@ module Engine
             super
           end
 
+          def ability(entity)
+            return unless entity&.company?
+
+            @game.abilities(entity, :token) do |ability, _company|
+              return ability unless entity.value.positive?
+            end
+
+            @game.abilities(entity, :teleport) do |ability, _company|
+              return ability if !entity.value.positive? && ability.used?
+            end
+
+            nil
+          end
+
           def available_tokens(entity)
             ability = ability(entity)
             return [] unless ability


### PR DESCRIPTION
Fixes #9262

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* Private company powers in 18GB can only be used once the company has been closed (by using the `choice` ability on the company) by its owner. Therefore in the `abilities` function in `game.rb` for 18GB, abilities are filtered based on whether or not the company has been closed
* However, the standard `special_token` step (from which 18GB's `special_token` step inherits) was bypassing this check with its own `ability` function, allowing a token to still be placed at some times when it should not
* Therefore, this change updates 18GB's `special_token` step to filter out the abilities based on company status and avoid a token ability being used illegally