### PR TITLE
[18GB] receivership corps can't lease a train if there are none

### DIFF
--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -720,7 +720,7 @@ module Engine
         def route_trains(entity)
           return super unless insolvent?(entity)
 
-          [@depot.min_depot_train]
+          @depot.upcoming.any? ? [@depot.min_depot_train] : []
         end
 
         def express_train?(train)

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -720,7 +720,7 @@ module Engine
         def route_trains(entity)
           return super unless insolvent?(entity)
 
-          @depot.upcoming.any? ? [@depot.min_depot_train] : []
+          @depot.upcoming.empty? ? [] : [@depot.min_depot_train]
         end
 
         def express_train?(train)

--- a/public/fixtures/18GB/18gb-leased_train.json
+++ b/public/fixtures/18GB/18gb-leased_train.json
@@ -1,0 +1,12138 @@
+{
+    "status": "finished",
+    "actions": [
+      {
+        "type": "bid",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 1,
+        "created_at": 1696474179,
+        "company": "LB",
+        "price": 40
+      },
+      {
+        "type": "bid",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 2,
+        "created_at": 1696527714,
+        "company": "CH",
+        "price": 30
+      },
+      {
+        "type": "bid",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 3,
+        "created_at": 1696528447,
+        "company": "LB",
+        "price": 50
+      },
+      {
+        "type": "bid",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 4,
+        "created_at": 1696530459,
+        "company": "TV",
+        "price": 60
+      },
+      {
+        "type": "bid",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 5,
+        "created_at": 1696532180,
+        "company": "LB",
+        "price": 55
+      },
+      {
+        "type": "bid",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 6,
+        "created_at": 1696533285,
+        "company": "LM",
+        "price": 45
+      },
+      {
+        "type": "bid",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 7,
+        "created_at": 1696533317,
+        "company": "LM",
+        "price": 50
+      },
+      {
+        "type": "bid",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 8,
+        "created_at": 1696534230,
+        "company": "SD",
+        "price": 35
+      },
+      {
+        "type": "bid",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 9,
+        "created_at": 1696534317,
+        "company": "GN",
+        "price": 70
+      },
+      {
+        "type": "bid",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 12,
+        "created_at": 1696557441,
+        "company": "LS",
+        "price": 30
+      },
+      {
+        "type": "bid",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 13,
+        "created_at": 1696557624,
+        "company": "LB",
+        "price": 60
+      },
+      {
+        "type": "bid",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 14,
+        "created_at": 1696559005,
+        "company": "AF",
+        "price": 30
+      },
+      {
+        "type": "bid",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 15,
+        "created_at": 1696560651,
+        "company": "SD",
+        "price": 40
+      },
+      {
+        "type": "bid",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 16,
+        "created_at": 1696575837,
+        "company": "TV",
+        "price": 65
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 17,
+        "created_at": 1696600020
+      },
+      {
+        "type": "bid",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 18,
+        "created_at": 1696602856,
+        "company": "TV",
+        "price": 70
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 19,
+        "created_at": 1696607695
+      },
+      {
+        "type": "bid",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 20,
+        "created_at": 1696611290,
+        "company": "LB",
+        "price": 65
+      },
+      {
+        "type": "bid",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 21,
+        "created_at": 1696611449,
+        "company": "LB",
+        "price": 70
+      },
+      {
+        "type": "bid",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 22,
+        "created_at": 1696613652,
+        "company": "CH",
+        "price": 35
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 23,
+        "created_at": 1696624049
+      },
+      {
+        "type": "bid",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 24,
+        "created_at": 1696631804,
+        "company": "GN",
+        "price": 80
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 25,
+        "created_at": 1696633161
+      },
+      {
+        "type": "bid",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 26,
+        "created_at": 1696633285,
+        "company": "LS",
+        "price": 35
+      },
+      {
+        "type": "bid",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 27,
+        "created_at": 1696636232,
+        "company": "TV",
+        "price": 75
+      },
+      {
+        "type": "bid",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 28,
+        "created_at": 1696637257,
+        "company": "AF",
+        "price": 35
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 29,
+        "created_at": 1696637612
+      },
+      {
+        "type": "bid",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 30,
+        "created_at": 1696638463,
+        "company": "SD",
+        "price": 45
+      },
+      {
+        "type": "bid",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 31,
+        "created_at": 1696638798,
+        "company": "SD",
+        "price": 50
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 32,
+        "created_at": 1696704932
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 33,
+        "created_at": 1696706315
+      },
+      {
+        "type": "bid",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 34,
+        "created_at": 1696706923,
+        "company": "TV",
+        "price": 80
+      },
+      {
+        "type": "bid",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 35,
+        "created_at": 1696729803,
+        "company": "CH",
+        "price": 40
+      },
+      {
+        "type": "bid",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 36,
+        "created_at": 1696780611,
+        "company": "CH",
+        "price": 45
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 37,
+        "created_at": 1696780895
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 38,
+        "created_at": 1696781330
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 39,
+        "created_at": 1696782320
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 40,
+        "created_at": 1696784436
+      },
+      {
+        "type": "par",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 41,
+        "created_at": 1696784500,
+        "corporation": "LYR",
+        "share_price": "75,0,5"
+      },
+      {
+        "type": "par",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 42,
+        "created_at": 1696793107,
+        "corporation": "LNWR",
+        "share_price": "70,0,4"
+      },
+      {
+        "type": "par",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 43,
+        "created_at": 1696797726,
+        "corporation": "GWR",
+        "share_price": "80,0,6"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "shares": [
+          "GWR_1"
+        ],
+        "percent": 20,
+        "entity_type": "player",
+        "id": 44,
+        "user": 15620,
+        "created_at": 1696798012
+      },
+      {
+        "type": "undo",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 45,
+        "user": 15620,
+        "created_at": 1696798015
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 46,
+        "created_at": 1696798022,
+        "shares": [
+          "LYR_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 47,
+        "created_at": 1696847414
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 48,
+        "created_at": 1696858807
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 49,
+        "created_at": 1696859963
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 50,
+        "created_at": 1696860021,
+        "shares": [
+          "LYR_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 51,
+        "created_at": 1696860090
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 52,
+        "created_at": 1696860409,
+        "unconditional": false,
+        "indefinite": true
+      },
+      {
+        "type": "program_disable",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 53,
+        "created_at": 1696861036,
+        "reason": "user",
+        "original_type": "program_share_pass"
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 54,
+        "created_at": 1696862912
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 55,
+        "created_at": 1696867008
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 56,
+        "created_at": 1696867043,
+        "shares": [
+          "LYR_3"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 57,
+        "created_at": 1696867351
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 58,
+        "created_at": 1696867389
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 59,
+        "created_at": 1696867698
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 60,
+        "created_at": 1696868521
+      },
+      {
+        "hex": "D23",
+        "tile": "G18-0",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 61,
+        "user": 15618,
+        "created_at": 1696870064
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 62,
+        "user": 15618,
+        "created_at": 1696870082
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 63,
+        "created_at": 1696870091,
+        "hex": "D23",
+        "tile": "G19-0",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 64,
+        "created_at": 1696870098,
+        "hex": "C24",
+        "tile": "4-0",
+        "rotation": 0
+      },
+      {
+        "type": "buy_train",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 65,
+        "created_at": 1696870107,
+        "train": "2+1-0",
+        "price": 80,
+        "variant": "2+1"
+      },
+      {
+        "type": "buy_train",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 66,
+        "created_at": 1696870110,
+        "train": "2+1-1",
+        "price": 80,
+        "variant": "2+1"
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 67,
+        "created_at": 1696870115
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 68,
+        "created_at": 1696873547,
+        "hex": "H15",
+        "tile": "G02-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 69,
+        "created_at": 1696873574,
+        "hex": "H13",
+        "tile": "8-0",
+        "rotation": 4
+      },
+      {
+        "type": "buy_train",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 70,
+        "created_at": 1696873583,
+        "train": "2+1-2",
+        "price": 80,
+        "variant": "2+1"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 71,
+        "created_at": 1696873595,
+        "train": "2+1-3",
+        "price": 80,
+        "variant": "2+1"
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 72,
+        "created_at": 1696873600
+      },
+      {
+        "type": "choose_ability",
+        "choice": "close",
+        "entity": "LB",
+        "entity_type": "company",
+        "id": 73,
+        "user": 15621,
+        "created_at": 1696873814
+      },
+      {
+        "hex": "F21",
+        "tile": "G03-0",
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 74,
+        "user": 15621,
+        "created_at": 1696873862
+      },
+      {
+        "hex": "F23",
+        "tile": "58-0",
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "id": 75,
+        "user": 15621,
+        "created_at": 1696873901
+      },
+      {
+        "type": "buy_train",
+        "price": 80,
+        "train": "2+1-4",
+        "entity": "LNWR",
+        "variant": "2+1",
+        "entity_type": "corporation",
+        "id": 76,
+        "user": 15621,
+        "created_at": 1696873914
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 77,
+        "user": 15621,
+        "created_at": 1696873928
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "action_id": 72,
+        "entity_type": "corporation",
+        "id": 78,
+        "user": 15621,
+        "created_at": 1696873948
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 79,
+        "created_at": 1696873955
+      },
+      {
+        "type": "buy_train",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 80,
+        "created_at": 1696873966,
+        "train": "2+1-4",
+        "price": 80,
+        "variant": "2+1"
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 81,
+        "created_at": 1696873981
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 82,
+        "created_at": 1696876928,
+        "hex": "C26",
+        "tile": "8-1",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 83,
+        "created_at": 1696876935,
+        "hex": "D25",
+        "tile": "G41-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 84,
+        "created_at": 1696877062,
+        "routes": [
+          {
+            "train": "2+1-0",
+            "connections": [
+              [
+                "C24",
+                "C22",
+                "D23"
+              ],
+              [
+                "D27",
+                "C26",
+                "C24"
+              ]
+            ],
+            "hexes": [
+              "D23",
+              "C24",
+              "D27"
+            ],
+            "revenue": 40,
+            "revenue_str": "D23-C24-D27",
+            "nodes": [
+              "C24-0",
+              "D23-0",
+              "D27-0"
+            ]
+          },
+          {
+            "train": "2+1-1",
+            "connections": [
+              [
+                "D23",
+                "D25"
+              ]
+            ],
+            "hexes": [
+              "D25",
+              "D23"
+            ],
+            "revenue": 30,
+            "revenue_str": "D25-D23",
+            "nodes": [
+              "D23-0",
+              "D25-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 85,
+        "created_at": 1696877076,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 86,
+        "created_at": 1696877096
+      },
+      {
+        "hex": "G16",
+        "tile": "G03-0",
+        "type": "lay_tile",
+        "entity": "LYR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 87,
+        "user": 15620,
+        "created_at": 1696877135
+      },
+      {
+        "type": "undo",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 88,
+        "user": 15620,
+        "created_at": 1696877145
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 89,
+        "created_at": 1696877162,
+        "hex": "G16",
+        "tile": "G03-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 90,
+        "created_at": 1696877171,
+        "hex": "F17",
+        "tile": "3-0",
+        "rotation": 4
+      },
+      {
+        "type": "run_routes",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 91,
+        "created_at": 1696877189,
+        "routes": [
+          {
+            "train": "2+1-2",
+            "connections": [
+              [
+                "H15",
+                "G16"
+              ]
+            ],
+            "hexes": [
+              "G16",
+              "H15"
+            ],
+            "revenue": 60,
+            "revenue_str": "G16-H15",
+            "nodes": [
+              "H15-0",
+              "G16-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 92,
+        "created_at": 1696877223,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 93,
+        "created_at": 1696877352
+      },
+      {
+        "type": "choose_ability",
+        "entity": "LB",
+        "entity_type": "company",
+        "id": 94,
+        "created_at": 1696878510,
+        "choice": "close"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 95,
+        "created_at": 1696878519,
+        "hex": "F21",
+        "tile": "G03-1",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 96,
+        "created_at": 1696878525,
+        "hex": "F23",
+        "tile": "58-0",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 97,
+        "created_at": 1696878545,
+        "routes": [
+          {
+            "train": "2+1-4",
+            "connections": [
+              [
+                "F21",
+                "F23"
+              ]
+            ],
+            "hexes": [
+              "F23",
+              "F21"
+            ],
+            "revenue": 40,
+            "revenue_str": "F23-F21",
+            "nodes": [
+              "F21-0",
+              "F23-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 98,
+        "created_at": 1696878558,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 99,
+        "created_at": 1696878613
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 100,
+        "created_at": 1696880171
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 101,
+        "created_at": 1696881203
+      },
+      {
+        "type": "par",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 102,
+        "created_at": 1696881652,
+        "corporation": "LSWR",
+        "share_price": "75,0,5"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 103,
+        "created_at": 1696881746,
+        "shares": [
+          "GWR_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 104,
+        "created_at": 1696882545,
+        "shares": [
+          "LYR_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "par",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 105,
+        "created_at": 1696882550,
+        "corporation": "CR",
+        "share_price": "75,0,5"
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 106,
+        "created_at": 1696882569
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 107,
+        "created_at": 1696883428
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 108,
+        "created_at": 1696884360
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 109,
+        "created_at": 1696884491
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 110,
+        "created_at": 1696884562
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 111,
+        "created_at": 1696884566,
+        "routes": [
+          {
+            "train": "2+1-0",
+            "connections": [
+              [
+                "C24",
+                "C22",
+                "D23"
+              ],
+              [
+                "D27",
+                "C26",
+                "C24"
+              ]
+            ],
+            "hexes": [
+              "D23",
+              "C24",
+              "D27"
+            ],
+            "revenue": 40,
+            "revenue_str": "D23-C24-D27",
+            "nodes": [
+              "C24-0",
+              "D23-0",
+              "D27-0"
+            ]
+          },
+          {
+            "train": "2+1-1",
+            "connections": [
+              [
+                "D23",
+                "D25"
+              ]
+            ],
+            "hexes": [
+              "D23",
+              "D25"
+            ],
+            "revenue": 30,
+            "revenue_str": "D23-D25",
+            "nodes": [
+              "D23-0",
+              "D25-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 112,
+        "created_at": 1696884567,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 113,
+        "created_at": 1696884572
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 114,
+        "created_at": 1696884601
+      },
+      {
+        "type": "buy_train",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 115,
+        "created_at": 1696884619,
+        "train": "2+1-6",
+        "price": 80,
+        "variant": "2+1"
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 116,
+        "created_at": 1696884626
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 117,
+        "created_at": 1696884723,
+        "hex": "G4",
+        "tile": "G02-1",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 118,
+        "created_at": 1696884768,
+        "hex": "H3",
+        "tile": "4-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 119,
+        "created_at": 1696884790
+      },
+      {
+        "type": "buy_train",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 120,
+        "created_at": 1696884799,
+        "train": "3+1-0",
+        "price": 200,
+        "variant": "3+1"
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 121,
+        "created_at": 1696884810
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 122,
+        "created_at": 1696894383,
+        "hex": "G18",
+        "tile": "G39-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 123,
+        "created_at": 1696894391,
+        "hex": "F19",
+        "tile": "8-2",
+        "rotation": 4
+      },
+      {
+        "type": "run_routes",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 124,
+        "created_at": 1696905438,
+        "routes": [
+          {
+            "train": "2+1-2",
+            "connections": [
+              [
+                "H15",
+                "G16"
+              ]
+            ],
+            "hexes": [
+              "H15",
+              "G16"
+            ],
+            "revenue": 60,
+            "revenue_str": "H15-G16",
+            "nodes": [
+              "H15-0",
+              "G16-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 125,
+        "created_at": 1696905440,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 126,
+        "created_at": 1696905442
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 127,
+        "created_at": 1696907635,
+        "hex": "F17",
+        "tile": "87-0",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 128,
+        "created_at": 1696907643,
+        "hex": "G24",
+        "tile": "8-3",
+        "rotation": 0
+      },
+      {
+        "city": "G03-0-0",
+        "slot": 0,
+        "type": "place_token",
+        "entity": "LNWR",
+        "tokener": "LNWR",
+        "entity_type": "corporation",
+        "id": 129,
+        "user": 15621,
+        "created_at": 1696907657
+      },
+      {
+        "type": "undo",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 130,
+        "user": 15621,
+        "created_at": 1696907821
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 131,
+        "created_at": 1696907830
+      },
+      {
+        "type": "run_routes",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 132,
+        "created_at": 1696907859,
+        "routes": [
+          {
+            "train": "2+1-4",
+            "connections": [
+              [
+                "F21",
+                "F23"
+              ],
+              [
+                "F23",
+                "G24",
+                "G26"
+              ]
+            ],
+            "hexes": [
+              "F21",
+              "F23",
+              "G26"
+            ],
+            "revenue": 80,
+            "revenue_str": "F21-F23-G26",
+            "nodes": [
+              "F21-0",
+              "F23-0",
+              "G26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 133,
+        "created_at": 1696907881,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 134,
+        "created_at": 1696907887,
+        "train": "3+1-1",
+        "price": 200,
+        "variant": "3+1"
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 135,
+        "created_at": 1696907900
+      },
+      {
+        "type": "choose_ability",
+        "choice": "close",
+        "entity": "TV",
+        "entity_type": "company",
+        "id": 136,
+        "user": 15618,
+        "created_at": 1696908333
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 137,
+        "user": 15618,
+        "created_at": 1696908354
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 138,
+        "created_at": 1696908414,
+        "hex": "C24",
+        "tile": "88-0",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 139,
+        "created_at": 1696908423,
+        "hex": "B25",
+        "tile": "8-4",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 140,
+        "created_at": 1696908440,
+        "routes": [
+          {
+            "train": "2+1-0",
+            "connections": [
+              [
+                "C24",
+                "C22",
+                "D23"
+              ],
+              [
+                "D27",
+                "C26",
+                "C24"
+              ]
+            ],
+            "hexes": [
+              "D23",
+              "C24",
+              "D27"
+            ],
+            "revenue": 40,
+            "revenue_str": "D23-C24-D27",
+            "nodes": [
+              "C24-0",
+              "D23-0",
+              "D27-0"
+            ]
+          },
+          {
+            "train": "2+1-1",
+            "connections": [
+              [
+                "D23",
+                "D25"
+              ]
+            ],
+            "hexes": [
+              "D23",
+              "D25"
+            ],
+            "revenue": 30,
+            "revenue_str": "D23-D25",
+            "nodes": [
+              "D23-0",
+              "D25-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 141,
+        "created_at": 1696908447,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 142,
+        "created_at": 1696908459,
+        "train": "3+1-2",
+        "price": 200,
+        "variant": "3+1"
+      },
+      {
+        "type": "choose_ability",
+        "entity": "SD",
+        "entity_type": "company",
+        "id": 143,
+        "created_at": 1696908535,
+        "choice": "close"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 144,
+        "created_at": 1696908541,
+        "hex": "I12",
+        "tile": "4-2",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 145,
+        "created_at": 1696908557,
+        "hex": "J11",
+        "tile": "G18-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 146,
+        "created_at": 1696908646,
+        "routes": [
+          {
+            "train": "2+1-2",
+            "connections": [
+              [
+                "H15",
+                "G16"
+              ]
+            ],
+            "hexes": [
+              "G16",
+              "H15"
+            ],
+            "revenue": 60,
+            "revenue_str": "G16-H15",
+            "nodes": [
+              "H15-0",
+              "G16-0"
+            ]
+          },
+          {
+            "train": "2+1-3",
+            "connections": [
+              [
+                "I12",
+                "J11"
+              ],
+              [
+                "H15",
+                "H13",
+                "I12"
+              ]
+            ],
+            "hexes": [
+              "J11",
+              "I12",
+              "H15"
+            ],
+            "revenue": 60,
+            "revenue_str": "J11-I12-H15",
+            "nodes": [
+              "I12-0",
+              "J11-0",
+              "H15-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 147,
+        "created_at": 1696908686,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 148,
+        "created_at": 1696908709,
+        "train": "3+1-3",
+        "price": 200,
+        "variant": "3+1"
+      },
+      {
+        "hex": "D25",
+        "tile": "G37-0",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "id": 149,
+        "user": 15618,
+        "created_at": 1696908854
+      },
+      {
+        "hex": "E26",
+        "tile": "3-1",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 150,
+        "user": 15618,
+        "created_at": 1696908868
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 151,
+        "user": 15618,
+        "created_at": 1696908890
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 152,
+        "user": 15618,
+        "created_at": 1696908896
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 153,
+        "created_at": 1696908932,
+        "hex": "D25",
+        "tile": "G36-0",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 154,
+        "created_at": 1696908940,
+        "hex": "E26",
+        "tile": "3-1",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 155,
+        "created_at": 1696909034,
+        "routes": [
+          {
+            "train": "2+1-6",
+            "connections": [
+              [
+                "D25",
+                "D23"
+              ],
+              [
+                "D25",
+                "E26"
+              ]
+            ],
+            "hexes": [
+              "D23",
+              "D25",
+              "E26"
+            ],
+            "revenue": 50,
+            "revenue_str": "D23-D25-E26",
+            "nodes": [
+              "D25-0",
+              "D23-0",
+              "E26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 156,
+        "created_at": 1696909037,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 157,
+        "created_at": 1696909042,
+        "train": "3+1-4",
+        "price": 200,
+        "variant": "3+1"
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 158,
+        "created_at": 1696909054
+      },
+      {
+        "hex": "F5",
+        "tile": "G40-0",
+        "type": "lay_tile",
+        "entity": "CR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 159,
+        "user": 15708,
+        "created_at": 1696941239
+      },
+      {
+        "type": "undo",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 160,
+        "user": 15708,
+        "created_at": 1696941258
+      },
+      {
+        "hex": "I2",
+        "tile": "G41-1",
+        "type": "lay_tile",
+        "entity": "CR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 161,
+        "user": 15708,
+        "created_at": 1696941265
+      },
+      {
+        "hex": "J1",
+        "tile": "8-5",
+        "type": "lay_tile",
+        "entity": "CR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 162,
+        "user": 15708,
+        "created_at": 1696941274
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 163,
+        "user": 15708,
+        "created_at": 1696941287
+      },
+      {
+        "type": "undo",
+        "entity": "CR",
+        "action_id": 158,
+        "entity_type": "corporation",
+        "id": 164,
+        "user": 15708,
+        "created_at": 1696941330
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 165,
+        "created_at": 1696941336,
+        "hex": "F5",
+        "tile": "G40-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 166,
+        "created_at": 1696941338
+      },
+      {
+        "type": "run_routes",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 167,
+        "created_at": 1696941351,
+        "routes": [
+          {
+            "train": "3+1-0",
+            "connections": [
+              [
+                "G4",
+                "H3"
+              ],
+              [
+                "F5",
+                "F3",
+                "G4"
+              ],
+              [
+                "E6",
+                "F5"
+              ]
+            ],
+            "hexes": [
+              "H3",
+              "G4",
+              "F5",
+              "E6"
+            ],
+            "revenue": 60,
+            "revenue_str": "H3-G4-F5-E6",
+            "nodes": [
+              "G4-0",
+              "H3-0",
+              "F5-0",
+              "E6-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 168,
+        "created_at": 1696941362,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 169,
+        "created_at": 1696941407
+      },
+      {
+        "type": "choose_ability",
+        "choice": "close",
+        "entity": "LM",
+        "entity_type": "company",
+        "id": 170,
+        "user": 15621,
+        "created_at": 1696947324
+      },
+      {
+        "hex": "F15",
+        "tile": "8-5",
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 171,
+        "user": 15621,
+        "created_at": 1696947349
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 172,
+        "user": 15621,
+        "created_at": 1696947356
+      },
+      {
+        "type": "undo",
+        "entity": "LNWR",
+        "action_id": 169,
+        "entity_type": "corporation",
+        "id": 173,
+        "user": 15621,
+        "created_at": 1696947533
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 174,
+        "created_at": 1696947597,
+        "hex": "F23",
+        "tile": "87-1",
+        "rotation": 3
+      },
+      {
+        "type": "choose_ability",
+        "entity": "LM",
+        "entity_type": "company",
+        "id": 175,
+        "created_at": 1696947608,
+        "choice": "close"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 176,
+        "created_at": 1696947626,
+        "hex": "F15",
+        "tile": "8-5",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 177,
+        "created_at": 1696947651
+      },
+      {
+        "type": "run_routes",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 178,
+        "created_at": 1696947667,
+        "routes": [
+          {
+            "train": "2+1-4",
+            "connections": [
+              [
+                "F21",
+                "F23"
+              ],
+              [
+                "F23",
+                "G24",
+                "G26"
+              ]
+            ],
+            "hexes": [
+              "F21",
+              "F23",
+              "G26"
+            ],
+            "revenue": 80,
+            "revenue_str": "F21-F23-G26",
+            "nodes": [
+              "F21-0",
+              "F23-0",
+              "G26-0"
+            ]
+          },
+          {
+            "train": "3+1-1",
+            "connections": [
+              [
+                "F17",
+                "F15",
+                "E14"
+              ],
+              [
+                "G18",
+                "F17"
+              ],
+              [
+                "F21",
+                "F19",
+                "G18"
+              ]
+            ],
+            "hexes": [
+              "E14",
+              "F17",
+              "G18",
+              "F21"
+            ],
+            "revenue": 100,
+            "revenue_str": "E14-F17-G18-F21+(LM)",
+            "nodes": [
+              "F17-0",
+              "E14-0",
+              "G18-0",
+              "F21-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 179,
+        "created_at": 1696947681,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 180,
+        "created_at": 1696947689,
+        "train": "4+2-0",
+        "price": 300,
+        "variant": "4+2"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 181,
+        "created_at": 1696947713,
+        "shares": [
+          "LNWR_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 182,
+        "created_at": 1696947732
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 183,
+        "created_at": 1696952611,
+        "shares": [
+          "LNWR_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 184,
+        "created_at": 1696955807,
+        "shares": [
+          "LNWR_3"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "par",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 185,
+        "created_at": 1696964339,
+        "corporation": "NBR",
+        "share_price": "80,0,6"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 186,
+        "created_at": 1696964644,
+        "shares": [
+          "NBR_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 187,
+        "created_at": 1696964907,
+        "shares": [
+          "LSWR_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 188,
+        "created_at": 1696970730,
+        "shares": [
+          "LYR_1"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 189,
+        "created_at": 1696973459
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 190,
+        "created_at": 1696973922,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15621,
+            "entity_type": "player",
+            "created_at": 1696973920
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 191,
+        "created_at": 1696974203
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 192,
+        "created_at": 1696975687
+      },
+      {
+        "hex": "D23",
+        "tile": "G26-0",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 193,
+        "user": 15618,
+        "created_at": 1696976480
+      },
+      {
+        "hex": "A24",
+        "tile": "8-6",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 194,
+        "user": 15618,
+        "created_at": 1696976496
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 195,
+        "user": 15618,
+        "created_at": 1696976577
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 196,
+        "user": 15618,
+        "created_at": 1696976579
+      },
+      {
+        "hex": "C22",
+        "tile": "G33-0",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 197,
+        "user": 15618,
+        "created_at": 1696976587
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 198,
+        "user": 15618,
+        "created_at": 1696976591
+      },
+      {
+        "type": "choose_ability",
+        "choice": "close",
+        "entity": "TV",
+        "entity_type": "company",
+        "id": 199,
+        "user": 15618,
+        "created_at": 1696976600
+      },
+      {
+        "hex": "C22",
+        "tile": "G33-0",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 200,
+        "user": 15618,
+        "created_at": 1696976604
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 201,
+        "user": 15618,
+        "created_at": 1696976609
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 202,
+        "user": 15618,
+        "created_at": 1696976610
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 203,
+        "created_at": 1696976766,
+        "hex": "D23",
+        "tile": "G26-0",
+        "rotation": 0
+      },
+      {
+        "hex": "C22",
+        "tile": "G33-0",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 204,
+        "user": 15618,
+        "created_at": 1696976783
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 205,
+        "user": 15618,
+        "created_at": 1696976826
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 206,
+        "created_at": 1696976831,
+        "hex": "A24",
+        "tile": "8-6",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 207,
+        "created_at": 1696976877,
+        "routes": [
+          {
+            "train": "3+1-2",
+            "connections": [
+              [
+                "D23",
+                "D25"
+              ],
+              [
+                "D23",
+                "C22",
+                "C24"
+              ],
+              [
+                "C24",
+                "B25",
+                "A24",
+                "a25"
+              ]
+            ],
+            "hexes": [
+              "D25",
+              "D23",
+              "C24",
+              "a25"
+            ],
+            "revenue": 100,
+            "revenue_str": "D25-D23-C24-a25",
+            "nodes": [
+              "D23-0",
+              "D25-0",
+              "C24-0",
+              "a25-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 208,
+        "created_at": 1696976880,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 209,
+        "created_at": 1696976913
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 210,
+        "created_at": 1696977468,
+        "hex": "I6",
+        "tile": "G19-1",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 211,
+        "created_at": 1696977486,
+        "hex": "H5",
+        "tile": "4-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 212,
+        "created_at": 1696977492
+      },
+      {
+        "type": "buy_train",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 213,
+        "created_at": 1696977498,
+        "train": "4+2-1",
+        "price": 300,
+        "variant": "4+2"
+      },
+      {
+        "type": "pass",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 214,
+        "created_at": 1696977501
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 215,
+        "created_at": 1696977908,
+        "hex": "E26",
+        "tile": "204-0",
+        "rotation": 5
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 216,
+        "created_at": 1696977922,
+        "hex": "F27",
+        "tile": "8-7",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 217,
+        "created_at": 1696978002,
+        "routes": [
+          {
+            "train": "3+1-4",
+            "connections": [
+              [
+                "D25",
+                "D23"
+              ],
+              [
+                "E26",
+                "D25"
+              ],
+              [
+                "G26",
+                "F27",
+                "E26"
+              ]
+            ],
+            "hexes": [
+              "D23",
+              "D25",
+              "E26",
+              "G26"
+            ],
+            "revenue": 110,
+            "revenue_str": "D23-D25-E26-G26",
+            "nodes": [
+              "D25-0",
+              "D23-0",
+              "E26-0",
+              "G26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 218,
+        "created_at": 1696978039,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 219,
+        "created_at": 1696978049
+      },
+      {
+        "hex": "F5",
+        "tile": "G38-0",
+        "type": "lay_tile",
+        "entity": "CR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 220,
+        "user": 15708,
+        "created_at": 1696978954
+      },
+      {
+        "hex": "G2",
+        "tile": "8-8",
+        "type": "lay_tile",
+        "entity": "CR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 221,
+        "user": 15708,
+        "created_at": 1696978997
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 222,
+        "user": 15708,
+        "created_at": 1696978999
+      },
+      {
+        "type": "undo",
+        "entity": "CR",
+        "action_id": 219,
+        "entity_type": "corporation",
+        "id": 223,
+        "user": 15708,
+        "created_at": 1696979039
+      },
+      {
+        "hex": "I2",
+        "tile": "G40-1",
+        "type": "lay_tile",
+        "entity": "CR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 224,
+        "user": 15708,
+        "created_at": 1696979058
+      },
+      {
+        "hex": "G2",
+        "tile": "8-8",
+        "type": "lay_tile",
+        "entity": "CR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 225,
+        "user": 15708,
+        "created_at": 1696979088
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 226,
+        "user": 15708,
+        "created_at": 1696979090
+      },
+      {
+        "type": "undo",
+        "entity": "CR",
+        "action_id": 219,
+        "entity_type": "corporation",
+        "id": 227,
+        "user": 15708,
+        "created_at": 1696979126
+      },
+      {
+        "city": "G40-0-0",
+        "slot": 0,
+        "type": "place_token",
+        "entity": "CR",
+        "tokener": "CR",
+        "entity_type": "corporation",
+        "id": 228,
+        "user": 15708,
+        "created_at": 1696979129
+      },
+      {
+        "type": "undo",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 229,
+        "user": 15708,
+        "created_at": 1696979133
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 230,
+        "created_at": 1696979140,
+        "hex": "F5",
+        "tile": "G38-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 231,
+        "created_at": 1696979172,
+        "hex": "G2",
+        "tile": "8-8",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 232,
+        "created_at": 1696979174
+      },
+      {
+        "type": "run_routes",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 233,
+        "created_at": 1696979185,
+        "routes": [
+          {
+            "train": "3+1-0",
+            "connections": [
+              [
+                "G4",
+                "H3"
+              ],
+              [
+                "F5",
+                "F3",
+                "G4"
+              ],
+              [
+                "E6",
+                "F5"
+              ]
+            ],
+            "hexes": [
+              "H3",
+              "G4",
+              "F5",
+              "E6"
+            ],
+            "revenue": 80,
+            "revenue_str": "H3-G4-F5-E6",
+            "nodes": [
+              "G4-0",
+              "H3-0",
+              "F5-0",
+              "E6-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 234,
+        "created_at": 1696979205,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 235,
+        "created_at": 1696979216
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 236,
+        "created_at": 1696991350,
+        "hex": "J9",
+        "tile": "8-9",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 237,
+        "created_at": 1696991353,
+        "hex": "J7",
+        "tile": "4-3",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 238,
+        "created_at": 1696991413,
+        "routes": [
+          {
+            "train": "3+1-3",
+            "connections": [
+              [
+                "G16",
+                "H15"
+              ],
+              [
+                "F17",
+                "G16"
+              ],
+              [
+                "E14",
+                "F15",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "H15",
+              "G16",
+              "F17",
+              "E14"
+            ],
+            "revenue": 110,
+            "revenue_str": "H15-G16-F17-E14",
+            "nodes": [
+              "G16-0",
+              "H15-0",
+              "F17-0",
+              "E14-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 239,
+        "created_at": 1696991436,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 240,
+        "created_at": 1696991450
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 241,
+        "created_at": 1697010704,
+        "hex": "G22",
+        "tile": "4-4",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 242,
+        "created_at": 1697010853,
+        "hex": "H21",
+        "tile": "G18-1",
+        "rotation": 1
+      },
+      {
+        "type": "place_token",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 243,
+        "created_at": 1697010855,
+        "city": "G18-1-0",
+        "slot": 0,
+        "tokener": "LNWR"
+      },
+      {
+        "type": "run_routes",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 244,
+        "created_at": 1697010919,
+        "routes": [
+          {
+            "train": "3+1-1",
+            "connections": [
+              [
+                "F23",
+                "G24",
+                "G26"
+              ],
+              [
+                "G22",
+                "F23"
+              ],
+              [
+                "H21",
+                "G22"
+              ]
+            ],
+            "hexes": [
+              "G26",
+              "F23",
+              "G22",
+              "H21"
+            ],
+            "revenue": 90,
+            "revenue_str": "G26-F23-G22-H21",
+            "nodes": [
+              "F23-0",
+              "G26-0",
+              "G22-0",
+              "H21-0"
+            ]
+          },
+          {
+            "train": "4+2-0",
+            "connections": [
+              [
+                "F17",
+                "F15",
+                "E14"
+              ],
+              [
+                "G18",
+                "F17"
+              ],
+              [
+                "F21",
+                "F19",
+                "G18"
+              ],
+              [
+                "F23",
+                "F21"
+              ]
+            ],
+            "hexes": [
+              "E14",
+              "F17",
+              "G18",
+              "F21",
+              "F23"
+            ],
+            "revenue": 130,
+            "revenue_str": "E14-F17-G18-F21-F23+(LM)",
+            "nodes": [
+              "F17-0",
+              "E14-0",
+              "G18-0",
+              "F21-0",
+              "F23-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 245,
+        "created_at": 1697010966,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 246,
+        "created_at": 1697022070,
+        "hex": "D21",
+        "tile": "4-5",
+        "rotation": 0
+      },
+      {
+        "hex": "D19",
+        "tile": "9-0",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 247,
+        "user": 15618,
+        "created_at": 1697022080
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 248,
+        "user": 15618,
+        "created_at": 1697022096
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 249,
+        "created_at": 1697022108,
+        "hex": "D19",
+        "tile": "9-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 250,
+        "created_at": 1697022139
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 251,
+        "created_at": 1697022155,
+        "routes": [
+          {
+            "train": "3+1-2",
+            "connections": [
+              [
+                "D23",
+                "D25"
+              ],
+              [
+                "D23",
+                "C22",
+                "C24"
+              ],
+              [
+                "C24",
+                "B25",
+                "A24",
+                "a25"
+              ]
+            ],
+            "hexes": [
+              "D25",
+              "D23",
+              "C24",
+              "a25"
+            ],
+            "revenue": 100,
+            "revenue_str": "D25-D23-C24-a25",
+            "nodes": [
+              "D23-0",
+              "D25-0",
+              "C24-0",
+              "a25-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 252,
+        "created_at": 1697022167,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 253,
+        "created_at": 1697022170
+      },
+      {
+        "hex": "E24",
+        "tile": "9-1",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 254,
+        "user": 15618,
+        "created_at": 1697022188
+      },
+      {
+        "hex": "E22",
+        "tile": "8-10",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "id": 255,
+        "user": 15618,
+        "created_at": 1697022195
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 256,
+        "user": 15618,
+        "created_at": 1697022203
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 257,
+        "user": 15618,
+        "created_at": 1697022204
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 258,
+        "created_at": 1697022214,
+        "hex": "E24",
+        "tile": "7-0",
+        "rotation": 5
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 259,
+        "created_at": 1697022218,
+        "hex": "F25",
+        "tile": "4-6",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 260,
+        "created_at": 1697022227
+      },
+      {
+        "type": "run_routes",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 261,
+        "created_at": 1697022247,
+        "routes": [
+          {
+            "train": "3+1-4",
+            "connections": [
+              [
+                "D25",
+                "D23"
+              ],
+              [
+                "E26",
+                "D25"
+              ],
+              [
+                "G26",
+                "F27",
+                "E26"
+              ]
+            ],
+            "hexes": [
+              "D23",
+              "D25",
+              "E26",
+              "G26"
+            ],
+            "revenue": 110,
+            "revenue_str": "D23-D25-E26-G26",
+            "nodes": [
+              "D25-0",
+              "D23-0",
+              "E26-0",
+              "G26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 262,
+        "created_at": 1697022250,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 263,
+        "created_at": 1697022256
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 264,
+        "created_at": 1697031399,
+        "hex": "G4",
+        "tile": "G04-0",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 265,
+        "created_at": 1697031433,
+        "hex": "G6",
+        "tile": "58-1",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 266,
+        "created_at": 1697031466
+      },
+      {
+        "type": "run_routes",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 267,
+        "created_at": 1697031487,
+        "routes": [
+          {
+            "train": "3+1-0",
+            "connections": [
+              [
+                "G4",
+                "H3"
+              ],
+              [
+                "F5",
+                "F3",
+                "G4"
+              ],
+              [
+                "E6",
+                "F5"
+              ]
+            ],
+            "hexes": [
+              "H3",
+              "G4",
+              "F5",
+              "E6"
+            ],
+            "revenue": 90,
+            "revenue_str": "H3-G4-F5-E6",
+            "nodes": [
+              "G4-1",
+              "H3-0",
+              "F5-0",
+              "E6-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 268,
+        "created_at": 1697031494,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 269,
+        "created_at": 1697031522,
+        "train": "4+2-2",
+        "price": 300,
+        "variant": "4+2"
+      },
+      {
+        "type": "place_token",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 270,
+        "created_at": 1697031529,
+        "city": "G18-0-0",
+        "slot": 0,
+        "tokener": "NBR"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 271,
+        "created_at": 1697031676,
+        "hex": "H9",
+        "tile": "G40-1",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 272,
+        "created_at": 1697031688
+      },
+      {
+        "type": "run_routes",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 273,
+        "created_at": 1697031812,
+        "routes": [
+          {
+            "train": "4+2-1",
+            "connections": [
+              [
+                "G4",
+                "F5"
+              ],
+              [
+                "H5",
+                "G4"
+              ],
+              [
+                "I6",
+                "H5"
+              ],
+              [
+                "I6",
+                "J5",
+                "J7"
+              ],
+              [
+                "J7",
+                "J9",
+                "K10",
+                "J11"
+              ]
+            ],
+            "hexes": [
+              "F5",
+              "G4",
+              "H5",
+              "I6",
+              "J7",
+              "J11"
+            ],
+            "revenue": 120,
+            "revenue_str": "F5-G4-H5-I6-J7-J11",
+            "nodes": [
+              "G4-0",
+              "F5-0",
+              "H5-0",
+              "I6-0",
+              "J7-0",
+              "J11-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 274,
+        "created_at": 1697031838,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 275,
+        "created_at": 1697031866
+      },
+      {
+        "hex": "E16",
+        "tile": "9-1",
+        "type": "lay_tile",
+        "entity": "LYR",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 276,
+        "user": 15620,
+        "created_at": 1697032184
+      },
+      {
+        "hex": "G18",
+        "tile": "G36-1",
+        "type": "lay_tile",
+        "entity": "LYR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 277,
+        "user": 15620,
+        "created_at": 1697032204
+      },
+      {
+        "type": "undo",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 278,
+        "user": 15620,
+        "created_at": 1697032215
+      },
+      {
+        "type": "undo",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 279,
+        "user": 15620,
+        "created_at": 1697032225
+      },
+      {
+        "hex": "G18",
+        "tile": "G37-0",
+        "type": "lay_tile",
+        "entity": "LYR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 280,
+        "user": 15620,
+        "created_at": 1697032381
+      },
+      {
+        "type": "undo",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 281,
+        "user": 15620,
+        "created_at": 1697032392
+      },
+      {
+        "hex": "E16",
+        "tile": "8-10",
+        "type": "lay_tile",
+        "entity": "LYR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 282,
+        "user": 15620,
+        "created_at": 1697032502
+      },
+      {
+        "hex": "D17",
+        "tile": "7-1",
+        "type": "lay_tile",
+        "entity": "LYR",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "id": 283,
+        "user": 15620,
+        "created_at": 1697032534
+      },
+      {
+        "type": "undo",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 284,
+        "user": 15620,
+        "created_at": 1697032552
+      },
+      {
+        "type": "undo",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 285,
+        "user": 15620,
+        "created_at": 1697032557
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 286,
+        "created_at": 1697032618
+      },
+      {
+        "type": "run_routes",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 287,
+        "created_at": 1697032633,
+        "routes": [
+          {
+            "train": "3+1-3",
+            "connections": [
+              [
+                "G16",
+                "H15"
+              ],
+              [
+                "F17",
+                "G16"
+              ],
+              [
+                "E14",
+                "F15",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "H15",
+              "G16",
+              "F17",
+              "E14"
+            ],
+            "revenue": 110,
+            "revenue_str": "H15-G16-F17-E14",
+            "nodes": [
+              "G16-0",
+              "H15-0",
+              "F17-0",
+              "E14-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 288,
+        "created_at": 1697032638,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 289,
+        "created_at": 1697032644
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 290,
+        "created_at": 1697033117,
+        "hex": "G22",
+        "tile": "88-1",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 291,
+        "created_at": 1697033136,
+        "hex": "I20",
+        "tile": "58-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 292,
+        "created_at": 1697033216,
+        "routes": [
+          {
+            "train": "3+1-1",
+            "connections": [
+              [
+                "F23",
+                "G24",
+                "G26"
+              ],
+              [
+                "G22",
+                "F23"
+              ],
+              [
+                "H21",
+                "G22"
+              ]
+            ],
+            "hexes": [
+              "G26",
+              "F23",
+              "G22",
+              "H21"
+            ],
+            "revenue": 90,
+            "revenue_str": "G26-F23-G22-H21",
+            "nodes": [
+              "F23-0",
+              "G26-0",
+              "G22-0",
+              "H21-0"
+            ]
+          },
+          {
+            "train": "4+2-0",
+            "connections": [
+              [
+                "F17",
+                "F15",
+                "E14"
+              ],
+              [
+                "G18",
+                "F17"
+              ],
+              [
+                "F21",
+                "F19",
+                "G18"
+              ],
+              [
+                "F23",
+                "F21"
+              ]
+            ],
+            "hexes": [
+              "E14",
+              "F17",
+              "G18",
+              "F21",
+              "F23"
+            ],
+            "revenue": 130,
+            "revenue_str": "E14-F17-G18-F21-F23+(LM)",
+            "nodes": [
+              "F17-0",
+              "E14-0",
+              "G18-0",
+              "F21-0",
+              "F23-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 293,
+        "created_at": 1697033225,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 294,
+        "created_at": 1697040889,
+        "shares": [
+          "NBR_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 295,
+        "created_at": 1697049461,
+        "shares": [
+          "NBR_3"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 296,
+        "created_at": 1697049772,
+        "shares": [
+          "GWR_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15620,
+        "shares": [
+          "GWR_1"
+        ],
+        "percent": 20,
+        "entity_type": "player",
+        "id": 297,
+        "user": 15620,
+        "created_at": 1697052636
+      },
+      {
+        "type": "undo",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 298,
+        "user": 15620,
+        "created_at": 1697052696
+      },
+      {
+        "type": "par",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 299,
+        "created_at": 1697053385,
+        "corporation": "NER",
+        "share_price": "80,0,6"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 300,
+        "created_at": 1697061109,
+        "shares": [
+          "LSWR_2"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 301,
+        "created_at": 1697061551
+      },
+      {
+        "type": "choose",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 302,
+        "created_at": 1697062725,
+        "choice": "convert_GWR"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 303,
+        "created_at": 1697062744,
+        "shares": [
+          "GWR_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "choose",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 304,
+        "created_at": 1697063037,
+        "choice": "convert_LYR"
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 305,
+        "created_at": 1697063095
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 306,
+        "created_at": 1697071420,
+        "shares": [
+          "LYR_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 307,
+        "created_at": 1697086638,
+        "shares": [
+          "LYR_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 308,
+        "created_at": 1697087949,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15618,
+            "entity_type": "player",
+            "created_at": 1697087948
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 309,
+        "created_at": 1697088049,
+        "shares": [
+          "GWR_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 310,
+        "created_at": 1697116007
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 311,
+        "created_at": 1697119361,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15621,
+            "entity_type": "player",
+            "created_at": 1697119360
+          },
+          {
+            "type": "program_disable",
+            "entity": 15618,
+            "entity_type": "player",
+            "created_at": 1697119360,
+            "reason": "Lawk3t bought on corporation GWR and is unsecure"
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "choose",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 312,
+        "created_at": 1697119904,
+        "choice": "convert_LSWR"
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 313,
+        "created_at": 1697119960
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 314,
+        "created_at": 1697132574,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 15621,
+            "entity_type": "player",
+            "created_at": 1697132573,
+            "reason": "LSWR converted to 10-share"
+          }
+        ]
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 315,
+        "created_at": 1697133141,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15621,
+            "entity_type": "player",
+            "created_at": 1697133141
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 316,
+        "created_at": 1697133730
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 317,
+        "created_at": 1697134663,
+        "hex": "I2",
+        "tile": "G40-2",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 318,
+        "created_at": 1697134686
+      },
+      {
+        "type": "run_routes",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 319,
+        "created_at": 1697134884,
+        "routes": [
+          {
+            "train": "3+1-0",
+            "connections": [
+              [
+                "H3",
+                "G4"
+              ],
+              [
+                "I2",
+                "H3"
+              ]
+            ],
+            "hexes": [
+              "G4",
+              "H3",
+              "I2"
+            ],
+            "revenue": 60,
+            "revenue_str": "G4-H3-I2",
+            "nodes": [
+              "H3-0",
+              "G4-1",
+              "I2-0"
+            ]
+          },
+          {
+            "train": "4+2-2",
+            "connections": [
+              [
+                "F5",
+                "F3",
+                "G4"
+              ],
+              [
+                "G6",
+                "F5"
+              ],
+              [
+                "H9",
+                "G8",
+                "G6"
+              ]
+            ],
+            "hexes": [
+              "G4",
+              "F5",
+              "G6",
+              "H9"
+            ],
+            "revenue": 80,
+            "revenue_str": "G4-F5-G6-H9",
+            "nodes": [
+              "F5-0",
+              "G4-1",
+              "G6-0",
+              "H9-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 320,
+        "created_at": 1697134890,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 321,
+        "created_at": 1697135012
+      },
+      {
+        "type": "run_routes",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 322,
+        "created_at": 1697135023,
+        "routes": [
+          {
+            "train": "4+2-1",
+            "connections": [
+              [
+                "G4",
+                "F5"
+              ],
+              [
+                "H5",
+                "G4"
+              ],
+              [
+                "I6",
+                "H5"
+              ],
+              [
+                "I6",
+                "J5",
+                "J7"
+              ],
+              [
+                "J7",
+                "J9",
+                "K10",
+                "J11"
+              ]
+            ],
+            "hexes": [
+              "F5",
+              "G4",
+              "H5",
+              "I6",
+              "J7",
+              "J11"
+            ],
+            "revenue": 120,
+            "revenue_str": "F5-G4-H5-I6-J7-J11",
+            "nodes": [
+              "G4-0",
+              "F5-0",
+              "H5-0",
+              "I6-0",
+              "J7-0",
+              "J11-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 323,
+        "created_at": 1697135028,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 324,
+        "created_at": 1697135174,
+        "train": "3+1-0",
+        "price": 1
+      },
+      {
+        "type": "choose_ability",
+        "entity": "TV",
+        "entity_type": "company",
+        "id": 325,
+        "created_at": 1697135393,
+        "choice": "close"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 326,
+        "created_at": 1697135407,
+        "hex": "D17",
+        "tile": "8-10",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 327,
+        "created_at": 1697135445,
+        "hex": "D21",
+        "tile": "88-2",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 328,
+        "created_at": 1697135464
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 329,
+        "created_at": 1697135547,
+        "routes": [
+          {
+            "train": "3+1-2",
+            "connections": [
+              [
+                "D23",
+                "D25"
+              ],
+              [
+                "D23",
+                "C22",
+                "C24"
+              ],
+              [
+                "C24",
+                "B25",
+                "A24",
+                "a25"
+              ]
+            ],
+            "hexes": [
+              "D25",
+              "D23",
+              "C24",
+              "a25"
+            ],
+            "revenue": 100,
+            "revenue_str": "D25-D23-C24-a25",
+            "nodes": [
+              "D23-0",
+              "D25-0",
+              "C24-0",
+              "a25-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 330,
+        "created_at": 1697135550,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 331,
+        "created_at": 1697135559,
+        "train": "4+2-3",
+        "price": 300,
+        "variant": "4+2"
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 332,
+        "created_at": 1697135562
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 333,
+        "created_at": 1697139531,
+        "hex": "H13",
+        "tile": "28-0",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 334,
+        "created_at": 1697139544,
+        "hex": "I14",
+        "tile": "G40-3",
+        "rotation": 2
+      },
+      {
+        "type": "place_token",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 335,
+        "created_at": 1697139591,
+        "city": "G39-0-0",
+        "slot": 0,
+        "tokener": "LYR"
+      },
+      {
+        "type": "run_routes",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 336,
+        "created_at": 1697139653,
+        "routes": [
+          {
+            "train": "3+1-3",
+            "connections": [
+              [
+                "G16",
+                "H15"
+              ],
+              [
+                "F17",
+                "G16"
+              ],
+              [
+                "E14",
+                "F15",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "H15",
+              "G16",
+              "F17",
+              "E14"
+            ],
+            "revenue": 110,
+            "revenue_str": "H15-G16-F17-E14",
+            "nodes": [
+              "G16-0",
+              "H15-0",
+              "F17-0",
+              "E14-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 337,
+        "created_at": 1697139660,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 338,
+        "created_at": 1697139666,
+        "train": "4+2-4",
+        "price": 300,
+        "variant": "4+2"
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 339,
+        "created_at": 1697139670
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 340,
+        "created_at": 1697158680,
+        "hex": "I18",
+        "tile": "9-1",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 341,
+        "created_at": 1697158743,
+        "hex": "I16",
+        "tile": "4-7",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 342,
+        "created_at": 1697158846,
+        "routes": [
+          {
+            "train": "3+1-1",
+            "connections": [
+              [
+                "F23",
+                "G24",
+                "G26"
+              ],
+              [
+                "F21",
+                "F23"
+              ],
+              [
+                "G18",
+                "F19",
+                "F21"
+              ]
+            ],
+            "hexes": [
+              "G26",
+              "F23",
+              "F21",
+              "G18"
+            ],
+            "revenue": 100,
+            "revenue_str": "G26-F23-F21-G18",
+            "nodes": [
+              "F23-0",
+              "G26-0",
+              "F21-0",
+              "G18-0"
+            ]
+          },
+          {
+            "train": "4+2-0",
+            "connections": [
+              [
+                "I20",
+                "I18",
+                "I16"
+              ],
+              [
+                "H21",
+                "I20"
+              ],
+              [
+                "G22",
+                "H21"
+              ],
+              [
+                "F23",
+                "G22"
+              ]
+            ],
+            "hexes": [
+              "I16",
+              "I20",
+              "H21",
+              "G22",
+              "F23"
+            ],
+            "revenue": 60,
+            "revenue_str": "I16-I20-H21-G22-F23",
+            "nodes": [
+              "I20-0",
+              "I16-0",
+              "H21-0",
+              "G22-0",
+              "F23-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 343,
+        "created_at": 1697158861,
+        "kind": "payout"
+      },
+      {
+        "hex": "F25",
+        "tile": "204-1",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 344,
+        "user": 15618,
+        "created_at": 1697160026
+      },
+      {
+        "hex": "F21",
+        "tile": "G06-0",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 345,
+        "user": 15618,
+        "created_at": 1697160213
+      },
+      {
+        "city": "G06-0-0",
+        "slot": 0,
+        "type": "place_token",
+        "entity": "LSWR",
+        "tokener": "LSWR",
+        "entity_type": "corporation",
+        "id": 346,
+        "user": 15618,
+        "created_at": 1697160214
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 347,
+        "user": 15618,
+        "created_at": 1697160228
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 348,
+        "user": 15618,
+        "created_at": 1697160331
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 349,
+        "user": 15618,
+        "created_at": 1697160332
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 350,
+        "user": 15618,
+        "created_at": 1697160333
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 351,
+        "user": 15618,
+        "created_at": 1697160336
+      },
+      {
+        "hex": "F25",
+        "tile": "204-1",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 352,
+        "user": 15618,
+        "created_at": 1697160380
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 353,
+        "user": 15618,
+        "created_at": 1697160389
+      },
+      {
+        "hex": "F25",
+        "tile": "204-1",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 354,
+        "user": 15618,
+        "created_at": 1697160420
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 355,
+        "user": 15618,
+        "created_at": 1697160496
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 356,
+        "created_at": 1697160540,
+        "hex": "F25",
+        "tile": "88-3",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 357,
+        "created_at": 1697160569,
+        "hex": "F21",
+        "tile": "G05-0",
+        "rotation": 3
+      },
+      {
+        "type": "place_token",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 358,
+        "created_at": 1697160574,
+        "city": "G05-0-1",
+        "slot": 0,
+        "tokener": "LSWR"
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 359,
+        "created_at": 1697160581
+      },
+      {
+        "type": "run_routes",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 360,
+        "created_at": 1697160768,
+        "routes": [
+          {
+            "train": "3+1-4",
+            "connections": [
+              [
+                "E26",
+                "F27",
+                "G26"
+              ],
+              [
+                "D25",
+                "E26"
+              ],
+              [
+                "D23",
+                "D25"
+              ]
+            ],
+            "hexes": [
+              "G26",
+              "E26",
+              "D25",
+              "D23"
+            ],
+            "revenue": 110,
+            "revenue_str": "G26-E26-D25-D23",
+            "nodes": [
+              "E26-0",
+              "G26-0",
+              "D25-0",
+              "D23-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 361,
+        "created_at": 1697160770,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 362,
+        "created_at": 1697160772,
+        "train": "5+2-0",
+        "price": 500,
+        "variant": "5+2"
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 363,
+        "created_at": 1697160785
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 364,
+        "created_at": 1697163630,
+        "hex": "J3",
+        "tile": "G40-0",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 365,
+        "created_at": 1697163636,
+        "hex": "K2",
+        "tile": "8-11",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 366,
+        "created_at": 1697163642
+      },
+      {
+        "type": "run_routes",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 367,
+        "created_at": 1697163768,
+        "routes": [
+          {
+            "train": "4+2-2",
+            "connections": [
+              [
+                "H3",
+                "G4"
+              ],
+              [
+                "I2",
+                "H3"
+              ],
+              [
+                "J3",
+                "I2"
+              ],
+              [
+                "J3",
+                "K2",
+                "K0"
+              ]
+            ],
+            "hexes": [
+              "G4",
+              "H3",
+              "I2",
+              "J3",
+              "K0"
+            ],
+            "revenue": 110,
+            "revenue_str": "G4-H3-I2-J3-K0",
+            "nodes": [
+              "H3-0",
+              "G4-1",
+              "I2-0",
+              "J3-0",
+              "K0-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 368,
+        "created_at": 1697163777,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 369,
+        "created_at": 1697163784
+      },
+      {
+        "hex": "C22",
+        "tile": "G33-0",
+        "type": "lay_tile",
+        "entity": "TV",
+        "rotation": 0,
+        "entity_type": "company",
+        "id": 370,
+        "user": 15618,
+        "created_at": 1697164655
+      },
+      {
+        "hex": "B21",
+        "tile": "G18-2",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 371,
+        "user": 15618,
+        "created_at": 1697164692
+      },
+      {
+        "city": "G18-2-0",
+        "slot": 0,
+        "type": "place_token",
+        "entity": "GWR",
+        "tokener": "GWR",
+        "entity_type": "corporation",
+        "id": 372,
+        "user": 15618,
+        "created_at": 1697164697
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 373,
+        "user": 15618,
+        "created_at": 1697164702
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 374,
+        "user": 15618,
+        "created_at": 1697165065
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 375,
+        "user": 15618,
+        "created_at": 1697165066
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 376,
+        "user": 15618,
+        "created_at": 1697165073
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 377,
+        "user": 15618,
+        "created_at": 1697165074
+      },
+      {
+        "hex": "C22",
+        "tile": "G33-0",
+        "type": "lay_tile",
+        "entity": "TV",
+        "rotation": 0,
+        "entity_type": "company",
+        "id": 378,
+        "user": 15618,
+        "created_at": 1697165110
+      },
+      {
+        "hex": "D23",
+        "tile": "G30-0",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 379,
+        "user": 15618,
+        "created_at": 1697165147
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 380,
+        "user": 15618,
+        "created_at": 1697165163
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 381,
+        "user": 15618,
+        "created_at": 1697165164
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 382,
+        "created_at": 1697165242,
+        "hex": "D23",
+        "tile": "G30-0",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 383,
+        "created_at": 1697165246,
+        "hex": "E22",
+        "tile": "9-2",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 384,
+        "created_at": 1697165269
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 385,
+        "created_at": 1697165374,
+        "routes": [
+          {
+            "train": "3+1-2",
+            "connections": [
+              [
+                "D23",
+                "E22",
+                "F21"
+              ],
+              [
+                "D23",
+                "C22",
+                "C24"
+              ],
+              [
+                "C24",
+                "B25",
+                "A24",
+                "a25"
+              ]
+            ],
+            "hexes": [
+              "F21",
+              "D23",
+              "C24",
+              "a25"
+            ],
+            "revenue": 140,
+            "revenue_str": "F21-D23-C24-a25",
+            "nodes": [
+              "D23-0",
+              "F21-1",
+              "C24-0",
+              "a25-0"
+            ]
+          },
+          {
+            "train": "4+2-3",
+            "connections": [
+              [
+                "C24",
+                "C26",
+                "D27"
+              ],
+              [
+                "D23",
+                "C24"
+              ],
+              [
+                "D21",
+                "D23"
+              ],
+              [
+                "C16",
+                "D17",
+                "D19",
+                "D21"
+              ]
+            ],
+            "hexes": [
+              "D27",
+              "C24",
+              "D23",
+              "D21",
+              "C16"
+            ],
+            "revenue": 120,
+            "revenue_str": "D27-C24-D23-D21-C16",
+            "nodes": [
+              "C24-0",
+              "D27-0",
+              "D23-0",
+              "D21-0",
+              "C16-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 386,
+        "created_at": 1697165377,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 387,
+        "created_at": 1697165484
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 388,
+        "created_at": 1697167728,
+        "hex": "I8",
+        "tile": "8-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 389,
+        "created_at": 1697167734,
+        "hex": "I6",
+        "tile": "G21-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 390,
+        "created_at": 1697167742
+      },
+      {
+        "type": "run_routes",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 391,
+        "created_at": 1697167919,
+        "routes": [
+          {
+            "train": "4+2-1",
+            "connections": [
+              [
+                "F5",
+                "E6"
+              ],
+              [
+                "G4",
+                "F5"
+              ],
+              [
+                "H5",
+                "G4"
+              ],
+              [
+                "H5",
+                "I6"
+              ]
+            ],
+            "hexes": [
+              "E6",
+              "F5",
+              "G4",
+              "H5",
+              "I6"
+            ],
+            "revenue": 120,
+            "revenue_str": "E6-F5-G4-H5-I6",
+            "nodes": [
+              "F5-0",
+              "E6-0",
+              "G4-0",
+              "H5-0",
+              "I6-1"
+            ]
+          },
+          {
+            "train": "3+1-0",
+            "connections": [
+              [
+                "J11",
+                "K10",
+                "J9",
+                "J7"
+              ],
+              [
+                "J7",
+                "J5",
+                "I6"
+              ]
+            ],
+            "hexes": [
+              "J11",
+              "J7",
+              "I6"
+            ],
+            "revenue": 60,
+            "revenue_str": "J11-J7-I6",
+            "nodes": [
+              "J11-0",
+              "J7-0",
+              "I6-1"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 392,
+        "created_at": 1697167926,
+        "kind": "payout"
+      },
+      {
+        "city": "G40-3-0",
+        "slot": 0,
+        "type": "place_token",
+        "entity": "LYR",
+        "tokener": "LYR",
+        "entity_type": "corporation",
+        "id": 393,
+        "user": 15620,
+        "created_at": 1697185440
+      },
+      {
+        "type": "undo",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 394,
+        "user": 15620,
+        "created_at": 1697185454
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 395,
+        "created_at": 1697185601,
+        "hex": "I14",
+        "tile": "G38-1",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 396,
+        "created_at": 1697185653,
+        "hex": "I12",
+        "tile": "87-2",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 397,
+        "created_at": 1697185678
+      },
+      {
+        "type": "run_routes",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 398,
+        "created_at": 1697185843,
+        "routes": [
+          {
+            "train": "3+1-3",
+            "connections": [
+              [
+                "G18",
+                "F19",
+                "F21"
+              ],
+              [
+                "F17",
+                "G18"
+              ],
+              [
+                "F17",
+                "F15",
+                "E14"
+              ]
+            ],
+            "hexes": [
+              "F21",
+              "G18",
+              "F17",
+              "E14"
+            ],
+            "revenue": 100,
+            "revenue_str": "F21-G18-F17-E14",
+            "nodes": [
+              "G18-0",
+              "F21-0",
+              "F17-0",
+              "E14-0"
+            ]
+          },
+          {
+            "train": "4+2-4",
+            "connections": [
+              [
+                "I12",
+                "J11"
+              ],
+              [
+                "I14",
+                "I12"
+              ],
+              [
+                "H15",
+                "H13",
+                "I14"
+              ],
+              [
+                "G16",
+                "H15"
+              ],
+              [
+                "F17",
+                "G16"
+              ]
+            ],
+            "hexes": [
+              "J11",
+              "I12",
+              "I14",
+              "H15",
+              "G16",
+              "F17"
+            ],
+            "revenue": 120,
+            "revenue_str": "J11-I12-I14-H15-G16-F17",
+            "nodes": [
+              "I12-0",
+              "J11-0",
+              "I14-0",
+              "H15-0",
+              "G16-0",
+              "F17-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 399,
+        "created_at": 1697185852,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 400,
+        "created_at": 1697185858
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 401,
+        "created_at": 1697226627,
+        "hex": "I12",
+        "tile": "911-0",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 402,
+        "created_at": 1697226654,
+        "hex": "I10",
+        "tile": "9-3",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 403,
+        "created_at": 1697226722,
+        "routes": [
+          {
+            "train": "3+1-1",
+            "connections": [
+              [
+                "F23",
+                "G24",
+                "G26"
+              ],
+              [
+                "F21",
+                "F23"
+              ],
+              [
+                "G18",
+                "F19",
+                "F21"
+              ]
+            ],
+            "hexes": [
+              "G26",
+              "F23",
+              "F21",
+              "G18"
+            ],
+            "revenue": 120,
+            "revenue_str": "G26-F23-F21-G18",
+            "nodes": [
+              "F23-0",
+              "G26-0",
+              "F21-0",
+              "G18-0"
+            ]
+          },
+          {
+            "train": "4+2-0",
+            "connections": [
+              [
+                "I12",
+                "J11"
+              ],
+              [
+                "I14",
+                "I12"
+              ],
+              [
+                "I16",
+                "I14"
+              ],
+              [
+                "I20",
+                "I18",
+                "I16"
+              ],
+              [
+                "H21",
+                "I20"
+              ]
+            ],
+            "hexes": [
+              "J11",
+              "I12",
+              "I14",
+              "I16",
+              "I20",
+              "H21"
+            ],
+            "revenue": 90,
+            "revenue_str": "J11-I12-I14-I16-I20-H21",
+            "nodes": [
+              "I12-0",
+              "J11-0",
+              "I14-0",
+              "I16-0",
+              "I20-0",
+              "H21-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 404,
+        "created_at": 1697226736,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 405,
+        "created_at": 1697227938,
+        "hex": "C24",
+        "tile": "911-1",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "TV",
+        "entity_type": "company",
+        "id": 406,
+        "created_at": 1697227985,
+        "hex": "C22",
+        "tile": "G33-0",
+        "rotation": 0
+      },
+      {
+        "type": "place_token",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 407,
+        "created_at": 1697228143,
+        "city": "G30-0-0",
+        "slot": 1,
+        "tokener": "LSWR"
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 408,
+        "created_at": 1697228149
+      },
+      {
+        "type": "run_routes",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 409,
+        "created_at": 1697228655,
+        "routes": [
+          {
+            "train": "3+1-4",
+            "connections": [
+              [
+                "E26",
+                "F27",
+                "G26"
+              ],
+              [
+                "D25",
+                "E26"
+              ],
+              [
+                "D23",
+                "D25"
+              ]
+            ],
+            "hexes": [
+              "G26",
+              "E26",
+              "D25",
+              "D23"
+            ],
+            "revenue": 170,
+            "revenue_str": "G26-E26-D25-D23+(EW)",
+            "nodes": [
+              "E26-0",
+              "G26-0",
+              "D25-0",
+              "D23-0"
+            ]
+          },
+          {
+            "train": "5+2-0",
+            "connections": [
+              [
+                "C24",
+                "B25",
+                "A24",
+                "a25"
+              ],
+              [
+                "D23",
+                "C22",
+                "C24"
+              ],
+              [
+                "F21",
+                "E22",
+                "D23"
+              ],
+              [
+                "G22",
+                "F21"
+              ],
+              [
+                "F23",
+                "G22"
+              ],
+              [
+                "G26",
+                "G24",
+                "F23"
+              ]
+            ],
+            "hexes": [
+              "a25",
+              "C24",
+              "D23",
+              "F21",
+              "G22",
+              "F23",
+              "G26"
+            ],
+            "revenue": 220,
+            "revenue_str": "a25-C24-D23-F21-G22-F23-G26",
+            "nodes": [
+              "C24-0",
+              "a25-0",
+              "D23-0",
+              "F21-1",
+              "G22-0",
+              "F23-0",
+              "G26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 410,
+        "created_at": 1697228678,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 411,
+        "created_at": 1697228742,
+        "train": "3+1-2",
+        "price": 200
+      },
+      {
+        "type": "par",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 412,
+        "created_at": 1697280750,
+        "corporation": "MR",
+        "share_price": "70,0,4"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 413,
+        "created_at": 1697371047,
+        "shares": [
+          "LSWR_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 414,
+        "created_at": 1697381823,
+        "shares": [
+          "NER_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 415,
+        "created_at": 1697382403,
+        "shares": [
+          "LSWR_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 416,
+        "created_at": 1697382424,
+        "shares": [
+          "LSWR_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 417,
+        "created_at": 1697393500,
+        "shares": [
+          "MR_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 418,
+        "created_at": 1697417796,
+        "shares": [
+          "LYR_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 419,
+        "created_at": 1697430762,
+        "shares": [
+          "LSWR_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 420,
+        "created_at": 1697453994,
+        "shares": [
+          "GWR_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 421,
+        "created_at": 1697485139,
+        "shares": [
+          "MR_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 422,
+        "created_at": 1697485479,
+        "shares": [
+          "LYR_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 423,
+        "created_at": 1697493032,
+        "shares": [
+          "LSWR_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 424,
+        "created_at": 1697504188,
+        "shares": [
+          "LYR_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 425,
+        "created_at": 1697511057,
+        "shares": [
+          "MR_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 426,
+        "created_at": 1697555267,
+        "shares": [
+          "LSWR_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 427,
+        "created_at": 1697555455,
+        "shares": [
+          "MR_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 428,
+        "created_at": 1697560145
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 429,
+        "created_at": 1697560700
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 430,
+        "created_at": 1697561496
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 431,
+        "created_at": 1697561521
+      },
+      {
+        "hex": "I2",
+        "tile": "G38-2",
+        "type": "lay_tile",
+        "entity": "CR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 432,
+        "user": 15708,
+        "created_at": 1697567673
+      },
+      {
+        "hex": "J1",
+        "tile": "8-12",
+        "type": "lay_tile",
+        "entity": "CR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 433,
+        "user": 15708,
+        "created_at": 1697567679
+      },
+      {
+        "city": "G21-0-0",
+        "slot": 0,
+        "type": "place_token",
+        "entity": "CR",
+        "tokener": "CR",
+        "entity_type": "corporation",
+        "id": 434,
+        "user": 15708,
+        "created_at": 1697567713
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 435,
+        "user": 15708,
+        "created_at": 1697567734
+      },
+      {
+        "type": "undo",
+        "entity": "CR",
+        "action_id": 431,
+        "entity_type": "corporation",
+        "id": 436,
+        "user": 15708,
+        "created_at": 1697567800
+      },
+      {
+        "type": "lay_tile",
+        "entity": "AF",
+        "entity_type": "company",
+        "id": 437,
+        "created_at": 1697567832,
+        "hex": "I2",
+        "tile": "G38-2",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 438,
+        "created_at": 1697567837,
+        "hex": "J1",
+        "tile": "8-12",
+        "rotation": 5
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 439,
+        "created_at": 1697567845,
+        "hex": "K2",
+        "tile": "28-1",
+        "rotation": 3
+      },
+      {
+        "type": "place_token",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 440,
+        "created_at": 1697567850,
+        "city": "G21-0-0",
+        "slot": 0,
+        "tokener": "CR"
+      },
+      {
+        "type": "run_routes",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 441,
+        "created_at": 1697567973,
+        "routes": [
+          {
+            "train": "4+2-2",
+            "connections": [
+              [
+                "I2",
+                "J1",
+                "K2",
+                "K0"
+              ],
+              [
+                "I2",
+                "H3"
+              ],
+              [
+                "H3",
+                "G4"
+              ],
+              [
+                "G4",
+                "F3",
+                "F5"
+              ]
+            ],
+            "hexes": [
+              "K0",
+              "I2",
+              "H3",
+              "G4",
+              "F5"
+            ],
+            "revenue": 130,
+            "revenue_str": "K0-I2-H3-G4-F5",
+            "nodes": [
+              "I2-0",
+              "K0-0",
+              "H3-0",
+              "G4-1",
+              "F5-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 442,
+        "created_at": 1697567978,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 443,
+        "created_at": 1697568095
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 444,
+        "created_at": 1697573109,
+        "hex": "B21",
+        "tile": "G19-2",
+        "rotation": 5
+      },
+      {
+        "type": "place_token",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 445,
+        "created_at": 1697573677,
+        "city": "G19-2-0",
+        "slot": 0,
+        "tokener": "GWR"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 446,
+        "created_at": 1697573683,
+        "hex": "C20",
+        "tile": "4-8",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 447,
+        "created_at": 1697573736,
+        "routes": [
+          {
+            "train": "4+2-3",
+            "connections": [
+              [
+                "D21",
+                "D19",
+                "D17",
+                "C16"
+              ],
+              [
+                "D23",
+                "D21"
+              ],
+              [
+                "C24",
+                "C22",
+                "D23"
+              ],
+              [
+                "a25",
+                "A24",
+                "B25",
+                "C24"
+              ]
+            ],
+            "hexes": [
+              "C16",
+              "D21",
+              "D23",
+              "C24",
+              "a25"
+            ],
+            "revenue": 130,
+            "revenue_str": "C16-D21-D23-C24-a25",
+            "nodes": [
+              "D21-0",
+              "C16-0",
+              "D23-0",
+              "C24-0",
+              "a25-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 448,
+        "user": 15618,
+        "created_at": 1697573750
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 449,
+        "user": 15618,
+        "created_at": 1697573763
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 450,
+        "created_at": 1697573764,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 451,
+        "created_at": 1697573773,
+        "train": "4X-0",
+        "price": 550,
+        "variant": "4X"
+      },
+      {
+        "type": "place_token",
+        "entity": "GN",
+        "entity_type": "company",
+        "id": 452,
+        "created_at": 1697573902,
+        "city": "G38-1-0",
+        "slot": 0,
+        "tokener": "NBR"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 453,
+        "created_at": 1697573956,
+        "hex": "G4",
+        "tile": "G15-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 454,
+        "created_at": 1697574089
+      },
+      {
+        "type": "run_routes",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 455,
+        "created_at": 1697574322,
+        "routes": [
+          {
+            "train": "4+2-1",
+            "connections": [
+              [
+                "F5",
+                "E6"
+              ],
+              [
+                "G4",
+                "F5"
+              ],
+              [
+                "G4",
+                "H5"
+              ],
+              [
+                "H5",
+                "I6"
+              ],
+              [
+                "I6",
+                "J5",
+                "J7"
+              ]
+            ],
+            "hexes": [
+              "E6",
+              "F5",
+              "G4",
+              "H5",
+              "I6",
+              "J7"
+            ],
+            "revenue": 150,
+            "revenue_str": "E6-F5-G4-H5-I6-J7",
+            "nodes": [
+              "F5-0",
+              "E6-0",
+              "G4-1",
+              "H5-0",
+              "I6-1",
+              "J7-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 456,
+        "created_at": 1697574353,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 457,
+        "created_at": 1697574939
+      },
+      {
+        "hex": "G18",
+        "tile": "G37-0",
+        "type": "lay_tile",
+        "entity": "LYR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 458,
+        "user": 15620,
+        "created_at": 1697589799
+      },
+      {
+        "type": "undo",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 459,
+        "user": 15620,
+        "created_at": 1697589807
+      },
+      {
+        "hex": "F17",
+        "tile": "911-2",
+        "type": "lay_tile",
+        "entity": "LYR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 460,
+        "user": 15620,
+        "created_at": 1697589832
+      },
+      {
+        "hex": "E18",
+        "tile": "58-2",
+        "type": "lay_tile",
+        "entity": "LYR",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "id": 461,
+        "user": 15620,
+        "created_at": 1697589841
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 462,
+        "user": 15620,
+        "created_at": 1697589878
+      },
+      {
+        "type": "undo",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 463,
+        "user": 15620,
+        "created_at": 1697589998
+      },
+      {
+        "type": "undo",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 464,
+        "user": 15620,
+        "created_at": 1697590002
+      },
+      {
+        "type": "undo",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 465,
+        "user": 15620,
+        "created_at": 1697590005
+      },
+      {
+        "hex": "I8",
+        "tile": "23-0",
+        "type": "lay_tile",
+        "entity": "LYR",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "id": 466,
+        "user": 15620,
+        "created_at": 1697590017
+      },
+      {
+        "type": "undo",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 467,
+        "user": 15620,
+        "created_at": 1697590033
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 468,
+        "created_at": 1697590038,
+        "hex": "I10",
+        "tile": "24-0",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 469,
+        "created_at": 1697590051,
+        "hex": "H9",
+        "tile": "G38-3",
+        "rotation": 2
+      },
+      {
+        "type": "place_token",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 470,
+        "created_at": 1697590054,
+        "city": "G38-3-0",
+        "slot": 0,
+        "tokener": "LYR"
+      },
+      {
+        "type": "run_routes",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 471,
+        "created_at": 1697590090,
+        "routes": [
+          {
+            "train": "4+2-4",
+            "connections": [
+              [
+                "I12",
+                "I10",
+                "H9"
+              ],
+              [
+                "H15",
+                "H13",
+                "I12"
+              ],
+              [
+                "G16",
+                "H15"
+              ],
+              [
+                "F17",
+                "G16"
+              ],
+              [
+                "E14",
+                "F15",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "H9",
+              "I12",
+              "H15",
+              "G16",
+              "F17",
+              "E14"
+            ],
+            "revenue": 140,
+            "revenue_str": "H9-I12-H15-G16-F17-E14",
+            "nodes": [
+              "I12-0",
+              "H9-0",
+              "H15-0",
+              "G16-0",
+              "F17-0",
+              "E14-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 472,
+        "created_at": 1697590094,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 473,
+        "created_at": 1697590097
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 474,
+        "created_at": 1697634851,
+        "hex": "F19",
+        "tile": "23-0",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 475,
+        "created_at": 1697634856,
+        "hex": "F17",
+        "tile": "911-2",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 476,
+        "created_at": 1697634959,
+        "routes": [
+          {
+            "train": "4+2-0",
+            "connections": [
+              [
+                "F17",
+                "F15",
+                "E14"
+              ],
+              [
+                "F21",
+                "F19",
+                "F17"
+              ],
+              [
+                "F23",
+                "F21"
+              ],
+              [
+                "F25",
+                "F23"
+              ],
+              [
+                "G26",
+                "F25"
+              ]
+            ],
+            "hexes": [
+              "E14",
+              "F17",
+              "F21",
+              "F23",
+              "F25",
+              "G26"
+            ],
+            "revenue": 200,
+            "revenue_str": "E14-F17-F21-F23-F25-G26+(LM)",
+            "nodes": [
+              "F17-0",
+              "E14-0",
+              "F21-0",
+              "F23-0",
+              "F25-0",
+              "G26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 477,
+        "created_at": 1697634977,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 478,
+        "created_at": 1697634983
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 479,
+        "created_at": 1697636428,
+        "hex": "H19",
+        "tile": "G40-3",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 480,
+        "created_at": 1697636433,
+        "hex": "I18",
+        "tile": "23-1",
+        "rotation": 3
+      },
+      {
+        "type": "buy_train",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 481,
+        "created_at": 1697636494,
+        "train": "4+2-2",
+        "price": 50
+      },
+      {
+        "type": "buy_train",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 482,
+        "created_at": 1697636496,
+        "train": "5X-0",
+        "price": 650,
+        "variant": "5X"
+      },
+      {
+        "hex": "D19",
+        "tile": "23-2",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 483,
+        "user": 15618,
+        "created_at": 1697651043
+      },
+      {
+        "hex": "E18",
+        "tile": "58-2",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 484,
+        "user": 15618,
+        "created_at": 1697651047
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 485,
+        "user": 15618,
+        "created_at": 1697651055
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 486,
+        "user": 15618,
+        "created_at": 1697651056
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 487,
+        "created_at": 1697651070,
+        "hex": "E20",
+        "tile": "9-4",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 488,
+        "created_at": 1697651074,
+        "hex": "F19",
+        "tile": "47-0",
+        "rotation": 3
+      },
+      {
+        "type": "place_token",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 489,
+        "created_at": 1697651078,
+        "city": "G03-0-0",
+        "slot": 0,
+        "tokener": "LSWR"
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 490,
+        "created_at": 1697651083
+      },
+      {
+        "type": "run_routes",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 491,
+        "created_at": 1697651153,
+        "routes": [
+          {
+            "train": "5+2-0",
+            "connections": [
+              [
+                "C24",
+                "B25",
+                "A24",
+                "a25"
+              ],
+              [
+                "D23",
+                "C22",
+                "C24"
+              ],
+              [
+                "F21",
+                "E22",
+                "D23"
+              ],
+              [
+                "G22",
+                "F21"
+              ],
+              [
+                "F23",
+                "G22"
+              ],
+              [
+                "F23",
+                "G24",
+                "G26"
+              ]
+            ],
+            "hexes": [
+              "a25",
+              "C24",
+              "D23",
+              "F21",
+              "G22",
+              "F23",
+              "G26"
+            ],
+            "revenue": 250,
+            "revenue_str": "a25-C24-D23-F21-G22-F23-G26+(EW)",
+            "nodes": [
+              "C24-0",
+              "a25-0",
+              "D23-0",
+              "F21-1",
+              "G22-0",
+              "F23-0",
+              "G26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 492,
+        "created_at": 1697651159,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 493,
+        "created_at": 1697651200,
+        "train": "4+2-3",
+        "price": 150
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 494,
+        "created_at": 1697651763,
+        "hex": "G6",
+        "tile": "87-3",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 495,
+        "created_at": 1697651769,
+        "hex": "F7",
+        "tile": "8-13",
+        "rotation": 2
+      },
+      {
+        "type": "convert",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 496,
+        "created_at": 1697651840
+      },
+      {
+        "type": "buy_train",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 497,
+        "created_at": 1697651854,
+        "train": "5X-1",
+        "price": 650,
+        "variant": "5X"
+      },
+      {
+        "type": "buy_train",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 498,
+        "created_at": 1697651857,
+        "train": "5X-0",
+        "price": 1
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 499,
+        "created_at": 1697651872
+      },
+      {
+        "hex": "I14",
+        "tile": "G34-0",
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 500,
+        "user": 15621,
+        "created_at": 1697652136
+      },
+      {
+        "hex": "I8",
+        "tile": "23-2",
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "id": 501,
+        "user": 15621,
+        "created_at": 1697652152
+      },
+      {
+        "type": "undo",
+        "entity": "LNWR",
+        "action_id": 499,
+        "entity_type": "corporation",
+        "id": 502,
+        "user": 15621,
+        "created_at": 1697652235
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 503,
+        "created_at": 1697652256,
+        "hex": "F21",
+        "tile": "G14-0",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 504,
+        "created_at": 1697652280,
+        "hex": "E16",
+        "tile": "9-3",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 505,
+        "created_at": 1697652362,
+        "routes": [
+          {
+            "train": "4+2-0",
+            "connections": [
+              [
+                "F17",
+                "F15",
+                "E14"
+              ],
+              [
+                "F21",
+                "F19",
+                "F17"
+              ],
+              [
+                "F23",
+                "F21"
+              ],
+              [
+                "F25",
+                "F23"
+              ],
+              [
+                "G26",
+                "F25"
+              ]
+            ],
+            "hexes": [
+              "E14",
+              "F17",
+              "F21",
+              "F23",
+              "F25",
+              "G26"
+            ],
+            "revenue": 220,
+            "revenue_str": "E14-F17-F21-F23-F25-G26+(LM)",
+            "nodes": [
+              "F17-0",
+              "E14-0",
+              "F21-0",
+              "F23-0",
+              "F25-0",
+              "G26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 506,
+        "created_at": 1697652368,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 507,
+        "created_at": 1697652377
+      },
+      {
+        "hex": "A20",
+        "tile": "G40-2",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 508,
+        "user": 15618,
+        "created_at": 1697654082
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 509,
+        "user": 15618,
+        "created_at": 1697654100
+      },
+      {
+        "hex": "F15",
+        "tile": "25-0",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 510,
+        "user": 15618,
+        "created_at": 1697654151
+      },
+      {
+        "hex": "G14",
+        "tile": "G19-3",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 511,
+        "user": 15618,
+        "created_at": 1697654207
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 512,
+        "user": 15618,
+        "created_at": 1697654211
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 513,
+        "user": 15618,
+        "created_at": 1697654230
+      },
+      {
+        "hex": "E20",
+        "tile": "23-2",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 514,
+        "user": 15618,
+        "created_at": 1697654295
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 515,
+        "user": 15618,
+        "created_at": 1697654915
+      },
+      {
+        "hex": "F15",
+        "tile": "25-0",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 516,
+        "user": 15618,
+        "created_at": 1697654942
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 517,
+        "user": 15618,
+        "created_at": 1697654967
+      },
+      {
+        "hex": "C18",
+        "tile": "7-1",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 518,
+        "user": 15618,
+        "created_at": 1697655031
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 519,
+        "user": 15618,
+        "created_at": 1697655042
+      },
+      {
+        "hex": "E20",
+        "tile": "23-2",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 520,
+        "user": 15618,
+        "created_at": 1697655058
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 521,
+        "user": 15618,
+        "created_at": 1697655106
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 522,
+        "created_at": 1697655193,
+        "hex": "E20",
+        "tile": "23-2",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 523,
+        "created_at": 1697655331,
+        "hex": "A20",
+        "tile": "G40-2",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 524,
+        "created_at": 1697655337
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 525,
+        "user": 15618,
+        "created_at": 1697655363
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 526,
+        "user": 15618,
+        "created_at": 1697655373
+      },
+      {
+        "type": "redo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 527,
+        "user": 15618,
+        "created_at": 1697655595
+      },
+      {
+        "type": "redo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 528,
+        "user": 15618,
+        "created_at": 1697655597
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 529,
+        "created_at": 1697655752,
+        "routes": [
+          {
+            "train": "4X-0",
+            "connections": [
+              [
+                "F17",
+                "F15",
+                "E14"
+              ],
+              [
+                "D21",
+                "E20",
+                "F19",
+                "F17"
+              ],
+              [
+                "D23",
+                "D21"
+              ],
+              [
+                "D23",
+                "C22",
+                "C24"
+              ],
+              [
+                "C24",
+                "B25",
+                "A24",
+                "a25"
+              ]
+            ],
+            "hexes": [
+              "E14",
+              "F17",
+              "D21",
+              "D23",
+              "C24",
+              "a25"
+            ],
+            "revenue": 210,
+            "revenue_str": "E14-D23-a25+£80",
+            "nodes": [
+              "F17-0",
+              "E14-0",
+              "D21-0",
+              "D23-0",
+              "C24-0",
+              "a25-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 530,
+        "created_at": 1697655759,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 531,
+        "created_at": 1697655796
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 532,
+        "created_at": 1697657984,
+        "hex": "I6",
+        "tile": "G30-1",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 533,
+        "created_at": 1697658007,
+        "hex": "H7",
+        "tile": "8-14",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 534,
+        "created_at": 1697658020,
+        "routes": [
+          {
+            "train": "4+2-1",
+            "connections": [
+              [
+                "F5",
+                "E6"
+              ],
+              [
+                "G4",
+                "F5"
+              ],
+              [
+                "G4",
+                "H5"
+              ],
+              [
+                "H5",
+                "I6"
+              ],
+              [
+                "I6",
+                "J5",
+                "J7"
+              ]
+            ],
+            "hexes": [
+              "E6",
+              "F5",
+              "G4",
+              "H5",
+              "I6",
+              "J7"
+            ],
+            "revenue": 170,
+            "revenue_str": "E6-F5-G4-H5-I6-J7",
+            "nodes": [
+              "F5-0",
+              "E6-0",
+              "G4-1",
+              "H5-0",
+              "I6-0",
+              "J7-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 535,
+        "user": 15708,
+        "created_at": 1697658029
+      },
+      {
+        "type": "undo",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 536,
+        "user": 15708,
+        "created_at": 1697658083
+      },
+      {
+        "type": "dividend",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 537,
+        "created_at": 1697658090,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 538,
+        "created_at": 1697658143,
+        "train": "5X-0",
+        "price": 67
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 539,
+        "created_at": 1697658542,
+        "hex": "F7",
+        "tile": "24-1",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 540,
+        "created_at": 1697658600,
+        "hex": "G18",
+        "tile": "G36-1",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 541,
+        "created_at": 1697658705,
+        "routes": [
+          {
+            "train": "4+2-4",
+            "connections": [
+              [
+                "I12",
+                "H13",
+                "H15"
+              ],
+              [
+                "H9",
+                "I10",
+                "I12"
+              ],
+              [
+                "G6",
+                "G8",
+                "H9"
+              ],
+              [
+                "F5",
+                "G6"
+              ],
+              [
+                "G4",
+                "F3",
+                "F5"
+              ]
+            ],
+            "hexes": [
+              "H15",
+              "I12",
+              "H9",
+              "G6",
+              "F5",
+              "G4"
+            ],
+            "revenue": 150,
+            "revenue_str": "H15-I12-H9-G6-F5-G4",
+            "nodes": [
+              "I12-0",
+              "H15-0",
+              "H9-0",
+              "G6-0",
+              "F5-0",
+              "G4-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 542,
+        "created_at": 1697658716,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 543,
+        "created_at": 1697658720
+      },
+      {
+        "hex": "H23",
+        "tile": "8-11",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 544,
+        "user": 15618,
+        "created_at": 1697711270
+      },
+      {
+        "hex": "I22",
+        "tile": "4-4",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 545,
+        "user": 15618,
+        "created_at": 1697711275
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 546,
+        "user": 15618,
+        "created_at": 1697711366
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 547,
+        "user": 15618,
+        "created_at": 1697711368
+      },
+      {
+        "hex": "H21",
+        "tile": "G21-1",
+        "type": "lay_tile",
+        "entity": "LS",
+        "rotation": 1,
+        "entity_type": "company",
+        "id": 548,
+        "user": 15618,
+        "created_at": 1697711382
+      },
+      {
+        "hex": "H21",
+        "tile": "G30-2",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 549,
+        "user": 15618,
+        "created_at": 1697711722
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 550,
+        "user": 15618,
+        "created_at": 1697711750
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 551,
+        "user": 15618,
+        "created_at": 1697711752
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 552,
+        "created_at": 1697711765,
+        "hex": "H23",
+        "tile": "8-11",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 553,
+        "created_at": 1697711768,
+        "hex": "I22",
+        "tile": "4-4",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 554,
+        "created_at": 1697711772
+      },
+      {
+        "type": "run_routes",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 555,
+        "created_at": 1697712467,
+        "routes": [
+          {
+            "train": "5+2-0",
+            "connections": [
+              [
+                "C24",
+                "B25",
+                "A24",
+                "a25"
+              ],
+              [
+                "D23",
+                "C22",
+                "C24"
+              ],
+              [
+                "F21",
+                "E22",
+                "D23"
+              ],
+              [
+                "G22",
+                "F21"
+              ],
+              [
+                "F23",
+                "G22"
+              ],
+              [
+                "F23",
+                "G24",
+                "G26"
+              ]
+            ],
+            "hexes": [
+              "a25",
+              "C24",
+              "D23",
+              "F21",
+              "G22",
+              "F23",
+              "G26"
+            ],
+            "revenue": 270,
+            "revenue_str": "a25-C24-D23-F21-G22-F23-G26+(EW)",
+            "nodes": [
+              "C24-0",
+              "a25-0",
+              "D23-0",
+              "F21-1",
+              "G22-0",
+              "F23-0",
+              "G26-0"
+            ]
+          },
+          {
+            "train": "4+2-3",
+            "connections": [
+              [
+                "D21",
+                "D19",
+                "D17",
+                "C16"
+              ],
+              [
+                "D23",
+                "D21"
+              ],
+              [
+                "D25",
+                "D23"
+              ],
+              [
+                "E26",
+                "D25"
+              ],
+              [
+                "E26",
+                "F27",
+                "G26"
+              ]
+            ],
+            "hexes": [
+              "C16",
+              "D21",
+              "D23",
+              "D25",
+              "E26",
+              "G26"
+            ],
+            "revenue": 170,
+            "revenue_str": "C16-D21-D23-D25-E26-G26",
+            "nodes": [
+              "D21-0",
+              "C16-0",
+              "D23-0",
+              "D25-0",
+              "E26-0",
+              "G26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 556,
+        "created_at": 1697712750,
+        "kind": "withhold"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 557,
+        "created_at": 1697755939,
+        "hex": "H19",
+        "tile": "G37-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 558,
+        "created_at": 1697755954,
+        "hex": "G20",
+        "tile": "7-1",
+        "rotation": 4
+      },
+      {
+        "type": "run_routes",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 559,
+        "created_at": 1697755994,
+        "routes": [
+          {
+            "train": "4+2-2",
+            "connections": [
+              [
+                "I16",
+                "I14"
+              ],
+              [
+                "H19",
+                "I18",
+                "I16"
+              ],
+              [
+                "H19",
+                "G18"
+              ]
+            ],
+            "hexes": [
+              "I14",
+              "I16",
+              "H19",
+              "G18"
+            ],
+            "revenue": 70,
+            "revenue_str": "I14-I16-H19-G18",
+            "nodes": [
+              "I16-0",
+              "I14-0",
+              "H19-0",
+              "G18-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 560,
+        "created_at": 1697756000,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 561,
+        "created_at": 1697756008
+      },
+      {
+        "type": "undo",
+        "entity": 15618,
+        "action_id": 556,
+        "entity_type": "player",
+        "id": 562,
+        "user": 15618,
+        "created_at": 1697757316
+      },
+      {
+        "type": "redo",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 563,
+        "user": 15618,
+        "created_at": 1697757335
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 564,
+        "created_at": 1697757359,
+        "shares": [
+          "GWR_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 565,
+        "created_at": 1697757369,
+        "shares": [
+          "CR_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "choose",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 566,
+        "created_at": 1697782263,
+        "choice": "convert_LNWR"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 567,
+        "created_at": 1697782305,
+        "shares": [
+          "LNWR_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 568,
+        "created_at": 1697807498,
+        "shares": [
+          "NER_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 569,
+        "created_at": 1697832138,
+        "shares": [
+          "GWR_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 570,
+        "created_at": 1697832564,
+        "shares": [
+          "CR_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 571,
+        "created_at": 1697922239,
+        "shares": [
+          "LNWR_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 572,
+        "created_at": 1697941583,
+        "shares": [
+          "GWR_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 573,
+        "created_at": 1697955121
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 574,
+        "created_at": 1697971992,
+        "shares": [
+          "CR_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 575,
+        "created_at": 1697990183,
+        "shares": [
+          "CR_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 576,
+        "created_at": 1697990292
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 577,
+        "created_at": 1698003969
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 578,
+        "created_at": 1698004808,
+        "shares": [
+          "CR_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 579,
+        "created_at": 1698030341,
+        "shares": [
+          "CR_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 580,
+        "created_at": 1698030373
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 581,
+        "created_at": 1698044638
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 582,
+        "created_at": 1698065551,
+        "shares": [
+          "MR_1",
+          "MR_2",
+          "MR_3",
+          "MR_0"
+        ],
+        "percent": 50
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 583,
+        "created_at": 1698065573,
+        "shares": [
+          "CR_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 584,
+        "created_at": 1698076681,
+        "shares": [
+          "CR_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 585,
+        "user": 15620,
+        "created_at": 1698076695
+      },
+      {
+        "type": "undo",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 586,
+        "user": 15620,
+        "created_at": 1698076723
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 587,
+        "created_at": 1698076727,
+        "shares": [
+          "MR_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 588,
+        "created_at": 1698076737
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 589,
+        "created_at": 1698079420,
+        "shares": [
+          "MR_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 590,
+        "created_at": 1698080772,
+        "shares": [
+          "LNWR_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 591,
+        "created_at": 1698082731,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15621,
+            "entity_type": "player",
+            "created_at": 1698082730
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 592,
+        "created_at": 1698082808,
+        "shares": [
+          "NER_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 593,
+        "created_at": 1698101279,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15618,
+            "entity_type": "player",
+            "created_at": 1698101278
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 594,
+        "created_at": 1698119417,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15621,
+            "entity_type": "player",
+            "created_at": 1698119416
+          }
+        ],
+        "shares": [
+          "LNWR_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 595,
+        "created_at": 1698119925,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15618,
+            "entity_type": "player",
+            "created_at": 1698119924
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 596,
+        "created_at": 1698156005,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15621,
+            "entity_type": "player",
+            "created_at": 1698156004
+          }
+        ],
+        "shares": [
+          "LNWR_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 597,
+        "created_at": 1698156026,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15618,
+            "entity_type": "player",
+            "created_at": 1698156025
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 598,
+        "created_at": 1698159264
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 599,
+        "created_at": 1698164315,
+        "hex": "G18",
+        "tile": "G34-0",
+        "rotation": 1
+      },
+      {
+        "type": "place_token",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 600,
+        "created_at": 1698164317,
+        "city": "G34-0-0",
+        "slot": 1,
+        "tokener": "GWR"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 601,
+        "created_at": 1698164413,
+        "hex": "E22",
+        "tile": "23-3",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 602,
+        "created_at": 1698164512,
+        "routes": [
+          {
+            "train": "4X-0",
+            "connections": [
+              [
+                "F17",
+                "F15",
+                "E14"
+              ],
+              [
+                "G18",
+                "F17"
+              ],
+              [
+                "D21",
+                "E20",
+                "F19",
+                "G18"
+              ],
+              [
+                "D23",
+                "D21"
+              ],
+              [
+                "D23",
+                "C22",
+                "C24"
+              ],
+              [
+                "C24",
+                "B25",
+                "A24",
+                "a25"
+              ]
+            ],
+            "hexes": [
+              "E14",
+              "F17",
+              "G18",
+              "D21",
+              "D23",
+              "C24",
+              "a25"
+            ],
+            "revenue": 240,
+            "revenue_str": "E14-G18-D23-a25+£80",
+            "nodes": [
+              "F17-0",
+              "E14-0",
+              "G18-0",
+              "D21-0",
+              "D23-0",
+              "C24-0",
+              "a25-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 603,
+        "created_at": 1698164520,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 604,
+        "created_at": 1698164552,
+        "train": "5+2-0",
+        "price": 200
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 605,
+        "created_at": 1698165416,
+        "hex": "I4",
+        "tile": "G32-0",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 606,
+        "created_at": 1698165451,
+        "hex": "J3",
+        "tile": "G36-2",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 607,
+        "created_at": 1698165787,
+        "routes": [
+          {
+            "train": "4+2-1",
+            "connections": [
+              [
+                "J11",
+                "K10",
+                "J9",
+                "J7"
+              ],
+              [
+                "I12",
+                "J11"
+              ],
+              [
+                "I14",
+                "I12"
+              ],
+              [
+                "I14",
+                "H13",
+                "H15"
+              ]
+            ],
+            "hexes": [
+              "J7",
+              "J11",
+              "I12",
+              "I14",
+              "H15"
+            ],
+            "revenue": 90,
+            "revenue_str": "J7-J11-I12-I14-H15",
+            "nodes": [
+              "J11-0",
+              "J7-0",
+              "I12-0",
+              "I14-0",
+              "H15-0"
+            ]
+          },
+          {
+            "train": "5X-0",
+            "connections": [
+              [
+                "J3",
+                "K2",
+                "K0"
+              ],
+              [
+                "I6",
+                "J5",
+                "I4",
+                "J3"
+              ],
+              [
+                "H5",
+                "I6"
+              ],
+              [
+                "G4",
+                "H5"
+              ],
+              [
+                "F5",
+                "G4"
+              ]
+            ],
+            "hexes": [
+              "K0",
+              "J3",
+              "I6",
+              "H5",
+              "G4",
+              "F5"
+            ],
+            "revenue": 280,
+            "revenue_str": "K0-J3-I6-G4-F5+(FT)+£50",
+            "nodes": [
+              "J3-0",
+              "K0-0",
+              "I6-0",
+              "H5-0",
+              "G4-1",
+              "F5-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 608,
+        "created_at": 1698165791,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 609,
+        "created_at": 1698165843,
+        "hex": "I10",
+        "tile": "47-1",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 610,
+        "created_at": 1698165853,
+        "hex": "J11",
+        "tile": "G21-1",
+        "rotation": 4
+      },
+      {
+        "type": "run_routes",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 611,
+        "created_at": 1698165871,
+        "routes": [
+          {
+            "train": "4+2-4",
+            "connections": [
+              [
+                "I12",
+                "H13",
+                "H15"
+              ],
+              [
+                "H9",
+                "I10",
+                "I12"
+              ],
+              [
+                "G6",
+                "G8",
+                "H9"
+              ],
+              [
+                "F5",
+                "G6"
+              ],
+              [
+                "G4",
+                "F3",
+                "F5"
+              ]
+            ],
+            "hexes": [
+              "H15",
+              "I12",
+              "H9",
+              "G6",
+              "F5",
+              "G4"
+            ],
+            "revenue": 150,
+            "revenue_str": "H15-I12-H9-G6-F5-G4",
+            "nodes": [
+              "I12-0",
+              "H15-0",
+              "H9-0",
+              "G6-0",
+              "F5-0",
+              "G4-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 612,
+        "created_at": 1698165875,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 613,
+        "created_at": 1698165879
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 614,
+        "created_at": 1698166127,
+        "hex": "H9",
+        "tile": "G34-1",
+        "rotation": 2
+      },
+      {
+        "type": "place_token",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 615,
+        "created_at": 1698166129,
+        "city": "G34-1-0",
+        "slot": 1,
+        "tokener": "CR"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 616,
+        "created_at": 1698166201,
+        "hex": "K2",
+        "tile": "43-0",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 617,
+        "created_at": 1698166408,
+        "routes": [
+          {
+            "train": "5X-1",
+            "connections": [
+              [
+                "G8",
+                "F7",
+                "E6"
+              ],
+              [
+                "G8",
+                "H9"
+              ],
+              [
+                "H9",
+                "I8",
+                "I6"
+              ],
+              [
+                "I6",
+                "J5",
+                "I4",
+                "J3"
+              ],
+              [
+                "J3",
+                "K2",
+                "L1"
+              ],
+              [
+                "L1",
+                "K0"
+              ]
+            ],
+            "hexes": [
+              "E6",
+              "G8",
+              "H9",
+              "I6",
+              "J3",
+              "L1",
+              "K0"
+            ],
+            "revenue": 290,
+            "revenue_str": "E6-H9-I6-J3-K0+(FT)+(EW)+£60",
+            "nodes": [
+              "G8-0",
+              "E6-0",
+              "H9-0",
+              "I6-0",
+              "J3-0",
+              "L1-0",
+              "K0-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 618,
+        "created_at": 1698166439,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 619,
+        "created_at": 1698166976
+      },
+      {
+        "hex": "I14",
+        "tile": "G34-2",
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 620,
+        "user": 15621,
+        "created_at": 1698167576
+      },
+      {
+        "type": "undo",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 621,
+        "user": 15621,
+        "created_at": 1698167694
+      },
+      {
+        "hex": "I16",
+        "tile": "87-4",
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 622,
+        "user": 15621,
+        "created_at": 1698167802
+      },
+      {
+        "hex": "H15",
+        "tile": "G05-1",
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 623,
+        "user": 15621,
+        "created_at": 1698167827
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 624,
+        "user": 15621,
+        "created_at": 1698168040
+      },
+      {
+        "type": "undo",
+        "entity": "LNWR",
+        "action_id": 619,
+        "entity_type": "corporation",
+        "id": 625,
+        "user": 15621,
+        "created_at": 1698168200
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 626,
+        "created_at": 1698168203,
+        "hex": "I14",
+        "tile": "G34-2",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 627,
+        "created_at": 1698168214,
+        "hex": "I8",
+        "tile": "16-0",
+        "rotation": 0
+      },
+      {
+        "type": "place_token",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 628,
+        "created_at": 1698168224,
+        "city": "G34-2-0",
+        "slot": 1,
+        "tokener": "LNWR"
+      },
+      {
+        "type": "run_routes",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 629,
+        "created_at": 1698168241,
+        "routes": [
+          {
+            "train": "4+2-0",
+            "connections": [
+              [
+                "F17",
+                "F15",
+                "E14"
+              ],
+              [
+                "F21",
+                "F19",
+                "F17"
+              ],
+              [
+                "F23",
+                "F21"
+              ],
+              [
+                "F25",
+                "F23"
+              ],
+              [
+                "G26",
+                "F25"
+              ]
+            ],
+            "hexes": [
+              "E14",
+              "F17",
+              "F21",
+              "F23",
+              "F25",
+              "G26"
+            ],
+            "revenue": 220,
+            "revenue_str": "E14-F17-F21-F23-F25-G26+(LM)",
+            "nodes": [
+              "F17-0",
+              "E14-0",
+              "F21-0",
+              "F23-0",
+              "F25-0",
+              "G26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 630,
+        "created_at": 1698168245,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 631,
+        "created_at": 1698168250,
+        "train": "6X-0",
+        "price": 700,
+        "variant": "6X"
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 632,
+        "created_at": 1698168255
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 633,
+        "created_at": 1698169318,
+        "hex": "F23",
+        "tile": "911-3",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 634,
+        "created_at": 1698169339,
+        "hex": "J19",
+        "tile": "9-1",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 635,
+        "created_at": 1698169342
+      },
+      {
+        "type": "buy_train",
+        "price": 550,
+        "train": "4X-1",
+        "entity": "LSWR",
+        "variant": "4X",
+        "entity_type": "corporation",
+        "id": 636,
+        "user": 15618,
+        "created_at": 1698169365
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 637,
+        "user": 15618,
+        "created_at": 1698169370
+      },
+      {
+        "type": "undo",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 638,
+        "user": 15618,
+        "created_at": 1698169406
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 639,
+        "user": 15618,
+        "created_at": 1698169408
+      },
+      {
+        "type": "buy_train",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 640,
+        "created_at": 1698169423,
+        "train": "4X-1",
+        "price": 550,
+        "variant": "4X"
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 641,
+        "created_at": 1698169428
+      },
+      {
+        "type": "run_routes",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 642,
+        "created_at": 1698169449,
+        "routes": [
+          {
+            "train": "4X-2",
+            "connections": [
+              [
+                "H19",
+                "G18"
+              ],
+              [
+                "I16",
+                "I18",
+                "H19"
+              ],
+              [
+                "I14",
+                "I16"
+              ]
+            ],
+            "hexes": [
+              "G18",
+              "H19",
+              "I16",
+              "I14"
+            ],
+            "revenue": 110,
+            "revenue_str": "G18-H19-I14+£30",
+            "nodes": [
+              "H19-0",
+              "G18-0",
+              "I16-0",
+              "I14-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 643,
+        "created_at": 1698171703,
+        "hex": "J3",
+        "tile": "G34-3",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 644,
+        "created_at": 1698174931,
+        "hex": "H5",
+        "tile": "204-1",
+        "rotation": 2
+      },
+      {
+        "type": "run_routes",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 645,
+        "created_at": 1698174981,
+        "routes": [
+          {
+            "train": "5X-0",
+            "connections": [
+              [
+                "J3",
+                "K2",
+                "K0"
+              ],
+              [
+                "I6",
+                "J5",
+                "I4",
+                "J3"
+              ],
+              [
+                "H5",
+                "I6"
+              ],
+              [
+                "G4",
+                "H5"
+              ],
+              [
+                "F5",
+                "G4"
+              ]
+            ],
+            "hexes": [
+              "K0",
+              "J3",
+              "I6",
+              "H5",
+              "G4",
+              "F5"
+            ],
+            "revenue": 300,
+            "revenue_str": "K0-J3-I6-G4-F5+(FT)+£50",
+            "nodes": [
+              "J3-0",
+              "K0-0",
+              "I6-0",
+              "H5-0",
+              "G4-1",
+              "F5-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 646,
+        "created_at": 1698175012,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 647,
+        "created_at": 1698175024
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LS",
+        "entity_type": "company",
+        "id": 648,
+        "created_at": 1698188433,
+        "hex": "H21",
+        "tile": "G22-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 649,
+        "created_at": 1698188457,
+        "hex": "I22",
+        "tile": "204-2",
+        "rotation": 4
+      },
+      {
+        "hex": "H21",
+        "tile": "G30-2",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 650,
+        "user": 15618,
+        "created_at": 1698188509
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 651,
+        "user": 15618,
+        "created_at": 1698188527
+      },
+      {
+        "hex": "C18",
+        "tile": "7-2",
+        "type": "lay_tile",
+        "entity": "GWR",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 652,
+        "user": 15618,
+        "created_at": 1698188559
+      },
+      {
+        "type": "undo",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 653,
+        "user": 15618,
+        "created_at": 1698188569
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 654,
+        "created_at": 1698188585,
+        "hex": "C18",
+        "tile": "7-2",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 655,
+        "created_at": 1698191654,
+        "routes": [
+          {
+            "train": "4X-0",
+            "connections": [
+              [
+                "F17",
+                "F15",
+                "E14"
+              ],
+              [
+                "G18",
+                "F17"
+              ],
+              [
+                "D21",
+                "E20",
+                "F19",
+                "G18"
+              ],
+              [
+                "D23",
+                "D21"
+              ],
+              [
+                "C24",
+                "D23"
+              ],
+              [
+                "a25",
+                "A24",
+                "B25",
+                "C24"
+              ]
+            ],
+            "hexes": [
+              "E14",
+              "F17",
+              "G18",
+              "D21",
+              "D23",
+              "C24",
+              "a25"
+            ],
+            "revenue": 300,
+            "revenue_str": "E14-G18-D23-a25+(EW)+£80",
+            "nodes": [
+              "F17-0",
+              "E14-0",
+              "G18-0",
+              "D21-0",
+              "D23-0",
+              "C24-0",
+              "a25-0"
+            ]
+          },
+          {
+            "train": "5+2-0",
+            "connections": [
+              [
+                "E26",
+                "F27",
+                "G26"
+              ],
+              [
+                "F25",
+                "E24",
+                "E26"
+              ],
+              [
+                "F23",
+                "F25"
+              ],
+              [
+                "D23",
+                "E22",
+                "F23"
+              ],
+              [
+                "B21",
+                "C22",
+                "D23"
+              ],
+              [
+                "A22",
+                "B21"
+              ]
+            ],
+            "hexes": [
+              "G26",
+              "E26",
+              "F25",
+              "F23",
+              "D23",
+              "B21",
+              "A22"
+            ],
+            "revenue": 210,
+            "revenue_str": "G26-E26-F25-F23-D23-B21-A22+(S)",
+            "nodes": [
+              "E26-0",
+              "G26-0",
+              "F25-0",
+              "F23-0",
+              "D23-0",
+              "B21-0",
+              "A22-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 656,
+        "created_at": 1698191703,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 657,
+        "created_at": 1698198543
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 658,
+        "created_at": 1698198545
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 659,
+        "created_at": 1698204658,
+        "hex": "I2",
+        "tile": "G34-4",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 660,
+        "created_at": 1698204679,
+        "hex": "H7",
+        "tile": "19-0",
+        "rotation": 0
+      },
+      {
+        "type": "place_token",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 661,
+        "created_at": 1698204704,
+        "city": "G21-1-1",
+        "slot": 0,
+        "tokener": "CR"
+      },
+      {
+        "type": "run_routes",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 662,
+        "created_at": 1698204830,
+        "routes": [
+          {
+            "train": "5X-1",
+            "connections": [
+              [
+                "J3",
+                "K2",
+                "K0"
+              ],
+              [
+                "I6",
+                "J5",
+                "I4",
+                "J3"
+              ],
+              [
+                "H9",
+                "I8",
+                "I6"
+              ],
+              [
+                "G8",
+                "H9"
+              ],
+              [
+                "E6",
+                "F7",
+                "G8"
+              ]
+            ],
+            "hexes": [
+              "K0",
+              "J3",
+              "I6",
+              "H9",
+              "G8",
+              "E6"
+            ],
+            "revenue": 330,
+            "revenue_str": "K0-J3-I6-H9-E6+(FT)+(EW)+£60",
+            "nodes": [
+              "J3-0",
+              "K0-0",
+              "I6-0",
+              "H9-0",
+              "G8-0",
+              "E6-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 663,
+        "created_at": 1698204854,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 664,
+        "created_at": 1698204860
+      },
+      {
+        "hex": "H21",
+        "tile": "G30-2",
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "id": 665,
+        "user": 15621,
+        "created_at": 1698207452
+      },
+      {
+        "type": "undo",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 666,
+        "user": 15621,
+        "created_at": 1698207676
+      },
+      {
+        "type": "undo",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 667,
+        "user": 15621,
+        "created_at": 1698207684
+      },
+      {
+        "type": "redo",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 668,
+        "user": 15621,
+        "created_at": 1698207703
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 669,
+        "created_at": 1698207741,
+        "hex": "H21",
+        "tile": "G30-2",
+        "rotation": 4
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 670,
+        "created_at": 1698207756,
+        "hex": "I24",
+        "tile": "8-2",
+        "rotation": 3
+      },
+      {
+        "type": "run_routes",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 671,
+        "created_at": 1698208282,
+        "routes": [
+          {
+            "train": "6X-0",
+            "connections": [
+              [
+                "I12",
+                "J11"
+              ],
+              [
+                "I14",
+                "I12"
+              ],
+              [
+                "I16",
+                "I14"
+              ],
+              [
+                "I20",
+                "I18",
+                "I16"
+              ],
+              [
+                "H21",
+                "I20"
+              ],
+              [
+                "G22",
+                "H21"
+              ],
+              [
+                "F23",
+                "G22"
+              ],
+              [
+                "F21",
+                "F23"
+              ],
+              [
+                "F17",
+                "F19",
+                "F21"
+              ],
+              [
+                "E14",
+                "F15",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "J11",
+              "I12",
+              "I14",
+              "I16",
+              "I20",
+              "H21",
+              "G22",
+              "F23",
+              "F21",
+              "F17",
+              "E14"
+            ],
+            "revenue": 300,
+            "revenue_str": "J11-I14-H21-F21-E14+(LM)+£50",
+            "nodes": [
+              "I12-0",
+              "J11-0",
+              "I14-0",
+              "I16-0",
+              "I20-0",
+              "H21-0",
+              "G22-0",
+              "F23-0",
+              "F21-0",
+              "F17-0",
+              "E14-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 672,
+        "created_at": 1698208301,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 673,
+        "created_at": 1698208339
+      },
+      {
+        "hex": "D19",
+        "tile": "24-2",
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 674,
+        "user": 15618,
+        "created_at": 1698223762
+      },
+      {
+        "type": "undo",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 675,
+        "user": 15618,
+        "created_at": 1698223822
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 676,
+        "created_at": 1698223895,
+        "hex": "E22",
+        "tile": "41-0",
+        "rotation": 4
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 677,
+        "created_at": 1698223946,
+        "hex": "D19",
+        "tile": "24-2",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 678,
+        "created_at": 1698224193,
+        "routes": [
+          {
+            "train": "4X-1",
+            "connections": [
+              [
+                "E26",
+                "F27",
+                "G26"
+              ],
+              [
+                "F25",
+                "E24",
+                "E26"
+              ],
+              [
+                "F23",
+                "F25"
+              ],
+              [
+                "G22",
+                "F23"
+              ],
+              [
+                "F21",
+                "G22"
+              ],
+              [
+                "D21",
+                "E20",
+                "F21"
+              ],
+              [
+                "D23",
+                "D21"
+              ],
+              [
+                "C24",
+                "C22",
+                "D23"
+              ],
+              [
+                "a25",
+                "A24",
+                "B25",
+                "C24"
+              ]
+            ],
+            "hexes": [
+              "G26",
+              "E26",
+              "F25",
+              "F23",
+              "G22",
+              "F21",
+              "D21",
+              "D23",
+              "C24",
+              "a25"
+            ],
+            "revenue": 340,
+            "revenue_str": "G26-F21-D23-a25+(EW)+£70",
+            "nodes": [
+              "E26-0",
+              "G26-0",
+              "F25-0",
+              "F23-0",
+              "G22-0",
+              "F21-1",
+              "D21-0",
+              "D23-0",
+              "C24-0",
+              "a25-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 679,
+        "created_at": 1698224198,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 680,
+        "created_at": 1698224240,
+        "train": "5+2-0",
+        "price": 435
+      },
+      {
+        "type": "run_routes",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 681,
+        "created_at": 1698224316,
+        "routes": [
+          {
+            "train": "4X-2",
+            "connections": [
+              [
+                "I16",
+                "I14"
+              ],
+              [
+                "H19",
+                "I18",
+                "I16"
+              ],
+              [
+                "H21",
+                "G20",
+                "H19"
+              ],
+              [
+                "I22",
+                "H21"
+              ],
+              [
+                "G22",
+                "H23",
+                "I22"
+              ],
+              [
+                "F23",
+                "G22"
+              ],
+              [
+                "F25",
+                "F23"
+              ],
+              [
+                "E26",
+                "E24",
+                "F25"
+              ],
+              [
+                "G26",
+                "F27",
+                "E26"
+              ]
+            ],
+            "hexes": [
+              "I14",
+              "I16",
+              "H19",
+              "H21",
+              "I22",
+              "G22",
+              "F23",
+              "F25",
+              "E26",
+              "G26"
+            ],
+            "revenue": 240,
+            "revenue_str": "I14-H19-H21-G26+£70",
+            "nodes": [
+              "I16-0",
+              "I14-0",
+              "H19-0",
+              "H21-0",
+              "I22-0",
+              "G22-0",
+              "F23-0",
+              "F25-0",
+              "E26-0",
+              "G26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 682,
+        "created_at": 1698241488,
+        "shares": [
+          "LYR_5",
+          "LYR_6",
+          "LYR_7"
+        ],
+        "percent": 30,
+        "share_price": 57
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 683,
+        "created_at": 1698241508,
+        "shares": [
+          "MR_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 684,
+        "created_at": 1698243189,
+        "shares": [
+          "MR_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 685,
+        "created_at": 1698245320,
+        "shares": [
+          "LYR_3",
+          "LYR_1",
+          "LYR_0"
+        ],
+        "percent": 40,
+        "share_price": 57
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 686,
+        "created_at": 1698245342,
+        "shares": [
+          "GWR_1",
+          "GWR_3",
+          "GWR_8"
+        ],
+        "percent": 30
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 687,
+        "created_at": 1698245347,
+        "shares": [
+          "LNWR_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 688,
+        "created_at": 1698245352,
+        "shares": [
+          "LSWR_6",
+          "LSWR_7"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 689,
+        "created_at": 1698245357
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 690,
+        "created_at": 1698259471,
+        "shares": [
+          "LYR_0"
+        ],
+        "percent": 20,
+        "share_price": 37
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 691,
+        "created_at": 1698259474
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 692,
+        "created_at": 1698260150,
+        "shares": [
+          "MR_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 693,
+        "created_at": 1698263514,
+        "shares": [
+          "GWR_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 694,
+        "created_at": 1698263538,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15620,
+            "entity_type": "player",
+            "created_at": 1698263536
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "choose",
+        "choice": "convert_NBR",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 695,
+        "user": 15708,
+        "created_at": 1698268108
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "shares": [
+          "NBR_4"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 696,
+        "user": 15708,
+        "created_at": 1698268113
+      },
+      {
+        "type": "undo",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 697,
+        "user": 15708,
+        "created_at": 1698268175
+      },
+      {
+        "type": "undo",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 698,
+        "user": 15708,
+        "created_at": 1698268180
+      },
+      {
+        "type": "undo",
+        "entity": 15708,
+        "action_id": 693,
+        "entity_type": "player",
+        "id": 699,
+        "user": 15708,
+        "created_at": 1698268186
+      },
+      {
+        "type": "redo",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 700,
+        "user": 15708,
+        "created_at": 1698268401
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "shares": [
+          "LSWR_6"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 701,
+        "user": 15708,
+        "created_at": 1698268431
+      },
+      {
+        "type": "undo",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 702,
+        "user": 15708,
+        "created_at": 1698268454
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 703,
+        "created_at": 1698268457,
+        "shares": [
+          "LNWR_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 704,
+        "created_at": 1698269674,
+        "shares": [
+          "MR_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15618,
+        "shares": [
+          "GWR_2"
+        ],
+        "percent": 10,
+        "entity_type": "player",
+        "id": 705,
+        "user": 15618,
+        "created_at": 1698277774
+      },
+      {
+        "type": "undo",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 706,
+        "user": 15618,
+        "created_at": 1698277803
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 707,
+        "created_at": 1698277812,
+        "shares": [
+          "LNWR_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 708,
+        "created_at": 1698277874,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 15620,
+            "entity_type": "player",
+            "created_at": 1698277871,
+            "reason": "Shares were sold"
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 709,
+        "created_at": 1698277915
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 15620,
+        "entity_type": "player",
+        "id": 710,
+        "created_at": 1698278350,
+        "unconditional": true,
+        "indefinite": true
+      },
+      {
+        "type": "choose",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 711,
+        "created_at": 1698284585,
+        "choice": "convert_NBR"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 712,
+        "created_at": 1698284598,
+        "shares": [
+          "NBR_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 713,
+        "created_at": 1698285845,
+        "shares": [
+          "NBR_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 714,
+        "created_at": 1698288816,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15620,
+            "entity_type": "player",
+            "created_at": 1698288814
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 715,
+        "created_at": 1698292519
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 716,
+        "created_at": 1698293670,
+        "shares": [
+          "LSWR_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 717,
+        "created_at": 1698293674,
+        "shares": [
+          "NBR_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 718,
+        "created_at": 1698294859,
+        "shares": [
+          "LYR_8"
+        ],
+        "percent": 10,
+        "share_price": 32
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 719,
+        "created_at": 1698294866,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15620,
+            "entity_type": "player",
+            "created_at": 1698294865
+          }
+        ],
+        "shares": [
+          "GWR_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 720,
+        "created_at": 1698324127,
+        "shares": [
+          "LNWR_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 721,
+        "created_at": 1698324133,
+        "shares": [
+          "NBR_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 722,
+        "created_at": 1698329405,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15621,
+            "entity_type": "player",
+            "created_at": 1698329403
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 723,
+        "created_at": 1698331187,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15618,
+            "entity_type": "player",
+            "created_at": 1698331185
+          },
+          {
+            "type": "pass",
+            "entity": 15620,
+            "entity_type": "player",
+            "created_at": 1698331185
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 724,
+        "created_at": 1698333385
+      },
+      {
+        "type": "place_token",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 725,
+        "created_at": 1698340533,
+        "city": "G30-2-0",
+        "slot": 1,
+        "tokener": "GWR"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 726,
+        "created_at": 1698340602,
+        "hex": "J25",
+        "tile": "G40-1",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 727,
+        "created_at": 1698340620,
+        "hex": "C18",
+        "tile": "29-0",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 728,
+        "created_at": 1698340949,
+        "routes": [
+          {
+            "train": "4X-0",
+            "connections": [
+              [
+                "F17",
+                "E16",
+                "D15",
+                "C14"
+              ],
+              [
+                "G18",
+                "F17"
+              ],
+              [
+                "D21",
+                "E20",
+                "F19",
+                "G18"
+              ],
+              [
+                "D21",
+                "D23"
+              ],
+              [
+                "D23",
+                "E22",
+                "F23"
+              ],
+              [
+                "F23",
+                "F25"
+              ],
+              [
+                "F25",
+                "E24",
+                "E26"
+              ],
+              [
+                "E26",
+                "F27",
+                "G26"
+              ]
+            ],
+            "hexes": [
+              "C14",
+              "F17",
+              "G18",
+              "D21",
+              "D23",
+              "F23",
+              "F25",
+              "E26",
+              "G26"
+            ],
+            "revenue": 300,
+            "revenue_str": "C14-G18-D23-G26+(EW)+£80",
+            "nodes": [
+              "F17-0",
+              "C14-0",
+              "G18-0",
+              "D21-0",
+              "D23-0",
+              "F23-0",
+              "F25-0",
+              "E26-0",
+              "G26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 729,
+        "created_at": 1698340953,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 730,
+        "created_at": 1698340971,
+        "train": "4X-1",
+        "price": 390
+      },
+      {
+        "hex": "H7",
+        "tile": "46-0",
+        "type": "lay_tile",
+        "entity": "CR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 731,
+        "user": 15708,
+        "created_at": 1698343367
+      },
+      {
+        "hex": "I8",
+        "tile": "43-1",
+        "type": "lay_tile",
+        "entity": "CR",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 732,
+        "user": 15708,
+        "created_at": 1698343446
+      },
+      {
+        "type": "run_routes",
+        "entity": "CR",
+        "routes": [
+          {
+            "hexes": [
+              "K0",
+              "J3",
+              "I6",
+              "H9",
+              "G8",
+              "E6"
+            ],
+            "nodes": [
+              "J3-0",
+              "K0-0",
+              "I6-0",
+              "H9-0",
+              "G8-0",
+              "E6-0"
+            ],
+            "train": "5X-1",
+            "revenue": 330,
+            "connections": [
+              [
+                "J3",
+                "K2",
+                "K0"
+              ],
+              [
+                "I6",
+                "J5",
+                "I4",
+                "J3"
+              ],
+              [
+                "H9",
+                "I8",
+                "I6"
+              ],
+              [
+                "G8",
+                "H9"
+              ],
+              [
+                "E6",
+                "F7",
+                "G8"
+              ]
+            ],
+            "revenue_str": "K0-J3-I6-H9-E6+(FT)+(EW)+£60"
+          }
+        ],
+        "entity_type": "corporation",
+        "extra_revenue": 0,
+        "id": 733,
+        "user": 15708,
+        "created_at": 1698343467
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 734,
+        "user": 15708,
+        "created_at": 1698343477
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 735,
+        "user": 15708,
+        "created_at": 1698343484
+      },
+      {
+        "type": "undo",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 736,
+        "user": 15708,
+        "created_at": 1698343683
+      },
+      {
+        "type": "undo",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 737,
+        "user": 15708,
+        "created_at": 1698343685
+      },
+      {
+        "type": "undo",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 738,
+        "user": 15708,
+        "created_at": 1698343687
+      },
+      {
+        "type": "undo",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 739,
+        "user": 15708,
+        "created_at": 1698343689
+      },
+      {
+        "type": "undo",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 740,
+        "user": 15708,
+        "created_at": 1698343691
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 741,
+        "created_at": 1698343698,
+        "hex": "I8",
+        "tile": "43-1",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 742,
+        "created_at": 1698343715,
+        "hex": "H7",
+        "tile": "45-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 743,
+        "created_at": 1698343718,
+        "routes": [
+          {
+            "train": "5X-1",
+            "connections": [
+              [
+                "J3",
+                "K2",
+                "K0"
+              ],
+              [
+                "I6",
+                "J5",
+                "I4",
+                "J3"
+              ],
+              [
+                "H9",
+                "I8",
+                "I6"
+              ],
+              [
+                "G8",
+                "H9"
+              ],
+              [
+                "E6",
+                "F7",
+                "G8"
+              ]
+            ],
+            "hexes": [
+              "K0",
+              "J3",
+              "I6",
+              "H9",
+              "G8",
+              "E6"
+            ],
+            "revenue": 330,
+            "revenue_str": "K0-J3-I6-H9-E6+(FT)+(EW)+£60",
+            "nodes": [
+              "J3-0",
+              "K0-0",
+              "I6-0",
+              "H9-0",
+              "G8-0",
+              "E6-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 744,
+        "created_at": 1698343720,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 745,
+        "created_at": 1698343771
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 746,
+        "created_at": 1698346212,
+        "hex": "J25",
+        "tile": "G38-3",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 747,
+        "created_at": 1698346346
+      },
+      {
+        "type": "run_routes",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 748,
+        "created_at": 1698346436,
+        "routes": [
+          {
+            "train": "6X-0",
+            "connections": [
+              [
+                "J25",
+                "J27"
+              ],
+              [
+                "I22",
+                "I24",
+                "J25"
+              ],
+              [
+                "H21",
+                "I22"
+              ],
+              [
+                "G22",
+                "H21"
+              ],
+              [
+                "F23",
+                "G22"
+              ],
+              [
+                "F21",
+                "F23"
+              ],
+              [
+                "F17",
+                "F19",
+                "F21"
+              ],
+              [
+                "E14",
+                "F15",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "J27",
+              "J25",
+              "I22",
+              "H21",
+              "G22",
+              "F23",
+              "F21",
+              "F17",
+              "E14"
+            ],
+            "revenue": 330,
+            "revenue_str": "J27-J25-H21-F21-E14+(LM)+£90",
+            "nodes": [
+              "J25-0",
+              "J27-0",
+              "I22-0",
+              "H21-0",
+              "G22-0",
+              "F23-0",
+              "F21-0",
+              "F17-0",
+              "E14-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 749,
+        "created_at": 1698346442,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 750,
+        "created_at": 1698346447
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 751,
+        "created_at": 1698346876,
+        "hex": "J11",
+        "tile": "G30-3",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 752,
+        "created_at": 1698346900,
+        "hex": "F7",
+        "tile": "42-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 753,
+        "created_at": 1698346910
+      },
+      {
+        "type": "run_routes",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 754,
+        "created_at": 1698346949,
+        "routes": [
+          {
+            "train": "5X-0",
+            "connections": [
+              [
+                "J3",
+                "K2",
+                "K0"
+              ],
+              [
+                "I6",
+                "J5",
+                "I4",
+                "J3"
+              ],
+              [
+                "H5",
+                "I6"
+              ],
+              [
+                "G4",
+                "H5"
+              ],
+              [
+                "F5",
+                "G4"
+              ]
+            ],
+            "hexes": [
+              "K0",
+              "J3",
+              "I6",
+              "H5",
+              "G4",
+              "F5"
+            ],
+            "revenue": 300,
+            "revenue_str": "K0-J3-I6-G4-F5+(FT)+£50",
+            "nodes": [
+              "J3-0",
+              "K0-0",
+              "I6-0",
+              "H5-0",
+              "G4-1",
+              "F5-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 755,
+        "created_at": 1698346955,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 756,
+        "created_at": 1698346963,
+        "train": "6X-1",
+        "price": 700,
+        "variant": "6X"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 757,
+        "created_at": 1698350187,
+        "hex": "B19",
+        "tile": "9-5",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 758,
+        "created_at": 1698350191,
+        "hex": "A20",
+        "tile": "G38-1",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 759,
+        "created_at": 1698350396,
+        "routes": [
+          {
+            "train": "5+2-0",
+            "connections": [
+              [
+                "C24",
+                "B25",
+                "A24",
+                "a25"
+              ],
+              [
+                "D23",
+                "C22",
+                "C24"
+              ],
+              [
+                "F21",
+                "E22",
+                "D23"
+              ],
+              [
+                "G22",
+                "F21"
+              ],
+              [
+                "F23",
+                "G22"
+              ],
+              [
+                "G26",
+                "G24",
+                "F23"
+              ]
+            ],
+            "hexes": [
+              "a25",
+              "C24",
+              "D23",
+              "F21",
+              "G22",
+              "F23",
+              "G26"
+            ],
+            "revenue": 300,
+            "revenue_str": "a25-C24-D23-F21-G22-F23-G26+(EW)",
+            "nodes": [
+              "C24-0",
+              "a25-0",
+              "D23-0",
+              "F21-1",
+              "G22-0",
+              "F23-0",
+              "G26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 760,
+        "created_at": 1698350397,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 761,
+        "created_at": 1698350415
+      },
+      {
+        "type": "run_routes",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 762,
+        "created_at": 1698350512,
+        "routes": [
+          {
+            "train": "6X-2",
+            "connections": [
+              [
+                "H15",
+                "G16"
+              ],
+              [
+                "I12",
+                "H13",
+                "H15"
+              ],
+              [
+                "H9",
+                "I10",
+                "I12"
+              ],
+              [
+                "H9",
+                "H7",
+                "H5"
+              ],
+              [
+                "H5",
+                "G4"
+              ],
+              [
+                "G4",
+                "F5"
+              ],
+              [
+                "F5",
+                "E6"
+              ]
+            ],
+            "hexes": [
+              "G16",
+              "H15",
+              "I12",
+              "H9",
+              "H5",
+              "G4",
+              "F5",
+              "E6"
+            ],
+            "revenue": 260,
+            "revenue_str": "G16-H15-H9-G4-F5-E6+£60",
+            "nodes": [
+              "H15-0",
+              "G16-0",
+              "I12-0",
+              "H9-0",
+              "H5-0",
+              "G4-1",
+              "F5-0",
+              "E6-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 763,
+        "created_at": 1698354128,
+        "routes": [
+          {
+            "train": "6X-2",
+            "connections": [
+              [
+                "I16",
+                "I14"
+              ],
+              [
+                "H19",
+                "I18",
+                "I16"
+              ],
+              [
+                "H21",
+                "G20",
+                "H19"
+              ]
+            ],
+            "hexes": [
+              "I14",
+              "I16",
+              "H19",
+              "H21"
+            ],
+            "revenue": 140,
+            "revenue_str": "I14-H19-H21+£40",
+            "nodes": [
+              "I16-0",
+              "I14-0",
+              "H19-0",
+              "H21-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "buy_train",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 764,
+        "created_at": 1698354289,
+        "train": "6X-0",
+        "price": 441
+      },
+      {
+        "type": "pass",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 765,
+        "created_at": 1698354316
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 766,
+        "created_at": 1698357496,
+        "hex": "H23",
+        "tile": "25-0",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 767,
+        "created_at": 1698357499,
+        "hex": "H25",
+        "tile": "8-15",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 768,
+        "created_at": 1698357860,
+        "routes": [
+          {
+            "train": "4X-0",
+            "connections": [
+              [
+                "I22",
+                "J21",
+                "J19",
+                "J17"
+              ],
+              [
+                "H21",
+                "I22"
+              ],
+              [
+                "G22",
+                "H21"
+              ],
+              [
+                "F23",
+                "G22"
+              ],
+              [
+                "D23",
+                "E22",
+                "F23"
+              ],
+              [
+                "C24",
+                "C22",
+                "D23"
+              ],
+              [
+                "a25",
+                "A24",
+                "B25",
+                "C24"
+              ]
+            ],
+            "hexes": [
+              "J17",
+              "I22",
+              "H21",
+              "G22",
+              "F23",
+              "D23",
+              "C24",
+              "a25"
+            ],
+            "revenue": 270,
+            "revenue_str": "J17-H21-D23-a25+£100",
+            "nodes": [
+              "I22-0",
+              "J17-2",
+              "H21-0",
+              "G22-0",
+              "F23-0",
+              "D23-0",
+              "C24-0",
+              "a25-0"
+            ]
+          },
+          {
+            "train": "4X-1",
+            "connections": [
+              [
+                "C24",
+                "C26",
+                "D27"
+              ],
+              [
+                "D23",
+                "C24"
+              ],
+              [
+                "D21",
+                "D23"
+              ],
+              [
+                "G18",
+                "F19",
+                "E20",
+                "D21"
+              ],
+              [
+                "F17",
+                "G18"
+              ],
+              [
+                "E14",
+                "F15",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "D27",
+              "C24",
+              "D23",
+              "D21",
+              "G18",
+              "F17",
+              "E14"
+            ],
+            "revenue": 250,
+            "revenue_str": "D27-D23-G18-E14+£70",
+            "nodes": [
+              "C24-0",
+              "D27-0",
+              "D23-0",
+              "D21-0",
+              "G18-0",
+              "F17-0",
+              "E14-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 769,
+        "created_at": 1698357863,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 770,
+        "created_at": 1698424203,
+        "hex": "F5",
+        "tile": "G34-5",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 771,
+        "created_at": 1698424226,
+        "hex": "H3",
+        "tile": "87-4",
+        "rotation": 4
+      },
+      {
+        "type": "run_routes",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 772,
+        "created_at": 1698424232,
+        "routes": [
+          {
+            "train": "5X-1",
+            "connections": [
+              [
+                "J3",
+                "K2",
+                "K0"
+              ],
+              [
+                "I6",
+                "J5",
+                "I4",
+                "J3"
+              ],
+              [
+                "H9",
+                "I8",
+                "I6"
+              ],
+              [
+                "G8",
+                "H9"
+              ],
+              [
+                "E6",
+                "F7",
+                "G8"
+              ]
+            ],
+            "hexes": [
+              "K0",
+              "J3",
+              "I6",
+              "H9",
+              "G8",
+              "E6"
+            ],
+            "revenue": 330,
+            "revenue_str": "K0-J3-I6-H9-E6+(FT)+(EW)+£60",
+            "nodes": [
+              "J3-0",
+              "K0-0",
+              "I6-0",
+              "H9-0",
+              "G8-0",
+              "E6-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 773,
+        "created_at": 1698424235,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 774,
+        "created_at": 1698424262,
+        "train": "5X-0",
+        "price": 337
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 775,
+        "created_at": 1698447709,
+        "hex": "I16",
+        "tile": "87-2",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 776,
+        "created_at": 1698447766,
+        "hex": "H15",
+        "tile": "G05-1",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 777,
+        "created_at": 1698447774
+      },
+      {
+        "type": "pass",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 778,
+        "created_at": 1698447866
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 779,
+        "created_at": 1698451762,
+        "hex": "G2",
+        "tile": "23-4",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 780,
+        "created_at": 1698451768,
+        "hex": "J1",
+        "tile": "28-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 781,
+        "created_at": 1698451775
+      },
+      {
+        "type": "run_routes",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 782,
+        "created_at": 1698451878,
+        "routes": [
+          {
+            "train": "6X-1",
+            "connections": [
+              [
+                "J3",
+                "K2",
+                "K0"
+              ],
+              [
+                "I6",
+                "J5",
+                "I4",
+                "J3"
+              ],
+              [
+                "H5",
+                "I6"
+              ],
+              [
+                "G4",
+                "H5"
+              ],
+              [
+                "F5",
+                "G4"
+              ],
+              [
+                "E6",
+                "F5"
+              ]
+            ],
+            "hexes": [
+              "K0",
+              "J3",
+              "I6",
+              "H5",
+              "G4",
+              "F5",
+              "E6"
+            ],
+            "revenue": 390,
+            "revenue_str": "K0-J3-I6-G4-F5-E6+(FT)+(EW)+£60",
+            "nodes": [
+              "J3-0",
+              "K0-0",
+              "I6-0",
+              "H5-0",
+              "G4-1",
+              "F5-0",
+              "E6-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 783,
+        "created_at": 1698451884,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 784,
+        "created_at": 1698451889,
+        "train": "6X-2",
+        "price": 700,
+        "variant": "6X"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 785,
+        "created_at": 1698453334,
+        "hex": "E20",
+        "tile": "45-1",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 786,
+        "created_at": 1698453343,
+        "hex": "E18",
+        "tile": "4-5",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 787,
+        "created_at": 1698453406,
+        "routes": [
+          {
+            "train": "5+2-0",
+            "connections": [
+              [
+                "C24",
+                "B25",
+                "A24",
+                "a25"
+              ],
+              [
+                "D23",
+                "C22",
+                "C24"
+              ],
+              [
+                "F21",
+                "E22",
+                "D23"
+              ],
+              [
+                "G22",
+                "F21"
+              ],
+              [
+                "F23",
+                "G22"
+              ],
+              [
+                "F23",
+                "G24",
+                "G26"
+              ]
+            ],
+            "hexes": [
+              "a25",
+              "C24",
+              "D23",
+              "F21",
+              "G22",
+              "F23",
+              "G26"
+            ],
+            "revenue": 300,
+            "revenue_str": "a25-C24-D23-F21-G22-F23-G26+(EW)",
+            "nodes": [
+              "C24-0",
+              "a25-0",
+              "D23-0",
+              "F21-1",
+              "G22-0",
+              "F23-0",
+              "G26-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 788,
+        "created_at": 1698453407,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 789,
+        "created_at": 1698453409,
+        "train": "6X-3",
+        "price": 700,
+        "variant": "6X"
+      },
+      {
+        "type": "run_routes",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 790,
+        "created_at": 1698453583,
+        "routes": [
+          {
+            "train": "6X-4",
+            "connections": [
+              [
+                "L1",
+                "K0"
+              ],
+              [
+                "J3",
+                "K2",
+                "L1"
+              ],
+              [
+                "I2",
+                "J1",
+                "J3"
+              ],
+              [
+                "H3",
+                "I2"
+              ],
+              [
+                "H5",
+                "I4",
+                "H3"
+              ],
+              [
+                "H9",
+                "H7",
+                "H5"
+              ],
+              [
+                "G8",
+                "H9"
+              ],
+              [
+                "E6",
+                "F7",
+                "G8"
+              ]
+            ],
+            "hexes": [
+              "K0",
+              "L1",
+              "J3",
+              "I2",
+              "H3",
+              "H5",
+              "H9",
+              "G8",
+              "E6"
+            ],
+            "revenue": 270,
+            "revenue_str": "K0-J3-I2-H9-E6+(EW)+£60",
+            "nodes": [
+              "L1-0",
+              "K0-0",
+              "J3-0",
+              "I2-0",
+              "H3-0",
+              "H5-0",
+              "H9-0",
+              "G8-0",
+              "E6-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 791,
+        "created_at": 1698469339,
+        "hex": "G14",
+        "tile": "G18-2",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 792,
+        "created_at": 1698469365,
+        "hex": "G20",
+        "tile": "27-0",
+        "rotation": 4
+      },
+      {
+        "type": "place_token",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 793,
+        "created_at": 1698469398,
+        "city": "G05-1-0",
+        "slot": 0,
+        "tokener": "MR"
+      },
+      {
+        "type": "run_routes",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 794,
+        "created_at": 1698469456,
+        "routes": [
+          {
+            "train": "6X-0",
+            "connections": [
+              [
+                "G14",
+                "F13",
+                "E14"
+              ],
+              [
+                "H15",
+                "G14"
+              ],
+              [
+                "I16",
+                "H15"
+              ],
+              [
+                "H19",
+                "I18",
+                "I16"
+              ],
+              [
+                "F21",
+                "G20",
+                "H19"
+              ]
+            ],
+            "hexes": [
+              "E14",
+              "G14",
+              "H15",
+              "I16",
+              "H19",
+              "F21"
+            ],
+            "revenue": 260,
+            "revenue_str": "E14-G14-H15-H19-F21+(LM)+£40",
+            "nodes": [
+              "G14-0",
+              "E14-0",
+              "H15-0",
+              "I16-0",
+              "H19-0",
+              "F21-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 795,
+        "created_at": 1698469459,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15620,
+            "entity_type": "player",
+            "created_at": 1698469458
+          }
+        ],
+        "kind": "payout"
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 796,
+        "created_at": 1698469568,
+        "shares": [
+          "LNWR_1",
+          "LNWR_4",
+          "LNWR_5",
+          "LNWR_0"
+        ],
+        "percent": 50,
+        "share_price": 65
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 797,
+        "created_at": 1698469595,
+        "shares": [
+          "NBR_8"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 798,
+        "created_at": 1698487369,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15618,
+            "entity_type": "player",
+            "created_at": 1698487367
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "sell_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 799,
+        "created_at": 1698500162,
+        "shares": [
+          "LNWR_3",
+          "LNWR_0"
+        ],
+        "percent": 30,
+        "share_price": 37
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 800,
+        "created_at": 1698500254,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15620,
+            "entity_type": "player",
+            "created_at": 1698500252
+          }
+        ],
+        "shares": [
+          "LSWR_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 801,
+        "created_at": 1698548275,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 15618,
+            "entity_type": "player",
+            "created_at": 1698548273,
+            "reason": "Shares were sold"
+          }
+        ],
+        "shares": [
+          "LSWR_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 802,
+        "created_at": 1698568682
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 803,
+        "created_at": 1698574374,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15620,
+            "entity_type": "player",
+            "created_at": 1698574373
+          }
+        ],
+        "shares": [
+          "LSWR_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 804,
+        "created_at": 1698633858,
+        "shares": [
+          "MR_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 15618,
+        "entity_type": "player",
+        "id": 805,
+        "created_at": 1698660064,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15618,
+            "entity_type": "player",
+            "created_at": 1698660062
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 806,
+        "created_at": 1698664132,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15620,
+            "entity_type": "player",
+            "created_at": 1698664131
+          }
+        ],
+        "shares": [
+          "MR_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 807,
+        "created_at": 1698671993,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15618,
+            "entity_type": "player",
+            "created_at": 1698671991
+          }
+        ],
+        "shares": [
+          "MR_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 15708,
+        "entity_type": "player",
+        "id": 808,
+        "created_at": 1698680379,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 15620,
+            "entity_type": "player",
+            "created_at": 1698680377
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 15621,
+        "entity_type": "player",
+        "id": 809,
+        "created_at": 1698704310
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 810,
+        "created_at": 1698708117,
+        "hex": "E16",
+        "tile": "23-0",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 811,
+        "created_at": 1698708204,
+        "hex": "H23",
+        "tile": "46-0",
+        "rotation": 0
+      },
+      {
+        "type": "run_routes",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 812,
+        "created_at": 1698708842,
+        "routes": [
+          {
+            "train": "4X-0",
+            "connections": [
+              [
+                "I22",
+                "J21",
+                "J19",
+                "J17"
+              ],
+              [
+                "H21",
+                "I22"
+              ],
+              [
+                "G22",
+                "H21"
+              ],
+              [
+                "F23",
+                "G22"
+              ],
+              [
+                "D23",
+                "E22",
+                "F23"
+              ],
+              [
+                "C24",
+                "C22",
+                "D23"
+              ],
+              [
+                "a25",
+                "A24",
+                "B25",
+                "C24"
+              ]
+            ],
+            "hexes": [
+              "J17",
+              "I22",
+              "H21",
+              "G22",
+              "F23",
+              "D23",
+              "C24",
+              "a25"
+            ],
+            "revenue": 270,
+            "revenue_str": "J17-H21-D23-a25+£100",
+            "nodes": [
+              "I22-0",
+              "J17-2",
+              "H21-0",
+              "G22-0",
+              "F23-0",
+              "D23-0",
+              "C24-0",
+              "a25-0"
+            ]
+          },
+          {
+            "train": "4X-1",
+            "connections": [
+              [
+                "C24",
+                "C26",
+                "D27"
+              ],
+              [
+                "D23",
+                "C24"
+              ],
+              [
+                "D21",
+                "D23"
+              ],
+              [
+                "G18",
+                "F19",
+                "E20",
+                "D21"
+              ],
+              [
+                "F17",
+                "G18"
+              ],
+              [
+                "E14",
+                "F15",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "D27",
+              "C24",
+              "D23",
+              "D21",
+              "G18",
+              "F17",
+              "E14"
+            ],
+            "revenue": 250,
+            "revenue_str": "D27-D23-G18-E14+£70",
+            "nodes": [
+              "C24-0",
+              "D27-0",
+              "D23-0",
+              "D21-0",
+              "G18-0",
+              "F17-0",
+              "E14-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "GWR",
+        "entity_type": "corporation",
+        "id": 813,
+        "created_at": 1698708845,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 814,
+        "created_at": 1698767163
+      },
+      {
+        "type": "run_routes",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 815,
+        "created_at": 1698767231,
+        "routes": [
+          {
+            "train": "5X-1",
+            "connections": [
+              [
+                "J3",
+                "K2",
+                "K0"
+              ],
+              [
+                "I6",
+                "J5",
+                "I4",
+                "J3"
+              ],
+              [
+                "H9",
+                "I8",
+                "I6"
+              ],
+              [
+                "G8",
+                "H9"
+              ],
+              [
+                "E6",
+                "F7",
+                "G8"
+              ]
+            ],
+            "hexes": [
+              "K0",
+              "J3",
+              "I6",
+              "H9",
+              "G8",
+              "E6"
+            ],
+            "revenue": 330,
+            "revenue_str": "K0-J3-I6-H9-E6+(FT)+(EW)+£60",
+            "nodes": [
+              "J3-0",
+              "K0-0",
+              "I6-0",
+              "H9-0",
+              "G8-0",
+              "E6-0"
+            ]
+          },
+          {
+            "train": "5X-0",
+            "connections": [
+              [
+                "L1",
+                "K0"
+              ],
+              [
+                "I2",
+                "J1",
+                "K2",
+                "L1"
+              ],
+              [
+                "H3",
+                "I2"
+              ],
+              [
+                "G4",
+                "H3"
+              ],
+              [
+                "G4",
+                "G6"
+              ],
+              [
+                "G6",
+                "F5"
+              ],
+              [
+                "F5",
+                "E6"
+              ]
+            ],
+            "hexes": [
+              "K0",
+              "L1",
+              "I2",
+              "H3",
+              "G4",
+              "G6",
+              "F5",
+              "E6"
+            ],
+            "revenue": 300,
+            "revenue_str": "K0-I2-G4-F5-E6+(EW)+£60",
+            "nodes": [
+              "L1-0",
+              "K0-0",
+              "I2-0",
+              "H3-0",
+              "G4-0",
+              "G6-0",
+              "F5-0",
+              "E6-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "CR",
+        "entity_type": "corporation",
+        "id": 816,
+        "created_at": 1698767233,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 817,
+        "created_at": 1698767247,
+        "hex": "H13",
+        "tile": "46-1",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 818,
+        "created_at": 1698767254,
+        "hex": "G12",
+        "tile": "58-2",
+        "rotation": 5
+      },
+      {
+        "type": "run_routes",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 819,
+        "created_at": 1698767348,
+        "routes": [
+          {
+            "train": "6X-1",
+            "connections": [
+              [
+                "J3",
+                "K2",
+                "K0"
+              ],
+              [
+                "I6",
+                "J5",
+                "I4",
+                "J3"
+              ],
+              [
+                "H5",
+                "I6"
+              ],
+              [
+                "G4",
+                "H5"
+              ],
+              [
+                "F5",
+                "G4"
+              ],
+              [
+                "E6",
+                "F5"
+              ]
+            ],
+            "hexes": [
+              "K0",
+              "J3",
+              "I6",
+              "H5",
+              "G4",
+              "F5",
+              "E6"
+            ],
+            "revenue": 390,
+            "revenue_str": "K0-J3-I6-G4-F5-E6+(FT)+(EW)+£60",
+            "nodes": [
+              "J3-0",
+              "K0-0",
+              "I6-0",
+              "H5-0",
+              "G4-1",
+              "F5-0",
+              "E6-0"
+            ]
+          },
+          {
+            "train": "6X-2",
+            "connections": [
+              [
+                "G14",
+                "H15"
+              ],
+              [
+                "G12",
+                "F13",
+                "G14"
+              ],
+              [
+                "I12",
+                "H13",
+                "G12"
+              ],
+              [
+                "J11",
+                "I12"
+              ],
+              [
+                "I6",
+                "I8",
+                "I10",
+                "J11"
+              ],
+              [
+                "I2",
+                "I4",
+                "I6"
+              ],
+              [
+                "I0",
+                "I2"
+              ]
+            ],
+            "hexes": [
+              "H15",
+              "G14",
+              "G12",
+              "I12",
+              "J11",
+              "I6",
+              "I2",
+              "I0"
+            ],
+            "revenue": 320,
+            "revenue_str": "H15-G14-J11-I6-I2-I0+£80",
+            "nodes": [
+              "G14-0",
+              "H15-0",
+              "G12-0",
+              "I12-0",
+              "J11-0",
+              "I6-0",
+              "I2-0",
+              "I0-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "NBR",
+        "entity_type": "corporation",
+        "id": 820,
+        "created_at": 1698767352,
+        "kind": "payout"
+      },
+      {
+        "hex": "H15",
+        "tile": "G14-1",
+        "type": "lay_tile",
+        "entity": "MR",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "id": 821,
+        "user": 15621,
+        "created_at": 1698857255
+      },
+      {
+        "type": "undo",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 822,
+        "user": 15621,
+        "created_at": 1698857332
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 823,
+        "created_at": 1698857355,
+        "hex": "H17",
+        "tile": "G19-3",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 824,
+        "created_at": 1698857387
+      },
+      {
+        "type": "run_routes",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 825,
+        "created_at": 1698857429,
+        "routes": [
+          {
+            "train": "6X-0",
+            "connections": [
+              [
+                "G14",
+                "F13",
+                "E14"
+              ],
+              [
+                "H15",
+                "G14"
+              ],
+              [
+                "I16",
+                "H15"
+              ],
+              [
+                "H17",
+                "I16"
+              ],
+              [
+                "H19",
+                "H17"
+              ],
+              [
+                "F21",
+                "G20",
+                "H19"
+              ]
+            ],
+            "hexes": [
+              "E14",
+              "G14",
+              "H15",
+              "I16",
+              "H17",
+              "H19",
+              "F21"
+            ],
+            "revenue": 280,
+            "revenue_str": "E14-G14-H15-H17-H19-F21+(LM)+£40",
+            "nodes": [
+              "G14-0",
+              "E14-0",
+              "H15-0",
+              "I16-0",
+              "H17-0",
+              "H19-0",
+              "F21-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "MR",
+        "entity_type": "corporation",
+        "id": 826,
+        "created_at": 1698857434,
+        "kind": "payout"
+      },
+      {
+        "type": "run_routes",
+        "entity": "LNWR",
+        "entity_type": "corporation",
+        "id": 827,
+        "created_at": 1698857767,
+        "routes": [
+          {
+            "train": "6X-4",
+            "connections": [
+              [
+                "J25",
+                "J27"
+              ],
+              [
+                "I22",
+                "I24",
+                "J25"
+              ],
+              [
+                "H21",
+                "I22"
+              ],
+              [
+                "G22",
+                "H21"
+              ],
+              [
+                "F23",
+                "G22"
+              ],
+              [
+                "F21",
+                "F23"
+              ],
+              [
+                "F17",
+                "F19",
+                "F21"
+              ],
+              [
+                "C14",
+                "D15",
+                "E16",
+                "F17"
+              ]
+            ],
+            "hexes": [
+              "J27",
+              "J25",
+              "I22",
+              "H21",
+              "G22",
+              "F23",
+              "F21",
+              "F17",
+              "C14"
+            ],
+            "revenue": 330,
+            "revenue_str": "J27-J25-H21-F21-C14+(EW)+£100",
+            "nodes": [
+              "J25-0",
+              "J27-0",
+              "I22-0",
+              "H21-0",
+              "G22-0",
+              "F23-0",
+              "F21-0",
+              "F17-0",
+              "C14-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 828,
+        "created_at": 1698857935,
+        "hex": "I24",
+        "tile": "25-1",
+        "rotation": 3
+      },
+      {
+        "type": "lay_tile",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 829,
+        "created_at": 1698857950,
+        "hex": "H25",
+        "tile": "24-3",
+        "rotation": 1
+      },
+      {
+        "type": "run_routes",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 830,
+        "created_at": 1698858143,
+        "routes": [
+          {
+            "train": "5+2-0",
+            "connections": [
+              [
+                "F17",
+                "F15",
+                "E14"
+              ],
+              [
+                "D21",
+                "E20",
+                "F19",
+                "F17"
+              ],
+              [
+                "D23",
+                "D21"
+              ],
+              [
+                "C24",
+                "C22",
+                "D23"
+              ],
+              [
+                "D27",
+                "C26",
+                "C24"
+              ]
+            ],
+            "hexes": [
+              "E14",
+              "F17",
+              "D21",
+              "D23",
+              "C24",
+              "D27"
+            ],
+            "revenue": 220,
+            "revenue_str": "E14-F17-D21-D23-C24-D27+(EW)",
+            "nodes": [
+              "F17-0",
+              "E14-0",
+              "D21-0",
+              "D23-0",
+              "C24-0",
+              "D27-0"
+            ]
+          },
+          {
+            "train": "6X-3",
+            "connections": [
+              [
+                "C24",
+                "B25",
+                "A24",
+                "a25"
+              ],
+              [
+                "D23",
+                "C24"
+              ],
+              [
+                "D25",
+                "D23"
+              ],
+              [
+                "E26",
+                "D25"
+              ],
+              [
+                "F25",
+                "E24",
+                "E26"
+              ],
+              [
+                "F23",
+                "F25"
+              ],
+              [
+                "F21",
+                "E22",
+                "F23"
+              ],
+              [
+                "G22",
+                "F21"
+              ],
+              [
+                "I22",
+                "H23",
+                "G22"
+              ],
+              [
+                "J25",
+                "I24",
+                "I22"
+              ],
+              [
+                "K22",
+                "K24",
+                "J25"
+              ]
+            ],
+            "hexes": [
+              "a25",
+              "C24",
+              "D23",
+              "D25",
+              "E26",
+              "F25",
+              "F23",
+              "F21",
+              "G22",
+              "I22",
+              "J25",
+              "K22"
+            ],
+            "revenue": 340,
+            "revenue_str": "a25-D23-D25-F21-J25-K22+£110",
+            "nodes": [
+              "C24-0",
+              "a25-0",
+              "D23-0",
+              "D25-0",
+              "E26-0",
+              "F25-0",
+              "F23-0",
+              "F21-1",
+              "G22-0",
+              "I22-0",
+              "J25-0",
+              "K22-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "LSWR",
+        "entity_type": "corporation",
+        "id": 831,
+        "created_at": 1699823003,
+        "kind": "payout"
+      },
+      {
+        "type": "run_routes",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 832,
+        "created_at": 1704396994,
+        "routes": [],
+        "extra_revenue": 0
+      },
+      {
+        "type": "pass",
+        "entity": "LYR",
+        "entity_type": "corporation",
+        "id": 833,
+        "created_at": 1704397001
+      }
+    ],
+    "id": "hs_mahcuefh_136880",
+    "players": [
+      {
+        "id": 15620,
+        "name": "Lawk3t"
+      },
+      {
+        "id": 15708,
+        "name": "frodobro"
+      },
+      {
+        "id": 15621,
+        "name": "ndmvkilroy"
+      },
+      {
+        "id": 15618,
+        "name": "WESTalan"
+      }
+    ],
+    "title": "18GB",
+    "description": "Cloned from game 136880",
+    "min_players": 4,
+    "max_players": 5,
+    "user": {
+      "id": 0,
+      "name": "You"
+    },
+    "settings": {
+      "seed": 176656074,
+      "is_async": true,
+      "unlisted": true,
+      "auto_routing": false,
+      "player_order": null,
+      "optional_rules": []
+    },
+    "user_settings": null,
+    "turn": 8,
+    "round": "Operating Round",
+    "acting": [
+      15620,
+      15618,
+      15708,
+      15621
+    ],
+    "result": {"15618":5065, "15620":1416, "15621":4006, "15708":5075},
+    "loaded": true,
+    "created_at": "2024-01-04",
+    "updated_at": 1704397001,
+    "finished_at": null,
+    "mode": "hotseat",
+    "manually_ended": false
+  }


### PR DESCRIPTION
Fixes #9877

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

If a corp in receivership would have to lease a train but there are none, it doesn't get to lease one at all

This should be a no-op in practice, as the game ends soon after the final train is purchased - and receivership corps just withhold to buy a train anyway (which never happens as there are none)

Shouldn't require pins as this PR handles an edge case that would have broken existing games

See linked older PR for more details
