### PR TITLE
Fix Tredgar in 18VA

### DIFF
--- a/lib/engine/game/g_18_va/entities.rb
+++ b/lib/engine/game/g_18_va/entities.rb
@@ -45,7 +45,7 @@ module Engine
                 trains: %w[2 3 4 5 6 4D],
                 count: 1,
                 closed_when_used_up: true,
-                when: 'buying_train',
+                when: 'buy_train',
               },
             ],
           },


### PR DESCRIPTION
Fixes #9686 


### Before clicking "Create"

- [ x] Branch is derived from the latest `master`
- [ x] Add the `pins` label if this change will break existing games
- [ x] Code passes linter with `docker compose exec rack rubocop -a`
- [ x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes
* **Explanation of Change**

Changing the timing from `buying_train` to `buy_train` fixes Tredgar; looking at the `ability_right_time?` implementation it looks like `buying_train` isn't the name of a step or explicitly stated so it doesn't get past this

https://github.com/tobymao/18xx/blob/master/lib/engine/game/base.rb#L3082
* **Screenshots**

* **Any Assumptions / Hacks**
Are other games that use `when: 'buying_train'` broken?
Looking at this and the blame for game::base, I'm not sure how Tredgar ever worked