### PR TITLE
[18Ardennes] Starting major corporations

### DIFF
--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -181,8 +181,15 @@ module View
 
           buttons = []
           if @step.may_bid?(company) && @step.min_bid(company) <= @step.max_place_bid(@current_entity, company)
-            bid_str = @step.respond_to?(:bid_str) ? @step.bid_str(company) : 'Place Bid'
-            buttons << h(:button, { on: { click: -> { create_bid(company, input) } } }, bid_str)
+            if @step.respond_to?(:bid_choices) && (choices = @step.bid_choices(company))
+              choices.map do |choice, label|
+                bid_lambda = -> { create_assigned_bid(company, choice, input) }
+                buttons << h(:button, { on: { click: bid_lambda } }, label)
+              end
+            else
+              bid_str = @step.respond_to?(:bid_str) ? @step.bid_str(company) : 'Place Bid'
+              buttons << h(:button, { on: { click: -> { create_bid(company, input) } } }, bid_str)
+            end
           end
           buttons.concat(render_move_bid_buttons(company, input))
 
@@ -438,6 +445,27 @@ module View
           process_action(Engine::Action::Bid.new(
             @current_entity,
             company: target,
+            price: price,
+          ))
+          store(:selected_company, nil, skip: true)
+        end
+
+        # Creates and processes an Action::Bid where a company is being
+        # auctioned and a corporation is associated with the bid.  Used by
+        # {Engine::Game::G18Ardennes::Step::MajorAuction} for the auctions where
+        # players bid for the right to start a major (a company of type
+        # +:concession+) in exchange for a minor (a corporation of type
+        # +:minor+).
+        # @param company [Engine::Company] The company being bid for.
+        # @param corporation [Engine::Corporation] The corporation associated with the bid.
+        # @param input [Snabberb::Component] The input element containing the bid price.
+        def create_assigned_bid(company, corporation, input)
+          hide!
+          price = input.JS['elm'].JS['value'].to_i
+          process_action(Engine::Action::Bid.new(
+            @current_entity,
+            company: company,
+            corporation: corporation,
             price: price,
           ))
           store(:selected_company, nil, skip: true)

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -58,6 +58,7 @@ module View
 
           children = []
 
+          children.concat(render_bankruptcy) if @current_actions.include?('bankrupt')
           children << h(Choose) if @current_actions.include?('choose') && @step.choice_available?(@current_entity)
           children << h(FlexibleBuy) if @current_actions.include?('buy_shares') && @flexible_player
 
@@ -150,6 +151,24 @@ module View
           end
 
           [h(:button, { on: { click: merge } }, @step.merge_action)]
+        end
+
+        def render_bankruptcy
+          resign = lambda do
+            process_action(Engine::Action::Bankrupt.new(@current_entity))
+          end
+
+          props = {
+            style: {
+              width: 'max-content',
+            },
+            on: { click: resign },
+          }
+
+          [h(:div, [
+            h(:button, props, 'Declare Bankruptcy'),
+            h(:div, @step.bankruptcy_description(@current_entity)),
+          ])]
         end
 
         def render_payoff_player_debt_button

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -437,12 +437,28 @@ module Engine
           companies
         end
 
+        def concession_companies
+          companies.select { |company| company.type == :concession }
+        end
+
+        def minor_companies
+          companies.select { |company| company.type == :minor }
+        end
+
+        def major_corporations
+          corporations.reject { |corporations| corporations.type == :minor }
+        end
+
+        def minor_corporations
+          corporations.select { |corporations| corporations.type == :minor }
+        end
+
         def reservation_corporations
-          corporations.select { |c| c.type == :minor }
+          minor_corporations
         end
 
         def sorted_corporations
-          corporations.reject { |corp| corp.type == :minor }.sort
+          major_corporations.sort
         end
 
         def can_par?(corporation, _parrer)

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -390,7 +390,7 @@ module Engine
         # The minimum amount of cash needed to start a major company.
         def min_concession_cost(concession)
           major = major_corporations.find do |corp|
-            corp.par_via_exchange = concession
+            corp.par_via_exchange == concession
           end
           minor = pledged_minors[major]
           min_par = lowest_major_par

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -16,108 +16,6 @@ module Engine
             text_color: :black,
             abilities: [{ type: 'no_buy' }],
           },
-          {
-            sym: 'BY',
-            name: 'Königlich Bayerische Staats-Eisenbahn',
-            type: :concession,
-            value: 0,
-            discount: 0,
-            color: :lightblue,
-            text_color: :black,
-            abilities: [
-              {
-                type: 'exchange',
-                corporations: ['BY'],
-                owner_type: 'player',
-                from: 'par',
-              },
-            ],
-          },
-          {
-            sym: 'N',
-            name: 'Compagnie des chemins de fer du Nord',
-            type: :concession,
-            value: 0,
-            discount: 0,
-            color: :saddlebrown,
-            text_color: :white,
-            abilities: [
-              {
-                type: 'exchange',
-                corporations: ['N'],
-                owner_type: 'player',
-                from: 'par',
-              },
-            ],
-          },
-          {
-            sym: 'E',
-            name: 'Compagnie des chemins de fer de l\'Est',
-            type: :concession,
-            value: 0,
-            discount: 0,
-            color: :orange,
-            text_color: :black,
-            abilities: [
-              {
-                type: 'exchange',
-                corporations: ['E'],
-                owner_type: 'player',
-                from: 'par',
-              },
-            ],
-          },
-          {
-            sym: 'NL',
-            name: 'Maatschappij tot Exploitatie van Staatsspoorwegen',
-            type: :concession,
-            value: 0,
-            discount: 0,
-            color: :yellow,
-            text_color: :black,
-            abilities: [
-              {
-                type: 'exchange',
-                corporations: ['NL'],
-                owner_type: 'player',
-                from: 'par',
-              },
-            ],
-          },
-          {
-            sym: 'BE',
-            name: 'État Belge',
-            type: :concession,
-            value: 0,
-            discount: 0,
-            color: :darkgreen,
-            text_color: :white,
-            abilities: [
-              {
-                type: 'exchange',
-                corporations: ['BE'],
-                owner_type: 'player',
-                from: 'par',
-              },
-            ],
-          },
-          {
-            sym: 'P',
-            name: 'Preußische Staatseisenbahnen',
-            type: :concession,
-            value: 0,
-            discount: 0,
-            color: :darkblue,
-            text_color: :white,
-            abilities: [
-              {
-                type: 'exchange',
-                corporations: ['P'],
-                owner_type: 'player',
-                from: 'par',
-              },
-            ],
-          },
         ].freeze
 
         CORPORATIONS = [
@@ -437,16 +335,8 @@ module Engine
           super.reject { |c| c[:type] == :minor }
         end
 
-        def init_company_abilities
-          super
-
-          # Link concessions to corporations.
-          @companies.each do |company|
-            next unless (ability = abilities(company, :exchange))
-            next unless ability.from.include?(:par)
-
-            exchange_corporations(ability).first.par_via_exchange = company
-          end
+        def setup_preround
+          @companies.concat(init_concessions)
         end
 
         def concession_companies
@@ -508,6 +398,22 @@ module Engine
         end
 
         private
+
+        # Creates a concession company for each major corporations
+        def init_concessions
+          major_corporations.map do |corporation|
+            concession = Company.new(
+              sym: corporation.id,
+              name: corporation.name,
+              type: :concession,
+              value: 0,
+              color: corporation.color,
+              text_color: corporation.text_color,
+            )
+            corporation.par_via_exchange = concession
+            concession
+          end
+        end
 
         # The minimum amount of cash needed to start one of the corporations
         # that the player is under obligation for.

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -8,12 +8,115 @@ module Engine
           {
             sym: 'GL',
             name: 'Guillaume-Luxembourg',
+            type: :minor,
             value: 100,
             discount: 0,
             revenue: 25,
             color: :yellow,
             text_color: :black,
             abilities: [{ type: 'no_buy' }],
+          },
+          {
+            sym: 'BY',
+            name: 'Königlich Bayerische Staats-Eisenbahn',
+            type: :concession,
+            value: 0,
+            discount: 0,
+            color: :lightblue,
+            text_color: :black,
+            abilities: [
+              {
+                type: 'exchange',
+                corporations: ['BY'],
+                owner_type: 'player',
+                from: 'par',
+              },
+            ],
+          },
+          {
+            sym: 'N',
+            name: 'Compagnie des chemins de fer du Nord',
+            type: :concession,
+            value: 0,
+            discount: 0,
+            color: :saddlebrown,
+            text_color: :white,
+            abilities: [
+              {
+                type: 'exchange',
+                corporations: ['N'],
+                owner_type: 'player',
+                from: 'par',
+              },
+            ],
+          },
+          {
+            sym: 'E',
+            name: 'Compagnie des chemins de fer de l\'Est',
+            type: :concession,
+            value: 0,
+            discount: 0,
+            color: :orange,
+            text_color: :black,
+            abilities: [
+              {
+                type: 'exchange',
+                corporations: ['E'],
+                owner_type: 'player',
+                from: 'par',
+              },
+            ],
+          },
+          {
+            sym: 'NL',
+            name: 'Maatschappij tot Exploitatie van Staatsspoorwegen',
+            type: :concession,
+            value: 0,
+            discount: 0,
+            color: :yellow,
+            text_color: :black,
+            abilities: [
+              {
+                type: 'exchange',
+                corporations: ['NL'],
+                owner_type: 'player',
+                from: 'par',
+              },
+            ],
+          },
+          {
+            sym: 'BE',
+            name: 'État Belge',
+            type: :concession,
+            value: 0,
+            discount: 0,
+            color: :darkgreen,
+            text_color: :white,
+            abilities: [
+              {
+                type: 'exchange',
+                corporations: ['BE'],
+                owner_type: 'player',
+                from: 'par',
+              },
+            ],
+          },
+          {
+            sym: 'P',
+            name: 'Preußische Staatsiesenbahnen',
+            type: :concession,
+            value: 0,
+            discount: 0,
+            color: :darkblue,
+            text_color: :white,
+            abilities: [
+              {
+                type: 'exchange',
+                corporations: ['P'],
+                owner_type: 'player',
+                from: 'par',
+              },
+            ],
           },
         ].freeze
 
@@ -245,6 +348,7 @@ module Engine
             always_market_price: true,
             capitalization: :incremental,
             tokens: [0, 100, 100, 100, 100, 100],
+            coordinates: %w[E25 G25 H26 I21 J24],
           },
           {
             sym: 'N',
@@ -258,6 +362,7 @@ module Engine
             always_market_price: true,
             capitalization: :incremental,
             tokens: [0, 100, 100, 100, 100, 100],
+            coordinates: %w[G3 H6 K5 M7],
           },
           {
             sym: 'E',
@@ -271,6 +376,7 @@ module Engine
             always_market_price: true,
             capitalization: :incremental,
             tokens: [0, 100, 100, 100, 100, 100],
+            coordinates: %w[I21 J18 J24 K11 M7],
           },
           {
             sym: 'NL',
@@ -284,6 +390,7 @@ module Engine
             always_market_price: true,
             capitalization: :incremental,
             tokens: [0, 100, 100, 100, 100, 100],
+            coordinates: %w[B8 B12 C7 E5 E9 E15],
           },
           {
             sym: 'BE',
@@ -297,6 +404,7 @@ module Engine
             always_market_price: true,
             capitalization: :incremental,
             tokens: [0, 100, 100, 100, 100, 100],
+            coordinates: %w[E9 E15 F4 F10 H6 H10],
           },
           {
             sym: 'P',
@@ -310,14 +418,23 @@ module Engine
             always_market_price: true,
             capitalization: :incremental,
             tokens: [0, 100, 100, 100, 100, 100],
+            coordinates: %w[B16 D18 E15 E25],
           },
         ].freeze
 
-        def game_companies
-          # The Guillaume-Luxembourg is only used in four-player games.
-          return [] unless @players.size == 4
+        def company_header(company)
+          case company.type
+          when :minor then 'MINOR COMPANY'
+          when :concession then 'PUBLIC COMPANY'
+          else raise GameError, 'Unknown type of private company'
+          end
+        end
 
-          super
+        def game_companies
+          companies = super
+          # The Guillaume-Luxembourg is only used in four-player games.
+          companies.reject! { |c| c[:type] == :minor } unless @players.size == 4
+          companies
         end
 
         def reservation_corporations

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -431,10 +431,10 @@ module Engine
         end
 
         def game_companies
-          companies = super
+          return super if @players.size == 4
+
           # The Guillaume-Luxembourg is only used in four-player games.
-          companies.reject! { |c| c[:type] == :minor } unless @players.size == 4
-          companies
+          super.reject { |c| c[:type] == :minor }
         end
 
         def init_company_abilities

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -103,7 +103,7 @@ module Engine
           },
           {
             sym: 'P',
-            name: 'Preußische Staatsiesenbahnen',
+            name: 'Preußische Staatseisenbahnen',
             type: :concession,
             value: 0,
             discount: 0,
@@ -408,7 +408,7 @@ module Engine
           },
           {
             sym: 'P',
-            name: 'Preußische Staatsiesenbahnen',
+            name: 'Preußische Staatseisenbahnen',
             color: :darkblue,
             text_color: :white,
             logo: '18_ardennes/P',

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -437,6 +437,18 @@ module Engine
           companies
         end
 
+        def init_company_abilities
+          super
+
+          # Link concessions to corporations.
+          @companies.each do |company|
+            next unless (ability = abilities(company, :exchange))
+            next unless ability.from.include?(:par)
+
+            exchange_corporations(ability).first.par_via_exchange = company
+          end
+        end
+
         def concession_companies
           companies.select { |company| company.type == :concession }
         end
@@ -461,9 +473,13 @@ module Engine
           major_corporations.sort
         end
 
-        def can_par?(corporation, _parrer)
-          # TODO: major corporation concessions
-          corporation.type == :minor
+        # 18Ardennes doesn't have multiple layers of private companies.
+        def check_new_layer; end
+
+        def can_par?(corporation, parrer)
+          return true if corporation.type == :minor
+
+          super
         end
       end
     end

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -38,6 +38,8 @@ module Engine
         HOME_TOKEN_TIMING = :par
 
         MUST_BUY_TRAIN = :always # Just for majors, minors are handled in #must_buy_train?
+        BANKRUPTCY_ALLOWED = true
+        BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
 
         def setup
           super
@@ -114,6 +116,15 @@ module Engine
         def operating_order
           minor_corporations.select(&:ipoed).sort +
           major_corporations.select(&:ipoed).sort
+        end
+
+        # Checks whether a player really is bankrupt.
+        def can_go_bankrupt?(player, _corporation)
+          return super if @round.is_a?(Round::Operating)
+
+          # Has the player won the auction for a major company concession
+          # that they cannot afford to start?
+          bankrupt?(player)
         end
       end
     end

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -31,6 +31,9 @@ module Engine
         MUST_BID_INCREMENT_MULTIPLE = true
         COMPANY_SALE_FEE = 0 # Fee for selling Guillaume-Luxembourg to the bank.
 
+        SELL_BUY_ORDER = :sell_buy
+        SELL_AFTER = :operate
+
         CAPITALIZATION = :incremental
         HOME_TOKEN_TIMING = :par
 
@@ -91,7 +94,7 @@ module Engine
             Engine::Step::DiscardTrain,
             Engine::Step::Exchange,
             Engine::Step::SpecialTrack,
-            Engine::Step::BuySellParSharesCompanies,
+            G18Ardennes::Step::BuySellParSharesCompanies,
           ])
         end
 
@@ -106,6 +109,11 @@ module Engine
             Engine::Step::DiscardTrain,
             Engine::Step::BuyTrain,
           ], round_num: round_num)
+        end
+
+        def operating_order
+          minor_corporations.select(&:ipoed).sort +
+          major_corporations.select(&:ipoed).sort
         end
       end
     end

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -21,6 +21,12 @@ module Engine
         include Tiles
         include Trains
 
+        # Minors that have been pledged in bids to start public companies.
+        # Used by {Step::MajorAuction} to pass this information to
+        # {Step::BuySellParSharesCompanies}. This is a hash whose keys are
+        # the major corporations and the values are the minor corporations.
+        attr_accessor :pledged_minors
+
         MIN_BID_INCREMENT = 5
         MUST_BID_INCREMENT_MULTIPLE = true
         COMPANY_SALE_FEE = 0 # Fee for selling Guillaume-Luxembourg to the bank.
@@ -34,6 +40,7 @@ module Engine
           super
 
           setup_tokens
+          @pledged_minors = major_corporations.to_h { |corp| [corp, nil] }
         end
 
         def next_round!

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -36,10 +36,46 @@ module Engine
           setup_tokens
         end
 
-        def new_auction_round
+        def next_round!
+          @round =
+            case @round
+            when Round::Auction
+              if @turn == 1
+                init_round_finished
+                reorder_players
+              end
+              new_stock_round
+            when Round::Stock
+              @operating_rounds = @phase.operating_rounds
+              reorder_players
+              new_operating_round
+            when Round::Operating
+              if @round.round_num < @operating_rounds
+                or_round_finished
+                new_operating_round(@round.round_num + 1)
+              else
+                @turn += 1
+                or_round_finished
+                or_set_finished
+                major_auction_round
+              end
+            end
+        end
+
+        def init_round
+          minor_auction_round
+        end
+
+        def minor_auction_round
           Engine::Round::Auction.new(self, [
             G18Ardennes::Step::HomeHexTile,
             G18Ardennes::Step::MinorAuction,
+          ])
+        end
+
+        def major_auction_round
+          Engine::Round::Auction.new(self, [
+            G18Ardennes::Step::MajorAuction,
           ])
         end
 

--- a/lib/engine/game/g_18_ardennes/map.rb
+++ b/lib/engine/game/g_18_ardennes/map.rb
@@ -353,6 +353,13 @@ module Engine
                            same_hex_allowed: true)
           clear_graph_for_entity(entity)
         end
+
+        def place_home_token(corporation)
+          # Public companies get their starting tokens by exchange.
+          return unless corporation.type == :minor
+
+          super
+        end
       end
     end
   end

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares_companies'
+require_relative 'minor_exchange'
+
+module Engine
+  module Game
+    module G18Ardennes
+      module Step
+        class BuySellParSharesCompanies < Engine::Step::BuySellParSharesCompanies
+          include MinorExchange
+
+          def sellable_companies(entity)
+            # Only the GL is sellable. Make sure concessions aren't visible.
+            super.select { |company| company.type == :minor }
+          end
+
+          # Corporations whose cards are visible in the stock round.
+          # Hide those whose concessions have not yet been auctioned.
+          def visible_corporations
+            @game.major_corporations.select do |corporation|
+              corporation.floated || !corporation.par_via_exchange.owner.nil?
+            end
+          end
+
+          # Valid par prices for public companies.
+          def get_par_prices(_player, _corporation)
+            @game.stock_market.par_prices.select { |pp| pp.types.include?(:par_2) }
+          end
+
+          # This function is called from View::Game::Par to calculate how many
+          # shares can be bought at each possible par price. In 18Ardennes you
+          # get an extra share when floating a public company, part paid for by
+          # exchanging the pledged minor, so pretend that the player has extra
+          # cash to pay for this extra share.
+          def available_par_cash(player, corporation, _share_price: nil)
+            available_cash(player) +
+              (@game.pledged_minors[corporation].share_price.price * 2)
+          end
+
+          def process_par(action)
+            super
+
+            major = action.corporation
+            minor = @game.pledged_minors[major]
+            concession = major.par_via_exchange
+
+            concession.close!
+            exchange_minor(minor, major)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_ardennes/step/major_auction.rb
+++ b/lib/engine/game/g_18_ardennes/step/major_auction.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative '../../../step/auctioner'
+
+module Engine
+  module Game
+    module G18Ardennes
+      module Step
+        class MajorAuction < Engine::Step::Base
+          include Engine::Step::Auctioner
+          ACTIONS = %w[bid pass].freeze
+          MIN_PRICE = 0
+
+          def actions(entity)
+            return [] unless entity.player?
+            return [] unless entity == current_entity
+            return [] unless can_bid_any?(entity)
+
+            ACTIONS
+          end
+
+          def description
+            'Bid on public companies'
+          end
+
+          def setup
+            setup_auction
+            @concessions = @game.companies.select do |company|
+              company.type == :concession && company.owner.nil?
+            end
+            # Hash showing which minors can be used to start a public company.
+            # The public companies are the has keys, each value is an array of
+            # minor companies.
+            @eligible_minors = {}
+            # Array of minor companies that are currently commited in a bid on
+            # a major company.
+            @pledged_minors = []
+          end
+
+          def auctioning
+            nil
+          end
+
+          def auctioneer?
+            false
+          end
+
+          def may_purchase?(_company)
+            false
+          end
+
+          def available
+            @concessions
+          end
+
+          def min_bid(company)
+            return unless company
+
+            return MIN_PRICE if @bids[company].empty?
+
+            high_bid = highest_bid(company)
+            (high_bid.price || company.min_bid) + min_increment
+          end
+
+          def max_bid(player, _company)
+            # TODO: must have enough cash + sellable shares left to float companies
+            player.cash
+          end
+
+          def bid_choices(concession)
+            eligible_minors(concession)
+              .difference(@pledged_minors)
+              .select { |minor| minor.owner == current_entity }
+              .to_h { |minor| [minor, "Bid with M#{minor.id}"] }
+          end
+
+          def process_bid(action)
+            player = action.entity
+            concession = action.company
+            minor = action.corporation
+            price = action.price
+
+            @log << "#{player.name} bids #{@game.format_currency(price)} " \
+                    "for #{concession.id} with minor #{minor.id}"
+            link_concession_minor(concession, minor)
+            player.unpass!
+            replace_bid(action)
+            next_entity!
+          end
+
+          def process_pass(action)
+            log_pass(action.entity)
+            current_entity.pass!
+            next_entity!
+          end
+
+          def skip!
+            current_entity.pass!
+            next_entity!
+          end
+
+          private
+
+          def can_bid_any?(player)
+            # TODO: bids + 280 * number winning bids
+            player.cash >= 280
+          end
+
+          def next_entity!
+            return all_passed! if entities.all?(&:passed?)
+
+            @round.next_entity_index!
+            # # Skip any players who are unable to add a new bid.
+            # next_entity! unless can_bid_any?(entities[entity_index])
+          end
+
+          def all_passed!
+            resolve_bids
+            # Need to move entity round once more to be back to the priority deal player
+            @round.next_entity_index!
+            pass!
+          end
+
+          def resolve_bids
+            @bids.each do |company, bids|
+              next if bids.empty?
+
+              win_bid(bids.first, company)
+            end
+          end
+
+          def win_bid(winner, _company)
+            player = winner.entity
+            company = winner.company
+            minor = @game.pledged_minors[concession_corporation(company)]
+            price = winner.price
+            company.owner = player
+            player.companies << company
+
+            player.spend(price, @game.bank) if price.positive?
+            @game.after_buy_company(player, company, price)
+            @log <<
+                "#{player.name} wins the auction for #{company.name} "\
+                "with a bid of #{@game.format_currency(price)} " \
+                "and minor #{minor.id}"
+          end
+
+          def committed_cash(player, _show_hidden = false)
+            bids_for_player(player).sum(&:price)
+          end
+
+          # Returns the corporation that a concession is associated with.
+          def concession_corporation(concession)
+            @game.corporation_by_id(concession.id)
+          end
+
+          # If no public companies have yet been started then there are
+          # geographical restrictions on which minor companies can be used to
+          # start a public company.
+          def restricted?
+            if @restricted.nil?
+              @restricted = @game.corporations.none? do |corporation|
+                corporation.floated && corporation.type != :minor
+              end
+            end
+            @restricted
+          end
+
+          # Finds all the minors that can be used to start the public company
+          # associated with the concession. If this isn't the first auction
+          # round then any minor can be used.
+          def eligible_minors(concession)
+            @eligible_minors[concession] ||=
+              @game.corporations.select do |corporation|
+                next false if corporation.closed?
+                next false unless corporation.type == :minor
+                next true unless restricted?
+
+                coords ||= concession_corporation(concession).coordinates
+                corporation.placed_tokens
+                           .map(&:hex)
+                           .map(&:coordinates)
+                           .intersect?(coords)
+              end
+          end
+
+          # Associates a minor corporation to the concession for a major.
+          # Any existing minor <-> concession associations are removed.
+          def link_concession_minor(concession, minor)
+            # This is a bit of a hack. The `corporations` array for an exchange
+            # ability is supposed to be a list of shares the company can be
+            # swapped for.  This initially contains the associated major
+            # corporation, here we stick the minor onto the end of the array,
+            # where it can be found in the next stock round. As the minor
+            # corporations never have any buyable shares this won't affect
+            # anything else.
+            ability = concession.abilities.first
+            # remove any existing minors
+            old_bid = ability.corporations.slice(1..-1)
+            @pledged_minors.delete(old_bid)
+            ability.corporations << minor
+            @pledged_minors << minor
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_ardennes/step/major_auction.rb
+++ b/lib/engine/game/g_18_ardennes/step/major_auction.rb
@@ -33,9 +33,6 @@ module Engine
             # The public companies are the has keys, each value is an array of
             # minor companies.
             @eligible_minors = {}
-            # Array of minor companies that are currently commited in a bid on
-            # a major company.
-            @pledged_minors = []
           end
 
           def auctioning
@@ -70,7 +67,7 @@ module Engine
 
           def bid_choices(concession)
             eligible_minors(concession)
-              .difference(@pledged_minors)
+              .difference(@game.pledged_minors.values)
               .select { |minor| minor.owner == current_entity }
               .to_h { |minor| [minor, "Bid with M#{minor.id}"] }
           end
@@ -188,19 +185,7 @@ module Engine
           # Associates a minor corporation to the concession for a major.
           # Any existing minor <-> concession associations are removed.
           def link_concession_minor(concession, minor)
-            # This is a bit of a hack. The `corporations` array for an exchange
-            # ability is supposed to be a list of shares the company can be
-            # swapped for.  This initially contains the associated major
-            # corporation, here we stick the minor onto the end of the array,
-            # where it can be found in the next stock round. As the minor
-            # corporations never have any buyable shares this won't affect
-            # anything else.
-            ability = concession.abilities.first
-            # remove any existing minors
-            old_bid = ability.corporations.slice(1..-1)
-            @pledged_minors.delete(old_bid)
-            ability.corporations << minor
-            @pledged_minors << minor
+            @game.pledged_minors[concession_corporation(concession)] = minor
           end
         end
       end

--- a/lib/engine/game/g_18_ardennes/step/minor_auction.rb
+++ b/lib/engine/game/g_18_ardennes/step/minor_auction.rb
@@ -28,8 +28,7 @@ module Engine
 
           def setup
             setup_auction
-            @minors = @game.companies.select { |c| c.type == :minor } +
-                      @game.corporations.select { |corp| corp.type == :minor }
+            @minors = @game.minor_companies + @game.minor_corporations
           end
 
           def description

--- a/lib/engine/game/g_18_ardennes/step/minor_auction.rb
+++ b/lib/engine/game/g_18_ardennes/step/minor_auction.rb
@@ -28,7 +28,7 @@ module Engine
 
           def setup
             setup_auction
-            @minors = @game.companies +
+            @minors = @game.companies.select { |c| c.type == :minor } +
                       @game.corporations.select { |corp| corp.type == :minor }
           end
 

--- a/lib/engine/game/g_18_ardennes/step/minor_exchange.rb
+++ b/lib/engine/game/g_18_ardennes/step/minor_exchange.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G18Ardennes
+      module Step
+        # Code shared between Step::BuySellParSharesCompanies and Step::Convert.
+        module MinorExchange
+          private
+
+          def exchange_minor(minor, major)
+            player = major.owner
+            bundle = major.treasury_shares.first.to_bundle
+            extra_cost = [0, major.share_price.price - (minor.share_price.price * 2)].max
+
+            msg = "#{player.name} exchanges minor #{minor.name} "
+            msg += "and #{@game.format_currency(extra_cost)} " if extra_cost.positive?
+            msg += "for a #{bundle.percent}% share of #{major.name}"
+            @game.log << msg
+
+            @game.share_pool.buy_shares(player,
+                                        bundle,
+                                        exchange: minor,
+                                        exchange_price: extra_cost,
+                                        silent: true)
+            transfer_assets(minor, major)
+            @game.close_corporation(minor)
+          end
+
+          # Moves all assets from a minor to a major and logs what was transferred.
+          def transfer_assets(minor, major)
+            assets = []
+            assets << transfer_cash(minor, major)
+            assets << transfer_trains(minor, major)
+            assets << transfer_tokens(minor, major)
+            assets << transfer_forts(minor, major, :fort)
+            @game.log << "#{major.name} receives #{minor.name}’s assets: " \
+                         "#{assets.compact.join(', ')}."
+          end
+
+          # Transfers treasury cash.
+          # Returns a string describing the transfer, or nil if there was no cash
+          # to transfer.
+          def transfer_cash(minor, major)
+            return if minor.cash.zero?
+
+            cash = minor.cash
+            minor.spend(minor.cash, major)
+            "cash (#{@game.format_currency(cash)})"
+          end
+
+          # Transfers trains.
+          # Returns a string describing the transfer, or nil if there was no
+          # train to transfer.
+          def transfer_trains(minor, major)
+            return if minor.trains.empty?
+
+            trains = @game.transfer(:trains, minor, major).map(&:name)
+            "#{trains.one? ? 'a train' : 'trains'} (#{trains.join(' and ')})"
+          end
+
+          # Transfers station tokens. Also copies across assignments for mine
+          # and port tokens.
+          # Returns a string describing the station tokens transferred.
+          def transfer_tokens(minor, major)
+            cities = []
+            minor.placed_tokens.each do |token|
+              city = token.city
+              token.remove!
+              city.place_token(major, major.next_token, check_tokenable: false)
+              hex = city.hex.coordinates
+              prefix = ''
+              if minor.assigned?(hex)
+                if Map::MINE_HEXES.include?(hex)
+                  prefix = '⚒ '
+                  minor.remove_assignment!(hex)
+                  major.assign!(hex)
+                elsif Map::PORT_HEXES.include?(hex)
+                  prefix = '⚓ '
+                  minor.remove_assignment!(hex)
+                  major.assign!(hex)
+                end
+              end
+              cities << (prefix + city.hex.location_name)
+            end
+            "#{cities.one? ? 'a token' : 'tokens'} (#{cities.join(' and ')})"
+          end
+
+          # Transfers fort tokens.
+          # Returns a string describing the transfer, or nil if there was
+          # nothing to transfer.
+          def transfer_forts(minor, major)
+            forts = minor.assignments.keys.intersection(Map::FORT_HEXES.keys)
+            return if forts.empty?
+
+            forts.each do |fort|
+              minor.remove_assignment!(fort)
+              major.assign!(fort)
+            end
+            "#{forts.count} fort token#{forts.count == 1 ? '' : 's'}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Explanation of Change

In 18Ardennes major companies are started by converting minors. There is an auction at the start of each stock round for the rights to start a major, with the players bidding amounts for the rights to start the major, and saying which minor will be converted. The players’ first action(s) in the stock round must be converting the minors into majors.


### Implementation Notes

This is done by first having an auction round to buy (hidden) concession private companies linked to the major corporations. The majors are started in the `BuySellParSharesCompanies` step, in the `process_par` method. A `pledged_minors` hash is added to the game state, to track which minors are going to be used to start the majors.

There are a couple of places where this touches the core rendering code:

1. When placing a bid for the right to start a major, you have to bid an amount and state which minor you will use to start the major. I've implemented this by putting multiple bid buttons next to the bid amount, one for each eligible minor. The array of minor names used to produce these buttons come from a method called `bid_choices`, inspired a similar idea in `G18FL::Step::BuyCert`.
![image](https://github.com/tobymao/18xx/assets/11144854/4041471b-0652-4287-8e92-a473df7b441d)

2. It's possible (though unlikely) to bankrupt in the stock round. If you've won the right to start a major company then you *must* start it in the following stock round. If you're unable to raise enough cash to do this then you are bankrupt and out of the game. A button to declare bankruptcy is rendered if this has happened, with a description of what went wrong.
![image](https://github.com/tobymao/18xx/assets/11144854/30108f90-c576-4d7e-8c99-67875381b75f)






### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~~Add the `pins` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
