### PR TITLE
[1822CA] move to alpha (update welcome page), add home+dest info to concessions

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -17,9 +17,9 @@ module View
 
     def render_notification
       message = <<~MESSAGE
-        <p><a href="https://github.com/tobymao/18xx/wiki/1844">1844</a> is in beta.</p>
-        <p>The random seed entered when creating a game is now used to seed random events within the game, not just inital turn order. See <a href="https://github.com/tobymao/18xx/wiki/Random-Seeds">the wiki page</a> for more details.</p>
-        <p><a href="https://github.com/tobymao/18xx/wiki/1850Jr">1850jr</a> is in alpha.</p>
+        <p><a href="https://github.com/tobymao/18xx/wiki/1822CA">1822CA</a> is in alpha.
+        <a href="https://github.com/tobymao/18xx/wiki/1844">1844</a> is in beta.
+        <a href="https://github.com/tobymao/18xx/wiki/1850Jr">1850jr</a> is in alpha.</p>
         <p>Learn how to get <a href='https://github.com/tobymao/18xx/wiki/Notifications'>notifications</a> by email, Slack, Discord, and Telegram.</p>
         <p>Please submit problem reports and make suggestions for improvements on
         <a href='https://github.com/tobymao/18xx/issues'>GitHub</a>. Join the

--- a/lib/engine/game/g_1822_ca/entities.rb
+++ b/lib/engine/game/g_1822_ca/entities.rb
@@ -662,7 +662,8 @@ module Engine
             sym: 'C1',
             value: 100,
             revenue: 10,
-            desc: 'Has a face value of $100 and contributes $100 to conversion into the CNoR director’s certificate.',
+            desc: 'Has a face value of $100 and contributes $100 to conversion into the CNoR director’s '\
+                  'certificate. Home: Winnipeg (N16). Destination: Vancouver (C15).',
             abilities: [
               {
                 type: 'exchange',
@@ -680,7 +681,7 @@ module Engine
             value: 100,
             revenue: 10,
             desc: 'Has a face value of $100 and converts into the CPR’s 10% director certificate. CPR may also put '\
-                  'its destination token into Vancouver when converted.',
+                  'its destination token into Vancouver when converted. Home: Montréal (AF12). Destination: Vancouver (C15).',
             abilities: [
               {
                 type: 'exchange',
@@ -698,7 +699,7 @@ module Engine
             value: 100,
             revenue: 10,
             desc: 'Has a face value of $100 and contributes $100 to conversion into the GNWR director’s '\
-                  'certificate.',
+                  'certificate. Home: Thunder Bay (R16). Destination: N Winnipeg (N16).',
             abilities: [
               {
                 type: 'exchange',
@@ -716,7 +717,7 @@ module Engine
             value: 100,
             revenue: 10,
             desc: 'Has a face value of $100 and contributes $100 to conversion into the GT director’s '\
-                  'certificate.',
+                  'certificate. Home: Toronto (AC21). Destination: S Montréal (AF12).',
             abilities: [
               {
                 type: 'exchange',
@@ -733,7 +734,8 @@ module Engine
             sym: 'C5',
             value: 100,
             revenue: 10,
-            desc: 'Has a face value of $100 and contributes $100 to conversion into the GTP director’s certificate.',
+            desc: 'Has a face value of $100 and contributes $100 to conversion into the GTP director’s '\
+                  'certificate. Home: Winnipeg (N16). Destination: Prince Rupert (A7).',
             abilities: [
               {
                 type: 'exchange',
@@ -750,7 +752,8 @@ module Engine
             sym: 'C6',
             value: 100,
             revenue: 10,
-            desc: 'Has a face value of $100 and contributes $100 to conversion into the GWR director’s certificate.',
+            desc: 'Has a face value of $100 and contributes $100 to conversion into the GWR director’s '\
+                  'certificate. Home: Hamilton (AB24). Destination: Windsor (Z28).',
             abilities: [
               {
                 type: 'exchange',
@@ -767,7 +770,8 @@ module Engine
             sym: 'C7',
             value: 100,
             revenue: 10,
-            desc: 'Has a face value of $100 and contributes $100 to conversion into the ICR director’s certificate.',
+            desc: 'Has a face value of $100 and contributes $100 to conversion into the ICR director’s '\
+                  'certificate. Home: Halifax (AP4). Destination: Any Québec (AH8).',
             abilities: [
               {
                 type: 'exchange',
@@ -784,7 +788,8 @@ module Engine
             sym: 'C8',
             value: 100,
             revenue: 10,
-            desc: 'Has a face value of $100 and contributes $100 to conversion into the NTR director’s certificate.',
+            desc: 'Has a face value of $100 and contributes $100 to conversion into the NTR director’s '\
+                  'certificate. Home: Moncton (AO3). Destination: SE Winnipeg (N16).',
             abilities: [
               {
                 type: 'exchange',
@@ -801,7 +806,8 @@ module Engine
             sym: 'C9',
             value: 100,
             revenue: 10,
-            desc: 'Has a face value of $100 and contributes $100 to conversion into the PGE director’s certificate.',
+            desc: 'Has a face value of $100 and contributes $100 to conversion into the PGE director’s '\
+                  'certificate. Home: Vancouver (C15). Destination: Prince George (D10).',
             abilities: [
               {
                 type: 'exchange',
@@ -818,7 +824,8 @@ module Engine
             sym: 'C10',
             value: 100,
             revenue: 10,
-            desc: 'Has a face value of $100 and contributes $100 to conversion into the QMOO director’s certificate.',
+            desc: 'Has a face value of $100 and contributes $100 to conversion into the QMOO director’s '\
+                  'certificate. Home: Québec (AH8). Destination: North Bay (AA15).',
             abilities: [
               {
                 type: 'exchange',

--- a/lib/engine/game/g_1822_ca/meta.rb
+++ b/lib/engine/game/g_1822_ca/meta.rb
@@ -9,7 +9,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :prealpha
+        DEV_STAGE = :alpha
         DEPENDS_ON = '1822'
 
         GAME_SUBTITLE = 'The Railways of Canada'

--- a/lib/engine/game/g_1822_ca/scenario.rb
+++ b/lib/engine/game/g_1822_ca/scenario.rb
@@ -190,6 +190,16 @@ module Engine
 
         def block_detroit_duluth; end
         def event_open_detroit_duluth!; end
+
+        def init_companies(players)
+          game_companies.map do |company|
+            next if players.size < (company[:min_players] || 0)
+            next unless starting_companies.include?(company[:sym])
+
+            opts = self.class::STARTING_COMPANIES_OVERRIDE[company[:sym]] || {}
+            Company.new(**company.merge(opts))
+          end.compact
+        end
       end
     end
   end

--- a/lib/engine/game/g_1822_ca_ers/entities.rb
+++ b/lib/engine/game/g_1822_ca_ers/entities.rb
@@ -18,6 +18,17 @@ module Engine
         STARTING_CORPORATIONS = %w[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
                                    CPR GT GWR ICR NTR QMOO].freeze
 
+        STARTING_COMPANIES_OVERRIDE = {
+          'C2' => {
+            desc: 'Has a face value of $100 and contributes $100 to conversion into the CPR director’s '\
+                  'certificate. Home: Moncton (AO3). Destination: Winnipeg (T14).',
+          },
+          'C8' => {
+            desc: 'Has a face value of $100 and contributes $100 to conversion into the NTR director’s '\
+                  'certificate. Home: Montréal (AF12). Destination: Vancouver (T12).',
+          },
+        }.freeze
+
         STARTING_CORPORATIONS_OVERRIDE = {
           'CPR' => { destination_coordinates: 'T12', destination_icon_in_city_slot: [0, 0] },
           'NTR' => { destination_coordinates: 'T14', destination_icon_in_city_slot: [0, 2] },

--- a/lib/engine/game/g_1822_ca_wrs/entities.rb
+++ b/lib/engine/game/g_1822_ca_wrs/entities.rb
@@ -25,6 +25,15 @@ module Engine
           },
 
           'M19' => { desc: 'A 50% director’s certificate in the associated minor company. Starting location is T12 (Moncton).' },
+
+          'C2' => {
+            desc: 'Has a face value of $100 and converts into the CPR’s 10% director certificate. CPR may also put '\
+                  'its destination token into Vancouver when converted. Home: Montréal (T14). Destination: Vancouver (C15).',
+          },
+          'C8' => {
+            desc: 'Has a face value of $100 and contributes $100 to conversion into the NTR director’s '\
+                  'certificate. Home: Moncton (T12). Destination: SE Winnipeg (N16).',
+          },
         }.freeze
 
         STARTING_CORPORATIONS_OVERRIDE = {

--- a/lib/engine/game/g_1822_ca_wrs/game.rb
+++ b/lib/engine/game/g_1822_ca_wrs/game.rb
@@ -46,16 +46,6 @@ module Engine
 
         PENDING_HOME_TOKENERS = [MINOR_14_ID, 'GNWR'].freeze
 
-        def init_companies(players)
-          game_companies.map do |company|
-            next if players.size < (company[:min_players] || 0)
-            next unless starting_companies.include?(company[:sym])
-
-            opts = self.class::STARTING_COMPANIES_OVERRIDE[company[:sym]] || {}
-            Company.new(**company.merge(opts))
-          end.compact
-        end
-
         def after_lay_tile(hex, _old_tile, _tile)
           super
           update_home(gnwr, tile_trigger: true) if hex.id == gnwr.coordinates


### PR DESCRIPTION
Move `init_companies` from `g_1822_ca_wrs/game.rb` into `g_1822_ca/scenario.rb` so ERS can use it as well, so the corporations with a different home/dest in the scenarios can have their concession description updated as well.

Closes #9376
