### PR TITLE
Fix 1822CA's grain bonus computation

### DIFF
--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -468,7 +468,7 @@ module Engine
           sawmill_bonus = sawmill_bonus(route.routes)
           str += " + Sawmill ($#{sawmill_bonus[:revenue]})" if sawmill_bonus && sawmill_bonus[:route] == route
 
-          str += grain_and_port_bonus(route.train, route.stops)[:description]
+          str += grain_and_port_bonus(route.train, route.visited_stops)[:description]
 
           str
         end


### PR DESCRIPTION
Before, rendering https://18xx.games/game/147861?action=1276 takes nearly a minute. After this change, it's down to about 6 seconds.

In game 147861 at action 1276, it is PGE's route step in OR 9.2. The route they ran in OR 9.1 combined a G-train with their 7-train to visit 19 (!) stops. The G-train is not automatically re-attached to the same train they used last time, so that 19-stop route is invalid for the 7-train. The grain bonus calculation was using `stops` instead of `visited_stops`, leading to a bad loop of trying to compute the revenue-generating stops on an invalid route.

Fixes #10123