### PR TITLE
[18EU][18MT] Change default Pass optional to conditional in programmed auction bid, was causing infinite loops

### DIFF
--- a/lib/engine/step/programmer_auction_bid.rb
+++ b/lib/engine/step/programmer_auction_bid.rb
@@ -53,7 +53,7 @@ module Engine
                                              reason: "Price for #{target.name} exceeded maximum bid")]
         end
 
-        [Action::Pass.new(entity)]
+        []
       end
 
       def auto_buy?(_entity, program)

--- a/lib/engine/step/programmer_auction_bid.rb
+++ b/lib/engine/step/programmer_auction_bid.rb
@@ -53,7 +53,7 @@ module Engine
                                              reason: "Price for #{target.name} exceeded maximum bid")]
         end
 
-        []
+        actions(entity).include?('pass') ? [Action::Pass.new(entity)] : []
       end
 
       def auto_buy?(_entity, program)

--- a/spec/lib/engine/games/g_18eu_spec.rb
+++ b/spec/lib/engine/games/g_18eu_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require './spec/spec_helper'
+
+require 'json'
+require 'timeout'
+
+module Engine
+  describe Game::G18EU do
+    let(:players) { %w[a b c] }
+
+    let(:actions) do
+      [
+        { 'type' => 'bid', 'entity' => 'a', 'entity_type' => 'player', 'minor' => '1', 'price' => 100, 'id' => 1 },
+        { 'type' => 'pass', 'entity' => 'b', 'entity_type' => 'player', 'id' => 2 },
+        { 'type' => 'bid', 'entity' => 'c', 'entity_type' => 'player', 'minor' => '1', 'price' => 410, 'id' => 3 },
+        { 'type' => 'pass', 'entity' => 'a', 'entity_type' => 'player', 'id' => 4 },
+        {
+          'type' => 'program_auction_bid',
+          'entity' => 'c',
+          'entity_type' => 'player',
+          'id' => 5,
+          'bid_target' => '15',
+          'enable_maximum_bid' => false,
+          'maximum_bid' => '100',
+          'enable_buy_price' => true,
+          'buy_price' => '60',
+          'auto_pass_after' => false,
+        },
+        { 'type' => 'bid', 'entity' => 'b', 'entity_type' => 'player', 'minor' => '2', 'price' => 100, 'id' => 6 },
+      ]
+    end
+
+    # issue 9615
+    # with the right combination of auto actions and player order, the auto actions could enter an infinite loop
+    # of continuous Pass actions.  This test creates those conditions, attempting to trigger the loop,
+    # but protected by a timeout.
+
+    context '18EU programmed actions loop setup' do
+      let(:players) { %w[a b c] }
+      subject(:subject_with_actions) { Game::G18EU::Game.new(players, actions: actions) }
+
+      it 'should not enter infinite loop' do
+        expect(subject_with_actions.raw_actions.size).to be 6
+        expect(subject_with_actions.current_entity.name).to be players[0]
+        expect(subject.players.map(&:cash)).to eq([450, 450, 40])
+
+        Timeout.timeout(10) do
+          # Do not allow longer than 10 seconds to process pass action
+          action = Engine::Action::Pass.new(subject_with_actions.current_entity)
+          subject_with_actions.process_action(action, add_auto_actions: true)
+
+          expect(subject_with_actions.raw_actions.size).to be 7
+          expect(subject_with_actions.current_entity.name).to be players[2]
+          expect(subject.players.map(&:cash)).to eq([450, 350, 40])
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/engine/games/g_18mt_spec.rb
+++ b/spec/lib/engine/games/g_18mt_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require './spec/spec_helper'
+
+require 'json'
+require 'timeout'
+require 'pry-byebug'
+
+module Engine
+  describe Game::G18MT do
+    let(:players) { %w[a b c] }
+
+    let(:actions) do
+      [
+        {
+          'type' => 'program_auction_bid',
+          'entity' => 'c',
+          'entity_type' => 'player',
+          'id' => 1,
+          'bid_target' => 'GP',
+          'enable_maximum_bid' => false,
+          'maximum_bid' => '20',
+          'enable_buy_price' => true,
+          'buy_price' => '15',
+          'auto_pass_after' => false,
+        },
+        { 'type' => 'bid', 'entity' => 'a', 'entity_type' => 'player', 'company' => 'GV', 'price' => 35, 'id' => 2 },
+
+      ]
+    end
+
+    context '18MT programmed actions step' do
+      let(:players) { %w[a b c] }
+      subject(:subject_with_actions) { Game::G18MT::Game.new(players, actions: actions) }
+
+      it 'should not pass unexpectedly' do
+        expect(subject_with_actions.raw_actions.size).to be 2
+        action = Engine::Action::Bid.new(subject_with_actions.current_entity, company: subject_with_actions.company_by_id('MW'),
+                                                                              price: 45)
+        subject_with_actions.process_action(action, add_auto_actions: true)
+
+        expect(subject_with_actions.raw_actions.size).to be 3
+        expect(subject_with_actions.current_entity.name).to be players[2]
+      end
+    end
+  end
+end

--- a/spec/lib/engine/games/g_18mt_spec.rb
+++ b/spec/lib/engine/games/g_18mt_spec.rb
@@ -3,8 +3,6 @@
 require './spec/spec_helper'
 
 require 'json'
-require 'timeout'
-require 'pry-byebug'
 
 module Engine
   describe Game::G18MT do

--- a/spec/lib/engine/games/g_18mt_spec.rb
+++ b/spec/lib/engine/games/g_18mt_spec.rb
@@ -31,14 +31,14 @@ module Engine
       let(:players) { %w[a b c] }
       subject(:subject_with_actions) { Game::G18MT::Game.new(players, actions: actions) }
 
-      it 'should not pass unexpectedly' do
+      it 'should pass if pass is an option' do
         expect(subject_with_actions.raw_actions.size).to be 2
         action = Engine::Action::Bid.new(subject_with_actions.current_entity, company: subject_with_actions.company_by_id('MW'),
                                                                               price: 45)
         subject_with_actions.process_action(action, add_auto_actions: true)
 
         expect(subject_with_actions.raw_actions.size).to be 3
-        expect(subject_with_actions.current_entity.name).to be players[2]
+        expect(subject_with_actions.current_entity.name).to be players[0]
       end
     end
   end


### PR DESCRIPTION
Fixes #9615 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
   Two games allow expanded auto action options during the initial private/minor auction (18EU & 18MT).  In 18EU, in certain cases, a player can be next to "act", have auto actions programmed, actually be unable to pass (not enough money to spend in auction, thus already eliminated OR must select a minor to auction), but the default auto action is Pass.  This triggers an infinite loop of Pass actions which do not change the game state (player cannot Pass), thus freezing the game.

   This change returns an empty array if pass is not a valid action, otherwise it returns Pass.  This accommodates the "Pass after max bid reached / buy price impossible" functionality.

* **Screenshots**

* **Any Assumptions / Hacks**
