### PR TITLE
[1870] adds $400 finish variant

### DIFF
--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -56,6 +56,27 @@ module Engine
           %w[0c 0c 0c 10b 20b 30b 40o],
         ].freeze
 
+        VARIANT_MARKET = [
+          %w[64y 68 72 76 82 90 100p 110 120 140 160 180 200 225 250 275 300 325 350 375 400e],
+          %w[60y 64y 68 72 76 82 90p 100 110 120 140 160 180 200 225 250 275 300 325 350 375],
+          %w[55y 60y 64y 68 72 76 82p 90 100 110 120 140 160 180 200 225 250i 275i 300i 325i 350i],
+          %w[50o 55y 60y 64y 68 72 76p 82 90 100 110 120 140 160i 180i 200i 225i 250i 275i 300i 325i],
+          %w[40b 50o 55y 60y 64 68 72p 76 82 90 100 110i 120i 140i 160i 180i],
+          %w[30b 40o 50o 55y 60y 64 68p 72 76 82 90i 100i 110i],
+          %w[20b 30b 40o 50o 55y 60y 64 68 72 76i 82i],
+          %w[10b 20b 30b 40o 50y 55y 60y 64 68i 72i],
+          %w[0c 10b 20b 30b 40o 50y 55y 60i 64i],
+          %w[0c 0c 10b 20b 30b 40o 50y],
+          %w[0c 0c 0c 10b 20b 30b 40o],
+        ].freeze
+
+        STANDARD_GAME_END_CHECK = { bankrupt: :immediate, bank: :full_or }.freeze
+        VARIANT_GAME_END_CHECK = { bankrupt: :immediate, bank: :full_or, stock_market: :immediate }.freeze
+
+        def game_end_check_values
+          @optional_rules&.include?(:finish_on_400) ? self.class::VARIANT_GAME_END_CHECK : self.class::STANDARD_GAME_END_CHECK
+        end
+
         STANDARD_PHASES = [
           {
             name: '1',
@@ -306,8 +327,13 @@ module Engine
         end
 
         def init_stock_market
-          G1870::StockMarket.new(self.class::MARKET, self.class::CERT_LIMIT_TYPES,
-                                 multiple_buy_types: self.class::MULTIPLE_BUY_TYPES)
+          if @optional_rules&.include?(:finish_on_400)
+            G1870::StockMarket.new(self.class::VARIANT_MARKET, self.class::CERT_LIMIT_TYPES,
+                                   multiple_buy_types: self.class::MULTIPLE_BUY_TYPES)
+          else
+            G1870::StockMarket.new(self.class::MARKET, self.class::CERT_LIMIT_TYPES,
+                                   multiple_buy_types: self.class::MULTIPLE_BUY_TYPES)
+          end
         end
 
         def ipo_reserved_name(_entity = nil)

--- a/lib/engine/game/g_1870/meta.rb
+++ b/lib/engine/game/g_1870/meta.rb
@@ -23,6 +23,11 @@ module Engine
             short_name: 'Diesels variant (Alpha)',
             desc: 'Diesel trains replace 8, 10, and 12 trains. Uses all 1830 Diesel rules.',
           },
+          {
+            sym: :finish_on_400,
+            short_name: '$400 Finish',
+            desc: 'Game ends as soon as a corporation hits 400 on the stock market. No further operations.',
+          },
         ].freeze
       end
     end


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Adds the $400 Finish variant to 1870, page 24 of rulebook (screenshot below) 

* **Screenshots**
![image](https://github.com/tobymao/18xx/assets/26125362/59c5f015-b3d1-47e4-805e-3620a89cd243)

* **Any Assumptions / Hacks**
