### PR TITLE
[18AL] Fix ability timing for train_discount.

### DIFF
--- a/lib/engine/game/g_18_al/entities.rb
+++ b/lib/engine/game/g_18_al/entities.rb
@@ -82,7 +82,7 @@ module Engine
                 trains: %w[3 4 5],
                 count: 1,
                 closed_when_used_up: true,
-                when: 'buying_train',
+                when: 'single_depot_train_buy',
               },
             ],
           },

--- a/public/fixtures/18AL/hs_pzujrnou_144868.json
+++ b/public/fixtures/18AL/hs_pzujrnou_144868.json
@@ -1,0 +1,1931 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 10505,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1702569029,
+      "company": "SNAR",
+      "price": 45
+    },
+    {
+      "type": "bid",
+      "entity": 12593,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1702573173,
+      "company": "BLC",
+      "price": 75
+    },
+    {
+      "type": "bid",
+      "entity": 399,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1702576521,
+      "company": "M&C",
+      "price": 105
+    },
+    {
+      "type": "bid",
+      "entity": 10505,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1702588322,
+      "company": "NDY",
+      "price": 125
+    },
+    {
+      "type": "bid",
+      "entity": 12593,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1702591319,
+      "company": "TR",
+      "price": 20
+    },
+    {
+      "type": "par",
+      "entity": 399,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1702596925,
+      "corporation": "ABC",
+      "share_price": "75,1,4"
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 399,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1702596933,
+      "corporation": "ABC",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "par",
+      "entity": 10505,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1702602721,
+      "corporation": "TAG",
+      "share_price": "70,1,3"
+    },
+    {
+      "type": "par",
+      "entity": 12593,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1702602817,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 399,
+          "entity_type": "player",
+          "created_at": 1702602815,
+          "shares": [
+            "ABC_1"
+          ],
+          "percent": 10
+        }
+      ],
+      "corporation": "WRA",
+      "share_price": "75,1,4"
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 12593,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1702602822,
+      "corporation": "WRA",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 10505,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1702603086,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702603086,
+          "shares": [
+            "TAG_1"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 12593,
+          "entity_type": "player",
+          "created_at": 1702603086,
+          "shares": [
+            "WRA_1"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 399,
+          "entity_type": "player",
+          "created_at": 1702603086,
+          "shares": [
+            "ABC_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702603086,
+          "shares": [
+            "TAG_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 12593,
+          "entity_type": "player",
+          "created_at": 1702603086,
+          "shares": [
+            "WRA_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 399,
+          "entity_type": "player",
+          "created_at": 1702603086,
+          "shares": [
+            "ABC_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702603086,
+          "shares": [
+            "TAG_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 12593,
+          "entity_type": "player",
+          "created_at": 1702603086,
+          "shares": [
+            "WRA_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 399,
+          "entity_type": "player",
+          "created_at": 1702603086,
+          "shares": [
+            "ABC_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702603086,
+          "shares": [
+            "TAG_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 12593,
+          "entity_type": "player",
+          "created_at": 1702603086,
+          "shares": [
+            "WRA_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 399,
+          "entity_type": "player",
+          "created_at": 1702603086,
+          "reason": "ABC is floated"
+        }
+      ],
+      "corporation": "TAG",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "pass",
+      "entity": 399,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1702629035,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702629037,
+          "reason": "TAG is floated"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 10505,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1702647258,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702647257
+        },
+        {
+          "type": "program_disable",
+          "entity": 12593,
+          "entity_type": "player",
+          "created_at": 1702647257,
+          "reason": "WRA is floated"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12593,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1702647432,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12593,
+          "entity_type": "player",
+          "created_at": 1702647431
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 15,
+      "created_at": 1702647888,
+      "hex": "G6",
+      "tile": "6-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 16,
+      "created_at": 1702647900
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 17,
+      "created_at": 1702647901,
+      "train": "2-0",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 18,
+      "created_at": 1702648120,
+      "hex": "L5",
+      "tile": "6-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 19,
+      "created_at": 1702648136
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 20,
+      "created_at": 1702648137,
+      "train": "2-1",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 21,
+      "created_at": 1702648139
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 22,
+      "created_at": 1702648518,
+      "hex": "C6",
+      "tile": "58-0",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 23,
+      "created_at": 1702648527,
+      "train": "2-2",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 24,
+      "created_at": 1702648528
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 399,
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1702648571,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 399,
+          "entity_type": "player",
+          "created_at": 1702648571
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 10505,
+      "entity_type": "player",
+      "id": 26,
+      "created_at": 1702648590,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702648590
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12593,
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1702649301,
+      "shares": [
+        "ABC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12593,
+      "entity_type": "player",
+      "id": 28,
+      "created_at": 1702649403,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12593,
+          "entity_type": "player",
+          "created_at": 1702649402
+        },
+        {
+          "type": "pass",
+          "entity": 399,
+          "entity_type": "player",
+          "created_at": 1702649402
+        },
+        {
+          "type": "pass",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702649403
+        },
+        {
+          "type": "pass",
+          "entity": 12593,
+          "entity_type": "player",
+          "created_at": 1702649403
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 29,
+      "created_at": 1702649553,
+      "hex": "H7",
+      "tile": "8-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 30,
+      "created_at": 1702649557
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 31,
+      "created_at": 1702649559,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "G6",
+            "G8"
+          ],
+          "revenue": 60,
+          "revenue_str": "G6-G8",
+          "nodes": [
+            "G6-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 32,
+      "created_at": 1702649560,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 33,
+      "created_at": 1702649561,
+      "train": "2-3",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 34,
+      "created_at": 1702649562
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 35,
+      "created_at": 1702661583,
+      "hex": "K6",
+      "tile": "9-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 36,
+      "created_at": 1702661585
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 37,
+      "created_at": 1702661588,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "L5",
+              "K4"
+            ]
+          ],
+          "hexes": [
+            "L5",
+            "K4"
+          ],
+          "revenue": 40,
+          "revenue_str": "L5-K4",
+          "nodes": [
+            "L5-0",
+            "K4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 38,
+      "created_at": 1702661589,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 39,
+      "created_at": 1702661592,
+      "train": "2-4",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 40,
+      "created_at": 1702661593
+    },
+    {
+      "hex": "B5",
+      "tile": "8-1",
+      "type": "lay_tile",
+      "entity": "TAG",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "id": 41,
+      "user": 10505,
+      "created_at": 1702669351
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "routes": [
+        {
+          "hexes": [
+            "C6",
+            "E6",
+            "D7"
+          ],
+          "nodes": [
+            "C6-0",
+            "E6-0",
+            "D7-0"
+          ],
+          "train": "2-2",
+          "revenue": 40,
+          "connections": [
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "E6",
+              "D7"
+            ]
+          ],
+          "revenue_str": "C6-E6-D7"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 42,
+      "user": 10505,
+      "created_at": 1702669363
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 43,
+      "user": 10505,
+      "created_at": 1702669365
+    },
+    {
+      "type": "buy_train",
+      "price": 180,
+      "train": "3-0",
+      "entity": "TAG",
+      "variant": "3",
+      "entity_type": "corporation",
+      "id": 44,
+      "user": 10505,
+      "created_at": 1702669367
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 45,
+      "user": 10505,
+      "created_at": 1702669369
+    },
+    {
+      "type": "buy_company",
+      "price": 60,
+      "entity": "TAG",
+      "company": "SNAR",
+      "entity_type": "corporation",
+      "id": 46,
+      "user": 10505,
+      "created_at": 1702669380
+    },
+    {
+      "type": "buy_company",
+      "price": 180,
+      "entity": "TAG",
+      "company": "NDY",
+      "entity_type": "corporation",
+      "id": 47,
+      "user": 10505,
+      "created_at": 1702669385
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "action_id": 40,
+      "entity_type": "corporation",
+      "id": 48,
+      "user": 10505,
+      "created_at": 1702669425
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 49,
+      "created_at": 1702669437,
+      "hex": "B5",
+      "tile": "8-1",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 50,
+      "created_at": 1702669440,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "E6",
+              "D7"
+            ]
+          ],
+          "hexes": [
+            "C6",
+            "E6",
+            "D7"
+          ],
+          "revenue": 40,
+          "revenue_str": "C6-E6-D7",
+          "nodes": [
+            "C6-0",
+            "E6-0",
+            "D7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 51,
+      "created_at": 1702669441,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 52,
+      "created_at": 1702669442,
+      "train": "3-0",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 53,
+      "created_at": 1702669443
+    },
+    {
+      "type": "buy_company",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 54,
+      "created_at": 1702669449,
+      "company": "SNAR",
+      "price": 60
+    },
+    {
+      "type": "buy_company",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 55,
+      "created_at": 1702669453,
+      "company": "NDY",
+      "price": 180
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 56,
+      "created_at": 1702669455
+    },
+    {
+      "type": "buy_shares",
+      "entity": 399,
+      "entity_type": "player",
+      "id": 57,
+      "created_at": 1702669500,
+      "shares": [
+        "WRA_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 399,
+      "entity_type": "player",
+      "id": 58,
+      "created_at": 1702669503
+    },
+    {
+      "type": "sell_shares",
+      "entity": 10505,
+      "entity_type": "player",
+      "id": 59,
+      "created_at": 1702673882,
+      "shares": [
+        "TAG_1",
+        "TAG_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "par",
+      "entity": 10505,
+      "entity_type": "player",
+      "id": 60,
+      "created_at": 1702673932,
+      "corporation": "L&N",
+      "share_price": "75,1,4"
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12593,
+      "entity_type": "player",
+      "id": 61,
+      "created_at": 1702674003,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12593,
+          "entity_type": "player",
+          "created_at": 1702674003
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 399,
+      "entity_type": "player",
+      "id": 62,
+      "created_at": 1702674029
+    },
+    {
+      "type": "buy_shares",
+      "entity": 10505,
+      "entity_type": "player",
+      "id": 63,
+      "created_at": 1702675033,
+      "shares": [
+        "L&N_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 10505,
+      "entity_type": "player",
+      "id": 64,
+      "created_at": 1702675035,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12593,
+          "entity_type": "player",
+          "created_at": 1702675035
+        }
+      ]
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 10505,
+      "entity_type": "player",
+      "id": 65,
+      "created_at": 1702675053,
+      "corporation": "L&N",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 399,
+      "entity_type": "player",
+      "id": 66,
+      "created_at": 1702675176,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 399,
+          "entity_type": "player",
+          "created_at": 1702675177
+        },
+        {
+          "type": "buy_shares",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702675177,
+          "shares": [
+            "L&N_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702675177
+        },
+        {
+          "type": "pass",
+          "entity": 12593,
+          "entity_type": "player",
+          "created_at": 1702675177
+        },
+        {
+          "type": "pass",
+          "entity": 399,
+          "entity_type": "player",
+          "created_at": 1702675177
+        },
+        {
+          "type": "buy_shares",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702675178,
+          "shares": [
+            "L&N_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702675178
+        },
+        {
+          "type": "pass",
+          "entity": 12593,
+          "entity_type": "player",
+          "created_at": 1702675178
+        },
+        {
+          "type": "pass",
+          "entity": 399,
+          "entity_type": "player",
+          "created_at": 1702675178
+        },
+        {
+          "type": "buy_shares",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702675178,
+          "shares": [
+            "L&N_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702675178,
+          "reason": "L&N is floated"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 10505,
+      "entity_type": "player",
+      "id": 67,
+      "created_at": 1702675545,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702675545
+        },
+        {
+          "type": "pass",
+          "entity": 12593,
+          "entity_type": "player",
+          "created_at": 1702675545
+        },
+        {
+          "type": "pass",
+          "entity": 399,
+          "entity_type": "player",
+          "created_at": 1702675545
+        },
+        {
+          "type": "pass",
+          "entity": 10505,
+          "entity_type": "player",
+          "created_at": 1702675545
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 68,
+      "created_at": 1702675568,
+      "hex": "G4",
+      "tile": "441a-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 69,
+      "created_at": 1702675575
+    },
+    {
+      "type": "place_token",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 70,
+      "created_at": 1702675578,
+      "city": "441a-0-0",
+      "slot": 0,
+      "tokener": "ABC"
+    },
+    {
+      "type": "run_routes",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 71,
+      "created_at": 1702675585,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "G6",
+              "H5"
+            ]
+          ],
+          "hexes": [
+            "G6",
+            "H5"
+          ],
+          "revenue": 50,
+          "revenue_str": "G6-H5",
+          "nodes": [
+            "G6-0",
+            "H5-0"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "G6",
+              "H7",
+              "G8"
+            ]
+          ],
+          "hexes": [
+            "G6",
+            "G8"
+          ],
+          "revenue": 60,
+          "revenue_str": "G6-G8",
+          "nodes": [
+            "G6-0",
+            "G8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 72,
+      "created_at": 1702675589,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 73,
+      "created_at": 1702675592,
+      "train": "3-1",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 74,
+      "created_at": 1702675592
+    },
+    {
+      "type": "buy_company",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 75,
+      "created_at": 1702675602,
+      "company": "M&C",
+      "price": 150
+    },
+    {
+      "type": "pass",
+      "entity": "ABC",
+      "entity_type": "corporation",
+      "id": 76,
+      "created_at": 1702675606
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 77,
+      "created_at": 1702676062,
+      "hex": "J7",
+      "tile": "57-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 78,
+      "created_at": 1702676063
+    },
+    {
+      "type": "place_token",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 79,
+      "created_at": 1702676066,
+      "city": "57-0-0",
+      "slot": 0,
+      "tokener": "WRA"
+    },
+    {
+      "type": "run_routes",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 80,
+      "created_at": 1702676071,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "J7",
+              "K6",
+              "L5"
+            ]
+          ],
+          "hexes": [
+            "J7",
+            "L5"
+          ],
+          "revenue": 40,
+          "revenue_str": "J7-L5",
+          "nodes": [
+            "J7-0",
+            "L5-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "L5",
+              "K4"
+            ]
+          ],
+          "hexes": [
+            "L5",
+            "K4"
+          ],
+          "revenue": 40,
+          "revenue_str": "L5-K4",
+          "nodes": [
+            "L5-0",
+            "K4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 81,
+      "created_at": 1702676074,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 82,
+      "created_at": 1702676077,
+      "train": "3-2",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 83,
+      "created_at": 1702676080
+    },
+    {
+      "type": "buy_company",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 84,
+      "created_at": 1702676086,
+      "company": "TR",
+      "price": 30
+    },
+    {
+      "type": "buy_company",
+      "entity": "WRA",
+      "entity_type": "corporation",
+      "id": 85,
+      "created_at": 1702676090,
+      "company": "BLC",
+      "price": 105
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "target": "E6",
+      "entity_type": "company",
+      "target_type": "hex",
+      "id": 86,
+      "user": 10505,
+      "created_at": 1702676145
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 87,
+      "user": 10505,
+      "created_at": 1702676151
+    },
+    {
+      "hex": "B3",
+      "tile": "9-1",
+      "type": "lay_tile",
+      "entity": "L&N",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 88,
+      "user": 10505,
+      "created_at": 1702676159
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "action_id": 85,
+      "entity_type": "corporation",
+      "id": 89,
+      "user": 10505,
+      "created_at": 1702676163
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 90,
+      "created_at": 1702676177,
+      "hex": "C4",
+      "tile": "5-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 91,
+      "created_at": 1702676193
+    },
+    {
+      "type": "buy_train",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 92,
+      "created_at": 1702676197,
+      "train": "3-3",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 93,
+      "user": 10505,
+      "created_at": 1702676206
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "target": "E6",
+      "entity_type": "company",
+      "target_type": "hex",
+      "id": 94,
+      "user": 10505,
+      "created_at": 1702676213
+    },
+    {
+      "hex": "E6",
+      "tile": "15-0",
+      "type": "lay_tile",
+      "entity": "TAG",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 95,
+      "user": 10505,
+      "created_at": 1702676280
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 96,
+      "user": 10505,
+      "created_at": 1702676286
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "routes": [
+        {
+          "hexes": [
+            "E6",
+            "C6",
+            "C4",
+            "A4"
+          ],
+          "nodes": [
+            "E6-0",
+            "C6-0",
+            "C4-0",
+            "A4-0"
+          ],
+          "train": "3-0",
+          "revenue": 110,
+          "connections": [
+            [
+              "E6",
+              "C6"
+            ],
+            [
+              "C6",
+              "B5",
+              "C4"
+            ],
+            [
+              "C4",
+              "A4"
+            ]
+          ],
+          "revenue_str": "E6-C6-C4-A4 + Coal(E6)"
+        },
+        {
+          "hexes": [
+            "E6",
+            "D7"
+          ],
+          "nodes": [
+            "E6-0",
+            "D7-0"
+          ],
+          "train": "2-2",
+          "revenue": 50,
+          "connections": [
+            [
+              "E6",
+              "D7"
+            ]
+          ],
+          "revenue_str": "E6-D7 + Coal(E6)"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 97,
+      "user": 10505,
+      "created_at": 1702676293
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 98,
+      "user": 10505,
+      "created_at": 1702676295
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 100,
+      "user": 12593,
+      "created_at": 1702735265
+    },
+    {
+      "type": "redo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 101,
+      "user": 12593,
+      "created_at": 1702735268
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "action_id": 93,
+      "entity_type": "corporation",
+      "id": 106,
+      "user": 10505,
+      "created_at": 1702735606
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 107,
+      "user": 10505,
+      "created_at": 1702735614
+    },
+    {
+      "type": "redo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 108,
+      "user": 10505,
+      "created_at": 1702735635
+    },
+    {
+      "type": "redo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 109,
+      "user": 10505,
+      "created_at": 1702735637
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "action_id": 93,
+      "entity_type": "corporation",
+      "id": 110,
+      "user": 10505,
+      "created_at": 1702735716
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 111,
+      "user": 10505,
+      "created_at": 1702735720
+    },
+    {
+      "type": "buy_train",
+      "price": 99,
+      "train": "2-2",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 112,
+      "user": 10505,
+      "created_at": 1702735724
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 113,
+      "user": 10505,
+      "created_at": 1702735727
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 114,
+      "user": 10505,
+      "created_at": 1702735732
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 115,
+      "user": 10505,
+      "created_at": 1702735737
+    },
+    {
+      "hex": "E6",
+      "tile": "15-0",
+      "type": "lay_tile",
+      "entity": "TAG",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 116,
+      "user": 10505,
+      "created_at": 1702735757
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 117,
+      "user": 10505,
+      "created_at": 1702735760
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "routes": [
+        {
+          "hexes": [
+            "A4",
+            "C4",
+            "C6",
+            "E6",
+            "D7"
+          ],
+          "nodes": [
+            "A4-0",
+            "C4-0",
+            "C6-0",
+            "E6-0",
+            "D7-0"
+          ],
+          "train": "3-0",
+          "revenue": 110,
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ],
+            [
+              "C4",
+              "B5",
+              "C6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "E6",
+              "D7"
+            ]
+          ],
+          "revenue_str": "A4-C4-C6-E6-D7"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 118,
+      "user": 10505,
+      "created_at": 1702735763
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 119,
+      "user": 10505,
+      "created_at": 1702735764
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "action_id": 113,
+      "entity_type": "corporation",
+      "id": 120,
+      "user": 10505,
+      "created_at": 1702735777
+    },
+    {
+      "hex": "E6",
+      "tile": "15-0",
+      "type": "lay_tile",
+      "entity": "TAG",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 121,
+      "user": 10505,
+      "created_at": 1702735791
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "target": "E6",
+      "entity_type": "company",
+      "target_type": "hex",
+      "id": 122,
+      "user": 10505,
+      "created_at": 1702735801
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 123,
+      "user": 10505,
+      "created_at": 1702735803
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "routes": [
+        {
+          "hexes": [
+            "A4",
+            "C4",
+            "C6",
+            "E6",
+            "D7"
+          ],
+          "nodes": [
+            "A4-0",
+            "C4-0",
+            "C6-0",
+            "E6-0",
+            "D7-0"
+          ],
+          "train": "3-0",
+          "revenue": 120,
+          "connections": [
+            [
+              "A4",
+              "C4"
+            ],
+            [
+              "C4",
+              "B5",
+              "C6"
+            ],
+            [
+              "C6",
+              "E6"
+            ],
+            [
+              "E6",
+              "D7"
+            ]
+          ],
+          "revenue_str": "A4-C4-C6-E6-D7 + Coal(E6)"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 124,
+      "user": 10505,
+      "created_at": 1702735807
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 125,
+      "user": 10505,
+      "created_at": 1702735809
+    },
+    {
+      "type": "buy_train",
+      "price": 300,
+      "train": "4-0",
+      "entity": "TAG",
+      "variant": "4",
+      "entity_type": "corporation",
+      "id": 126,
+      "user": 10505,
+      "created_at": 1702735818
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 127,
+      "user": 10505,
+      "created_at": 1702735834
+    },
+    {
+      "type": "undo",
+      "entity": "ABC",
+      "action_id": 113,
+      "entity_type": "corporation",
+      "id": 128,
+      "user": 10505,
+      "created_at": 1702735877
+    },
+    {
+      "type": "undo",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 130,
+      "user": 10505,
+      "created_at": 1702735967
+    },
+    {
+      "type": "undo",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 131,
+      "user": 10505,
+      "created_at": 1702735970
+    },
+    {
+      "type": "pass",
+      "entity": "L&N",
+      "entity_type": "corporation",
+      "id": 132,
+      "created_at": 1702735991
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 133,
+      "created_at": 1702735997,
+      "hex": "E6",
+      "tile": "15-0",
+      "rotation": 2
+    },
+    {
+      "type": "assign",
+      "entity": "SNAR",
+      "entity_type": "company",
+      "id": 134,
+      "created_at": 1702736000,
+      "target": "E6",
+      "target_type": "hex"
+    },
+    {
+      "type": "pass",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 135,
+      "created_at": 1702736003
+    },
+    {
+      "type": "run_routes",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 136,
+      "created_at": 1702736007,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "E6",
+              "C6"
+            ],
+            [
+              "C6",
+              "B5",
+              "C4"
+            ],
+            [
+              "C4",
+              "A4"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "C6",
+            "C4",
+            "A4"
+          ],
+          "revenue": 110,
+          "revenue_str": "E6-C6-C4-A4 + Coal(E6)",
+          "nodes": [
+            "E6-0",
+            "C6-0",
+            "C4-0",
+            "A4-0"
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "E6",
+              "D7"
+            ]
+          ],
+          "hexes": [
+            "E6",
+            "D7"
+          ],
+          "revenue": 50,
+          "revenue_str": "E6-D7 + Coal(E6)",
+          "nodes": [
+            "E6-0",
+            "D7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 137,
+      "created_at": 1702736009,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NDY",
+      "entity_type": "company",
+      "id": 138,
+      "created_at": 1705275771,
+      "train": "4-0",
+      "price": 150,
+      "variant": "4"
+    },
+    {
+      "type": "end_game",
+      "entity": "TAG",
+      "entity_type": "corporation",
+      "id": 139,
+      "created_at": 1705275807
+    }
+  ],
+  "id": "hs_pzujrnou_144868",
+  "players": [
+    {
+      "id": 10505,
+      "name": "saccenti"
+    },
+    {
+      "id": 12593,
+      "name": "flyingmonkey127"
+    },
+    {
+      "id": 399,
+      "name": "timox"
+    }
+  ],
+  "title": "18AL",
+  "description": "Casual pace, 1+ move/day",
+  "min_players": 3,
+  "max_players": 3,
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "settings": {
+    "seed": 144868,
+    "is_async": true,
+    "unlisted": false,
+    "legacy_seed": 215162267,
+    "auto_routing": true,
+    "player_order": [
+      10505,
+      12593,
+      399
+    ],
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "turn": 3,
+  "round": "Operating Round",
+  "acting": [
+    10505
+  ],
+  "result": {
+    "10505": 768,
+    "12593": 824,
+    "399": 850
+  },
+  "loaded": true,
+  "created_at": "2024-01-14",
+  "updated_at": 1705275807,
+  "finished_at": 1703096693,
+  "mode": "hotseat",
+  "manually_ended": true
+}


### PR DESCRIPTION
Fixes #10023

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

    Similar to #10098

    This is slightly different though, because there is only a single train buy allowed, the appropriate step here isn't 'buy_train' but instead is 'single_depot_train_buy'.  Same logic applies though, 'buying_trains' does not pass the "right time" check.

* **Screenshots**

* **Any Assumptions / Hacks**
