### PR TITLE
[1822CA] minors also get the sawmill bonus

### DIFF
--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -503,7 +503,6 @@ module Engine
         end
 
         def receives_sawmill_bonus?(entity)
-          return false if entity.type != :major
           return @sawmill_owner == entity if @sawmill_owner
 
           true


### PR DESCRIPTION
Fixes #10176

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

My reading of the rules is that minors are allowed to get the sawmill bonus, it says "all companies" get the bonus if sawmill is `Open` and doesn't state minors don't get that bonus

It does say that only Majors may acquire the P13

Game is alpha so pins not needed. This would result in more money being paid out so unlikely to break games

* **Screenshots**

![image](https://github.com/tobymao/18xx/assets/1711810/de80200f-2ce6-4b52-b54f-0df5e8a6493d)


* **Any Assumptions / Hacks**
