### PR TITLE
implements full price sales on unoperated corps

### DIFF
--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -4,7 +4,7 @@ require_relative 'entities'
 require_relative 'map'
 require_relative 'meta'
 require_relative '../base'
-require_relative '../trainless_shares_half_value'
+require_relative 'trainless_shares_half_value'
 require_relative '../../distance_graph'
 
 module Engine

--- a/lib/engine/game/g_1860/meta.rb
+++ b/lib/engine/game/g_1860/meta.rb
@@ -44,6 +44,11 @@ module Engine
             short_name: 'Re-enter hexes',
             desc: 'Routes may enter the same hex more than once, so long as no track is re-used.',
           },
+          {
+            sym: :non_operated_full_value,
+            short_name: 'Non-operated shares worth full value',
+            desc: 'Shares of unoperated corps sell for full value',
+          },
         ].freeze
       end
     end

--- a/lib/engine/game/g_1860/trainless_shares_half_value.rb
+++ b/lib/engine/game/g_1860/trainless_shares_half_value.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative '../trainless_shares_half_value'
+
+module Engine
+  module Game
+    module G1860
+      module TrainlessSharesHalfValue
+        def bundles_for_corporation(share_holder, corporation, shares: nil)
+          return [] unless corporation.ipoed
+
+          shares = (shares || share_holder.shares_of(corporation)).sort_by(&:price)
+
+          shares.flat_map.with_index do |share, index|
+            bundle = shares.take(index + 1)
+            percent = bundle.sum(&:percent)
+            bundles = [Engine::ShareBundle.new(bundle, percent)]
+            if share.president
+              normal_percent = corporation.share_percent
+              difference = corporation.presidents_percent - normal_percent
+              num_partial_bundles = difference / normal_percent
+              (1..num_partial_bundles).each do |n|
+                bundles.insert(0, Engine::ShareBundle.new(bundle, percent - (normal_percent * n)))
+              end
+            end
+            if @optional_rules&.include?(:non_operated_full_value) && corporation.operating_history.empty?
+              bundles.each { |b| b.share_price = b.price_per_share.to_i }
+            else
+              bundles.each { |b| b.share_price = (b.price_per_share / 2).to_i if corporation.trains.empty? }
+            end
+            bundles
+          end
+        end
+
+        def player_value(player)
+          trainless_shares, train_shares = player.shares.partition { |s| s.corporation.trains.empty? }
+          if @optional_rules&.include?(:non_operated_full_value)
+            unoperated_corps, operated_corps = trainless_shares.partition { |s| s.corporation.operating_history.empty? }
+            player.cash + player.companies.sum(&:value) + unoperated_corps.sum(&:price) + operated_corps.sum do |s|
+                                                                                            (s.price / 2).to_i
+                                                                                          end
+          else
+            player.cash + train_shares.sum(&:price) + trainless_shares.sum do |s|
+                                                        (s.price / 2).to_i
+                                                      end + player.companies.sum(&:value)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Implements the variant from the screenshot below: 
![image](https://github.com/tobymao/18xx/assets/26125362/19f8db74-66c6-4213-a3a9-8672eeb1abf6)

* **Screenshots**

* **Any Assumptions / Hacks**
I created a new trainless_shares_half_value directly in the 1860 folder for this purpose. 
