### PR TITLE
[18GA] Adds a reduced token variant from the rules

### DIFF
--- a/lib/engine/game/g_18_ga/game.rb
+++ b/lib/engine/game/g_18_ga/game.rb
@@ -79,6 +79,8 @@ module Engine
 
           neutral.tokens.each { |token| token.type = :neutral }
 
+          corporation_by_id('CoG').tokens.pop if @optional_rules&.include?(:remove_cog_token)
+
           city_by_id('E1-0-0').place_token(neutral, neutral.next_token)
           city_by_id('J4-0-0').place_token(neutral, neutral.next_token)
 

--- a/lib/engine/game/g_18_ga/meta.rb
+++ b/lib/engine/game/g_18_ga/meta.rb
@@ -30,6 +30,11 @@ module Engine
             desc: 'The Georgia & Florida Railroad home is moved from Albany to Columbus',
           },
           {
+            sym: :remove_cog_token,
+            short_name: 'Reduce CoG token',
+            desc: 'CoG has one fewer station token than normal',
+          },
+          {
             sym: :soft_rust_4t,
             short_name: 'Soft rust',
             desc: '4 trains run once more after 8 train is bought',


### PR DESCRIPTION

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Implements a variant rule from the rulebook where Central of Georgia has one token fewer than usual.

* **Screenshots**

* **Any Assumptions / Hacks**
