### PR TITLE
[18nl] esthetic update to hex E6

### DIFF
--- a/lib/engine/game/g_18_nl/map.rb
+++ b/lib/engine/game/g_18_nl/map.rb
@@ -183,7 +183,7 @@ module Engine
             ['E4'] => 'city=revenue:0;upgrade=cost:80,terrain:water',
           },
           yellow: {
-            ['E6'] => 'city=revenue:40,loc:1;city=revenue:40,loc:5;path=a:1,b:_0;path=a:5,b:_1;upgrade=cost:80,terrain:water;'\
+            ['E6'] => 'city=revenue:40,loc:2;city=revenue:40,loc:5;path=a:1,b:_0;path=a:5,b:_1;upgrade=cost:80,terrain:water;'\
                       'label=X',
             ['G2'] => 'city=revenue:30;city=revenue:30,loc:5;path=a:3,b:_0;path=a:4,b:_1;label=X',
             ['H3'] => 'city=revenue:30;city=revenue:30,loc:5;path=a:3,b:_0;path=a:5,b:_1;upgrade=cost:80,terrain:water;label=X',


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Tweaked the map code of E6 so elements aren't overlapping. 

* **Screenshots**

Before: 
![image](https://github.com/tobymao/18xx/assets/26125362/2718c517-c2d0-4b2f-8213-ef545683e479)

After:
![image](https://github.com/tobymao/18xx/assets/26125362/10b25ee4-2da7-4f28-be13-c3ac47051cbc)


* **Any Assumptions / Hacks**
