### PR TITLE
1841: add and use new parameter for SharePool.transfer_shares

### DIFF
--- a/lib/engine/game/g_1841/game.rb
+++ b/lib/engine/game/g_1841/game.rb
@@ -2085,10 +2085,10 @@ module Engine
           tshares.each_with_index do |share, i|
             if i.even?
               @log << "Moving #{share.percent}% share of #{share.corporation.name} from #{old.name} to #{newa.name} treasury"
-              @share_pool.transfer_shares(share.to_bundle, newa, allow_president_change: true)
+              @share_pool.transfer_shares(share.to_bundle, newa, allow_president_change: true, corporate_transfer: true)
             else
               @log << "Moving #{share.percent}% share of #{share.corporation.name} from #{old.name} to #{newb.name} treasury"
-              @share_pool.transfer_shares(share.to_bundle, newb, allow_president_change: true)
+              @share_pool.transfer_shares(share.to_bundle, newb, allow_president_change: true, corporate_transfer: true)
             end
           end
         end

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -177,7 +177,8 @@ module Engine
                         allow_president_change: true,
                         swap: nil,
                         borrow_from: nil,
-                        swap_to_entity: nil)
+                        swap_to_entity: nil,
+                        corporate_transfer: nil)
       corporation = bundle.corporation
       owner = bundle.owner
       previous_president = bundle.president
@@ -287,7 +288,7 @@ module Engine
       # previous president if they haven't sold the president's share
       # give the president the president's share
       # if the owner only sold half of their president's share, take one away
-      if owner.player? && to_entity.player? && bundle.presidents_share
+      if ((owner.player? && to_entity.player?) || corporate_transfer) && bundle.presidents_share
         # special case when doing a player-to-player purchase of the president's share
         transfer_to = to_entity
         swap_to = to_entity


### PR DESCRIPTION
Fixes #10158 

This adds a parameter to SharePool::transfer_shares to handle moving a president certificate between corporations correctly. It is needed for mergers in 1841.