### PR TITLE
[1822PNW] P19 may be used on mountain hexes w/ a cost

### DIFF
--- a/lib/engine/game/g_1822_pnw/entities.rb
+++ b/lib/engine/game/g_1822_pnw/entities.rb
@@ -414,7 +414,7 @@ module Engine
                 when: 'track',
                 count: 1,
                 closed_when_used_up: false,
-                hexes: %w[A16 B15 C14 D15 E16 F17 H17 I18 K16 L15 M14 N13],
+                hexes: %w[A16 B15 C14 D15 E16 F17 G4 G18 H5 I6 H17 I18 J17 K16 L15 M14 N13],
                 tiles: %w[PNW4],
               },
             ],

--- a/lib/engine/game/g_1822_pnw/entities.rb
+++ b/lib/engine/game/g_1822_pnw/entities.rb
@@ -414,7 +414,7 @@ module Engine
                 when: 'track',
                 count: 1,
                 closed_when_used_up: false,
-                hexes: %w[B15 C14 D15 E16 F17 H17 I18 K16 L15],
+                hexes: %w[A16 B15 C14 D15 E16 F17 H17 I18 K16 L15 M14 N13],
                 tiles: %w[PNW4],
               },
             ],


### PR DESCRIPTION
Fixes #10191

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**


Add the 75 and 100 cost mountain hexes to P19

* **Screenshots**

Selecting the P19 at this step shows the "build cost" mountain hex (N13) as buildable


https://gist.github.com/benjaminxscott/bc798e0f0a1393d3e476be453b6b4989

![image](https://github.com/tobymao/18xx/assets/1711810/700b9180-822d-4fc5-964f-9c44ee311315)


![image](https://github.com/tobymao/18xx/assets/1711810/e3c0b705-528f-4c32-a259-2339243a60f1)


* **Any Assumptions / Hacks**
