### PR TITLE
[1822CA] hard code legal rotations for big city tiles

### DIFF
--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -864,6 +864,26 @@ module Engine
         def destinated?(entity)
           @destinated[entity]
         end
+
+        def legal_tile_rotation?(_entity, _hex, tile)
+          # special checks for the big cities
+          legal_rotations =
+            case tile.name
+            when 'M5', 'M6', 'M8', 'O2', 'O6', 'O8', 'Q6', 'Q8', 'T1', 'T2', 'T3', 'T4', 'T5', 'W2', 'W4', 'W5', 'W6', 'W7'
+              [0]
+            when 'M1', 'M2', 'M3', 'M4', 'O7'
+              [0, 5]
+            when 'M7', 'O1', 'O3', 'O4', 'O5'
+              [0, 1]
+            when 'Q1', 'Q2', 'Q3', 'Q4', 'Q5', 'Q7'
+              [0, 3, 5]
+            when 'W3'
+              [0, 2, 3]
+            end
+          return false if legal_rotations && !legal_rotations.include?(tile.rotation)
+
+          super
+        end
       end
     end
   end

--- a/spec/game_state_spec.rb
+++ b/spec/game_state_spec.rb
@@ -600,6 +600,32 @@ module Engine
 
       describe 2 do
         describe 'Winnipeg tile actions' do
+          it 'does not allow tile W3 with rotation 1, 4, or 5' do
+            action_index = 374
+            game = game_at_action(game_file, action_index)
+            winnipeg_hex = game.hex_by_id('N16')
+
+            w1_tile = game.tile_by_id('W1-0')
+            expect(winnipeg_hex.tile).to be(w1_tile)
+
+            entity = game.current_entity
+
+            w3_tile = game.tile_by_id('W3-0')
+            w3_tile.rotate!(0)
+            expect(game.legal_tile_rotation?(entity, winnipeg_hex, w3_tile)).to eq(true)
+            w3_tile.rotate!(2)
+            expect(game.legal_tile_rotation?(entity, winnipeg_hex, w3_tile)).to eq(true)
+            w3_tile.rotate!(3)
+            expect(game.legal_tile_rotation?(entity, winnipeg_hex, w3_tile)).to eq(true)
+
+            w3_tile.rotate!(1)
+            expect(game.legal_tile_rotation?(entity, winnipeg_hex, w3_tile)).to eq(false)
+            w3_tile.rotate!(4)
+            expect(game.legal_tile_rotation?(entity, winnipeg_hex, w3_tile)).to eq(false)
+            w3_tile.rotate!(5)
+            expect(game.legal_tile_rotation?(entity, winnipeg_hex, w3_tile)).to eq(false)
+          end
+
           it 'the correct cities join up for tile #W2' do
             action_index = 374
 


### PR DESCRIPTION
some illegal cases are slipping through the logic in `upgrades_to?`

Fixes #10164
