### PR TITLE
[rollingstock] market can have more than 5 shares

### DIFF
--- a/lib/engine/game/g_rolling_stock/game.rb
+++ b/lib/engine/game/g_rolling_stock/game.rb
@@ -39,6 +39,7 @@ module Engine
         BANK_CASH = 10_000
         STARTING_CASH = { 2 => 30, 3 => 30, 4 => 30, 5 => 30, 6 => 25 }.freeze
 
+        MARKET_SHARE_LIMIT = 100
         MARKET = [
           %w[0c
              5


### PR DESCRIPTION
Fixes #10215

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Override the default 50% limit

Should also cover RSS since it imports the RS config

* **Screenshots**

* **Any Assumptions / Hacks**
