### PR TITLE
[1856] Move stock marker up if sold out in SR1

### DIFF
--- a/lib/engine/game/g_1856/round/stock.rb
+++ b/lib/engine/game/g_1856/round/stock.rb
@@ -20,6 +20,10 @@ module Engine
             players_unvested_holdings[@entities[@entity_index]] = nil
             super
           end
+
+          def corporations_to_move_price
+            super.concat(@game.corporations.select { |c| sold_out?(c) }).uniq
+          end
         end
       end
     end

--- a/public/fixtures/1856/README.md
+++ b/public/fixtures/1856/README.md
@@ -28,3 +28,6 @@ hotseat002: (needs replacement)
 
  51745
  * Based off of #51745 - confirm that the nationalization of the Kitchener token is free
+
+ move_up_price_sr1
+ * confirm that price of a company moves up if sold out at the end of SR1

--- a/public/fixtures/1856/hotseat001.json
+++ b/public/fixtures/1856/hotseat001.json
@@ -1,1 +1,1032 @@
-{"status":"finished","actions":[{"type":"bid","entity":"Player 1","entity_type":"player","id":1,"created_at":1614998326,"company":"FT","price":20,"original_id":1},{"type":"bid","entity":"Player 2","entity_type":"player","id":2,"created_at":1614998327,"company":"WSRC","price":40,"original_id":2},{"type":"bid","entity":"Player 3","entity_type":"player","id":3,"created_at":1614998328,"company":"TCC","price":50,"original_id":3},{"type":"bid","entity":"Player 1","entity_type":"player","id":4,"created_at":1614998329,"company":"GLSC","price":70,"original_id":4},{"type":"bid","entity":"Player 2","entity_type":"player","id":5,"created_at":1614998330,"company":"NFSBC","price":100,"original_id":5},{"type":"bid","entity":"Player 3","entity_type":"player","id":6,"created_at":1614998330,"company":"SCFTC","price":100,"original_id":6},{"type":"par","entity":"Player 1","entity_type":"player","id":7,"created_at":1614998334,"corporation":"BBG","share_price":"65,5,4","original_id":7},{"type":"par","entity":"Player 2","entity_type":"player","id":8,"created_at":1614998336,"corporation":"WGB","share_price":"65,5,4","original_id":8},{"type":"buy_shares","entity":"Player 3","entity_type":"player","id":9,"created_at":1614998338,"shares":["WGB_1"],"percent":10,"original_id":9},{"type":"buy_shares","entity":"Player 1","entity_type":"player","id":10,"created_at":1614998339,"shares":["WGB_2"],"percent":10,"original_id":10},{"type":"buy_shares","entity":"Player 2","entity_type":"player","id":11,"created_at":1614998340,"shares":["WGB_3"],"percent":10,"original_id":11},{"type":"buy_shares","entity":"Player 3","entity_type":"player","id":12,"created_at":1614998341,"shares":["WGB_4"],"percent":10,"original_id":12},{"type":"buy_shares","entity":"Player 1","entity_type":"player","id":13,"created_at":1614998342,"shares":["WGB_5"],"percent":10,"original_id":13},{"type":"buy_shares","entity":"Player 2","entity_type":"player","id":14,"created_at":1614998343,"shares":["WGB_6"],"percent":10,"original_id":14},{"type":"buy_shares","entity":"Player 3","entity_type":"player","id":15,"created_at":1614998344,"shares":["WGB_7"],"percent":10,"original_id":15},{"type":"buy_shares","entity":"Player 1","entity_type":"player","id":16,"created_at":1614998345,"shares":["WGB_8"],"percent":10,"original_id":16},{"type":"pass","entity":"Player 2","entity_type":"player","id":17,"created_at":1614998346,"original_id":17},{"type":"pass","entity":"Player 3","entity_type":"player","id":18,"created_at":1614998347,"original_id":18},{"type":"pass","entity":"Player 1","entity_type":"player","id":19,"created_at":1614998347,"original_id":19},{"type":"lay_tile","entity":"BBG","entity_type":"corporation","id":20,"created_at":1614998351,"auto_actions":[{"type":"destination_connection","entity":"BBG","entity_type":"corporation","created_at":1614998351,"corporations":[]}],"hex":"J15","tile":"57-0","rotation":0,"original_id":20},{"type":"buy_train","entity":"BBG","entity_type":"corporation","id":21,"created_at":1614998352,"train":"2-0","price":100,"variant":"2","original_id":21},{"type":"pass","entity":"BBG","entity_type":"corporation","id":22,"created_at":1614998353,"original_id":22},{"type":"lay_tile","entity":"WGB","entity_type":"corporation","id":23,"created_at":1614998356,"auto_actions":[{"type":"destination_connection","entity":"WGB","entity_type":"corporation","created_at":1614998356,"corporations":[]}],"hex":"J11","tile":"57-1","rotation":0,"original_id":23},{"type":"buy_train","entity":"WGB","entity_type":"corporation","id":24,"created_at":1614998359,"train":"2-1","price":100,"variant":"2","original_id":24},{"type":"buy_train","entity":"WGB","entity_type":"corporation","id":25,"created_at":1614998359,"train":"2-2","price":100,"variant":"2","original_id":25},{"type":"buy_train","entity":"WGB","entity_type":"corporation","id":26,"created_at":1614998359,"train":"2-3","price":100,"variant":"2","original_id":26},{"type":"pass","entity":"WGB","entity_type":"corporation","id":27,"created_at":1614998362,"original_id":27},{"type":"pass","entity":"WGB","entity_type":"corporation","id":28,"created_at":1614998363,"original_id":28},{"type":"par","entity":"Player 2","entity_type":"player","id":29,"created_at":1614998371,"corporation":"CA","share_price":"65,5,4","original_id":29},{"type":"pass","entity":"Player 2","entity_type":"player","id":30,"created_at":1614998374,"original_id":30},{"type":"buy_shares","entity":"Player 3","entity_type":"player","id":31,"created_at":1614998375,"shares":["CA_1"],"percent":10,"original_id":31},{"type":"pass","entity":"Player 3","entity_type":"player","id":32,"created_at":1614998377,"original_id":32},{"type":"buy_shares","entity":"Player 1","entity_type":"player","id":33,"created_at":1614998378,"shares":["CA_2"],"percent":10,"original_id":33},{"type":"pass","entity":"Player 1","entity_type":"player","id":34,"created_at":1614998379,"original_id":34},{"type":"pass","entity":"Player 2","entity_type":"player","id":35,"created_at":1614998382,"original_id":35},{"type":"buy_shares","entity":"Player 3","entity_type":"player","id":36,"created_at":1614998383,"shares":["BBG_1"],"percent":10,"original_id":36},{"type":"pass","entity":"Player 3","entity_type":"player","id":37,"created_at":1614998385,"original_id":37},{"type":"pass","entity":"Player 1","entity_type":"player","id":38,"created_at":1614998387,"original_id":38},{"type":"pass","entity":"Player 2","entity_type":"player","id":39,"created_at":1614998387,"original_id":39},{"type":"pass","entity":"Player 3","entity_type":"player","id":40,"created_at":1614998388,"original_id":40},{"type":"take_loan","entity":"CA","entity_type":"corporation","id":41,"created_at":1614998392,"loan":0,"original_id":41},{"type":"pass","entity":"CA","entity_type":"corporation","id":42,"created_at":1614998392,"auto_actions":[{"type":"destination_connection","entity":"CA","entity_type":"corporation","created_at":1614998392,"corporations":[]}],"original_id":42},{"type":"buy_train","entity":"CA","entity_type":"corporation","id":43,"created_at":1614998393,"train":"2-4","price":100,"variant":"2","original_id":43},{"type":"buy_train","entity":"CA","entity_type":"corporation","id":44,"created_at":1614998399,"train":"2-1","price":250,"original_id":44},{"type":"lay_tile","entity":"WGB","entity_type":"corporation","id":45,"created_at":1614998404,"auto_actions":[{"type":"destination_connection","entity":"WGB","entity_type":"corporation","created_at":1614998404,"corporations":[]}],"hex":"J9","tile":"4-0","rotation":0,"original_id":46},{"type":"run_routes","entity":"WGB","entity_type":"corporation","id":46,"created_at":1614998407,"routes":[{"train":"2-2","connections":[["J11","J9"]],"hexes":["J9","J11"],"revenue":30,"revenue_str":"J9-J11"}],"original_id":47},{"type":"dividend","entity":"WGB","entity_type":"corporation","id":47,"created_at":1614998408,"kind":"payout","original_id":48},{"type":"buy_train","entity":"WGB","entity_type":"corporation","id":48,"created_at":1614998423,"train":"2-1","price":275,"original_id":49},{"type":"pass","entity":"WGB","entity_type":"corporation","id":49,"created_at":1614998424,"original_id":50},{"type":"lay_tile","entity":"BBG","entity_type":"corporation","id":50,"created_at":1614998427,"auto_actions":[{"type":"destination_connection","entity":"BBG","entity_type":"corporation","created_at":1614998427,"corporations":[]}],"hex":"J13","tile":"57-2","rotation":0,"original_id":51},{"type":"pass","entity":"BBG","entity_type":"corporation","id":51,"created_at":1614998429,"original_id":52},{"type":"run_routes","entity":"BBG","entity_type":"corporation","id":52,"created_at":1614998432,"routes":[{"train":"2-0","connections":[["J15","J13"]],"hexes":["J13","J15"],"revenue":40,"revenue_str":"J13-J15"}],"original_id":53},{"type":"dividend","entity":"BBG","entity_type":"corporation","id":53,"created_at":1614998433,"kind":"payout","original_id":54},{"type":"take_loan","entity":"BBG","entity_type":"corporation","id":54,"created_at":1614998438,"loan":1,"original_id":57},{"type":"buy_train","entity":"BBG","entity_type":"corporation","id":55,"created_at":1614998439,"train":"2'-0","price":100,"variant":"2'","original_id":58},{"type":"pass","entity":"BBG","entity_type":"corporation","id":56,"created_at":1614998439,"original_id":59},{"type":"pass","entity":"Player 1","entity_type":"player","id":57,"created_at":1614998441,"original_id":61},{"type":"pass","entity":"Player 2","entity_type":"player","id":58,"created_at":1614998441,"original_id":62},{"type":"pass","entity":"Player 3","entity_type":"player","id":59,"created_at":1614998441,"original_id":63},{"type":"lay_tile","entity":"WGB","entity_type":"corporation","id":60,"created_at":1614998444,"auto_actions":[{"type":"destination_connection","entity":"WGB","entity_type":"corporation","created_at":1614998444,"corporations":[]}],"hex":"J7","tile":"8-0","rotation":0,"original_id":64},{"type":"pass","entity":"WGB","entity_type":"corporation","id":61,"created_at":1614998446,"original_id":65},{"type":"run_routes","entity":"WGB","entity_type":"corporation","id":62,"created_at":1614998447,"routes":[{"train":"2-2","connections":[["J11","J9"]],"hexes":["J11","J9"],"revenue":30,"revenue_str":"J11-J9"}],"original_id":66},{"type":"dividend","entity":"WGB","entity_type":"corporation","id":63,"created_at":1614998448,"kind":"payout","original_id":67},{"type":"pass","entity":"WGB","entity_type":"corporation","id":64,"created_at":1614998449,"original_id":68},{"type":"lay_tile","entity":"BBG","entity_type":"corporation","id":65,"created_at":1614998453,"auto_actions":[{"type":"destination_connection","entity":"BBG","entity_type":"corporation","created_at":1614998453,"corporations":[]}],"hex":"J17","tile":"56-0","rotation":1,"original_id":69},{"type":"pass","entity":"BBG","entity_type":"corporation","id":66,"created_at":1614998455,"original_id":70},{"type":"run_routes","entity":"BBG","entity_type":"corporation","id":67,"created_at":1614998456,"routes":[{"train":"2-0","connections":[["J15","J13"]],"hexes":["J15","J13"],"revenue":40,"revenue_str":"J15-J13"}],"original_id":71},{"type":"dividend","entity":"BBG","entity_type":"corporation","id":68,"created_at":1614998457,"kind":"payout","original_id":72},{"type":"pass","entity":"BBG","entity_type":"corporation","id":69,"created_at":1614998457,"original_id":73},{"type":"pass","entity":"BBG","entity_type":"corporation","id":70,"created_at":1614998458,"original_id":74},{"type":"pass","entity":"CA","entity_type":"corporation","id":71,"created_at":1614998459,"auto_actions":[{"type":"destination_connection","entity":"CA","entity_type":"corporation","created_at":1614998459,"corporations":[]}],"original_id":75},{"type":"buy_train","entity":"CA","entity_type":"corporation","id":72,"created_at":1614998463,"train":"3-0","price":225,"variant":"3","original_id":78},{"type":"pass","entity":"CA","entity_type":"corporation","id":73,"created_at":1614998464,"original_id":79},{"type":"pass","entity":"CA","entity_type":"corporation","id":74,"created_at":1614998465,"original_id":80},{"type":"pass","entity":"CA","entity_type":"corporation","id":75,"created_at":1614998465,"original_id":81},{"type":"pass","entity":"Player 1","entity_type":"player","id":76,"created_at":1614998467,"original_id":82},{"type":"pass","entity":"Player 2","entity_type":"player","id":77,"created_at":1614998467,"original_id":83},{"type":"pass","entity":"Player 3","entity_type":"player","id":78,"created_at":1614998467,"original_id":84},{"type":"lay_tile","entity":"WGB","entity_type":"corporation","id":79,"created_at":1614998470,"auto_actions":[{"type":"destination_connection","entity":"WGB","entity_type":"corporation","created_at":1614998470,"corporations":["WGB"]}],"hex":"I6","tile":"9-0","rotation":2,"original_id":85},{"type":"pass","entity":"WGB","entity_type":"corporation","id":80,"created_at":1614998471,"original_id":86},{"type":"run_routes","entity":"WGB","entity_type":"corporation","id":81,"created_at":1614998475,"routes":[{"train":"2-2","connections":[["J11","J9"]],"hexes":["J11","J9"],"revenue":30,"revenue_str":"J11-J9"}],"original_id":87},{"type":"dividend","entity":"WGB","entity_type":"corporation","id":82,"created_at":1614998475,"kind":"payout","original_id":88},{"type":"buy_train","entity":"WGB","entity_type":"corporation","id":83,"created_at":1614998477,"train":"3-1","price":225,"variant":"3","original_id":89},{"type":"pass","entity":"WGB","entity_type":"corporation","id":84,"created_at":1614998480,"original_id":90},{"type":"pass","entity":"WGB","entity_type":"corporation","id":85,"created_at":1614998481,"original_id":91},{"type":"pass","entity":"BBG","entity_type":"corporation","id":86,"created_at":1614998482,"auto_actions":[{"type":"destination_connection","entity":"BBG","entity_type":"corporation","created_at":1614998482,"corporations":[]}],"original_id":92},{"type":"end_game","entity":"BBG","entity_type":"corporation","id":87,"created_at":1614998488,"original_id":93}],"id":"hs_kembbzhz_1614998324","players":[{"name":"Player 1"},{"name":"Player 2"},{"name":"Player 3"}],"title":"1856","description":"","max_players":"3","settings":{"optional_rules":[]},"mode":"hotseat","user":{"id":0,"name":"You"},"created_at":"2021-03-05","loaded":true,"result":{"Player 2":756,"Player 3":735,"Player 1":698},"turn":4,"round":"Operating Round","acting":["Player 1"],"updated_at":1614998488}
+{
+    "status": "finished",
+    "actions": [
+        {
+            "type": "bid",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 1,
+            "created_at": 1614998326,
+            "company": "FT",
+            "price": 20,
+            "original_id": 1
+        },
+        {
+            "type": "bid",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 2,
+            "created_at": 1614998327,
+            "company": "WSRC",
+            "price": 40,
+            "original_id": 2
+        },
+        {
+            "type": "bid",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 3,
+            "created_at": 1614998328,
+            "company": "TCC",
+            "price": 50,
+            "original_id": 3
+        },
+        {
+            "type": "bid",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 4,
+            "created_at": 1614998329,
+            "company": "GLSC",
+            "price": 70,
+            "original_id": 4
+        },
+        {
+            "type": "bid",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 5,
+            "created_at": 1614998330,
+            "company": "NFSBC",
+            "price": 100,
+            "original_id": 5
+        },
+        {
+            "type": "bid",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 6,
+            "created_at": 1614998330,
+            "company": "SCFTC",
+            "price": 100,
+            "original_id": 6
+        },
+        {
+            "type": "par",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 7,
+            "created_at": 1614998334,
+            "corporation": "BBG",
+            "share_price": "65,5,4",
+            "original_id": 7
+        },
+        {
+            "type": "par",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 8,
+            "created_at": 1614998336,
+            "corporation": "WGB",
+            "share_price": "65,5,4",
+            "original_id": 8
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 9,
+            "created_at": 1614998338,
+            "shares": [
+                "WGB_1"
+            ],
+            "percent": 10,
+            "original_id": 9
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 10,
+            "created_at": 1614998339,
+            "shares": [
+                "WGB_2"
+            ],
+            "percent": 10,
+            "original_id": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 11,
+            "created_at": 1614998340,
+            "shares": [
+                "WGB_3"
+            ],
+            "percent": 10,
+            "original_id": 11
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 12,
+            "created_at": 1614998341,
+            "shares": [
+                "WGB_4"
+            ],
+            "percent": 10,
+            "original_id": 12
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 13,
+            "created_at": 1614998342,
+            "shares": [
+                "WGB_5"
+            ],
+            "percent": 10,
+            "original_id": 13
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 14,
+            "created_at": 1614998343,
+            "shares": [
+                "WGB_6"
+            ],
+            "percent": 10,
+            "original_id": 14
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 15,
+            "created_at": 1614998344,
+            "shares": [
+                "WGB_7"
+            ],
+            "percent": 10,
+            "original_id": 15
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 16,
+            "created_at": 1614998345,
+            "shares": [
+                "WGB_8"
+            ],
+            "percent": 10,
+            "original_id": 16
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 17,
+            "created_at": 1614998346,
+            "original_id": 17
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 18,
+            "created_at": 1614998347,
+            "original_id": 18
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 19,
+            "created_at": 1614998347,
+            "original_id": 19
+        },
+        {
+            "type": "lay_tile",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 20,
+            "created_at": 1614998351,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "BBG",
+                    "entity_type": "corporation",
+                    "created_at": 1614998351,
+                    "corporations": []
+                }
+            ],
+            "hex": "J15",
+            "tile": "57-0",
+            "rotation": 0,
+            "original_id": 20
+        },
+        {
+            "type": "buy_train",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 21,
+            "created_at": 1614998352,
+            "train": "2-0",
+            "price": 100,
+            "variant": "2",
+            "original_id": 21
+        },
+        {
+            "type": "pass",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 22,
+            "created_at": 1614998353,
+            "original_id": 22
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 23,
+            "created_at": 1614998356,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "WGB",
+                    "entity_type": "corporation",
+                    "created_at": 1614998356,
+                    "corporations": []
+                }
+            ],
+            "hex": "J11",
+            "tile": "57-1",
+            "rotation": 0,
+            "original_id": 23
+        },
+        {
+            "type": "buy_train",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 24,
+            "created_at": 1614998359,
+            "train": "2-1",
+            "price": 100,
+            "variant": "2",
+            "original_id": 24
+        },
+        {
+            "type": "buy_train",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 25,
+            "created_at": 1614998359,
+            "train": "2-2",
+            "price": 100,
+            "variant": "2",
+            "original_id": 25
+        },
+        {
+            "type": "buy_train",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 26,
+            "created_at": 1614998359,
+            "train": "2-3",
+            "price": 100,
+            "variant": "2",
+            "original_id": 26
+        },
+        {
+            "type": "pass",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 27,
+            "created_at": 1614998362,
+            "original_id": 27
+        },
+        {
+            "type": "pass",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 28,
+            "created_at": 1614998363,
+            "original_id": 28
+        },
+        {
+            "type": "par",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 29,
+            "created_at": 1614998371,
+            "corporation": "CA",
+            "share_price": "65,5,4",
+            "original_id": 29
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 30,
+            "created_at": 1614998374,
+            "original_id": 30
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 31,
+            "created_at": 1614998375,
+            "shares": [
+                "CA_1"
+            ],
+            "percent": 10,
+            "original_id": 31
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 32,
+            "created_at": 1614998377,
+            "original_id": 32
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 33,
+            "created_at": 1614998378,
+            "shares": [
+                "CA_2"
+            ],
+            "percent": 10,
+            "original_id": 33
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 34,
+            "created_at": 1614998379,
+            "original_id": 34
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 35,
+            "created_at": 1614998382,
+            "original_id": 35
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 36,
+            "created_at": 1614998383,
+            "shares": [
+                "BBG_1"
+            ],
+            "percent": 10,
+            "original_id": 36
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 37,
+            "created_at": 1614998385,
+            "original_id": 37
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 38,
+            "created_at": 1614998387,
+            "original_id": 38
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 39,
+            "created_at": 1614998387,
+            "original_id": 39
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 40,
+            "created_at": 1614998388,
+            "original_id": 40
+        },
+        {
+            "type": "take_loan",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "id": 41,
+            "created_at": 1614998392,
+            "loan": 0,
+            "original_id": 41
+        },
+        {
+            "type": "pass",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "id": 42,
+            "created_at": 1614998392,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "CA",
+                    "entity_type": "corporation",
+                    "created_at": 1614998392,
+                    "corporations": []
+                }
+            ],
+            "original_id": 42
+        },
+        {
+            "type": "buy_train",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "id": 43,
+            "created_at": 1614998393,
+            "train": "2-4",
+            "price": 100,
+            "variant": "2",
+            "original_id": 43
+        },
+        {
+            "type": "buy_train",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "id": 44,
+            "created_at": 1614998399,
+            "train": "2-1",
+            "price": 250,
+            "original_id": 44
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 45,
+            "created_at": 1614998404,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "WGB",
+                    "entity_type": "corporation",
+                    "created_at": 1614998404,
+                    "corporations": []
+                }
+            ],
+            "hex": "J9",
+            "tile": "4-0",
+            "rotation": 0,
+            "original_id": 46
+        },
+        {
+            "type": "run_routes",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 46,
+            "created_at": 1614998407,
+            "routes": [
+                {
+                    "train": "2-2",
+                    "connections": [
+                        [
+                            "J11",
+                            "J9"
+                        ]
+                    ],
+                    "hexes": [
+                        "J9",
+                        "J11"
+                    ],
+                    "revenue": 30,
+                    "revenue_str": "J9-J11"
+                }
+            ],
+            "original_id": 47
+        },
+        {
+            "type": "dividend",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 47,
+            "created_at": 1614998408,
+            "kind": "payout",
+            "original_id": 48
+        },
+        {
+            "type": "buy_train",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 48,
+            "created_at": 1614998423,
+            "train": "2-1",
+            "price": 275,
+            "original_id": 49
+        },
+        {
+            "type": "pass",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 49,
+            "created_at": 1614998424,
+            "original_id": 50
+        },
+        {
+            "type": "lay_tile",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 50,
+            "created_at": 1614998427,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "BBG",
+                    "entity_type": "corporation",
+                    "created_at": 1614998427,
+                    "corporations": []
+                }
+            ],
+            "hex": "J13",
+            "tile": "57-2",
+            "rotation": 0,
+            "original_id": 51
+        },
+        {
+            "type": "pass",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 51,
+            "created_at": 1614998429,
+            "original_id": 52
+        },
+        {
+            "type": "run_routes",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 52,
+            "created_at": 1614998432,
+            "routes": [
+                {
+                    "train": "2-0",
+                    "connections": [
+                        [
+                            "J15",
+                            "J13"
+                        ]
+                    ],
+                    "hexes": [
+                        "J13",
+                        "J15"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "J13-J15"
+                }
+            ],
+            "original_id": 53
+        },
+        {
+            "type": "dividend",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 53,
+            "created_at": 1614998433,
+            "kind": "payout",
+            "original_id": 54
+        },
+        {
+            "type": "take_loan",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 54,
+            "created_at": 1614998438,
+            "loan": 1,
+            "original_id": 57
+        },
+        {
+            "type": "buy_train",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 55,
+            "created_at": 1614998439,
+            "train": "2'-0",
+            "price": 100,
+            "variant": "2'",
+            "original_id": 58
+        },
+        {
+            "type": "pass",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 56,
+            "created_at": 1614998439,
+            "original_id": 59
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 57,
+            "created_at": 1614998441,
+            "original_id": 61
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 58,
+            "created_at": 1614998441,
+            "original_id": 62
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 59,
+            "created_at": 1614998441,
+            "original_id": 63
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 60,
+            "created_at": 1614998444,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "WGB",
+                    "entity_type": "corporation",
+                    "created_at": 1614998444,
+                    "corporations": []
+                }
+            ],
+            "hex": "J7",
+            "tile": "8-0",
+            "rotation": 0,
+            "original_id": 64
+        },
+        {
+            "type": "pass",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 61,
+            "created_at": 1614998446,
+            "original_id": 65
+        },
+        {
+            "type": "run_routes",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 62,
+            "created_at": 1614998447,
+            "routes": [
+                {
+                    "train": "2-2",
+                    "connections": [
+                        [
+                            "J11",
+                            "J9"
+                        ]
+                    ],
+                    "hexes": [
+                        "J11",
+                        "J9"
+                    ],
+                    "revenue": 30,
+                    "revenue_str": "J11-J9"
+                }
+            ],
+            "original_id": 66
+        },
+        {
+            "type": "dividend",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 63,
+            "created_at": 1614998448,
+            "kind": "payout",
+            "original_id": 67
+        },
+        {
+            "type": "pass",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 64,
+            "created_at": 1614998449,
+            "original_id": 68
+        },
+        {
+            "type": "lay_tile",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 65,
+            "created_at": 1614998453,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "BBG",
+                    "entity_type": "corporation",
+                    "created_at": 1614998453,
+                    "corporations": []
+                }
+            ],
+            "hex": "J17",
+            "tile": "56-0",
+            "rotation": 1,
+            "original_id": 69
+        },
+        {
+            "type": "pass",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 66,
+            "created_at": 1614998455,
+            "original_id": 70
+        },
+        {
+            "type": "run_routes",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 67,
+            "created_at": 1614998456,
+            "routes": [
+                {
+                    "train": "2-0",
+                    "connections": [
+                        [
+                            "J15",
+                            "J13"
+                        ]
+                    ],
+                    "hexes": [
+                        "J15",
+                        "J13"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "J15-J13"
+                }
+            ],
+            "original_id": 71
+        },
+        {
+            "type": "dividend",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 68,
+            "created_at": 1614998457,
+            "kind": "payout",
+            "original_id": 72
+        },
+        {
+            "type": "pass",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 69,
+            "created_at": 1614998457,
+            "original_id": 73
+        },
+        {
+            "type": "pass",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 70,
+            "created_at": 1614998458,
+            "original_id": 74
+        },
+        {
+            "type": "pass",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "id": 71,
+            "created_at": 1614998459,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "CA",
+                    "entity_type": "corporation",
+                    "created_at": 1614998459,
+                    "corporations": []
+                }
+            ],
+            "original_id": 75
+        },
+        {
+            "type": "buy_train",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "id": 72,
+            "created_at": 1614998463,
+            "train": "3-0",
+            "price": 225,
+            "variant": "3",
+            "original_id": 78
+        },
+        {
+            "type": "pass",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "id": 73,
+            "created_at": 1614998464,
+            "original_id": 79
+        },
+        {
+            "type": "pass",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "id": 74,
+            "created_at": 1614998465,
+            "original_id": 80
+        },
+        {
+            "type": "pass",
+            "entity": "CA",
+            "entity_type": "corporation",
+            "id": 75,
+            "created_at": 1614998465,
+            "original_id": 81
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 76,
+            "created_at": 1614998467,
+            "original_id": 82
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 77,
+            "created_at": 1614998467,
+            "original_id": 83
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 78,
+            "created_at": 1614998467,
+            "original_id": 84
+        },
+        {
+            "type": "lay_tile",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 79,
+            "created_at": 1614998470,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "WGB",
+                    "entity_type": "corporation",
+                    "created_at": 1614998470,
+                    "corporations": [
+                        "WGB"
+                    ]
+                }
+            ],
+            "hex": "I6",
+            "tile": "9-0",
+            "rotation": 2,
+            "original_id": 85
+        },
+        {
+            "type": "pass",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 80,
+            "created_at": 1614998471,
+            "original_id": 86
+        },
+        {
+            "type": "run_routes",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 81,
+            "created_at": 1614998475,
+            "routes": [
+                {
+                    "train": "2-2",
+                    "connections": [
+                        [
+                            "J11",
+                            "J9"
+                        ]
+                    ],
+                    "hexes": [
+                        "J11",
+                        "J9"
+                    ],
+                    "revenue": 30,
+                    "revenue_str": "J11-J9"
+                }
+            ],
+            "original_id": 87
+        },
+        {
+            "type": "dividend",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 82,
+            "created_at": 1614998475,
+            "kind": "payout",
+            "original_id": 88
+        },
+        {
+            "type": "buy_train",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 83,
+            "created_at": 1614998477,
+            "train": "3-1",
+            "price": 225,
+            "variant": "3",
+            "original_id": 89
+        },
+        {
+            "type": "pass",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 84,
+            "created_at": 1614998480,
+            "original_id": 90
+        },
+        {
+            "type": "pass",
+            "entity": "WGB",
+            "entity_type": "corporation",
+            "id": 85,
+            "created_at": 1614998481,
+            "original_id": 91
+        },
+        {
+            "type": "pass",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 86,
+            "created_at": 1614998482,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "BBG",
+                    "entity_type": "corporation",
+                    "created_at": 1614998482,
+                    "corporations": []
+                }
+            ],
+            "original_id": 92
+        },
+        {
+            "type": "end_game",
+            "entity": "BBG",
+            "entity_type": "corporation",
+            "id": 87,
+            "created_at": 1614998488,
+            "original_id": 93
+        }
+    ],
+    "id": "hs_kembbzhz_1614998324",
+    "players": [
+        {
+            "name": "Player 1"
+        },
+        {
+            "name": "Player 2"
+        },
+        {
+            "name": "Player 3"
+        }
+    ],
+    "title": "1856",
+    "description": "",
+    "max_players": "3",
+    "settings": {
+        "optional_rules": []
+    },
+    "mode": "hotseat",
+    "user": {
+        "id": 0,
+        "name": "You"
+    },
+    "created_at": "2021-03-05",
+    "loaded": true,
+    "result": {
+        "Player 2": 756,
+        "Player 3": 735,
+        "Player 1": 698
+    },
+    "turn": 4,
+    "round": "Operating Round",
+    "acting": [
+        "Player 1"
+    ],
+    "updated_at": 1614998488
+}

--- a/public/fixtures/1856/hotseat001.json
+++ b/public/fixtures/1856/hotseat001.json
@@ -166,20 +166,8 @@
             "original_id": 15
         },
         {
-            "type": "buy_shares",
-            "entity": "Player 1",
-            "entity_type": "player",
-            "id": 16,
-            "created_at": 1614998345,
-            "shares": [
-                "WGB_8"
-            ],
-            "percent": 10,
-            "original_id": 16
-        },
-        {
             "type": "pass",
-            "entity": "Player 2",
+            "entity": "Player 1",
             "entity_type": "player",
             "id": 17,
             "created_at": 1614998346,
@@ -187,7 +175,7 @@
         },
         {
             "type": "pass",
-            "entity": "Player 3",
+            "entity": "Player 2",
             "entity_type": "player",
             "id": 18,
             "created_at": 1614998347,
@@ -195,7 +183,7 @@
         },
         {
             "type": "pass",
-            "entity": "Player 1",
+            "entity": "Player 3",
             "entity_type": "player",
             "id": 19,
             "created_at": 1614998347,
@@ -308,6 +296,26 @@
             "id": 28,
             "created_at": 1614998363,
             "original_id": 28
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 16,
+            "created_at": 1614998345,
+            "shares": [
+                "WGB_8"
+            ],
+            "percent": 10,
+            "original_id": 16
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 30,
+            "created_at": 1614998374,
+            "original_id": 30
         },
         {
             "type": "par",

--- a/public/fixtures/1856/hotseat004.json
+++ b/public/fixtures/1856/hotseat004.json
@@ -902,9 +902,9 @@
     "created_at": "2021-05-28",
     "loaded": true,
     "result": {
-        "Player 1": 884,
-        "Player 3": 863,
-        "Player 2": 863
+        "Player 1": 1004,
+        "Player 3": 953,
+        "Player 2": 953
     },
     "turn": 6,
     "round": "Stock Round",

--- a/public/fixtures/1856/hotseat004.json
+++ b/public/fixtures/1856/hotseat004.json
@@ -1,1 +1,915 @@
-{"status":"finished","actions":[{"type":"bid","entity":"Player 1","entity_type":"player","id":1,"created_at":1622213107,"company":"FT","price":20},{"type":"bid","entity":"Player 2","entity_type":"player","id":2,"created_at":1622213108,"company":"WSRC","price":40},{"type":"bid","entity":"Player 3","entity_type":"player","id":3,"created_at":1622213109,"company":"TCC","price":50},{"type":"bid","entity":"Player 1","entity_type":"player","id":4,"created_at":1622213109,"company":"GLSC","price":70},{"type":"bid","entity":"Player 2","entity_type":"player","id":5,"created_at":1622213110,"company":"NFSBC","price":100},{"type":"bid","entity":"Player 3","entity_type":"player","id":6,"created_at":1622213111,"company":"SCFTC","price":100},{"type":"par","entity":"Player 1","entity_type":"player","id":7,"created_at":1622213125,"corporation":"CV","share_price":"65,5,4"},{"type":"buy_shares","entity":"Player 2","entity_type":"player","id":8,"created_at":1622213126,"shares":["CV_1"],"percent":10},{"type":"buy_shares","entity":"Player 3","entity_type":"player","id":9,"created_at":1622213129,"shares":["CV_2"],"percent":10},{"type":"buy_shares","entity":"Player 1","entity_type":"player","id":10,"created_at":1622213130,"shares":["CV_3"],"percent":10},{"type":"buy_shares","entity":"Player 2","entity_type":"player","id":11,"created_at":1622213131,"shares":["CV_4"],"percent":10},{"type":"buy_shares","entity":"Player 3","entity_type":"player","id":12,"created_at":1622213132,"shares":["CV_5"],"percent":10},{"type":"buy_shares","entity":"Player 1","entity_type":"player","id":13,"created_at":1622213132,"shares":["CV_6"],"percent":10},{"type":"buy_shares","entity":"Player 2","entity_type":"player","id":14,"created_at":1622213133,"shares":["CV_7"],"percent":10},{"type":"buy_shares","entity":"Player 3","entity_type":"player","id":15,"created_at":1622213134,"shares":["CV_8"],"percent":10},{"type":"pass","entity":"Player 1","entity_type":"player","id":16,"created_at":1622213137},{"type":"pass","entity":"Player 2","entity_type":"player","id":17,"created_at":1622213137},{"type":"pass","entity":"Player 3","entity_type":"player","id":18,"created_at":1622213137},{"type":"lay_tile","entity":"CV","entity_type":"corporation","id":19,"created_at":1622213141,"auto_actions":[{"type":"destination_connection","entity":"CV","entity_type":"corporation","created_at":1622213141,"corporations":[]}],"hex":"M12","tile":"7-0","rotation":3},{"type":"buy_train","entity":"CV","entity_type":"corporation","id":20,"created_at":1622213143,"train":"2-0","price":100,"variant":"2"},{"type":"pass","entity":"CV","entity_type":"corporation","id":21,"created_at":1622213143},{"type":"pass","entity":"CV","entity_type":"corporation","id":22,"created_at":1622213145},{"type":"pass","entity":"Player 1","entity_type":"player","id":23,"created_at":1622213145},{"type":"pass","entity":"Player 2","entity_type":"player","id":24,"created_at":1622213146},{"type":"pass","entity":"Player 3","entity_type":"player","id":25,"created_at":1622213146},{"type":"lay_tile","entity":"CV","entity_type":"corporation","id":26,"created_at":1622213148,"auto_actions":[{"type":"destination_connection","entity":"CV","entity_type":"corporation","created_at":1622213148,"corporations":[]}],"hex":"M10","tile":"2-0","rotation":0},{"type":"run_routes","entity":"CV","entity_type":"corporation","id":27,"created_at":1622213151,"routes":[{"train":"2-0","connections":[["N11","M12","M10"]],"hexes":["M10","N11"],"revenue":40,"revenue_str":"M10-N11"}]},{"type":"dividend","entity":"CV","entity_type":"corporation","id":28,"created_at":1622213152,"kind":"payout"},{"type":"pass","entity":"CV","entity_type":"corporation","id":29,"created_at":1622213153},{"type":"pass","entity":"CV","entity_type":"corporation","id":30,"created_at":1622213153},{"type":"pass","entity":"Player 1","entity_type":"player","id":31,"created_at":1622213154},{"type":"pass","entity":"Player 2","entity_type":"player","id":32,"created_at":1622213154},{"type":"pass","entity":"Player 3","entity_type":"player","id":33,"created_at":1622213154},{"type":"lay_tile","entity":"CV","entity_type":"corporation","id":34,"created_at":1622213156,"auto_actions":[{"type":"destination_connection","entity":"CV","entity_type":"corporation","created_at":1622213156,"corporations":[]}],"hex":"M8","tile":"9-0","rotation":0},{"type":"run_routes","entity":"CV","entity_type":"corporation","id":35,"created_at":1622213161,"routes":[{"train":"2-0","connections":[["N11","M12","M10"]],"hexes":["M10","N11"],"revenue":40,"revenue_str":"M10-N11"}]},{"type":"dividend","entity":"CV","entity_type":"corporation","id":36,"created_at":1622213161,"kind":"payout"},{"type":"pass","entity":"CV","entity_type":"corporation","id":37,"created_at":1622213162},{"type":"pass","entity":"CV","entity_type":"corporation","id":38,"created_at":1622213163},{"type":"pass","entity":"Player 1","entity_type":"player","id":39,"created_at":1622213163},{"type":"pass","entity":"Player 2","entity_type":"player","id":40,"created_at":1622213163},{"type":"pass","entity":"Player 3","entity_type":"player","id":41,"created_at":1622213164},{"type":"lay_tile","entity":"CV","entity_type":"corporation","id":42,"created_at":1622213166,"auto_actions":[{"type":"destination_connection","entity":"CV","entity_type":"corporation","created_at":1622213166,"corporations":[]}],"hex":"M6","tile":"4-0","rotation":0,"skip":true},{"type":"run_routes","entity":"CV","entity_type":"corporation","id":43,"created_at":1622213169,"routes":[{"train":"2-0","connections":[["N11","M12","M10"]],"hexes":["N11","M10"],"revenue":40,"revenue_str":"N11-M10"}],"skip":true},{"type":"undo","entity":"CV","entity_type":"corporation","id":44,"created_at":1622213170,"skip":true},{"type":"undo","entity":"CV","entity_type":"corporation","id":45,"created_at":1622214727,"skip":true},{"type":"lay_tile","entity":"CV","entity_type":"corporation","id":46,"created_at":1622215151,"auto_actions":[{"type":"destination_connection","entity":"CV","entity_type":"corporation","created_at":1622215151,"corporations":["CPR"]}],"hex":"M6","tile":"4-0","rotation":0},{"type":"run_routes","entity":"CV","entity_type":"corporation","id":47,"created_at":1622215161,"routes":[{"train":"2-0","connections":[["N11","M12","M10"]],"hexes":["N11","M10"],"revenue":40,"revenue_str":"N11-M10"}]},{"type":"dividend","entity":"CV","entity_type":"corporation","id":48,"created_at":1622215161,"kind":"payout"},{"type":"pass","entity":"CV","entity_type":"corporation","id":49,"created_at":1622215162},{"type":"pass","entity":"CV","entity_type":"corporation","id":50,"created_at":1622215163},{"type":"par","entity":"Player 1","entity_type":"player","id":51,"created_at":1622215913,"corporation":"CPR","share_price":"65,5,4"},{"type":"pass","entity":"Player 1","entity_type":"player","id":52,"created_at":1622215916},{"type":"buy_shares","entity":"Player 2","entity_type":"player","id":53,"created_at":1622215917,"shares":["CPR_1"],"percent":10},{"type":"pass","entity":"Player 2","entity_type":"player","id":54,"created_at":1622215918},{"type":"buy_shares","entity":"Player 3","entity_type":"player","id":55,"created_at":1622215919,"shares":["CPR_2"],"percent":10},{"type":"pass","entity":"Player 3","entity_type":"player","id":56,"created_at":1622215920},{"type":"buy_shares","entity":"Player 1","entity_type":"player","id":57,"created_at":1622215921,"shares":["CPR_3"],"percent":10},{"type":"pass","entity":"Player 1","entity_type":"player","id":58,"created_at":1622215922},{"type":"buy_shares","entity":"Player 2","entity_type":"player","id":59,"created_at":1622215923,"shares":["CPR_4"],"percent":10},{"type":"pass","entity":"Player 2","entity_type":"player","id":60,"created_at":1622215924},{"type":"buy_shares","entity":"Player 3","entity_type":"player","id":61,"created_at":1622215925,"shares":["CPR_5"],"percent":10},{"type":"pass","entity":"Player 3","entity_type":"player","id":62,"created_at":1622215926},{"type":"buy_shares","entity":"Player 1","entity_type":"player","id":63,"created_at":1622215927,"shares":["CPR_6"],"percent":10},{"type":"pass","entity":"Player 1","entity_type":"player","id":64,"created_at":1622215928},{"type":"buy_shares","entity":"Player 2","entity_type":"player","id":65,"created_at":1622215929,"shares":["CPR_7"],"percent":10},{"type":"pass","entity":"Player 2","entity_type":"player","id":66,"created_at":1622215930},{"type":"buy_shares","entity":"Player 3","entity_type":"player","id":67,"created_at":1622215931,"shares":["CPR_8"],"percent":10},{"type":"pass","entity":"Player 3","entity_type":"player","id":68,"created_at":1622215931},{"type":"pass","entity":"Player 1","entity_type":"player","id":69,"created_at":1622215947},{"type":"pass","entity":"Player 2","entity_type":"player","id":70,"created_at":1622215948},{"type":"pass","entity":"Player 3","entity_type":"player","id":71,"created_at":1622215948},{"type":"pass","entity":"CV","entity_type":"corporation","id":72,"created_at":1622215953,"auto_actions":[{"type":"destination_connection","entity":"CV","entity_type":"corporation","created_at":1622215953,"corporations":[]}]},{"type":"run_routes","entity":"CV","entity_type":"corporation","id":73,"created_at":1622215954,"routes":[{"train":"2-0","connections":[["N11","M12","M10"]],"hexes":["N11","M10"],"revenue":40,"revenue_str":"N11-M10"}]},{"type":"dividend","entity":"CV","entity_type":"corporation","id":74,"created_at":1622215955,"kind":"payout"},{"type":"buy_train","entity":"CV","entity_type":"corporation","id":75,"created_at":1622215955,"train":"2-1","price":100,"variant":"2"},{"type":"pass","entity":"CV","entity_type":"corporation","id":76,"created_at":1622215956},{"type":"pass","entity":"CV","entity_type":"corporation","id":77,"created_at":1622215957},{"type":"lay_tile","entity":"CPR","entity_type":"corporation","id":78,"created_at":1622215961,"auto_actions":[{"type":"destination_connection","entity":"CPR","entity_type":"corporation","created_at":1622215961,"corporations":[]}],"hex":"N3","tile":"6-0","rotation":1},{"type":"pass","entity":"CPR","entity_type":"corporation","id":79,"created_at":1622215962},{"type":"buy_train","entity":"CPR","entity_type":"corporation","id":80,"created_at":1622215963,"train":"2-2","price":100,"variant":"2"},{"type":"buy_train","entity":"CPR","entity_type":"corporation","id":81,"created_at":1622215964,"train":"2-3","price":100,"variant":"2"},{"type":"buy_train","entity":"CPR","entity_type":"corporation","id":82,"created_at":1622215964,"train":"2-4","price":100,"variant":"2"},{"type":"buy_train","entity":"CPR","entity_type":"corporation","id":83,"created_at":1622215965,"train":"2'-0","price":100,"variant":"2'"},{"type":"pass","entity":"CPR","entity_type":"corporation","id":84,"created_at":1622215971},{"type":"end_game","entity":"Player 1","entity_type":"player","id":85,"created_at":1622215975}],"id":"hs_jmygoamy_1622213019","players":[{"name":"Player 1"},{"name":"Player 2"},{"name":"Player 3"}],"title":"1856","description":"","max_players":"3","settings":{"optional_rules":[]},"mode":"hotseat","user":{"id":0,"name":"You"},"created_at":"2021-05-28","loaded":true,"result":{"Player 1":884,"Player 3":863,"Player 2":863},"turn":6,"round":"Stock Round","acting":["Player 1"],"updated_at":1622215975}
+{
+    "status": "finished",
+    "actions": [
+        {
+            "type": "bid",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 1,
+            "created_at": 1622213107,
+            "company": "FT",
+            "price": 20
+        },
+        {
+            "type": "bid",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 2,
+            "created_at": 1622213108,
+            "company": "WSRC",
+            "price": 40
+        },
+        {
+            "type": "bid",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 3,
+            "created_at": 1622213109,
+            "company": "TCC",
+            "price": 50
+        },
+        {
+            "type": "bid",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 4,
+            "created_at": 1622213109,
+            "company": "GLSC",
+            "price": 70
+        },
+        {
+            "type": "bid",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 5,
+            "created_at": 1622213110,
+            "company": "NFSBC",
+            "price": 100
+        },
+        {
+            "type": "bid",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 6,
+            "created_at": 1622213111,
+            "company": "SCFTC",
+            "price": 100
+        },
+        {
+            "type": "par",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 7,
+            "created_at": 1622213125,
+            "corporation": "CV",
+            "share_price": "65,5,4"
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 8,
+            "created_at": 1622213126,
+            "shares": [
+                "CV_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 9,
+            "created_at": 1622213129,
+            "shares": [
+                "CV_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 10,
+            "created_at": 1622213130,
+            "shares": [
+                "CV_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 11,
+            "created_at": 1622213131,
+            "shares": [
+                "CV_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 12,
+            "created_at": 1622213132,
+            "shares": [
+                "CV_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 13,
+            "created_at": 1622213132,
+            "shares": [
+                "CV_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 14,
+            "created_at": 1622213133,
+            "shares": [
+                "CV_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 15,
+            "created_at": 1622213134,
+            "shares": [
+                "CV_8"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 16,
+            "created_at": 1622213137
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 17,
+            "created_at": 1622213137
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 18,
+            "created_at": 1622213137
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 19,
+            "created_at": 1622213141,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "CV",
+                    "entity_type": "corporation",
+                    "created_at": 1622213141,
+                    "corporations": []
+                }
+            ],
+            "hex": "M12",
+            "tile": "7-0",
+            "rotation": 3
+        },
+        {
+            "type": "buy_train",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 20,
+            "created_at": 1622213143,
+            "train": "2-0",
+            "price": 100,
+            "variant": "2"
+        },
+        {
+            "type": "pass",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 21,
+            "created_at": 1622213143
+        },
+        {
+            "type": "pass",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 22,
+            "created_at": 1622213145
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 23,
+            "created_at": 1622213145
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 24,
+            "created_at": 1622213146
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 25,
+            "created_at": 1622213146
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 26,
+            "created_at": 1622213148,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "CV",
+                    "entity_type": "corporation",
+                    "created_at": 1622213148,
+                    "corporations": []
+                }
+            ],
+            "hex": "M10",
+            "tile": "2-0",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 27,
+            "created_at": 1622213151,
+            "routes": [
+                {
+                    "train": "2-0",
+                    "connections": [
+                        [
+                            "N11",
+                            "M12",
+                            "M10"
+                        ]
+                    ],
+                    "hexes": [
+                        "M10",
+                        "N11"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "M10-N11"
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 28,
+            "created_at": 1622213152,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 29,
+            "created_at": 1622213153
+        },
+        {
+            "type": "pass",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 30,
+            "created_at": 1622213153
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 31,
+            "created_at": 1622213154
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 32,
+            "created_at": 1622213154
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 33,
+            "created_at": 1622213154
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 34,
+            "created_at": 1622213156,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "CV",
+                    "entity_type": "corporation",
+                    "created_at": 1622213156,
+                    "corporations": []
+                }
+            ],
+            "hex": "M8",
+            "tile": "9-0",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 35,
+            "created_at": 1622213161,
+            "routes": [
+                {
+                    "train": "2-0",
+                    "connections": [
+                        [
+                            "N11",
+                            "M12",
+                            "M10"
+                        ]
+                    ],
+                    "hexes": [
+                        "M10",
+                        "N11"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "M10-N11"
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 36,
+            "created_at": 1622213161,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 37,
+            "created_at": 1622213162
+        },
+        {
+            "type": "pass",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 38,
+            "created_at": 1622213163
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 39,
+            "created_at": 1622213163
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 40,
+            "created_at": 1622213163
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 41,
+            "created_at": 1622213164
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 42,
+            "created_at": 1622213166,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "CV",
+                    "entity_type": "corporation",
+                    "created_at": 1622213166,
+                    "corporations": []
+                }
+            ],
+            "hex": "M6",
+            "tile": "4-0",
+            "rotation": 0,
+            "skip": true
+        },
+        {
+            "type": "run_routes",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 43,
+            "created_at": 1622213169,
+            "routes": [
+                {
+                    "train": "2-0",
+                    "connections": [
+                        [
+                            "N11",
+                            "M12",
+                            "M10"
+                        ]
+                    ],
+                    "hexes": [
+                        "N11",
+                        "M10"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "N11-M10"
+                }
+            ],
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 44,
+            "created_at": 1622213170,
+            "skip": true
+        },
+        {
+            "type": "undo",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 45,
+            "created_at": 1622214727,
+            "skip": true
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 46,
+            "created_at": 1622215151,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "CV",
+                    "entity_type": "corporation",
+                    "created_at": 1622215151,
+                    "corporations": [
+                        "CPR"
+                    ]
+                }
+            ],
+            "hex": "M6",
+            "tile": "4-0",
+            "rotation": 0
+        },
+        {
+            "type": "run_routes",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 47,
+            "created_at": 1622215161,
+            "routes": [
+                {
+                    "train": "2-0",
+                    "connections": [
+                        [
+                            "N11",
+                            "M12",
+                            "M10"
+                        ]
+                    ],
+                    "hexes": [
+                        "N11",
+                        "M10"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "N11-M10"
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 48,
+            "created_at": 1622215161,
+            "kind": "payout"
+        },
+        {
+            "type": "pass",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 49,
+            "created_at": 1622215162
+        },
+        {
+            "type": "pass",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 50,
+            "created_at": 1622215163
+        },
+        {
+            "type": "par",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 51,
+            "created_at": 1622215913,
+            "corporation": "CPR",
+            "share_price": "65,5,4"
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 52,
+            "created_at": 1622215916
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 53,
+            "created_at": 1622215917,
+            "shares": [
+                "CPR_1"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 54,
+            "created_at": 1622215918
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 55,
+            "created_at": 1622215919,
+            "shares": [
+                "CPR_2"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 56,
+            "created_at": 1622215920
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 57,
+            "created_at": 1622215921,
+            "shares": [
+                "CPR_3"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 58,
+            "created_at": 1622215922
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 59,
+            "created_at": 1622215923,
+            "shares": [
+                "CPR_4"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 60,
+            "created_at": 1622215924
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 61,
+            "created_at": 1622215925,
+            "shares": [
+                "CPR_5"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 62,
+            "created_at": 1622215926
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 63,
+            "created_at": 1622215927,
+            "shares": [
+                "CPR_6"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 64,
+            "created_at": 1622215928
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 65,
+            "created_at": 1622215929,
+            "shares": [
+                "CPR_7"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 66,
+            "created_at": 1622215930
+        },
+        {
+            "type": "buy_shares",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 67,
+            "created_at": 1622215931,
+            "shares": [
+                "CPR_8"
+            ],
+            "percent": 10
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 68,
+            "created_at": 1622215931
+        },
+        {
+            "type": "pass",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 69,
+            "created_at": 1622215947
+        },
+        {
+            "type": "pass",
+            "entity": "Player 2",
+            "entity_type": "player",
+            "id": 70,
+            "created_at": 1622215948
+        },
+        {
+            "type": "pass",
+            "entity": "Player 3",
+            "entity_type": "player",
+            "id": 71,
+            "created_at": 1622215948
+        },
+        {
+            "type": "pass",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 72,
+            "created_at": 1622215953,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "CV",
+                    "entity_type": "corporation",
+                    "created_at": 1622215953,
+                    "corporations": []
+                }
+            ]
+        },
+        {
+            "type": "run_routes",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 73,
+            "created_at": 1622215954,
+            "routes": [
+                {
+                    "train": "2-0",
+                    "connections": [
+                        [
+                            "N11",
+                            "M12",
+                            "M10"
+                        ]
+                    ],
+                    "hexes": [
+                        "N11",
+                        "M10"
+                    ],
+                    "revenue": 40,
+                    "revenue_str": "N11-M10"
+                }
+            ]
+        },
+        {
+            "type": "dividend",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 74,
+            "created_at": 1622215955,
+            "kind": "payout"
+        },
+        {
+            "type": "buy_train",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 75,
+            "created_at": 1622215955,
+            "train": "2-1",
+            "price": 100,
+            "variant": "2"
+        },
+        {
+            "type": "pass",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 76,
+            "created_at": 1622215956
+        },
+        {
+            "type": "pass",
+            "entity": "CV",
+            "entity_type": "corporation",
+            "id": 77,
+            "created_at": 1622215957
+        },
+        {
+            "type": "lay_tile",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "id": 78,
+            "created_at": 1622215961,
+            "auto_actions": [
+                {
+                    "type": "destination_connection",
+                    "entity": "CPR",
+                    "entity_type": "corporation",
+                    "created_at": 1622215961,
+                    "corporations": []
+                }
+            ],
+            "hex": "N3",
+            "tile": "6-0",
+            "rotation": 1
+        },
+        {
+            "type": "pass",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "id": 79,
+            "created_at": 1622215962
+        },
+        {
+            "type": "buy_train",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "id": 80,
+            "created_at": 1622215963,
+            "train": "2-2",
+            "price": 100,
+            "variant": "2"
+        },
+        {
+            "type": "buy_train",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "id": 81,
+            "created_at": 1622215964,
+            "train": "2-3",
+            "price": 100,
+            "variant": "2"
+        },
+        {
+            "type": "buy_train",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "id": 82,
+            "created_at": 1622215964,
+            "train": "2-4",
+            "price": 100,
+            "variant": "2"
+        },
+        {
+            "type": "buy_train",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "id": 83,
+            "created_at": 1622215965,
+            "train": "2'-0",
+            "price": 100,
+            "variant": "2'"
+        },
+        {
+            "type": "pass",
+            "entity": "CPR",
+            "entity_type": "corporation",
+            "id": 84,
+            "created_at": 1622215971
+        },
+        {
+            "type": "end_game",
+            "entity": "Player 1",
+            "entity_type": "player",
+            "id": 85,
+            "created_at": 1622215975
+        }
+    ],
+    "id": "hs_jmygoamy_1622213019",
+    "players": [
+        {
+            "name": "Player 1"
+        },
+        {
+            "name": "Player 2"
+        },
+        {
+            "name": "Player 3"
+        }
+    ],
+    "title": "1856",
+    "description": "",
+    "max_players": "3",
+    "settings": {
+        "optional_rules": []
+    },
+    "mode": "hotseat",
+    "user": {
+        "id": 0,
+        "name": "You"
+    },
+    "created_at": "2021-05-28",
+    "loaded": true,
+    "result": {
+        "Player 1": 884,
+        "Player 3": 863,
+        "Player 2": 863
+    },
+    "turn": 6,
+    "round": "Stock Round",
+    "acting": [
+        "Player 1"
+    ],
+    "updated_at": 1622215975
+}

--- a/public/fixtures/1856/move_up_price_sr1.json
+++ b/public/fixtures/1856/move_up_price_sr1.json
@@ -1,0 +1,318 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1706237386,
+      "company": "FT",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1706237386,
+      "company": "WSRC",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1706237387,
+      "company": "TCC",
+      "price": 50
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1706237388,
+      "company": "GLSC",
+      "price": 70
+    },
+    {
+      "type": "bid",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1706237389,
+      "company": "NFSBC",
+      "price": 100
+    },
+    {
+      "type": "bid",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1706237390,
+      "company": "SCFTC",
+      "price": 100
+    },
+    {
+      "type": "par",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1706237392,
+      "corporation": "BBG",
+      "share_price": "65,5,4"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1706237393,
+      "shares": [
+        "BBG_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1706237394,
+      "shares": [
+        "BBG_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1706237395,
+      "shares": [
+        "BBG_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1706237396,
+      "shares": [
+        "BBG_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1706237397,
+      "shares": [
+        "BBG_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1706237398,
+      "shares": [
+        "BBG_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1706237399,
+      "shares": [
+        "BBG_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1706237400,
+      "shares": [
+        "BBG_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "undo",
+      "entity": "BBG",
+      "entity_type": "corporation",
+      "id": 16,
+      "created_at": 1706237481
+    },
+    {
+      "type": "redo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1706237489
+    },
+    {
+      "type": "undo",
+      "entity": "BBG",
+      "entity_type": "corporation",
+      "id": 18,
+      "created_at": 1706237503
+    },
+    {
+      "type": "redo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1706237524
+    },
+    {
+      "type": "undo",
+      "entity": "BBG",
+      "entity_type": "corporation",
+      "id": 20,
+      "created_at": 1706237545
+    },
+    {
+      "type": "redo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1706237554
+    },
+    {
+      "type": "undo",
+      "entity": "BBG",
+      "entity_type": "corporation",
+      "id": 22,
+      "created_at": 1706237577
+    },
+    {
+      "type": "redo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 23,
+      "created_at": 1706237599
+    },
+    {
+      "type": "undo",
+      "entity": "BBG",
+      "entity_type": "corporation",
+      "id": 24,
+      "created_at": 1706237605
+    },
+    {
+      "type": "redo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1706237620
+    },
+    {
+      "type": "undo",
+      "entity": "BBG",
+      "entity_type": "corporation",
+      "id": 26,
+      "created_at": 1706237653
+    },
+    {
+      "type": "redo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1706237660
+    },
+    {
+      "type": "undo",
+      "entity": "BBG",
+      "entity_type": "corporation",
+      "id": 28,
+      "created_at": 1706237667
+    },
+    {
+      "type": "redo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 29,
+      "created_at": 1706237674
+    },
+    {
+      "type": "end_game",
+      "entity": "BBG",
+      "entity_type": "corporation",
+      "id": 30,
+      "created_at": 1706237788
+    }
+  ],
+  "id": "hs_wstszqwv_1706237384",
+  "players": [
+    {
+      "name": "Player 1",
+      "id": 0
+    },
+    {
+      "name": "Player 2",
+      "id": 1
+    },
+    {
+      "name": "Player 3",
+      "id": 2
+    },
+    {
+      "name": "Player 4",
+      "id": 3
+    },
+    {
+      "name": "Player 5",
+      "id": 4
+    },
+    {
+      "name": "Player 6",
+      "id": 5
+    }
+  ],
+  "title": "1856",
+  "description": "",
+  "min_players": "6",
+  "max_players": "6",
+  "settings": {
+    "optional_rules": [],
+    "seed": ""
+  },
+  "mode": "hotseat",
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "created_at": "2024-01-25",
+  "loaded": true,
+  "result": {
+    "0": 270,
+    "1": 270,
+    "2": 270,
+    "3": 270,
+    "4": 275,
+    "5": 275
+  },
+  "manually_ended": true,
+  "turn": 1,
+  "round": "Operating Round",
+  "acting": [
+    0
+  ],
+  "updated_at": 1706237788
+}


### PR DESCRIPTION
Fixes #9940

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

     * Add override of `corporations_to_move_price` to 1856 to also include `sold_out?` corporations.
     * Add new test case to ensure stock price moves up
     * Modify two existing test cases that were affected by this change (one for final game values, the other was affected by corp operating order).

* **Screenshots**

* **Any Assumptions / Hacks**

    * I added the pins label, but I don't think I saw any live games that this would affect.  None had any sold out corps after SR1.
