### PR TITLE
[21Moon] fixes E-W bonus

### DIFF
--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -194,7 +194,7 @@ module Engine
         T_BONUS = 30
         T_TILE = 'X30'
         RIFT_BONUS = 60
-        EW_BONUS = 100
+        EW_BONUS = 80
         NE_HEXES = %w[K1 L2 L4].freeze
         SE_HEXES = %w[L14 M11 M13].freeze
         NW_HEXES = %w[A3 A5 B2].freeze


### PR DESCRIPTION
Fixes #10229

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

This fix will require pins, though I think every 21Moon game prior to a couple days ago was pinned already.

E-W bonus appears to have changed in late playtesting from $50 per off board to $40 per offboard, dropping the total from $100 to $80.

![image](https://github.com/tobymao/18xx/assets/26125362/3e9d12c2-1eb3-4a9f-b12a-c4f4853613e3)


* **Screenshots**

* **Any Assumptions / Hacks**
