### PR TITLE
[1894] Fix bug stopping company floated in last SR from running trains

### DIFF
--- a/lib/engine/game/g_1894/game.rb
+++ b/lib/engine/game/g_1894/game.rb
@@ -386,10 +386,15 @@ module Engine
             hex = hex_by_id(corporation.coordinates)
             tile = hex&.tile
 
-            return super if tile.color != :brown
-
-            place_home_token_brown_tile(corporation, hex, tile)
+            if tile.color != :brown
+              super
+            else
+              place_home_token_brown_tile(corporation, hex, tile)
+            end
           end
+
+          # track actions are skipped in the final OR set, so graph must be reset here to take the home token into account
+          @graph.clear if @skip_track_and_token
         end
 
         def place_home_token_brown_tile(corporation, hex, tile)

--- a/lib/engine/game/g_1894/game.rb
+++ b/lib/engine/game/g_1894/game.rb
@@ -386,10 +386,10 @@ module Engine
             hex = hex_by_id(corporation.coordinates)
             tile = hex&.tile
 
-            if tile.color != :brown
-              super
-            else
+            if tile.color == :brown
               place_home_token_brown_tile(corporation, hex, tile)
+            else
+              super
             end
           end
 


### PR DESCRIPTION
- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

In the last OR set, track and token steps are skipped. If a company floats just before that, it does place its home station but the graph is not recalculated, so for the engine it doesn't have any route.

Technically this requires pinning but it's unlikely to occur... If pinning is problematic, then we can risk not doing it.

