### PR TITLE
[1830][1880] Add new bottom center location to pointy tile labels

### DIFF
--- a/assets/app/view/game/part/label.rb
+++ b/assets/app/view/game/part/label.rb
@@ -174,6 +174,12 @@ module View
             x: 50,
             y: 37,
           },
+          # bottom center
+          {
+            region_weights: { [21] => 1.0, [22] => 0.5 },
+            x: 0,
+            y: 60,
+          },
         ].freeze
 
         def preferred_render_locations

--- a/lib/engine/test_tiles.rb
+++ b/lib/engine/test_tiles.rb
@@ -20,7 +20,7 @@ module Engine
       # open: https://github.com/tobymao/18xx/issues/5981
       { tile: 'H22', title: '1828.Games' },
 
-      # open: https://github.com/tobymao/18xx/issues/8178
+      # closed: https://github.com/tobymao/18xx/issues/8178
       { tile: 'H18', title: '1830', fixture: '26855', action: 385 },
 
       { tile: 'C15', title: '1846' },


### PR DESCRIPTION
Fixes #8178

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

    Add a new location that labels can use.  This will give the OO in the 1830 tile a better place to land.

* **Screenshots**
    Here are the two tiles I could find that were affected by this, and the changes look better in both cases (imo).

**1830**
(old on left, new on right)
![image](https://github.com/tobymao/18xx/assets/5263073/929d73ac-be5b-4186-8ffb-7d2353b0aa6a) ![image](https://github.com/tobymao/18xx/assets/5263073/d9b7dd5d-3292-4b23-9e60-052cc4855c8c)

**1880**
(old on left, new on right)
(ignore the color change here)
![image](https://github.com/tobymao/18xx/assets/5263073/d2422da2-df63-4ddd-b6ea-6325314d9f86) ![image](https://github.com/tobymao/18xx/assets/5263073/e9451833-da1c-4524-8f32-42537a1fb308)



* **Any Assumptions / Hacks**
