### PR TITLE
Remove duplicated pointy location layout locations

### DIFF
--- a/assets/app/view/game/part/small_item.rb
+++ b/assets/app/view/game/part/small_item.rb
@@ -120,12 +120,6 @@ module View
           y: -37.5,
         }.freeze
 
-        PP_BOTTOM_RIGHT_CORNER = {
-          region_weights: Base::BOTTOM_LEFT_CORNER,
-          x: 65,
-          y: 37.5,
-        }.freeze
-
         PP_BOTTOM_LEFT_CORNER = {
           region_weights: Base::BOTTOM_LEFT_CORNER,
           x: -65,

--- a/assets/app/view/game/part/small_item.rb
+++ b/assets/app/view/game/part/small_item.rb
@@ -108,18 +108,6 @@ module View
           y: -75,
         }.freeze
 
-        PP_TOP_LEFT_CORNER = {
-          region_weights: Base::UPPER_LEFT_CORNER,
-          x: -65,
-          y: -37.5,
-        }.freeze
-
-        PP_TOP_RIGHT_CORNER = {
-          region_weights: Base::UPPER_RIGHT_CORNER,
-          x: 65,
-          y: -37.5,
-        }.freeze
-
         PP_BOTTOM_LEFT_CORNER = {
           region_weights: Base::BOTTOM_LEFT_CORNER,
           x: -65,

--- a/assets/app/view/game/part/upgrade.rb
+++ b/assets/app/view/game/part/upgrade.rb
@@ -79,7 +79,7 @@ module View
           else
             [
               P_CENTER,
-              PP_TOP_RIGHT_CORNER,
+              PP_UPPER_RIGHT_CORNER,
               PP_EDGE2,
               PP_BOTTOM_LEFT_CORNER,
               PP_RIGHT_CORNER,


### PR DESCRIPTION
### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

    Found when I was looking around at other tile-related rendering issues.

    These 3 locations are repetitions of existing locations, some have incorrect region weights.
    *  _unused_: `PP_TOP_LEFT_CORNER` is an x/y duplicate of `PP_UPPER_LEFT_CORNER`, but `UPPER` has the correct region weights (`LEFT_CORNER = [5, 12].freeze`, from the flat tiles before rotated.) 

    * `PP_TOP_RIGHT_CORNER` is an exact duplicate of `PP_UPPER_RIGHT_CORNER`.  This one did have a single usage which I fixed.

    * `PP_BOTTOM_RIGHT_CORNER` is overwriting the variable of the same name at line 87.  This is an x/y duplicate, but the region_weights point to `BOTTOM_LEFT_CORNER` which is a different area of the tile, so I just deleted so the one at line 87 will be the one that's used.  This should allow things to more accurately be placed in that corner, I think it was checking the wrong areas for conflicts previously. 

    None of the tiles on the test page changed appearance.

* **Screenshots**

1825 J14
| Old | New |
|--------|--------|
| ![image](https://github.com/tobymao/18xx/assets/5263073/72a483c0-072c-48e2-861c-ad531ccd0081) |   ![image](https://github.com/tobymao/18xx/assets/5263073/b2546ad7-5a28-42b3-a198-be9d92e7d751) | 

1850 
| Old | New |
|--------|--------|
| ![image](https://github.com/tobymao/18xx/assets/5263073/097ea46d-cd35-4cf2-b9a1-1357dcf9b94d) | ![image](https://github.com/tobymao/18xx/assets/5263073/6f0dcf01-3e6f-456a-84f7-e56a392a7aa7) | 


* **Any Assumptions / Hacks**
