### PR TITLE
[1858] madrid can't be used twice in same route

### DIFF
--- a/lib/engine/game/g_1858/map.rb
+++ b/lib/engine/game/g_1858/map.rb
@@ -546,9 +546,9 @@ module Engine
                     'icon=image:1858/MZ,sticky:1;' \
                     'icon=image:1858/ZP,sticky:1;',
             %w[H11] =>
-                    'city=revenue:40,loc:1;path=a:1,b:_0;' \
-                    'city=revenue:40,loc:2.5;path=a:2,b:_1;' \
-                    'city=revenue:40,loc:4;path=a:0,b:_2;path=a:4,b:_2;' \
+                    'city=revenue:40,groups:Madrid,loc:1;path=a:1,b:_0;' \
+                    'city=revenue:40,groups:Madrid,loc:2.5;path=a:2,b:_1;' \
+                    'city=revenue:40,groups:Madrid,loc:4;path=a:0,b:_2;path=a:4,b:_2;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:3;' \
                     'label=M',


### PR DESCRIPTION
Fixes #10275

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Likely requires pins

Put Madrid cities in a group so they can't be reused (same logic as chicago in 46)

Madrid doesn't expand to any more cities so this should cover it

* **Screenshots**
![image](https://github.com/tobymao/18xx/assets/1711810/e57c96c0-d4b8-4677-abb4-5c48fdce7b56)


* **Any Assumptions / Hacks**
