### PR TITLE
[1846] fix text on corp cards

### DIFF
--- a/lib/engine/game/g_1846/entities.rb
+++ b/lib/engine/game/g_1846/entities.rb
@@ -274,7 +274,7 @@ module Engine
             abilities: [
             {
               type: 'token',
-              description: 'Reserved $40 token ($60 to "teleport" there if unconnected) in Ft. Wayne (E11)',
+              description: 'Reserved $40 token/$60 teleport on E11',
               desc_detail: 'May place token in Ft. Wayne (E11) for $40 if connected, $60 '\
                            'otherwise. This token slot is reserved until Phase IV.',
               hexes: ['E11'],
@@ -312,7 +312,7 @@ module Engine
             abilities: [
               {
                 type: 'token',
-                description: 'Reserved $40 token ($100 to "teleport" there if unconnected) in Cincinnati (H12)',
+                description: 'Reserved $40 token/$100 teleport on H12',
                 desc_detail: 'May place token in Cincinnati (H12) for $40 if connected, $100 '\
                              'otherwise. This token slot is reserved until Phase IV.',
                 hexes: ['H12'],
@@ -391,9 +391,15 @@ module Engine
             tokens: [0, 80, 80, 80],
             abilities: [
               {
+                type: 'base',
+                description: 'Receives an initial subsidy of 1x par value',
+                desc_detail: 'When floated IC receives a one-time subsidy equal to its par price into its treasury.',
+                remove: 'par',
+              },
+              {
                 type: 'tile_lay',
                 discount: 20,
-                description: 'Free yellow tile lays on "IC" hexes E5, F6, G5, H6 and J4',
+                description: 'Free yellow tile lays on "IC" hexes',
                 desc_detail: 'IC lays yellow tiles for free on hexes marked with an IC icon (E5, '\
                              'F6, G5, H6 and J4).',
                 passive: true,
@@ -401,6 +407,7 @@ module Engine
                 hexes: %w[E5 F6 G5 H6 J4],
                 tiles: %w[7 8 9],
               },
+
               {
                 type: 'token',
                 description: 'Reserved $40 Centralia (I5) token',
@@ -415,12 +422,7 @@ module Engine
                 hex: 'I5',
                 remove: 'IV',
               },
-              {
-                type: 'base',
-                description: 'Receives an initial subsidy equal to its par price',
-                desc_detail: 'When floated IC receives a one-time subsidy equal to its par price into its treasury.',
-                remove: 'par',
-              },
+
             ],
             coordinates: 'K3',
             color: '#32763f',


### PR DESCRIPTION
In the prior PR I accidentially made the text too long for the corp cards

https://github.com/tobymao/18xx/pull/10170

I also moved the IC's subsidy to the top, as it seems the most relevant when someone scans the corps

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

* **Screenshots**

![image](https://github.com/tobymao/18xx/assets/1711810/1955b447-b734-4e9f-b21a-e4a20b9106a0)

![Screenshot 2024-02-05 12 20 06 AM](https://github.com/tobymao/18xx/assets/1711810/d110120e-3637-44d8-8744-064c44e0b8ba)


![image](https://github.com/tobymao/18xx/assets/1711810/c7386155-4161-486c-8414-72fe3f1ea8f2)


* **Any Assumptions / Hacks**
