### PR TITLE
[18Chesapeake: Off the Rails] Update links in meta.rb

### DIFF
--- a/lib/engine/game/g_18_chesapeake_off_the_rails/meta.rb
+++ b/lib/engine/game/g_18_chesapeake_off_the_rails/meta.rb
@@ -13,9 +13,14 @@ module Engine
         DEPENDS_ON = '18Chesapeake'
 
         GAME_DESIGNER = 'Scott Petersen'
-        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Chesapeake'
+        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Chesapeake%3A-Off-the-Rails'
         GAME_PUBLISHER = :all_aboard_games
-        GAME_RULES_URL = 'https://www.dropbox.com/s/ivm4jsopnzabhru/18ChesOTR_Rules.png?dl=0'
+        GAME_RULES_URL = {
+          'Base 18Chesapeake Rules' =>
+          'https://cdn.shopify.com/s/files/1/0252/9371/7588/files/18Chesapeake.pdf?v=1597256917',
+          'Off the Rails Expansion Rules' =>
+            'https://www.dropbox.com/s/ivm4jsopnzabhru/18ChesOTR_Rules.png?dl=0',
+        }.freeze
         GAME_TITLE = '18Chesapeake: Off the Rails'
         GAME_ALIASES = %w[OTR 18ChesapeakeOTR].freeze
         GAME_IS_VARIANT_OF = G18Chesapeake::Meta

--- a/lib/engine/game/g_18_chesapeake_off_the_rails/meta.rb
+++ b/lib/engine/game/g_18_chesapeake_off_the_rails/meta.rb
@@ -17,7 +17,7 @@ module Engine
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = {
           'Base 18Chesapeake Rules' =>
-          'https://cdn.shopify.com/s/files/1/0252/9371/7588/files/18Chesapeake.pdf?v=1597256917',
+          G18Chesapeake::Meta::GAME_RULES_URL,
           'Off the Rails Expansion Rules' =>
             'https://www.dropbox.com/s/ivm4jsopnzabhru/18ChesOTR_Rules.png?dl=0',
         }.freeze


### PR DESCRIPTION
This PR links Off the Rails to it's respective wiki page rather than the base game wiki.  From there users can navigate to the base game wiki entry if need be.

It also adds a link to the base 18Chesapeake rules as the current link to the expansion rules does not have a lot of info.  Follows the same pattern used in the 18Mag meta.rb: https://github.com/tobymao/18xx/blob/bc9b3a270f21aab9dd7f8b508da2117061e60116/lib/engine/game/g_18_mag/meta.rb#L21

Fixes #10286 


- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

