### PR TITLE
[18RoyalGorge] basic setup for gold and steel companies

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1191,7 +1191,7 @@ module Engine
         self.class::SELL_AFTER == :first ? (@turn > 1 || !@round.stock?) : true
       end
 
-      def sell_movement
+      def sell_movement(_corporation = nil)
         self.class::SELL_MOVEMENT
       end
 
@@ -1200,7 +1200,7 @@ module Engine
         old_price = corporation.share_price
         was_president = corporation.president?(bundle.owner)
         @share_pool.sell_shares(bundle, allow_president_change: allow_president_change, swap: swap)
-        case movement || sell_movement
+        case movement || sell_movement(corporation)
         when :down_share
           bundle.num_shares.times { @stock_market.move_down(corporation) }
         when :down_per_10
@@ -1231,7 +1231,7 @@ module Engine
         else
           raise NotImplementedError
         end
-        log_share_price(corporation, old_price) if sell_movement != :none
+        log_share_price(corporation, old_price) if sell_movement(corporation) != :none
       end
 
       def sold_out_increase?(_corporation)

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -376,7 +376,7 @@ module Engine
           self.class::COMPANIES_EXTRA_TRACK_LAYS.include?(company.id)
         end
 
-        def sell_movement
+        def sell_movement(_corporation)
           @sell_movement ||= @players.size == 2 ? :left_share_pres : :left_per_10_if_pres_else_left_one
         end
 

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -14,6 +14,9 @@ module Engine
         include Map
         include Trains
 
+        attr_accessor :gold_shipped
+        attr_reader :gold_corp, :steel_corp, :available_steel, :gold_cubes
+
         CURRENCY_FORMAT_STR = '$%s'
         BANK_CASH = 99_999
         CERT_LIMIT = { 2 => 20, 3 => 14, 4 => 10 }.freeze
@@ -52,6 +55,14 @@ module Engine
           'CS' => 1898,
         }.freeze
 
+        GOLD_DIVIDENDS = [50, 90, 140, 200, 270, 350].freeze
+        GOLD_SHIP_LIMIT = {
+          'Yellow' => 2,
+          'Green' => 4,
+          'Brown' => 5,
+          'Silver' => 5,
+        }.freeze
+
         EVENTS_TEXT = Base::EVENTS_TEXT.merge(
           green_par: ['Green Par Available'],
           brown_par: ['Brown Par Available'],
@@ -75,7 +86,7 @@ module Engine
           corporations = corporations.sort_by { |c| ESTABLISHED[c[:sym]] }
 
           # put established year on charter
-          corporations.map do |corporation|
+          corporations = corporations.map do |corporation|
             corp = corporation.dup
             corp[:abilities] = [{ type: 'base', description: "Est. #{ESTABLISHED[corp[:sym]]}" }]
             corp
@@ -83,7 +94,7 @@ module Engine
 
           @log << "Railroads in the game: #{corporations.map { |c| c[:sym] }.join(', ')}"
 
-          corporations
+          corporations + self.class::METAL_CORPORATIONS
         end
 
         def setup
@@ -93,6 +104,37 @@ module Engine
           @corporations[4..4].each { |c| @corporation_phase_color[c.name] = 'Brown' }
 
           @available_par_groups = %i[par]
+
+          @steel_corp = init_metal_corp(corporation_by_id('CF&I'))
+          @gold_corp = init_metal_corp(corporation_by_id('VGC'))
+
+          init_available_steel
+          @steel_corp.cash = 50
+
+          @gold_cubes = Hash.new(0)
+          @gold_shipped = 0
+        end
+
+        def init_available_steel
+          @available_steel = {
+            yellow: {
+              'A' => [30, 20, 10, 0],
+              'B' => [30, 20, 10, 0],
+              'C' => [30, 20, 10, 0],
+              'D' => [30, 20, 10, 0],
+            },
+            green: {
+              'E' => [30, 20],
+              'F' => [30, 20],
+            },
+            brown: {
+              'G' => [30],
+              'H' => [30],
+            },
+            gray: {
+              'I' => [],
+            },
+          }
         end
 
         def status_array(corporation)
@@ -180,8 +222,126 @@ module Engine
             end
         end
 
+        def operating_order
+          super.select { |c| c.type == :rail }
+        end
+
+        def market_share_limit(corporation)
+          corporation.type == :metal ? 10 : self.class::MARKET_SHARE_LIMIT
+        end
+
+        def init_metal_corp(corporation)
+          corporation.ipoed = true
+          corporation.floated = true
+          price = @stock_market.share_price([0, 3])
+          @stock_market.set_par(corporation, price)
+          bundle = ShareBundle.new(corporation.shares_of(corporation))
+          @share_pool.transfer_shares(bundle, @share_pool)
+          corporation
+        end
+
         def corporation_opts
           @players.size == 2 ? { max_ownership_percent: 70 } : {}
+        end
+
+        def operating_round(round_num)
+          Round::Operating.new(self, [
+            Engine::Step::Bankrupt,
+            Engine::Step::Exchange,
+            Engine::Step::SpecialTrack,
+            Engine::Step::BuyCompany,
+            G18RoyalGorge::Step::Track,
+            Engine::Step::Token,
+            Engine::Step::Route,
+            G18RoyalGorge::Step::Dividend,
+            Engine::Step::DiscardTrain,
+            Engine::Step::BuyTrain,
+            [Engine::Step::BuyCompany, { blocks: true }],
+          ], round_num: round_num)
+        end
+
+        def or_round_finished
+          # debt increases
+        end
+
+        def or_set_finished
+          handle_metal_payout(@steel_corp)
+          init_available_steel
+          @steel_corp.cash = 50
+
+          handle_metal_payout(@gold_corp)
+          @gold_shipped = 0
+          update_gold_corp_cash!
+        end
+
+        def handle_metal_payout(entity)
+          revenue = entity.cash
+          per_share = revenue / 10
+          payouts = {}
+          @players.each do |payee|
+            amount = payee.num_shares_of(entity) * per_share
+            payouts[payee] = amount if amount.positive?
+            entity.spend(amount, payee, check_positive: false)
+          end
+          payouts[@bank] = entity.cash
+          entity.spend(entity.cash, @bank, check_positive: false)
+          receivers = payouts
+                        .sort_by { |_r, c| -c }
+                        .map { |receiver, cash| "#{format_currency(cash)} to #{receiver.name}" }.join(', ')
+          msg = "#{entity.name} pays out #{format_currency(revenue)} = "\
+                "#{format_currency(per_share)} per share"
+          msg += " (#{receivers})" unless receivers.empty?
+          @log << msg
+
+          # share movement
+          old_price = entity.share_price
+          right_times = [(revenue / old_price.price).to_i, 3].min
+          right_times.times do
+            @stock_market.move_right(entity)
+          end
+          log_share_price(entity, old_price, right_times)
+
+          # spreadsheet
+          entity.operating_history[[turn - 1, @round.round_num]] = OperatingInfo.new(
+            [],
+            nil,
+            revenue,
+            [],
+            dividend_kind: revenue.positive? ? 'paid out' : 'withhold',
+          )
+        end
+
+        def action_processed(action)
+          case action
+          when Action::LayTile
+            if action.tile.color == :yellow
+
+              hex = action.hex
+
+              hex.original_tile.icons.each do |icon|
+                if icon.name == 'mine'
+                  action.hex.tile.icons << Part::Icon.new('../icons/18_royal_gorge/gold_cube', 'gold')
+                  @gold_cubes[hex.id] += 1
+                end
+              end
+            end
+          end
+        end
+
+        def gold_slots_available?
+          @gold_shipped < GOLD_SHIP_LIMIT[@phase.name]
+        end
+
+        def gold_dividend
+          GOLD_DIVIDENDS[@gold_shipped]
+        end
+
+        def update_gold_corp_cash!
+          bank.spend(gold_dividend - @gold_corp.cash, @gold_corp)
+        end
+
+        def sell_movement(corporation)
+          corporation.type == :rail ? :left_block_pres : :none
         end
       end
     end

--- a/public/logos/18_royal_gorge/CF&I.svg
+++ b/public/logos/18_royal_gorge/CF&I.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="gray"/><text x="4" y="5" text-anchor="middle" font-weight="700" font-size="3" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">CF&amp;I</text></svg>

--- a/public/logos/18_royal_gorge/VGC.svg
+++ b/public/logos/18_royal_gorge/VGC.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="gold"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial">VGC</text></svg>


### PR DESCRIPTION
Full implementation coming in step classes later.

Basic idea:

* gold can be shipped from the map to give a route a bonus; the more gold shipped, the more dividends the gold company will pay out
* railroads need to pay the steel company for each track tile laid; that payment turns into the dividends the steel company pays out

Implemented here:

* gold and steel companies only pay out at the end of the OR set, not every OR
* when track is laid on a mine hex, the mine turns into a gold cube
* gold and steel companies in the table top game have no president; here that is approximated by having their share price not be affected when the "president" sells (there never any decisions to be made for the gold and steel companies) 
    * now the base `sell_movement` method optionally takes a corporation argument

#10110

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
