### PR TITLE
[18RoyalGorge] ship gold cube from route for dividend bonus

### DIFF
--- a/assets/app/view/game/choose.rb
+++ b/assets/app/view/game/choose.rb
@@ -11,6 +11,8 @@ module View
 
       def render
         step = @game.round.active_step
+        return '' if step.respond_to?(:render_choices?) && !step.render_choices?
+
         choices = if step.respond_to?(:entity_choices)
                     step.entity_choices(@entity)
                   else

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -212,6 +212,12 @@ module View
               token_type: next_token
             ))
           end
+          if @actions.include?('choose') && step.choices.include?(@hex.id)
+            return process_action(Engine::Action::Choose.new(
+                @entity,
+                choice: @hex.id,
+              ))
+          end
           return unless @actions.include?('lay_tile')
 
           if @selected && (tile = @tile_selector&.tile)

--- a/lib/engine/game/g_18_royal_gorge/step/dividend.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/dividend.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G18RoyalGorge
+      module Step
+        class Dividend < Engine::Step::Dividend
+          GOLD_BONUS = 50
+
+          def actions(entity)
+            actions = super.dup
+            actions << 'choose' if choosing?(entity)
+            actions
+          end
+
+          def setup
+            @shippable_gold = nil
+            @shipped_gold = false
+          end
+
+          # choices that still need to be implemented:
+          #
+          # - Y2: after last gold is shipped from a hex, may place a ghost town
+          # token there
+          # - G2: one-time +$130 instead of +$50
+
+          def choice_name
+            "Choose a Gold to ship for +#{@game.format_currency(GOLD_BONUS)}"
+          end
+
+          def choosing?
+            !@shipped_gold && @game.gold_slots_available? && !shippable_gold.empty?
+          end
+
+          def choices
+            ship_gold_choices
+          end
+
+          def ship_gold_choices
+            shippable_gold.to_h do |hex, _|
+              if hex.location_name
+                [hex.id, "#{hex.id} (#{hex.location_name})"]
+              else
+                [hex.id, hex.id]
+              end
+            end
+          end
+
+          def process_choose(action)
+            ship_gold(action)
+          end
+
+          def ship_gold(action)
+            @shipped_gold = true
+            @game.gold_shipped += 1
+            @game.update_gold_corp_cash!
+
+            entity = action.entity
+            hex_id = action.choice
+            hex = @game.hex_by_id(hex_id)
+            location = hex.location_name ? " (#{hex.location_name})" : ''
+
+            @log << "#{entity.name} ships gold from #{hex_id}#{location} for +#{@game.format_currency(GOLD_BONUS)}"
+            @round.extra_revenue += GOLD_BONUS
+
+            @game.gold_cubes[hex_id] -= 1
+            icons = hex.tile.icons
+            icon = icons.find { |i| i.name == 'gold' }
+            icons.delete(icon)
+
+            @game.gold_cubes.delete(hex_id) if @game.gold_cubes[hex_id].zero?
+          end
+
+          def shippable_gold
+            @shippable_gold ||=
+              begin
+                hexes = @round.routes.flat_map(&:all_hexes).uniq
+                hexes = hexes.select do |hex|
+                  @game.gold_cubes.include?(hex.id)
+                end.sort
+                hexes
+              end
+          end
+
+          def available_hex(entity, hex)
+            !@shipped_gold &&
+              entity == current_entity &&
+              shippable_gold.include?(hex)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#10110

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

#### Explanation of Change

During dividend step, a company may ship a single gold cube from anywhere along their routes, to add $50 to the total dividend. This affects how much the gold company will pay in dividends, and the gold company has a limit on how many gold it will ship in total across the OR set, based on phase.

This changes the `hex` and `choose` views to allow the choice to be made by clicking directly on the hex with the gold, which is much more natural than clicking a button on the side (the default `choose` UI).

#### Screenshots

Route for $50, option to ship gold:

![ship gold before](https://github.com/tobymao/18xx/assets/1045173/7d265031-e1bf-47c6-84fd-ad82e121d9e2)

One gold shipped, total dividend is now $50:

![ship gold after](https://github.com/tobymao/18xx/assets/1045173/eadcce7c-e619-4bb8-8b38-f5dca02d3dce)


