### PR TITLE
refactor how test fixture files are opened in game_state_spec.rb

### DIFF
--- a/spec/game_state_spec.rb
+++ b/spec/game_state_spec.rb
@@ -12,10 +12,21 @@ def raw_action(game, action_index)
   game.instance_variable_get(:@raw_all_actions)[action_index]
 end
 
+# get the title string from the `describe` block
+def game_title_for_test(test)
+  all_titles = Engine::GAME_META_BY_TITLE
+  parent = :parent_example_group
+
+  group = test.metadata[:example_group][parent]
+  group = group[parent] until all_titles.include?((title = group[:description]))
+  title
+end
+
 module Engine
   describe 'Fixture Game State' do
     let(:game_file) do
-      Find.find(FIXTURES_DIR).find { |f| File.basename(f) == "#{described_class}.json" }
+      title = game_title_for_test(RSpec.current_example)
+      Find.find("#{FIXTURES_DIR}/#{title}").find { |f| File.basename(f) == "#{described_class}.json" }
     end
 
     describe '18Chesapeake' do


### PR DESCRIPTION
* traverse only the subdirectory relevant for the given title (extracted from the string used in the `describe` block via RSPec metadata)
* allows fixtures for different titles to have the same game ID (18ZOO and 1822CA--in an upcoming PR for #10226--both have a fixture `4.json`)

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`