### PR TITLE
[1822/CA] fix `upgrade_minor_14_home_hex` to work with Toronto tiles in 1822CA

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1307,9 +1307,6 @@ module Engine
 
           # If we upgraded london, check if we need to add the extra slot from minor 14
           upgrade_minor_14_home_hex(hex) if hex.name == self.class::MINOR_14_HOME_HEX
-
-          # If we upgraded the english channel to brown, upgrade france as well since we got 2 lanes to france.
-          return if hex.name != self.class::ENGLISH_CHANNEL_HEX || tile.color != :brown
         end
 
         def bank_companies(prefix)
@@ -1845,7 +1842,7 @@ module Engine
           return unless @minor_14_city_exit
 
           extra_city = hex.tile.paths.find { |p| p.edges[0].num == @minor_14_city_exit }.city
-          return unless extra_city.tokens.size == 1
+          return unless extra_city.tokens.size <= extra_city.normal_slots
 
           extra_city.tokens[extra_city.normal_slots] = nil
         end

--- a/lib/engine/game/g_1822_ca_wrs/game.rb
+++ b/lib/engine/game/g_1822_ca_wrs/game.rb
@@ -44,7 +44,7 @@ module Engine
           },
         ]).freeze
 
-        PENDING_HOME_TOKENERS = [MINOR_14_ID, 'GNWR'].freeze
+        PENDING_HOME_TOKENERS = ['GNWR'].freeze
 
         def after_lay_tile(hex, _old_tile, _tile)
           super

--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -148,6 +148,8 @@ module Engine
         BIDDING_BOX_START_PRIVATE = 'P1'
         BIDDING_BOX_START_MINOR = nil
 
+        MINOR_14_ID = nil
+
         DOUBLE_HEX = %w[L19 M22 M26].freeze
 
         def init_graph

--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -173,6 +173,8 @@ module Engine
           'MC' => 'C',
         }.freeze
 
+        MINOR_14_ID = nil
+
         def setup_associated_minors
           @minor_associations = {
             '1' => 'CPR',

--- a/public/fixtures/1822CA/README.md
+++ b/public/fixtures/1822CA/README.md
@@ -11,3 +11,7 @@
 * `2`
     * various destination token (and slot icon) interactions with big city upgrades (issue #10147)
     * 9 tokens in Winnipeg; assets_spec test added to ensure rendering works (issue #10173)
+
+* `3`
+    * ICR's destination token staying in the correct city in Quebec when
+      upgraded to green (issue #10201)


### PR DESCRIPTION
In 1822, M14 in London is always in a city that only has one normal slot. On the Toronto hex and tiles in 1822CA, M13's home city can have 1-4 slots. This is progress on #10226.

A couple other small miscellaneous fixes:

* clean up some dead 1822 code missed in #9519
* add note to fixtures README about 1822CA game 3
* make `MINOR_14_ID` references explicit for PNW and MX
* remove `MINOR_14_ID` from `PENDING_HOME_TOKENERS` for CA WRS as M13 is not present there (probably worth a refactor to give this a more descriptive name at some point, it's weird for the constant named with "14" to refer to the minor company "13" in CA)

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`