### PR TITLE
[18RoyalGorge] implement paying steel company for track tiles

### DIFF
--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -4,6 +4,7 @@ require '../lib/storage'
 require '../lib/settings'
 require 'view/game/axis'
 require 'view/game/hex'
+require 'view/game/map_legend'
 require 'view/game/tile_confirmation'
 require 'view/game/tile_selector'
 require 'view/game/token_selector'
@@ -142,7 +143,7 @@ module View
         }
 
         map_elements = [h(:div, props, children), h(MapControls)]
-        map_elements << render_legend if @game.show_map_legend?
+        map_elements << h(MapLegend, game: @game) if @game.show_map_legend? && !@game.show_map_legend_on_left?
 
         h(:div, { style: { marginBottom: '1rem' } }, map_elements)
       end
@@ -195,44 +196,6 @@ module View
 
       def map_zoom
         Lib::Storage['map_zoom'] || 1
-      end
-
-      def render_legend
-        table_props, header, *chart = @game.map_legend(
-          color_for(:font),
-          color_for(:yellow),
-          color_for(:green),
-          color_for(:brown),
-          color_for(:gray)
-        )
-
-        head = header.map do |cell|
-          item = cell[:text] || h(:image, { attrs: { href: cell[:image] } })
-          if cell[:props]
-            h(:th, cell[:props], item)
-          else
-            h(:th, item)
-          end
-        end
-
-        rows = chart.map do |r|
-          columns = r.map do |cell|
-            item = cell[:text] || [h(:img, { attrs: { src: cell[:image], height: cell[:image_height] } })]
-            if cell[:props]
-              h(:td, cell[:props], item)
-            else
-              h(:td, item)
-            end
-          end
-          h(:tr, columns)
-        end
-
-        h(:table, table_props, [
-          h(:thead, [
-            h(:tr, head),
-          ]),
-          h(:tbody, rows),
-        ])
       end
     end
   end

--- a/assets/app/view/game/map_legend.rb
+++ b/assets/app/view/game/map_legend.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require '../lib/settings'
+
+module View
+  module Game
+    class MapLegend < Snabberb::Component
+      include Actionable
+      include Lib::Settings
+      needs :game, store: true
+
+      def render
+        table_props, header, *chart = @game.map_legend(
+          color_for(:font),
+          color_for(:yellow),
+          color_for(:green),
+          color_for(:brown),
+          color_for(:gray),
+          action_processor: ->(a) { process_action(a) },
+        )
+
+        head = header.map do |cell|
+          item = cell[:text] || h(:image, { attrs: { href: cell[:image] } })
+          if cell[:props]
+            h(:th, cell[:props], item)
+          else
+            h(:th, item)
+          end
+        end
+
+        rows = chart.map do |r|
+          columns = r.map do |cell|
+            item = cell[:text] || [h(:img, { attrs: { src: cell[:image], height: cell[:image_height] } })]
+            if cell[:props]
+              h(:td, cell[:props], item)
+            else
+              h(:td, item)
+            end
+          end
+          h(:tr, columns)
+        end
+
+        h(:table, table_props, [
+          h(:thead, [
+            h(:tr, head),
+          ]),
+          h(:tbody, rows),
+        ])
+      end
+    end
+  end
+end

--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -130,6 +130,7 @@ module View
           }
 
           aquire_company_action = @current_actions.include?('acquire_company')
+          left << h(MapLegend, game: @game) if @game.show_map_legend? && @game.show_map_legend_on_left?
           right << h(Map, game: @game) unless aquire_company_action
           right << h(:div, div_props, [h(BuyCompanies, limit_width: true)]) if @current_actions.include?('buy_company')
           right << h(:div, div_props, [h(AcquireCompanies)]) if aquire_company_action

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -3200,6 +3200,10 @@ module Engine
         false
       end
 
+      def show_map_legend_on_left?
+        false
+      end
+
       def train_purchase_name(train)
         train.name
       end

--- a/lib/engine/game/g_18_royal_gorge/step/track.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/track.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/track'
+
+module Engine
+  module Game
+    module G18RoyalGorge
+      module Step
+        class Track < Engine::Step::Track
+          MAX_STEEL_COST = 40
+
+          def help
+            [
+              "Used #{@round.num_laid_track}/6 track actions.",
+              'For each track action, a steel cube from the steel table must be bought from CF&I.',
+              'For each color of track tile, only one column of the steel table may be used per turn.',
+              'At the end of each set of operating rounds, CF&I pays its steel earnings as dividends to '\
+              'shareholders, and the steel table is refilled.',
+            ]
+          end
+
+          def round_state
+            super.merge(
+              {
+                laid_track: {
+                  yellow: false,
+                  green: false,
+                  brown: false,
+                },
+                steel_column_choice: {
+                  yellow: nil,
+                  green: nil,
+                  brown: nil,
+                  gray: nil,
+                },
+                steel_price_choice: {
+                  yellow: nil,
+                  green: nil,
+                  brown: nil,
+                  gray: nil,
+                },
+              }
+            )
+          end
+
+          def setup
+            @round.steel_column_choice[:yellow] = nil
+            @round.steel_column_choice[:green] = nil
+            @round.steel_column_choice[:brown] = nil
+            @round.steel_column_choice[:gray] = nil
+
+            @round.steel_price_choice[:yellow] = nil
+            @round.steel_price_choice[:green] = nil
+            @round.steel_price_choice[:brown] = nil
+            @round.steel_price_choice[:gray] = nil
+
+            @round.laid_track[:yellow] = false
+            @round.laid_track[:green] = false
+            @round.laid_track[:brown] = false
+
+            super
+          end
+
+          def actions(entity)
+            actions = super
+            actions << 'choose' if entity == current_entity
+            actions
+          end
+
+          def process_lay_tile(action)
+            entity = action.entity
+            color = action.tile.color
+
+            steel_cost =
+              if color == :gray
+                @round.steel_column_choice[color] = 'I'
+                MAX_STEEL_COST
+              else
+                column = @round.steel_column_choice[color]
+                if column.nil?
+                  column = @game.available_steel[color].min_by { |_, v| v[-1] || MAX_STEEL_COST }[0]
+                  @round.steel_column_choice[color] = column
+                end
+
+                chosen_price = @round.steel_price_choice[color] || @game.available_steel[color][column][-1]
+                @game.available_steel[color][column].delete(chosen_price) || MAX_STEEL_COST
+              end
+            if steel_cost.positive?
+              entity.spend(steel_cost, @game.steel_corp)
+              @log << "#{entity.name} pays #{@game.steel_corp.name} #{@game.format_currency(steel_cost)} for steel"
+            end
+
+            super
+
+            # update choice to one step up the column
+            if @round.steel_price_choice[color] && @round.steel_price_choice[color] != MAX_STEEL_COST
+              next_choice = nil
+              @game.available_steel[color][column].each_with_index do |price, _index|
+                break unless price > @round.steel_price_choice[color]
+
+                next_choice = price
+              end
+              @round.steel_price_choice[color] = (next_choice || MAX_STEEL_COST)
+            end
+
+            @round.laid_track[color] = true
+          end
+
+          def choice_name
+            'Steel cubes'
+          end
+
+          def choices
+            # never present a choice for gray, it's always the max
+            available_colors = @game.phase.tiles - [:gray]
+
+            choices = {}
+
+            available_colors.each do |color|
+              @game.available_steel[color].each do |column, prices|
+                (prices + [MAX_STEEL_COST]).each do |price|
+                  c = "#{column}-#{price}"
+                  choices[c] = c
+                end
+              end
+            end
+
+            choices
+          end
+
+          def process_choose(action)
+            column, price_s = action.choice.split('-')
+            price = price_s.to_i
+
+            color = @game.class::COLUMN_COLORS[column]
+
+            @round.steel_column_choice[color] = column
+            @round.steel_price_choice[color] = price
+
+            @log << "#{action.entity.name} chooses steel for next #{color} tile: column #{column}, "\
+                    "#{@game.format_currency(price)}"
+          end
+
+          # choices are accessed via the map_legend
+          def render_choices?
+            false
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#10110

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

* up to 6 track actions possible
* for each color laid, pick one column of that color from the steel table
    * a company can only take cubes from the chosen column 
    * a company can use columns that were used by previous companies 
    * cubes are refilled at the end of the OR set 
    * the cheapest option need not be used; if no explicit choice is made, the cheapest will be used 
    * cube/column choices are made by clicking directly on the steel table 
    * the currently chosen cube is highlighted in white 
    * when a column is committed, its header is higlighted in the column color
* re-uses the "map legend" from 21Moon to render the table, and allows clicking the table to process actions, so that the user can click directly on the cube they want to use

### Screenshots

By default, the first, cheapest column is selected:

![steel before](https://github.com/tobymao/18xx/assets/1045173/82d489ac-a69e-4302-9571-f2690b7c16d1)

Any cube for an available color can be selected before a tile has been laid; clicking on a cube will show a log message:

![steel chose 20 C](https://github.com/tobymao/18xx/assets/1045173/44dfa852-96eb-49ff-95b3-1daa99a1f2e1)

Once a tile has been laid, a different column cannot be chosen; the next cube chosen by default is the one above the one used--my assumption there is if a company is not using the cheapest, they want to save the cheapest for a company operating later; the  money spent on the previously selected cube is visible in the log:

![steel laid with C](https://github.com/tobymao/18xx/assets/1045173/24d8dc4b-425d-4e24-9053-f22d2f5e2a42)


### Any Assumptions / Hacks

An `action_processor` argument is added to pass a lambda to a game's `map_legend` method so that code from `View::Game::Actionable` can be used for processing the action when clicking on the table cell defined in the 18RoyalGorge game class.