### PR TITLE
rename after_ipo > after_float symbol

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -177,13 +177,13 @@ module Engine
       TURN_SELL_LIMIT = nil
 
       # when can a share holder sell shares
-      # first           -- after first stock round
-      # after_float     -- after stock round in which company floated
-      # operate         -- after operation
-      # full_or_turn    -- after corp completes a full OR turn
-      # p_any_operate   -- pres any time, share holders after operation
-      # any_time        -- at any time
-      # round           -- after the stock round the share was purchased in
+      # first            -- after first stock round
+      # after_sr_floated -- after stock round in which company floated
+      # operate          -- after operation
+      # full_or_turn     -- after corp completes a full OR turn
+      # p_any_operate    -- pres any time, share holders after operation
+      # any_time         -- at any time
+      # round            -- after the stock round the share was purchased in
       SELL_AFTER = :first
 
       # down_share -- down one row per share
@@ -1083,7 +1083,7 @@ module Engine
         case self.class::SELL_AFTER
         when :first
           @turn > 1 || @round.operating?
-        when :after_float
+        when :after_sr_floated
           corporation.operated? || @round.operating?
         when :operate
           corporation.operated?

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -178,7 +178,7 @@ module Engine
 
       # when can a share holder sell shares
       # first           -- after first stock round
-      # after_ipo       -- after stock round in which company is opened
+      # after_float     -- after stock round in which company floated
       # operate         -- after operation
       # full_or_turn    -- after corp completes a full OR turn
       # p_any_operate   -- pres any time, share holders after operation
@@ -1083,7 +1083,7 @@ module Engine
         case self.class::SELL_AFTER
         when :first
           @turn > 1 || @round.operating?
-        when :after_ipo
+        when :after_float
           corporation.operated? || @round.operating?
         when :operate
           corporation.operated?

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -188,7 +188,7 @@ module Engine
         POOL_SHARE_DROP = :down_share
         SELL_MOVEMENT = :none
         ALL_COMPANIES_ASSIGNABLE = true
-        SELL_AFTER = :after_ipo
+        SELL_AFTER = :after_float
         OBSOLETE_TRAINS_COUNT_FOR_LIMIT = true
         BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
 

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -188,7 +188,7 @@ module Engine
         POOL_SHARE_DROP = :down_share
         SELL_MOVEMENT = :none
         ALL_COMPANIES_ASSIGNABLE = true
-        SELL_AFTER = :after_float
+        SELL_AFTER = :after_sr_floated
         OBSOLETE_TRAINS_COUNT_FOR_LIMIT = true
         BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
 

--- a/lib/engine/game/g_system18/game.rb
+++ b/lib/engine/game/g_system18/game.rb
@@ -369,7 +369,7 @@ module Engine
           #
           if game_capitalization == :incremental
             redef_const(:SELL_BUY_ORDER, :sell_buy)
-            redef_const(:SELL_AFTER, :after_float)
+            redef_const(:SELL_AFTER, :after_sr_floated)
             redef_const(:SELL_MOVEMENT, :left_block_pres)
             redef_const(:SOLD_OUT_INCREASE, false)
             redef_const(:MUST_EMERGENCY_ISSUE_BEFORE_EBUY, true)

--- a/lib/engine/game/g_system18/game.rb
+++ b/lib/engine/game/g_system18/game.rb
@@ -369,7 +369,7 @@ module Engine
           #
           if game_capitalization == :incremental
             redef_const(:SELL_BUY_ORDER, :sell_buy)
-            redef_const(:SELL_AFTER, :after_ipo)
+            redef_const(:SELL_AFTER, :after_float)
             redef_const(:SELL_MOVEMENT, :left_block_pres)
             redef_const(:SOLD_OUT_INCREASE, false)
             redef_const(:MUST_EMERGENCY_ISSUE_BEFORE_EBUY, true)


### PR DESCRIPTION
Fixes #10255

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

FWIW @scottredracecar, the 1817 rules have no mention of the word "float". :)
