### PR TITLE
[SteamOverHolland] - implements fixed round structure

### DIFF
--- a/lib/engine/game/g_steam_over_holland/meta.rb
+++ b/lib/engine/game/g_steam_over_holland/meta.rb
@@ -10,6 +10,7 @@ module Engine
 
         DEV_STAGE = :prealpha
 
+        GAME_TITLE = 'Steam Over Holland'
         GAME_DESIGNER = 'Bart van Dijk'
         GAME_LOCATION = 'The Netherlands'
         GAME_RULES_URL = 'https://boardgamegeek.com/filepage/47246/corrected-english-manual-v2'


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Implements fixed round structure for the game, which runs 5 sets of SR-OR-OR after the initial auction

Still Pre-alpha

* **Screenshots**

* **Any Assumptions / Hacks**
Borrows code from 21Moon
