### PR TITLE
[1822CA] keep the name "5P" for the special private company 5-train

### DIFF
--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -321,7 +321,6 @@ module Engine
           @company_trains['P3'] = find_and_remove_train_by_id('2P-0', buyable: false)
           @company_trains['P4'] = find_and_remove_train_by_id('2P-1', buyable: false)
           @company_trains['P1'] = find_and_remove_train_by_id('5P-0')
-          @company_trains['P1'].name = '5'
           @company_trains['P5'] = find_and_remove_train_by_id('P-0', buyable: false)
           @company_trains['P6'] = find_and_remove_train_by_id('P-1', buyable: false)
           @company_trains['P2'] = find_and_remove_train_by_id('LP-0', buyable: false)


### PR DESCRIPTION
Renaming it to "5" in this way causes a mismatch with the variant that gets created when the train object is initialized. Updating the string in the variant could be done too, but it would be clunky and isn't worth it.

Fixes #10238
