### PR TITLE
System18: more updates; add player count and designer info to CreateGame options

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -259,7 +259,7 @@ module View
 
         desc_text = o_r[:desc] ? ": #{o_r[:desc]}" : ''
         parenthetical = ''
-        if o_r[:players]&.one? && o_r[:players][0] == 1
+        if o_r[:players] == [1]
           parenthetical = 'solo'
         elsif o_r[:players]&.one?
           parenthetical = "#{o_r[:players].min} players"

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -258,6 +258,20 @@ module View
         next if o_r[:hidden]
 
         desc_text = o_r[:desc] ? ": #{o_r[:desc]}" : ''
+        parenthetical = ''
+        if o_r[:players]&.one? && o_r[:players][0] == 1
+          parenthetical = 'solo'
+        elsif o_r[:players]&.one?
+          parenthetical = "#{o_r[:players].min} players"
+        elsif o_r[:players]
+          parenthetical = "#{o_r[:players].min}-#{o_r[:players].max} players"
+        end
+        if o_r[:designer]
+          parenthetical += ' ' if parenthetical != ''
+          parenthetical += "by #{o_r[:designer]}"
+        end
+        desc_text += " (#{parenthetical})" if parenthetical != ''
+
         label_text = "#{o_r[:short_name]}#{desc_text}"
         h(:li, [render_input(
           label_text,

--- a/assets/app/view/game/game_meta.rb
+++ b/assets/app/view/game/game_meta.rb
@@ -62,7 +62,9 @@ module View
         used_optional_rules = @game.meta::OPTIONAL_RULES.map do |o_r|
           next unless @game.optional_rules.include?(o_r[:sym])
 
-          h(:p, " * #{o_r[:short_name]}: #{o_r[:desc]}")
+          desc_text = o_r[:desc] ? ": #{o_r[:desc]}" : ''
+          desc_text += o_r[:designer] ? " by #{o_r[:designer]}" : ''
+          h(:p, " * #{o_r[:short_name]}#{desc_text}")
         end.compact
         return [] if used_optional_rules.empty?
 

--- a/lib/engine/game/g_1825/meta.rb
+++ b/lib/engine/game/g_1825/meta.rb
@@ -20,37 +20,32 @@ module Engine
           {
             sym: :unit_1,
             short_name: 'Unit 1',
-            desc: '2-5 players',
             players: [2, 3, 4, 5],
           },
           {
             sym: :unit_2,
             short_name: 'Unit 2',
-            desc: '2-3 players',
             players: [2, 3],
           },
           {
             sym: :unit_3,
             short_name: 'Unit 3',
-            desc: '2 players',
             players: [2],
           },
           {
             sym: :unit_12,
             short_name: 'Units 1+2',
-            desc: '3-7 players',
             players: [3, 4, 5, 6, 7],
           },
           {
             sym: :unit_23,
             short_name: 'Units 2+3',
-            desc: '3-5 players',
             players: [3, 4, 5],
           },
           {
             sym: :unit_123,
             short_name: 'Units 1+2+3',
-            desc: '4-8 players (4-9 with regionals)',
+            desc: '4-8 players w/o regionals',
             players: [4, 5, 6, 7, 8, 9],
           },
           {

--- a/lib/engine/game/g_1888/meta.rb
+++ b/lib/engine/game/g_1888/meta.rb
@@ -22,7 +22,7 @@ module Engine
           {
             sym: :north,
             short_name: '1888-N',
-            desc: 'North Map (3-6 players)',
+            desc: 'North Map',
             players: [3, 4, 5, 6],
             default: true,
           },

--- a/lib/engine/game/g_system18/game.rb
+++ b/lib/engine/game/g_system18/game.rb
@@ -199,21 +199,21 @@ module Engine
             on: '5',
             train_limit: 2,
             tiles: %i[yellow green brown],
-            operating_rounds: 3,
+            operating_rounds: 2,
           },
           {
             name: '6',
             on: '6',
             train_limit: 2,
             tiles: %i[yellow green brown],
-            operating_rounds: 3,
+            operating_rounds: 2,
           },
           {
             name: 'D',
             on: 'D',
             train_limit: 2,
             tiles: %i[yellow green brown gray],
-            operating_rounds: 3,
+            operating_rounds: 2,
           },
         ].freeze
 
@@ -265,7 +265,7 @@ module Engine
         ONLY_HIGHEST_BID_COMMITTED = true
         HOME_TOKEN_TIMING = :operate
         SELL_BUY_ORDER = :sell_buy_sell
-        GAME_END_CHECK = { bankrupt: :immediate, final_phase: :full_or }.freeze
+        GAME_END_CHECK = { bankrupt: :immediate, final_phase: :one_more_full_or_set }.freeze
         LAYOUT = :pointy
 
         # need to define constants that could be redefined
@@ -312,6 +312,10 @@ module Engine
               **corporation.merge(corporation_opts),
             )
           end
+        end
+
+        def find_corp(corps, sym)
+          corps.find { |c| c[:sym] == sym }
         end
 
         def location_name(coord)

--- a/lib/engine/game/g_system18/map_base_customization.rb
+++ b/lib/engine/game/g_system18/map_base_customization.rb
@@ -60,7 +60,7 @@ module Engine
                                on: '8',
                                train_limit: 2,
                                tiles: %i[yellow green brown gray],
-                               operating_rounds: 3,
+                               operating_rounds: 2,
                              })
           base_phases
         end

--- a/lib/engine/game/g_system18/map_neus_customization.rb
+++ b/lib/engine/game/g_system18/map_neus_customization.rb
@@ -40,6 +40,7 @@ module Engine
             'B5' => 'Detroit & Cleveland',
             'B7' => 'Erie',
             'B11' => 'Boston',
+            'C4' => 'Cincinnati',
             'C10' => 'New York City',
             'D9' => 'Washington DC',
           }
@@ -70,7 +71,7 @@ module Engine
               %w[C6] => 'town=revenue:0;town=revenue:0;upgrade=cost:120,terrain:mountain',
               %w[C8] => 'town=revenue:0;town=revenue:0;upgrade=cost:40,terrain:mountain',
               %w[B9 D5] => 'upgrade=cost:40,terrain:mountain',
-              ['D7'] => 'upgrade=cost:120,terrain:mountain',
+              ['D7'] => 'upgrade=cost:40,terrain:mountain',
             },
             yellow: {
               ['B3'] => 'city=revenue:30;path=a:2,b:_0;path=a:4,b:_0;label=B',
@@ -92,6 +93,8 @@ module Engine
           corps.each_with_index do |c, idx|
             c[:coordinates] = %w[B7 D9 B5 C10 B11][idx]
           end
+          find_corp(corps, 'KKN')[:city] = 0
+          find_corp(corps, 'GFN')[:city] = 0
 
           corps
         end

--- a/lib/engine/game/g_system18/meta.rb
+++ b/lib/engine/game/g_system18/meta.rb
@@ -21,16 +21,16 @@ module Engine
         OPTIONAL_RULES = [
           {
             sym: :map_NEUS,
-            short_name: 'Northeast US',
-            desc: 'Map: Northeast United States',
+            short_name: 'Map: Northeast US',
             players: [2, 3],
-            default: true,
+            designer: 'Scott Petersen',
           },
           {
             sym: :map_France,
-            short_name: 'France',
-            desc: 'Map: France',
+            short_name: 'Map: France',
             players: [2, 3, 4],
+            designer: 'Scott Petersen',
+            default: true,
           },
         ].freeze
 


### PR DESCRIPTION
* **Explanation of Change**

More tweaks to System18

Common code change: CreateGame
-> add display of player count and optional designer for options
Needed because various maps for System18 may have different designers
This won't affect any game option w/o `:players` or `:designer`

Common code change: Game::GameMeta
-> add display of optional designer

* **Screenshots**

CreateGame Before:
![new_game_before](https://github.com/tobymao/18xx/assets/8494213/85978f00-36af-4583-a0c2-c40297af1a17)

CreateGame After:
![new_game_after](https://github.com/tobymao/18xx/assets/8494213/3413d2f5-25fe-4e96-9bc8-20c454b3c57e)

GameMeta Before:
![game_meta_before](https://github.com/tobymao/18xx/assets/8494213/d221b55e-1224-41fc-84ea-4f5e893bf0fa)

GameMeta After:
![game_meta_after](https://github.com/tobymao/18xx/assets/8494213/eb13f2c8-96d1-459e-9696-2b752d4c4860)
