### PR TITLE
[SteamOverHolland] implements price shelves (take 2)

### DIFF
--- a/lib/engine/game/g_steam_over_holland/game.rb
+++ b/lib/engine/game/g_steam_over_holland/game.rb
@@ -28,6 +28,7 @@ module Engine
         CURRENCY_FORMAT_STR = 'fl. %s'
         MUST_SELL_IN_BLOCKS = true
         SELL_MOVEMENT = :left_share
+        MUST_EMERGENCY_ISSUE_BEFORE_EBUY = true
 
         BANK_CASH = 99_999
 
@@ -52,25 +53,25 @@ module Engine
             { price: 75, types: [:par] },
             { price: 80, types: [:par] },
             { price: 90, types: [:par] },
-            { price: 100, types: [:par] },
+            { price: 100, types: %i[par max_price_1] },
             { price: 110, types: [:ignore_sale_unless_president] },
             { price: 125, types: [:max_one_drop_unless_president] },
-            { price: 140, types: [:max_two_drops_unless_president] },
+            { price: 140, types: %i[max_two_drops_unless_president max_price_1] },
             { price: 160, types: [:ignore_sale_unless_president] },
             { price: 180, types: [:max_one_drop_unless_president] },
-            { price: 210, types: [:max_two_drops_unless_president] },
+            { price: 210, types: %i[max_two_drops_unless_president max_price_1] },
             { price: 240, types: [:ignore_sale_unless_president] },
             { price: 270, types: [:max_one_drop_unless_president] },
-            { price: 300, types: [:max_two_drops_unless_president] },
+            { price: 300, types: %i[max_two_drops_unless_president max_price_1] },
             { price: 330, types: [:ignore_sale_unless_president] },
             { price: 360, types: [:endgame] },
           ],
         ].freeze
 
-        STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(par: :yellow, ignore_unless_president: :green).freeze
+        STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(par: :yellow).freeze
 
         MARKET_TEXT = Base::MARKET_TEXT.merge(
-          ignore_unless_president: 'Price will not drop below these values in Stock Round unless president sells'
+          max_price_1: 'Price will not drop below black line in Stock Round unless president sells'
         ).freeze
 
         PHASES = [{ name: '2', train_limit: 4, tiles: [:yellow] },
@@ -263,20 +264,26 @@ module Engine
         end
 
         def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
-          super
-          num_shares = bundle.num_shares
-          unless bundle.owner == corporation.owner
-            # This allows for the ledges that prevent price drops unless the president is selling
+          price_drop = bundle.num_shares
+          corporation = bundle.corporation
+          old_price = corporation.share_price
+          @share_pool.sell_shares(bundle, allow_president_change: allow_president_change, swap: swap)
+
+          if bundle.owner == corporation.owner
+            super
+          else
+            # This section allows for the ledges that prevent price drops unless the president is selling
             case corporation.share_price.type
             when :ignore_sale_unless_president
-              num_shares = 0
+              price_drop = 0
             when :max_one_drop_unless_president
-              num_shares = 1
+              price_drop = 1
             when :max_two_drops_unless_president
-              num_shares = 2 unless num_shares == 1
+              price_drop = 2 unless bundle.num_shares == 1
             end
+            price_drop.times { @stock_market.move_left(corporation) }
+            log_share_price(corporation, old_price) if sell_movement(corporation) != :none
           end
-          num_shares.times { @stock_market.move_down(corporation) }
         end
 
         def issuable_shares(entity)


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
Implements the price shelves in Steam Over Holland's market, and the price movement rules for it. 

* **Screenshots**

* **Any Assumptions / Hacks**
