### PR TITLE
[18RoyalGorge] Treaty of Boston, debt, Royal Gorge hexes

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/buy_sell_par_shares.rb
@@ -10,6 +10,10 @@ module Engine
           def get_par_prices(entity, _corp)
             @game.par_prices.select { |p| p.price * 2 <= entity.cash }
           end
+
+          def visible_corporations
+            @game.sorted_corporations.reject { |c| c.type == :debt }
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_royal_gorge/step/special_choose.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/special_choose.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/special_choose'
+
+module Engine
+  module Game
+    module G18RoyalGorge
+      module Step
+        class SpecialChoose < Engine::Step::SpecialChoose
+          def process_choose_ability(action)
+            return unless action.choice == 'pay_debt'
+
+            debt_company = action.entity
+            corporation = debt_company.owner
+
+            ability = abilities(corporation)
+            ability.use!
+
+            debtor, = @game.indebted[corporation]
+
+            amount = @game.debt_corp.share_price.price
+            corporation.spend(amount, debtor)
+            @log << "#{corporation.name} pays #{@game.format_currency(amount)} to #{debtor.name} for one DEBT token"
+
+            @game.indebted[corporation][1] -= 1
+
+            return unless @game.indebted[corporation][1].zero?
+
+            @log << "#{corporation.name}'s DEBT is paid off."
+            @game.indebted.delete(corporation)
+            debt_company.close!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_royal_gorge/step/track.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/track.rb
@@ -90,6 +90,8 @@ module Engine
               @log << "#{entity.name} pays #{@game.steel_corp.name} #{@game.format_currency(steel_cost)} for steel"
             end
 
+            upgrade_other_royal_gorge_hexes(action) if @game.class::ROYAL_GORGE_HEXES_TO_TILES.include?(action.hex.id)
+
             super
 
             # update choice to one step up the column
@@ -144,6 +146,17 @@ module Engine
           # choices are accessed via the map_legend
           def render_choices?
             false
+          end
+
+          def upgrade_other_royal_gorge_hexes(action)
+            @game.class::ROYAL_GORGE_HEXES_TO_TILES.each do |hex_id, tiles|
+              _green_tile, brown_tile = tiles
+              hex = @game.hex_by_id(hex_id)
+              next if hex == action.hex
+
+              tile = @game.tile_by_id("#{brown_tile}-0")
+              hex.lay(tile)
+            end
           end
         end
       end

--- a/public/logos/18_royal_gorge/DEBT.svg
+++ b/public/logos/18_royal_gorge/DEBT.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="red"/><text x="4" y="5" text-anchor="middle" font-weight="700" font-size="3" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="#fff">DEBT</text></svg>


### PR DESCRIPTION
#10110

At the Treaty of Boston (second 3-train), the Royal Gorge is upgraded to green, and the Rio Grande corporation becomes indebted to the Santa Fe corporation, and the Santa Fe corporation becomes indebted to the Doc Holliday private company (or bank if that private is not in the game).

Royal Gorge hexes

* a three-hex green tile is laid, and Rio Grande gets tokens on the two cities
* there is also a three-hex brown tile that can upgrade these hexes; following the 18MEX lead, these work by allowing operators to upgrade one of the hexes and then the others are automatically upgraded

Debt

* each indebted party has a debt card with slots for tokens; when paying off debt, they fill one slot with a token; the leftmost open slot shows how many steps there stock price will move left at the end of the game
* instead of slots on a card, this is captured by a private company with an ability count showing how much debt is left
* the amount required to pay off a debt and acquire a token is given by the DEBT token in the stock market; it increases one step every OR
* each indebted entity can pay off one debt per OR
* if the debtor is not owned by a player (e.g., Santa Fe hasn't started yet or the Doc Holliday private was removed in setup), debt is paid to the bank
