### PR TITLE
[21Moon] sets default buying slot to Space Port

### DIFF
--- a/lib/engine/game/g_21_moon/step/buy_train.rb
+++ b/lib/engine/game/g_21_moon/step/buy_train.rb
@@ -133,8 +133,8 @@ module Engine
 
           def slot_dropdown_options(corp)
             options = []
-            options << { slot: 0, text: 'Local Base' } if room_for_lb?(corp)
             options << { slot: 1, text: 'Space Port Base' } if room_for_sp?(corp)
+            options << { slot: 0, text: 'Local Base' } if room_for_lb?(corp)
             options
           end
 


### PR DESCRIPTION
Fixes #10302 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

Swaps the position of Space Port and Local Base in the drop down menu when buying trains. 

I don't believe this will require pins
