### PR TITLE
[21Moon] prevents OLS from using hex D10 and E5

### DIFF
--- a/lib/engine/game/g_21_moon/entities.rb
+++ b/lib/engine/game/g_21_moon/entities.rb
@@ -15,10 +15,10 @@ module Engine
             revenue: 0,
             min_price: 1,
             max_price: 1,
-            desc: 'When buying the private, a player must immediately place the black “SD” token on any '\
-                  'mineral resource hex on the board in which the black “SD” token blocks an SD spot. '\
-                  'When sold to a corporation, the black SD token will be replaced by a token from the owning corporation. '\
-                  'Can be sold to a corporation for ₡1.',
+            desc: 'When buying the OLS, the buyer must immediately place the OLS token along with a yellow tile on any '\
+                  'mineral resource hex that is at least three hexes away from the Space Port (E9). The owning player '\
+                  'can later sell OLS to a corporation for ₡1. When sold, the OLS token will be replaced by an additional '\
+                  'station token for the owning corporation.',
             abilities: [],
             color: nil,
           },

--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -224,6 +224,7 @@ module Engine
         }.freeze
 
         MINERAL_HEXES = %w[A7 A9 B4 B12 D10 E15 F2 H10 I7 J2 J10 K5 K13 L10 H2 E5 G13].freeze
+        OLS_HEXES = %w[A7 A9 B4 B12 E15 F2 G13 H2 H10 I7 J2 J10 K5 K13 L10].freeze
 
         X_RESTRICTED_UPGRADES = {
           'X2' => %w[X4 X7],
@@ -398,7 +399,7 @@ module Engine
           @log << "#{player.name} must place tile for OLS"
           @round.pending_tracks << {
             entity: ols_minor,
-            hexes: MINERAL_HEXES.map { |h| hex_by_id(h) },
+            hexes: OLS_HEXES.map { |h| hex_by_id(h) },
           }
           @round.clear_cache!
         end


### PR DESCRIPTION
Fixes #10324 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
In the physical version of 21Moon, OLS can't be used fewer than 3 hexes from the Space Port. This implements that change. Also updates the private company card text.

This will require pins, presumably only on games where players used OLS on hexes D10 or E5. 

* **Screenshots**

![image](https://github.com/tobymao/18xx/assets/26125362/0c7d7723-68b7-4560-8c2d-a0de7a1be504)


* **Any Assumptions / Hacks**
