### PR TITLE
[1822PNW] Fix 10107 - add safe navigation operator

### DIFF
--- a/lib/engine/corporation.rb
+++ b/lib/engine/corporation.rb
@@ -260,7 +260,7 @@ module Engine
     end
 
     def remove_ability(ability)
-      return super if ability.owner == self
+      return super if ability&.owner == self
 
       @companies.each { |company| company.remove_ability(ability) }
     end


### PR DESCRIPTION
Fixes #10107 

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

#### Explanation of Change

I just added a safe nav operator on the offending line of code. Then I ran the game action on dev and it continued without error and provided the expected results:

* Companies successfully merged
* New merged company had correct Home and Destination token

#### Any Assumptions / Hacks

I am assuming that if object `ability` has no `.owner` method, then `remove_ability()` should continue its work. This didn't negatively impact the test game and all current spec tests passed.
