### PR TITLE
[1822CA] disallow sawmill in Y-cities, fix currency symbol on info page

### DIFF
--- a/lib/engine/game/g_1822_ca/entities.rb
+++ b/lib/engine/game/g_1822_ca/entities.rb
@@ -253,11 +253,11 @@ module Engine
             abilities: [
               {
                 type: 'assign_hexes',
-                hexes: %w[A7 A9 AA15 AA9 AB22 AD18 AD20 AE17 AF16 AG13 AG3
+                hexes: %w[A9 AA15 AA9 AB22 AD18 AD20 AE17 AF16 AG13 AG3
                           AG9 AH10 AH12 AK3 AK5 AL2 AM5 AM9 AO9 AP6 C9
-                          D10 D12 D14 D16 F10 F8 G11 G13 G15 G17 H16 H8 I11 I15
-                          I17 J12 J16 K11 K13 K15 K17 K9 L10 L16 L8 M17 M9 N6
-                          O15 O9 P14 Q7 R16 S15 U11 V18 W9 X12 Y17 Z10 Z26],
+                          D10 D12 D14 D16 F10 F8 G11 G13 G17 H16 H8 I11 I15
+                          I17 J12 J16 K11 K13 K17 K9 L10 L16 L8 M17 M9 N6
+                          O15 O9 P14 Q7 S15 U11 W9 X12 Y17 Z10 Z26],
                 count: 1,
                 owner_type: 'corporation',
                 when: 'owning_corp_or_turn',

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -233,6 +233,10 @@ module Engine
         )
 
         STATUS_TEXT = G1822::Game::STATUS_TEXT.merge(
+          'can_acquire_minor_bidbox' => ['Acquire a minor from bidbox',
+                                         'Can acquire a minor from bidbox for $200, must have connection '\
+                                         'to start location'],
+          'minor_float_phase1' => ['Minors receive $100 in capital', 'Minors receive 100 capital with 50 stock value'],
           'l_upgrade' => ['$70 L-train upgrades',
                           'The cost to upgrade an L-train to a 2-train is reduced from $80 to $70.']
         )


### PR DESCRIPTION
Fixes #10326

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`