### PR TITLE
Add in region weight debugging information when 'grid' URL parameter is used

### DIFF
--- a/assets/app/view/game/part/debug_region_weights.rb
+++ b/assets/app/view/game/part/debug_region_weights.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'lib/hex'
+require 'view/game/part/base'
+require 'view/game/part/region_coordinates'
+
+module View
+  module Game
+    module Part
+      class DebugRegionWeights < Base
+        include RegionCoordinates
+
+        needs :region_use, default: nil
+
+        def render_part
+          return [] if @region_use.nil?
+
+          children = []
+
+          REGION_CENTER_COORDINATES[layout].each do |tri, tri_coords|
+            text_attrs = {
+              'dominant-baseline': 'middle',
+              'font-size': 'large',
+              'stroke-width': '0.5',
+              fill: 'cyan',
+              transform: "#{rotation_for_layout} translate(#{tri_coords[:x]} #{tri_coords[:y]})",
+            }
+
+            children << h(:text, { attrs: text_attrs }, @region_use[tri].round(1))
+          end
+
+          h(:g, children)
+        end
+      end
+    end
+  end
+end

--- a/assets/app/view/game/part/region_coordinates.rb
+++ b/assets/app/view/game/part/region_coordinates.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'lib/hex'
+require 'view/game/part/base'
+
+module View
+  module Game
+    module Part
+      module RegionCoordinates
+        RC_OFFSET = 7
+
+        RC_ROWS = {
+          0 => (Lib::Hex::Y_T * (3 / 4)),
+          1 => (Lib::Hex::Y_T * (1 / 4)),
+          2 => (Lib::Hex::Y_B * (1 / 4)),
+          3 => (Lib::Hex::Y_B * (3 / 4)),
+        }.freeze
+
+        RC_COLS = {
+          0 => (Lib::Hex::X_L * (3 / 4)),
+          1 => (Lib::Hex::X_L * (2 / 4)),
+          2 => (Lib::Hex::X_L * (1 / 4)),
+          3 => 0,
+          4 => (Lib::Hex::X_R * (1 / 4)),
+          5 => (Lib::Hex::X_R * (2 / 4)),
+          6 => (Lib::Hex::X_R * (3 / 4)),
+        }.freeze
+
+        REGION_CENTER_COORDINATES = {
+          flat: {
+            0 => { region_weights: [0], x: RC_COLS[1], y: RC_ROWS[0] + RC_OFFSET },
+            1 => { region_weights: [1], x: RC_COLS[2], y: RC_ROWS[0] - RC_OFFSET },
+            2 => { region_weights: [2], x: RC_COLS[3], y: RC_ROWS[0] + RC_OFFSET },
+            3 => { region_weights: [3], x: RC_COLS[4], y: RC_ROWS[0] - RC_OFFSET },
+            4 => { region_weights: [4], x: RC_COLS[5], y: RC_ROWS[0] + RC_OFFSET },
+            5 => { region_weights: [5], x: RC_COLS[0], y: RC_ROWS[1] + RC_OFFSET },
+            6 => { region_weights: [6], x: RC_COLS[1], y: RC_ROWS[1] - RC_OFFSET },
+            7 => { region_weights: [7], x: RC_COLS[2], y: RC_ROWS[1] + RC_OFFSET },
+            8 => { region_weights: [8], x: RC_COLS[3], y: RC_ROWS[1] - RC_OFFSET },
+            9 => { region_weights: [9], x: RC_COLS[4], y: RC_ROWS[1] + RC_OFFSET },
+            10 => { region_weights: [10], x: RC_COLS[5], y: RC_ROWS[1] - RC_OFFSET },
+            11 => { region_weights: [11], x: RC_COLS[6], y: RC_ROWS[1] + RC_OFFSET },
+            12 => { region_weights: [12], x: RC_COLS[0], y: RC_ROWS[2] - RC_OFFSET },
+            13 => { region_weights: [13], x: RC_COLS[1], y: RC_ROWS[2] + RC_OFFSET },
+            14 => { region_weights: [14], x: RC_COLS[2], y: RC_ROWS[2] - RC_OFFSET },
+            15 => { region_weights: [15], x: RC_COLS[3], y: RC_ROWS[2] + RC_OFFSET },
+            16 => { region_weights: [16], x: RC_COLS[4], y: RC_ROWS[2] - RC_OFFSET },
+            17 => { region_weights: [17], x: RC_COLS[5], y: RC_ROWS[2] + RC_OFFSET },
+            18 => { region_weights: [18], x: RC_COLS[6], y: RC_ROWS[2] - RC_OFFSET },
+            19 => { region_weights: [19], x: RC_COLS[1], y: RC_ROWS[3] - RC_OFFSET },
+            20 => { region_weights: [20], x: RC_COLS[2], y: RC_ROWS[3] + RC_OFFSET },
+            21 => { region_weights: [21], x: RC_COLS[3], y: RC_ROWS[3] - RC_OFFSET },
+            22 => { region_weights: [22], x: RC_COLS[4], y: RC_ROWS[3] + RC_OFFSET },
+            23 => { region_weights: [23], x: RC_COLS[5], y: RC_ROWS[3] - RC_OFFSET },
+          },
+          pointy: {
+            0 => { region_weights: [0], x: RC_ROWS[1] + RC_OFFSET, y: RC_COLS[0] },
+            1 => { region_weights: [1], x: RC_ROWS[2] - RC_OFFSET, y: RC_COLS[0] },
+            2 => { region_weights: [2], x: RC_ROWS[2] + RC_OFFSET, y: RC_COLS[1] },
+            3 => { region_weights: [3], x: RC_ROWS[3] - RC_OFFSET, y: RC_COLS[1] },
+            4 => { region_weights: [4], x: RC_ROWS[3] + RC_OFFSET, y: RC_COLS[2] },
+            5 => { region_weights: [5], x: RC_ROWS[0] + RC_OFFSET, y: RC_COLS[1] },
+            6 => { region_weights: [6], x: RC_ROWS[1] - RC_OFFSET, y: RC_COLS[1] },
+            7 => { region_weights: [7], x: RC_ROWS[1] + RC_OFFSET, y: RC_COLS[2] },
+            8 => { region_weights: [8], x: RC_ROWS[2] - RC_OFFSET, y: RC_COLS[2] },
+            9 => { region_weights: [9], x: RC_ROWS[2] + RC_OFFSET, y: RC_COLS[3] },
+            10 => { region_weights: [10], x: RC_ROWS[3] - RC_OFFSET, y: RC_COLS[3] },
+            11 => { region_weights: [11], x: RC_ROWS[3] + RC_OFFSET, y: RC_COLS[4] },
+            12 => { region_weights: [12], x: RC_ROWS[0] - RC_OFFSET, y: RC_COLS[2] },
+            13 => { region_weights: [13], x: RC_ROWS[0] + RC_OFFSET, y: RC_COLS[3] },
+            14 => { region_weights: [14], x: RC_ROWS[1] - RC_OFFSET, y: RC_COLS[3] },
+            15 => { region_weights: [15], x: RC_ROWS[1] + RC_OFFSET, y: RC_COLS[4] },
+            16 => { region_weights: [16], x: RC_ROWS[2] - RC_OFFSET, y: RC_COLS[4] },
+            17 => { region_weights: [17], x: RC_ROWS[2] + RC_OFFSET, y: RC_COLS[5] },
+            18 => { region_weights: [18], x: RC_ROWS[3] - RC_OFFSET, y: RC_COLS[5] },
+            19 => { region_weights: [19], x: RC_ROWS[0] - RC_OFFSET, y: RC_COLS[4] },
+            20 => { region_weights: [20], x: RC_ROWS[0] + RC_OFFSET, y: RC_COLS[5] },
+            21 => { region_weights: [21], x: RC_ROWS[1] - RC_OFFSET, y: RC_COLS[5] },
+            22 => { region_weights: [22], x: RC_ROWS[1] + RC_OFFSET, y: RC_COLS[6] },
+            23 => { region_weights: [23], x: RC_ROWS[2] - RC_OFFSET, y: RC_COLS[6] },
+          },
+        }.freeze
+      end
+    end
+  end
+end

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -4,6 +4,7 @@ require 'lib/settings'
 require 'view/game/part/blocker'
 require 'view/game/part/borders'
 require 'view/game/part/cities'
+require 'view/game/part/debug_region_weights'
 require 'view/game/part/label'
 require 'view/game/part/location_name'
 require 'view/game/part/revenue'
@@ -119,6 +120,7 @@ module View
         # can be hidden
         children << rendered_loc_name if rendered_loc_name && setting_for(:show_location_names, @game)
         children << render_coords if @show_coords
+        children << render_tile_part(Part::DebugRegionWeights) if Lib::Params['grid']
 
         children.flatten!
 


### PR DESCRIPTION
<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

    I found this helpful when debugging, so I thought it might be good to add.  It uses the same `grid` parameter as the region lines for the tiles.  Text needs to be a little small so it can all fit.

* **Screenshots**

![image](https://github.com/tobymao/18xx/assets/5263073/c5eb2b4a-d758-4f4d-8777-6d7a8f62f0aa)


* **Any Assumptions / Hacks**
