### PR TITLE
[18SJ] Fixes bank pool dividends in Oscarian Era variant

### DIFF
--- a/lib/engine/game/g_18_sj/step/dividend.rb
+++ b/lib/engine/game/g_18_sj/step/dividend.rb
@@ -54,7 +54,7 @@ module Engine
             return 0 if entity.minor?
             # For Oscarian era shares in the Bank pool pay to corporation.
             # Corporations cannot have shares in Treasury.
-            return dividends_for_entity(entity, @game.bank, per_share) if @game.oscarian_era
+            return dividends_for_entity(entity, @game.share_pool, per_share) if @game.oscarian_era
 
             # Pay out for shares in treasury only.
             dividends_for_entity(entity, entity, per_share)


### PR DESCRIPTION
Fixes #10230 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

corrected code. Tested, works as expected now.

Will require pins for any games using the Oscarian Era variant. 

* **Screenshots**

* **Any Assumptions / Hacks**
