### PR TITLE
[1836Jr56] Fix wrong number of arguments into hexes_connected?

### DIFF
--- a/lib/engine/game/g_1836_jr56/game.rb
+++ b/lib/engine/game/g_1836_jr56/game.rb
@@ -271,6 +271,7 @@ module Engine
           # Corp -> Borrowed Train
           @borrowed_trains = {}
           create_destinations(DESTINATIONS)
+          national.destinated!
           national.add_ability(self.class::NATIONAL_IMMOBILE_SHARE_PRICE_ABILITY)
           national.add_ability(self.class::NATIONAL_FORCED_WITHHOLD_ABILITY)
         end

--- a/spec/lib/engine/games/g_1836jr56_spec.rb
+++ b/spec/lib/engine/games/g_1836jr56_spec.rb
@@ -8,7 +8,7 @@ module Engine
     let(:players) { %w[a b c] }
 
     let(:game_file) do
-      Find.find(FIXTURES_DIR).find { |f| File.basename(f) == '#{game_file_name}.json' }
+      Find.find(FIXTURES_DIR).find { |f| File.basename(f) == "#{game_file_name}.json" }
     end
 
     let(:actions) do
@@ -17,11 +17,18 @@ module Engine
         { 'type' => 'bid', 'entity' => 'b', 'entity_type' => 'player', 'company' => 'E-SF', 'price' => 40, 'id' => 2 },
         { 'type' => 'bid', 'entity' => 'c', 'entity_type' => 'player', 'company' => 'CdH', 'price' => 50, 'id' => 3 },
         { 'type' => 'bid', 'entity' => 'a', 'entity_type' => 'player', 'company' => 'RdP', 'price' => 70, 'id' => 4 },
-        { 'type' => 'par', 'entity' => 'b', 'entity_type' => 'player', 'corporation' => 'B', 'share_price' => '65,5,4', 'id' => 5 },
-        { 'type' => 'buy_shares', 'entity' => 'c', 'entity_type' => 'player', 'shares'=> ['B_1'], 'percent'=> 10, 'id' => 6 },
-        { 'type' => 'buy_shares', 'entity' => 'a', 'entity_type' => 'player', 'shares'=> ['B_2'], 'percent'=> 10, 'id' => 7 },
-        { 'type' => 'buy_shares', 'entity' => 'b', 'entity_type' => 'player', 'shares'=> ['B_3'], 'percent'=> 10, 'id' => 8 },
-        { 'type' => 'buy_shares', 'entity' => 'c', 'entity_type' => 'player', 'shares'=> ['B_4'], 'percent'=> 10, 'id' => 9 },
+        {
+          'type' => 'par',
+          'entity' => 'b',
+          'entity_type' => 'player',
+          'corporation' => 'B',
+          'share_price' => '65,5,4',
+          'id' => 5,
+        },
+        { 'type' => 'buy_shares', 'entity' => 'c', 'entity_type' => 'player', 'shares' => ['B_1'], 'percent' => 10, 'id' => 6 },
+        { 'type' => 'buy_shares', 'entity' => 'a', 'entity_type' => 'player', 'shares' => ['B_2'], 'percent' => 10, 'id' => 7 },
+        { 'type' => 'buy_shares', 'entity' => 'b', 'entity_type' => 'player', 'shares' => ['B_3'], 'percent' => 10, 'id' => 8 },
+        { 'type' => 'buy_shares', 'entity' => 'c', 'entity_type' => 'player', 'shares' => ['B_4'], 'percent' => 10, 'id' => 9 },
         { 'type' => 'pass', 'entity' => 'a', 'entity_type' => 'player', 'id' => 10 },
         { 'type' => 'pass', 'entity' => 'b', 'entity_type' => 'player', 'id' => 11 },
         { 'type' => 'pass', 'entity' => 'c', 'entity_type' => 'player', 'id' => 12 },
@@ -39,12 +46,12 @@ module Engine
 
       it 'should not enter infinite loop' do
         expect(game.raw_actions.size).to be 12
-        expect(game.current_entity.name).to be "B"
+        expect(game.current_entity.name).to be 'B'
 
         action = Engine::Action::LayTile.new(game.current_entity,
-          tile: game.tile_by_id('6-0'),
-          hex: game.hex_by_id('G7'),
-          rotation: 0)
+                                             tile: game.tile_by_id('6-0'),
+                                             hex: game.hex_by_id('G7'),
+                                             rotation: 0)
         game.process_action(action, add_auto_actions: true).maybe_raise!
 
         expect(game.raw_actions.size).to be 13

--- a/spec/lib/engine/games/g_1836jr56_spec.rb
+++ b/spec/lib/engine/games/g_1836jr56_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'find'
+require './spec/spec_helper'
+
+module Engine
+  describe Game::G1836Jr56::Game do
+    let(:players) { %w[a b c] }
+
+    let(:game_file) do
+      Find.find(FIXTURES_DIR).find { |f| File.basename(f) == '#{game_file_name}.json' }
+    end
+
+    let(:actions) do
+      [
+        { 'type' => 'bid', 'entity' => 'a', 'entity_type' => 'player', 'company' => 'ACC', 'price' => 20, 'id' => 1 },
+        { 'type' => 'bid', 'entity' => 'b', 'entity_type' => 'player', 'company' => 'E-SF', 'price' => 40, 'id' => 2 },
+        { 'type' => 'bid', 'entity' => 'c', 'entity_type' => 'player', 'company' => 'CdH', 'price' => 50, 'id' => 3 },
+        { 'type' => 'bid', 'entity' => 'a', 'entity_type' => 'player', 'company' => 'RdP', 'price' => 70, 'id' => 4 },
+        { 'type' => 'par', 'entity' => 'b', 'entity_type' => 'player', 'corporation' => 'B', 'share_price' => '65,5,4', 'id' => 5 },
+        { 'type' => 'buy_shares', 'entity' => 'c', 'entity_type' => 'player', 'shares'=> ['B_1'], 'percent'=> 10, 'id' => 6 },
+        { 'type' => 'buy_shares', 'entity' => 'a', 'entity_type' => 'player', 'shares'=> ['B_2'], 'percent'=> 10, 'id' => 7 },
+        { 'type' => 'buy_shares', 'entity' => 'b', 'entity_type' => 'player', 'shares'=> ['B_3'], 'percent'=> 10, 'id' => 8 },
+        { 'type' => 'buy_shares', 'entity' => 'c', 'entity_type' => 'player', 'shares'=> ['B_4'], 'percent'=> 10, 'id' => 9 },
+        { 'type' => 'pass', 'entity' => 'a', 'entity_type' => 'player', 'id' => 10 },
+        { 'type' => 'pass', 'entity' => 'b', 'entity_type' => 'player', 'id' => 11 },
+        { 'type' => 'pass', 'entity' => 'c', 'entity_type' => 'player', 'id' => 12 },
+      ]
+    end
+
+    # issue 9954
+    # This will attempt to lay track, which adds the auto_actions from Escrow, which check for hexes_connected?
+    # The original issue was that this tries to use @destinations, which the national corp does not have, so it would
+    # try to call hexes_connected? with 0 arguments.
+
+    context '1836Jr56 can lay initial track' do
+      let(:players) { %w[a b c] }
+      subject(:game) { Game::G1836Jr56::Game.new(players, actions: actions) }
+
+      it 'should not enter infinite loop' do
+        expect(game.raw_actions.size).to be 12
+        expect(game.current_entity.name).to be "B"
+
+        action = Engine::Action::LayTile.new(game.current_entity,
+          tile: game.tile_by_id('6-0'),
+          hex: game.hex_by_id('G7'),
+          rotation: 0)
+        game.process_action(action, add_auto_actions: true).maybe_raise!
+
+        expect(game.raw_actions.size).to be 13
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #9954 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

    When the auto_actions for the Escrow step are checked, it calls `@game.destination_connected?`, which calls `hexes_connected?(*@destinations[corp.id])`.  When this is called with a corp that has no destinations, it fails for having no arguments instead of the expected 2.

    This change mirrors the initialization in 1856, and this causes the capitalization type to be set to `:incremental`, which fails the first condition in `hexes_connected?`, allowing the game to proceed.

https://github.com/tobymao/18xx/blob/f283aaab87172b8c2e3e2177fbb5f534c26a2a0a/lib/engine/game/g_1856/game.rb#L609-L611

* **Screenshots**

* **Any Assumptions / Hacks**

