### PR TITLE
Suggestion for adding support for multirow revenue

### DIFF
--- a/assets/app/view/game/part/location_name.rb
+++ b/assets/app/view/game/part/location_name.rb
@@ -16,7 +16,11 @@ module View
         end
 
         def preferred_render_locations
-          return [l_center, l_up24, l_down24] if @tile.offboards.any?
+          if @tile.offboards.any?
+            return [l_center, l_up24] if @tile.offboards.first.rows > 1
+
+            return [l_center, l_up24, l_down24]
+          end
 
           return [l_center, l_up40, l_down40] if @tile.towns.one? && @tile.cities.empty?
 

--- a/assets/app/view/game/part/multi_revenue.rb
+++ b/assets/app/view/game/part/multi_revenue.rb
@@ -27,13 +27,11 @@ module View
           end
 
           # Compute total width of rectangles so we can center
-          total_width = []
           step_size = (computed_revenues.size / @rows.to_f).ceil
-          @rows.times do |row|
-            total_width_row = computed_revenues[(row - 1) * step_size, step_size].sum do |revenue|
+          total_width = @rows.times.map do |row|
+            computed_revenues[(row - 1) * step_size, step_size].sum do |revenue|
               revenue[:width]
             end
-            total_width.append(total_width_row)
           end
 
           row = 0

--- a/assets/app/view/game/part/multi_revenue.rb
+++ b/assets/app/view/game/part/multi_revenue.rb
@@ -10,7 +10,9 @@ module View
 
         needs :revenues
         needs :transform, default: 'translate(0 0)'
+        needs :rows, default: 1
 
+        HEIGHT = 27
         def render
           # Compute text and width first in order to get total_width
           computed_revenues = @revenues.map do |rev|
@@ -25,11 +27,19 @@ module View
           end
 
           # Compute total width of rectangles so we can center
-          total_width = computed_revenues.sum do |revenue|
-            revenue[:width]
+          total_width = []
+          step_size = (computed_revenues.size / @rows.to_f).ceil
+          @rows.times do |row|
+            total_width_row = computed_revenues[(row - 1) * step_size, step_size].sum do |revenue|
+              revenue[:width]
+            end
+            total_width.append(total_width_row)
           end
 
-          t_x = -(total_width * 0.5)
+          row = 0
+          t_x = -(total_width[row] * 0.5)
+          index = 0
+          t_y = 0
           children = computed_revenues.flat_map do |rev|
             fill = rev[:color].start_with?('#') ? rev[:color] : color_for(rev[:color])
             font_color = contrast_on(fill)
@@ -37,8 +47,8 @@ module View
 
             rect_attrs = {
               fill: fill,
-              transform: "translate(#{t_x} 0)",
-              height: 27,
+              transform: "translate(#{t_x} #{t_y})",
+              height: HEIGHT,
               width: width,
               x: 0,
               y: -12,
@@ -46,13 +56,19 @@ module View
 
             text_props = {
               attrs: {
-                transform: "translate(#{t_x + (width * 0.5)} 0)",
+                transform: "translate(#{t_x + (width * 0.5)} #{t_y})",
                 fill: font_color,
                 stroke: font_color,
                 'dominant-baseline': 'central',
               },
             }
             t_x += width
+            index += 1
+            if index == step_size && index < computed_revenues.size
+              row += 1
+              t_x = -(total_width[row] * 0.5)
+              t_y += HEIGHT
+            end
             [
               h(:rect, attrs: rect_attrs),
               h('text.number', text_props, rev[:text]),

--- a/assets/app/view/game/part/multi_revenue.rb
+++ b/assets/app/view/game/part/multi_revenue.rb
@@ -28,7 +28,7 @@ module View
 
           # Compute total width of rectangles so we can center
           step_size = (computed_revenues.size / @rows.to_f).ceil
-          total_width = @rows.times.map do |row|
+          total_width = Array.new(@rows) do |row|
             computed_revenues[(row - 1) * step_size, step_size].sum do |revenue|
               revenue[:width]
             end

--- a/assets/app/view/game/part/revenue.rb
+++ b/assets/app/view/game/part/revenue.rb
@@ -77,7 +77,7 @@ module View
           @cities = @tile.cities.size
           stops = @tile.stops
           @hide = stops.any?(&:hide)
-
+          @rows = (@tile.offboards&.first&.rows || 1)
           @revenue = @tile.revenue_to_render.first
         end
 
@@ -93,7 +93,7 @@ module View
           transform = "#{rotation_for_layout} #{translate}"
 
           if multi_revenue?
-            h(MultiRevenue, revenues: @revenue, transform: transform)
+            h(MultiRevenue, revenues: @revenue, transform: transform, rows: @rows)
           else
             h(SingleRevenue, revenue: @revenue, transform: transform)
           end

--- a/lib/engine/game/g_18_uruguay/map.rb
+++ b/lib/engine/game/g_18_uruguay/map.rb
@@ -264,19 +264,19 @@ module Engine
           },
           blue: {
             ['E1'] => 'offboard=revenue:yellow_30|green_30|brown_40|gray_60,format:+%d,visit_cost:0,route:optional'\
-                      ',groups:England;path=a:4,b:_0;path=a:5,b:_0',
-            ['G1'] => 'offboard=revenue:yellow_30|green_30|brown_40|gray_60,format:+%d,rows:2,visit_cost:0,route:optional'\
-                      ',groups:England;path=a:3,b:_0;path=a:4,b:_0',
+                      ',groups:England,rows:2;path=a:4,b:_0;path=a:5,b:_0',
+            ['G1'] => 'offboard=revenue:yellow_30|green_30|brown_40|gray_60,format:+%d,visit_cost:0,route:optional'\
+                      ',groups:England,rows:2;path=a:3,b:_0;path=a:4,b:_0',
             ['I1'] => 'offboard=revenue:yellow_20|green_30|brown_40|gray_60,format:+%d,visit_cost:0,route:optional'\
-                      ',groups:England;path=a:4,b:_0',
+                      ',groups:England,rows:2;path=a:4,b:_0',
             ['J14'] => 'offboard=revenue:yellow_20|green_30|brown_40|gray_60,format:+%d,visit_cost:0,route:optional'\
-                       ',groups:England;path=a:1,b:_0;path=a:2,b:_0',
+                       ',groups:England,rows:2;path=a:1,b:_0;path=a:2,b:_0',
             ['K5'] => 'offboard=revenue:yellow_20|green_40|brown_60|gray_80,format:+%d,visit_cost:0,route:optional'\
-                      ',groups:England;path=a:3,b:_0',
+                      ',groups:England,rows:2;path=a:3,b:_0',
             ['K7'] => 'offboard=revenue:yellow_20|green_40|brown_60|gray_80,format:+%d,visit_cost:0,route:optional'\
-                      ',groups:England;path=a:2,b:_0',
+                      ',groups:England,rows:2;path=a:2,b:_0',
             ['K13'] => 'offboard=revenue:yellow_20|green_30|brown_40|gray_60,format:+%d,visit_cost:0,route:optional'\
-                       ',groups:England;path=a:2,b:_0',
+                       ',groups:England,rows:2;path=a:2,b:_0',
             ['K15'] => 'city=revenue:0;path=a:4,b:_0,lanes:4',
             ['K17'] => 'offboard=revenue:yellow_30|green_40|brown_50,format:+%d,visit_cost:0,route:optional'\
                        ';path=a:1,b:_0,lanes:4',

--- a/lib/engine/part/revenue_center.rb
+++ b/lib/engine/part/revenue_center.rb
@@ -6,7 +6,7 @@ module Engine
   module Part
     class RevenueCenter < Node
       attr_accessor :groups, :revenue
-      attr_reader :hide, :revenue_to_render, :visit_cost, :route, :loc
+      attr_reader :hide, :revenue_to_render, :visit_cost, :route, :loc, :rows
 
       PHASES = %i[yellow green brown gray diesel].freeze
 
@@ -16,7 +16,7 @@ module Engine
         @hide = opts[:hide]
         @visit_cost = (opts[:visit_cost] || 1).to_i
         @loc = opts[:loc]
-
+        @rows = (opts[:rows] || 1).to_i
         @route = (opts[:route] || :mandatory).to_sym
       end
 

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -165,7 +165,8 @@ module Engine
                                       hide: params['hide'],
                                       visit_cost: params['visit_cost'],
                                       route: params['route'],
-                                      format: params['format'])
+                                      format: params['format'],
+                                      rows: params['rows'])
         cache << offboard
         offboard
       when 'label'


### PR DESCRIPTION


### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
In 18 Uruguay the offboard revenue box gets to big and hiding the rails.

Inspired by https://www.18xx-maker.com/elements/ "Offboard Revenues"
I suggest here to add an extra parameter "rows" to the offboard tile which will allow the revenue to be splitted over multiple rows.

In addition to split the row we also need to move the tile name so it does not collide with the revenue when multiple rows is configured

Example from the 18 Uruguay map
`            ['G1'] => 'offboard=revenue:yellow_30|green_30|brown_40|gray_60,format:+%d,visit_cost:0,route:optional'\
                      ',groups:England,rows:2;path=a:3,b:_0;path=a:4,b:_0',
`

* **Screenshots**
Before
![Single line revenue](https://github.com/tobymao/18xx/assets/8018982/b83575d2-cd1b-4d5b-a78c-eecaba00c8dc)

After
![Multirow revenue](https://github.com/tobymao/18xx/assets/8018982/60aecebd-b86a-4caa-8396-5bbc6d91b61e)


* **Any Assumptions / Hacks**
