### PR TITLE
[1873] Make colors controlled by settings for mine displays

### DIFF
--- a/assets/app/view/game/alternate_corporations.rb
+++ b/assets/app/view/game/alternate_corporations.rb
@@ -177,9 +177,12 @@ module View
         machine_size = @game.machine_size(mine)
         switcher_size = @game.switcher_size(mine) || 0
 
-        highlight_prop = { style: { border: '2px solid black' } }
-        shade_prop = { style: { backgroundColor: 'gray' } }
-        shade_highlight_prop = { style: { border: '2px solid black', backgroundColor: 'gray' } }
+        # this will create a reasonable contrast color to work with any background color
+        highlight_color = convert_hex_to_rgba(contrast_on(color_for(:bg)), 0.3)
+
+        highlight_prop = { style: { border: "2px solid #{color_for(:font)}" } }
+        shade_prop = { style: { backgroundColor: highlight_color } }
+        shade_highlight_prop = { style: { border: "2px solid #{color_for(:font)}", backgroundColor: highlight_color } }
         machine_row = @game.minor_info[mine][:machine_revenue].map.with_index do |mr, idx|
           if (idx == machine_size - 1) && (@game.connected_mine?(mine) || idx.zero?)
             h('td.padded_number', highlight_prop, mr)
@@ -228,7 +231,7 @@ module View
       def render_submines(use_checkboxes: true)
         mines = @game.public_mine_mines(@corporation)
 
-        row_props = { style: { border: '1px solid black' } }
+        row_props = { style: { border: "1px solid #{color_for(:font)}" } }
 
         item_props = { style: { verticalAlign: 'middle' } }
 


### PR DESCRIPTION
Fixes #4913 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
    
    * Change borders to use font color instead of black
    * Adjust highlight color to adjust based on background instead of just gray (more contrast for both light and dark theme)

* **Screenshots**

    #### Dark Mode
    | Old      | New |
    | ----------- | ----------- |
    | ![image](https://github.com/tobymao/18xx/assets/5263073/4475df74-2167-47db-a262-3a072d3e42e7) | ![image](https://github.com/tobymao/18xx/assets/5263073/0a9cd306-4d3c-465e-94a5-7682798bcdc8) |

    #### Light Mode
    | Old      | New |
    | ----------- | ----------- |
    | ![image](https://github.com/tobymao/18xx/assets/5263073/5e186442-54ce-49b9-911a-23dfafe72d81) | ![image](https://github.com/tobymao/18xx/assets/5263073/100c1e24-8f09-4b49-bf3b-82634277698e) |

    Just for fun
    ![image](https://github.com/tobymao/18xx/assets/5263073/e792bd8e-4c16-4226-8618-4b82a883acb9)


* **Any Assumptions / Hacks**
