### PR TITLE
Make must_sell messaging more specific to include the corp names

### DIFF
--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -65,6 +65,9 @@ module View
           if @step.respond_to?(:must_sell?) && @step.must_sell?(@current_entity)
             children << if @game.num_certs(@current_entity) > @game.cert_limit(@current_entity)
                           h('div.margined', 'Must sell stock: above certificate limit')
+                        elsif @step.respond_to?(:must_sell_corporations)
+                          corps_over_limit = @step.must_sell_corporations(@current_entity).map(&:name).join(', ')
+                          h('div.margined', "Must sell stock: above 60% limit in #{corps_over_limit}")
                         else
                           h('div.margined', 'Must sell stock: above 60% limit in corporation(s)')
                         end

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -107,9 +107,11 @@ module Engine
         return false unless can_sell_any?(entity)
         return true if @game.num_certs(entity) > @game.cert_limit(entity)
 
-        !@game.can_hold_above_corp_limit?(entity) && @game.corporations.any? do |corp|
-          !corp.holding_ok?(entity) && can_sell_any_bundles(entity, corp)
-        end
+        !@game.can_hold_above_corp_limit?(entity) && !must_sell_corporations(entity).empty?
+      end
+
+      def must_sell_corporations(entity)
+        @game.corporations.select { |corp| !corp.holding_ok?(entity) && can_sell_any_bundles(entity, corp) }
       end
 
       def can_sell?(entity, bundle)


### PR DESCRIPTION
Fixes #9990 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**
    Split the functionality for checking each individual corp into a new function.  Use that function and check for `empty?` in `must_sell`, but also use the list result when printing out which corps must be sold in the UI.

* **Screenshots**
    ![image](https://github.com/tobymao/18xx/assets/5263073/9f0acb26-eda3-4484-9f6d-03b02e163427)


* **Any Assumptions / Hacks**
