### PR TITLE
[core] add global LOGGER

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -35,9 +35,9 @@ class Api < Roda
     csp.frame_ancestors :none
   end
 
-  LOGGER = Logger.new($stdout)
+  API_LOGGER = Logger.new($stdout)
 
-  plugin :common_logger, LOGGER
+  plugin :common_logger, API_LOGGER
 
   plugin :not_found do
     halt(404, 'Page not found')
@@ -46,8 +46,8 @@ class Api < Roda
   plugin :error_handler
 
   error do |e|
-    LOGGER.error e.backtrace
-    LOGGER.error e.message
+    API_LOGGER.error e.backtrace
+    API_LOGGER.error e.message
     { error: e.message }
   end
 
@@ -122,7 +122,7 @@ class Api < Roda
           begin
             needs[:profile]['stats'] = JSON.parse(Bus[Bus::USER_STATS % id])
           rescue StandardError => e
-            LOGGER.error "Unable to get stats for #{id}: #{e}"
+            API_LOGGER.error "Unable to get stats for #{id}: #{e}"
           end
         end
 

--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -2,10 +2,12 @@
 
 # backtick_javascript: true
 
+require 'engine/logger'
 require 'index'
 require 'game_manager'
 require 'user_manager'
 require 'lib/connection'
+require 'lib/params'
 require 'lib/settings'
 require 'lib/storage'
 require 'view/about'
@@ -34,6 +36,8 @@ class App < Snabberb::Component
   needs :keywords, default: nil
 
   def render
+    setup_logger
+
     props = {
       props: { id: 'app' },
       style: {
@@ -141,5 +145,9 @@ class App < Snabberb::Component
   def store_app_route(skip: true)
     window_route = `window.location.pathname + window.location.search + window.location.hash`
     store(:app_route, window_route, skip: skip) unless window_route == ''
+  end
+
+  def setup_logger
+    Engine::Logger.set_level(Lib::Params['l'], @production)
   end
 end

--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -151,6 +151,7 @@ module View
         clear_ui_state
         store(:game, game)
       rescue StandardError => e
+        LOGGER.error(e)
         clear_ui_state
         store(:flash_opts, e.message)
         `setTimeout(function() { self['$store']('game', Opal.nil) }, 10)`

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -77,7 +77,9 @@ module View
       return @game.process_to_action(cursor) if game_id == @game&.id && cursor && cursor > @game.last_game_action_id
 
       load_game_with_class = lambda do
+        LOGGER.debug('Processing game...')
         @game = Engine::Game.load(@game_data, at_action: cursor, user: @user&.dig('id'))
+        LOGGER.debug('Done processing game')
         store(:game, @game, skip: true)
       end
 
@@ -99,6 +101,7 @@ module View
 
       return h('div.padded', 'Loading game...') unless @game
 
+      LOGGER.debug('Rendering game view...')
       page =
         case route_anchor
         when nil
@@ -120,6 +123,7 @@ module View
         when 'auto'
           h(Game::Auto, game: @game, game_data: @game_data, user: @user)
         end
+      LOGGER.debug('Done rendering game view')
 
       @connection = nil if @game_data[:mode] == :hotseat || cursor
 

--- a/assets/deps.rb
+++ b/assets/deps.rb
@@ -3,6 +3,7 @@
 # backtick_javascript: true
 
 `Opal.config.unsupported_features_severity = 'ignore'`
+require 'logger'
 require 'native'
 require 'json'
 require 'snabberb'

--- a/lib/engine.rb
+++ b/lib/engine.rb
@@ -2,6 +2,7 @@
 
 require_relative 'engine/deep_freeze'
 require_relative 'engine/jaro_winkler'
+require_relative 'engine/logger'
 
 if RUBY_ENGINE == 'opal'
   require_tree 'engine/game'

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -48,11 +48,11 @@ module Engine
 
       nodes.each do |node|
         if Time.now - now > path_timeout
-          puts 'Path timeout reached'
+          LOGGER.debug('Path timeout reached')
           path_walk_timed_out = true
           break
         else
-          puts "Path search: #{nodes.index(node)} / #{nodes.size} - paths starting from #{node.hex.name}"
+          LOGGER.debug { "Path search: #{nodes.index(node)} / #{nodes.size} - paths starting from #{node.hex.name}" }
         end
 
         walk_corporation = graph.no_blocking? ? nil : corporation
@@ -142,8 +142,10 @@ module Engine
       end
 
       # Check that there are no duplicate hexside bits (algorithm error)
-      puts "Evaluated #{connections.size} paths, found #{@next_hexside_bit} unique hexsides, and found valid routes "\
-           "#{train_routes.map { |k, v| k.name + ':' + v.size.to_s }.join(', ')} in: #{Time.now - now}"
+      LOGGER.debug do
+        "Evaluated #{connections.size} paths, found #{@next_hexside_bit} unique hexsides, and found valid routes "\
+          "#{train_routes.map { |k, v| k.name + ':' + v.size.to_s }.join(', ')} in: #{Time.now - now}"
+      end
 
       static.each do |route|
         # recompute bitfields of passed-in routes since the bits may have changed across auto-router runs
@@ -158,8 +160,10 @@ module Engine
       sorted_routes = train_routes.map { |_train, routes| routes }
 
       limit = sorted_routes.map(&:size).reduce(&:*)
-      puts "Finding route combos of best #{train_routes.map { |k, v| k.name + ':' + v.size.to_s }.join(', ')} "\
-           "routes with depth #{limit}"
+      LOGGER.debug do
+        "Finding route combos of best #{train_routes.map { |k, v| k.name + ':' + v.size.to_s }.join(', ')} "\
+          "routes with depth #{limit}"
+      end
 
       now = Time.now
       possibilities = js_evaluate_combos(sorted_routes, route_timeout)
@@ -180,7 +184,7 @@ module Engine
         @game.routes_revenue(routes)
       rescue GameError => e
         # report error but still include combo with errored route in the result set
-        puts " Sanity check error, likely an auto_router bug: #{e}"
+        LOGGER.debug { " Sanity check error, likely an auto_router bug: #{e}" }
         routes
       end || []
 
@@ -225,8 +229,8 @@ module Engine
               hexside_right  = node2.edges[0].id
               check_and_set(bitfield, hexside_left, hexside_right, hexside_bits)
             else
-              puts "  ERROR: auto-router found unexpected number of path node edges #{node1.edges.size}. "\
-                   'Route combos may be be incorrect'
+              LOGGER.debug "  ERROR: auto-router found unexpected number of path node edges #{node1.edges.size}. "\
+                           'Route combos may be be incorrect'
             end
           end
         end
@@ -380,8 +384,10 @@ module Engine
         }
       }
 
-      puts "Found #{possibilities_count} possible combos (#{rb_possibilities.size} best) and rejected #{conflicts} "\
-           "conflicting combos in: #{Time.now - now}"
+      LOGGER.debug do
+        "Found #{possibilities_count} possible combos (#{rb_possibilities.size} best) and rejected #{conflicts} "\
+          "conflicting combos in: #{Time.now - now}"
+      end
       rb_possibilities
     end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -762,6 +762,7 @@ module Engine
         action = Engine::Action::Base.action_from_h(action, self) if action.is_a?(Hash)
 
         action.id = current_action_id + 1
+        LOGGER.debug { "Game::Base#process_action({ id: #{action.id}, ... }, ...)" }
         @raw_actions << action.to_h
         return clone(@raw_actions) if action.is_a?(Action::Undo) || action.is_a?(Action::Redo)
 

--- a/lib/engine/game/g_18_dixie/step/conversion.rb
+++ b/lib/engine/game/g_18_dixie/step/conversion.rb
@@ -99,7 +99,7 @@ module Engine
                 token.swap!(new_token, check_tokenable: true)
                 major.tokens << new_token
               else
-                puts 'TODO: Confirm if unused minor tokens go onto a majors charter ever'
+                LOGGER.debug 'TODO: Confirm if unused minor tokens go onto a majors charter ever'
                 # If so, uncomment this, perhaps with additional conditioning
                 # unused << new_token
               end

--- a/lib/engine/game/g_18_neb/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_neb/step/buy_sell_par_shares.rb
@@ -36,7 +36,7 @@ module Engine
             return [] unless @round.current_actions.empty?
             return [] unless @game.check_sale_timing(entity, Share.new(entity).to_bundle)
 
-            puts "here: #{entity.name}, #{@game.issuable_shares(entity).inspect}"
+            LOGGER.debug { "here: #{entity.name}, #{@game.issuable_shares(entity).inspect}" }
 
             @game.issuable_shares(entity)
           end

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -552,18 +552,15 @@ module Engine
           bg_color = selected ? 'white' : color.to_s
 
           onclick = lambda do
-            puts "hello from #{column} #{cost}"
-
             if selected
-              puts '    NOOP: already using this cell'
+              LOGGER.debug '    NOOP: already using this cell'
             elsif chosen_column && chosen_column != column && @round.laid_track[color_sym]
-              puts '    NOOP: already using a different column'
+              LOGGER.debug '    NOOP: already using a different column'
             elsif blank
-              puts '    NOOP: no cube available'
+              LOGGER.debug '    NOOP: no cube available'
             elsif unchoosable_color
-              puts '    NOOP: color not available'
+              LOGGER.debug '    NOOP: color not available'
             else
-              puts '    should update choice to this cell'
               action = Engine::Action::Choose.new(
                 current_entity,
                 choice: "#{column}-#{cost}"

--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -173,6 +173,8 @@ module Engine
     end
 
     def compute(corporation, routes_only: false, one_token: nil)
+      LOGGER.debug { "    Graph#compute(#{corporation.name}, routes_only: #{routes_only}, one_token: #{one_token})" }
+
       hexes = Hash.new { |h, k| h[k] = {} }
       nodes = {}
       paths = {}
@@ -226,7 +228,10 @@ module Engine
       skip_paths = @check_regions ? @game.graph_border_paths(corporation) : @game.graph_skip_paths(corporation)
 
       tokens.keys.each do |node|
-        return nil if routes[:route_train_purchase] && routes_only
+        if routes[:route_train_purchase] && routes_only
+          LOGGER.debug '    Graph computed'
+          return nil
+        end
 
         visited = tokens.reject { |token, _| token == node }
         local_nodes = {}
@@ -291,6 +296,8 @@ module Engine
         @connected_paths[corporation] = paths
         @reachable_hexes[corporation] = paths.to_h { |path, _| [path.hex, true] }
       end
+
+      LOGGER.debug '    Graph computed'
     end
   end
 end

--- a/lib/engine/logger.rb
+++ b/lib/engine/logger.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+LOGGER = Logger.new($stdout)
+
+module Engine
+  module Logger
+    def self.set_level(level, production = false)
+      LOGGER.level =
+        if level
+          level.to_i
+        elsif production
+          ::Logger::INFO
+        else
+          ::Logger::DEBUG
+        end
+    end
+  end
+end
+
+if RUBY_ENGINE == 'opal'
+  # see `App#setup_logger` in assets/app/app.rb for browser logger setup
+else
+  Engine::Logger.set_level(ENV['ENGINE_LOG_LEVEL'], ENV['RACK_ENV'] == 'production')
+end

--- a/queue.rb
+++ b/queue.rb
@@ -16,7 +16,7 @@ Sequel.extension :pg_json_ops
 
 PRODUCTION = ENV['RACK_ENV'] == 'production'
 
-LOGGER = Logger.new($stdout)
+QUEUE_LOGGER = Logger.new($stdout)
 
 Bus.configure
 
@@ -33,10 +33,10 @@ def days_ago(days)
 end
 
 scheduler.cron '00 09 * * *' do
-  LOGGER.info('Calculating user stats')
+  QUEUE_LOGGER.info('Calculating user stats')
   UserStats.calculate_stats
 
-  LOGGER.info('Archiving Games')
+  QUEUE_LOGGER.info('Archiving Games')
 
   filter = <<~SQL
     (status = 'finished' AND created_at <= :finished) OR
@@ -129,7 +129,7 @@ MessageBus.subscribe '/turn' do |msg|
 
   users.each do |user|
     Mail.send(user, "18xx.games Game: #{game.title} - #{game.id} - #{data['type']}", html)
-    LOGGER.info("mail sent for game: #{game.id} to user: #{user.id}")
+    QUEUE_LOGGER.info("mail sent for game: #{game.id} to user: #{user.id}")
     user.settings['email_sent'] = Time.now.to_i
     user.save
   end

--- a/scripts/scripts_helper.rb
+++ b/scripts/scripts_helper.rb
@@ -11,3 +11,6 @@ Sequel.extension :pg_json_ops
 
 # game engine
 require_relative '../lib/engine'
+
+# can override in specific script if necessary
+Engine::Logger.set_level(Logger::FATAL)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'snabberb/component'
 
 require 'engine'
 
+Engine::Logger.set_level(Logger::FATAL)
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
By default, log level is `INFO` in production and `DEBUG` in development.

In the browser, the URL param `l` can be used to set the level. On the server, the environment variable `ENGINE_LOG_LEVEL` can be used. The level is set to an integer; 0/1/2/3/4 for `DEBUG`/`INFO`/`WARN`/`ERROR`/`FATAL`.

When the URL param or environment variable are not set, the log level will default to `INFO` in production and `DEBUG` in development.

Added logging:

* prealpha games - replace `puts` with `LOGGER.debug`

* auto_router - replace `puts` with `LOGGER.info`

* actionable view - log the rescued error with `LOGGER.error`

* add `LOGGER.debug` for some things I've made temporary local edits for countless times:

    * show each action ID as it is processed

    * start and end of:

        * processing game actions

        * rendering game

        * computing graph

Other changes:

* rename `LOGGER` in api.rb and queue.rb just to play it safe with possible name collisions

* add `rubocop-rails` for the `Output` cop, which flags uses of `puts`; only apply to `assets/` and `lib/engine/`


### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`