### PR TITLE
Fix lane rendering bug

### DIFF
--- a/assets/app/view/game/part/track_node_path.rb
+++ b/assets/app/view/game/part/track_node_path.rb
@@ -268,7 +268,7 @@ module View
             @end_edge = @path.edges.last.num
             @end_x = edge_x_pos(@end_edge, 87)
             @end_y = edge_y_pos(@end_edge, 87)
-            lanes = @path.lanes
+            lanes = @path.lanes.dup
 
             if @tile.crossover? && @path.straight?
               @crossover_dash = STRAIGHT_CROSSOVER
@@ -299,7 +299,7 @@ module View
                                  ]
                                end
             end
-            lanes = @path.lanes
+            lanes = @path.lanes.dup
             lanes.reverse! if @path.b.edge?
 
             if @tile.crossover? && @path.straight?
@@ -332,7 +332,7 @@ module View
                                    calculate_stop_y(@ct_edge1, @tile),
                                  ]
                                end
-              lanes = @path.lanes
+              lanes = @path.lanes.dup
               lanes.reverse! if @path.b == @stop0
             else
               @begin_edge = @ct_edge1
@@ -353,7 +353,7 @@ module View
                                    calculate_stop_y(@ct_edge0, @tile),
                                  ]
                                end
-              lanes = @path.lanes
+              lanes = @path.lanes.dup
               lanes.reverse! if @path.b == @stop1
             end
           end


### PR DESCRIPTION
While working on tiles for System18, I noticed this rendering problem when specifying lanes on a tile:
![lane_bug](https://github.com/tobymao/18xx/assets/8494213/b2a0863d-2505-4dc2-b006-d4431d0acda2)

The bug appeared to be dependent on the ordering of elements.
I took a look at the track rendering code I wrote 3.5 years ago and saw that I was missing dups on lane references.

Fixing it resulted in this:
![lane_fix](https://github.com/tobymao/18xx/assets/8494213/30489347-0b9e-4fad-b7a0-a089726c79f8)
