### PR TITLE
[1893] Fix exclusion of merge voter for share-only owner

### DIFF
--- a/lib/engine/game/g_1893/step/merger.rb
+++ b/lib/engine/game/g_1893/step/merger.rb
@@ -18,9 +18,17 @@ module Engine
           def actions(entity)
             return [] if entity.company?
             return [] unless choice_available?
-            return [] if @game.round.merger_candidates_for(@game.round.current_entity).empty?
+            return [] if mergable_owned.empty? && !merge_target_shares_owned?
 
             ACTIONS
+          end
+
+          def mergable_owned
+            @game.round.merger_candidates_for(@game.round.current_entity)
+          end
+
+          def merge_target_shares_owned?
+            @game.round.current_entity.shares.any? { |s| s.corporation == @game.round.merge_target }
           end
 
           def description
@@ -48,9 +56,10 @@ module Engine
           end
 
           def help
-            names = @game.round.names(@game.round.merger_candidates_for(@game.round.current_entity))
+            names = @game.round.names(mergable_owned)
             "Vote Yes or No to merge #{names} into #{@game.round.merge_target.name}. " \
               '50% Yes votes is required to execute merge. If No votes exceed 50% merge is postponed. ' \
+              'Shares in Market counts as No vote(s). ' \
               'Note! Even if declined, there is an automatic merge at the start of the Merge Round following '\
               'the next phase change.'
           end


### PR DESCRIPTION
Fixes #10311

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

I believe no games will break due to this fix. The fix now makes it possible to avoid getting stuck. Presumable those that got stuck, did instead do Undo, and then vote No, to get passed this lock. And as they now have worked around this situation nothing will happen.

### Implementation Notes

* **Explanation of Change**

In case a player owned shares of the corporation to be created by merge, the merge step did not regard this as a voter, so the GUI got stuck. Players had to decline merge to get passed this.

Now merge step considers share owners as well.

Also refactored and added a couple of simple methods to make code more readable.
And updated information to point out that shares in bank pool is regarded as No votes.

* **Screenshots**

Now vote buttons appear for the player that only owned share in AGV. The other players owned minors that were reserving shares in AGV so for them merge vote functionality worked.
![image](https://github.com/tobymao/18xx/assets/2631151/a24e3bb2-ff95-4fe1-be5d-a47c5eddbfc9)

* **Any Assumptions / Hacks**

None.
