### PR TITLE
[18SJ] Fix issue with Adelswärd selection of corporation

### DIFF
--- a/lib/engine/game/g_18_sj/game.rb
+++ b/lib/engine/game/g_18_sj/game.rb
@@ -558,6 +558,11 @@ module Engine
           def name
             "Bot:#{@receivership.name}"
           end
+
+          # GUI calls player? on this entity, so this method is needed. See issue #9895.
+          def player?
+            false
+          end
         end
 
         def acting_for_entity(entity)


### PR DESCRIPTION
Need to handle call to player? to the Adelswärd entity due to GUI issues.

Fixes #9895

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

To me it looks like 2 player 18SJ does not work at all, so do not think this will affect any game. In case it do, I suppose the game can be pinned or archived. (Quite rare that people play at this player count.)

### Implementation Notes

* **Explanation of Change**
Adelswärd is a bot that has some automatic actions, and some player controlled.
So it has to mimic a player in some ways. Therefor a Wrapper has been created in the game. This wrapper had only a name method, but it seems the GUI now required a player? method, so this has been added.

* **Screenshots**
No screen shot, but when testing the fix, the critical moment (that is, end of SR2) was passed without any problems.

* **Any Assumptions / Hacks**
Adding this player? method is kind of a hack. Have not investigated exactly where this occur. Did also try with return true from player? but that meant the method id was required as well, so I believe this fix is OK.
Did try out to play a couple of SRs more and the game seem to work.
