### PR TITLE
[1847 AE] Remove unnecessary info ability

### DIFF
--- a/lib/engine/game/g_1847_ae/game.rb
+++ b/lib/engine/game/g_1847_ae/game.rb
@@ -403,6 +403,14 @@ module Engine
           @recently_floated = []
         end
 
+        def after_par(corporation)
+          # Remove the information "ability" when it's no longer relevant
+          ability = corporation.all_abilities.find { |a| a.description&.include?('May not be started until') }
+          corporation.remove_ability(ability)
+
+          super
+        end
+
         def after_buy_company(player, company, _price)
           abilities(company, :shares) do |ability|
             ability.shares.each do |share|


### PR DESCRIPTION
### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

- Remove abilities that are only reminders about when a given corporation can be started once the corporation is started.
- It doesn't break games, so pinning isn't needed
