### PR TITLE
[1824] Corrections for train handling

### DIFF
--- a/lib/engine/game/g_1824/trains.rb
+++ b/lib/engine/game/g_1824/trains.rb
@@ -11,6 +11,7 @@ module Engine
             num: 9,
             price: 80,
             rusts_on: '4',
+            events: [{ 'type' => '1g_available' }],
           },
           {
             name: '1g',
@@ -19,7 +20,7 @@ module Engine
             num: 6,
             price: 120,
             available_on: '2',
-            rusts_on: '3g',
+            rusts_on: %w[3g 4g 5g 10],
           },
           {
             name: '3',
@@ -28,6 +29,7 @@ module Engine
             price: 180,
             rusts_on: '6',
             discount: { '2' => 40 },
+            events: [{ 'type' => '2g_available' }],
           },
           {
             name: '2g',
@@ -36,7 +38,7 @@ module Engine
             num: 5,
             price: 240,
             available_on: '3',
-            rusts_on: '4g',
+            rusts_on: %w[4g 5g 10],
             discount: { '1g' => 60 },
           },
           {
@@ -45,7 +47,7 @@ module Engine
             num: 4,
             price: 280,
             rusts_on: '8',
-            events: [{ 'type' => 'close_mountain_railways' }, { 'type' => 'sd_formation' }],
+            events: [{ 'type' => 'close_mountain_railways' }, { 'type' => 'sd_formation' }, { 'type' => '3g_available' }],
             discount: { '3' => 90 },
           },
           {
@@ -55,8 +57,9 @@ module Engine
             num: 4,
             price: 360,
             available_on: '4',
-            rusts_on: '5g',
+            rusts_on: %w[5g 10],
             discount: { '2g' => 120 },
+            events: [{ 'type' => '1g_rust' }],
           },
           {
             name: '5',
@@ -72,7 +75,7 @@ module Engine
             distance: 6,
             num: 3,
             price: 630,
-            events: [{ 'type' => 'kk_formation' }],
+            events: [{ 'type' => 'kk_formation' }, { 'type' => '4g_available' }],
             discount: { '5' => 200 },
           },
           {
@@ -83,6 +86,7 @@ module Engine
             price: 600,
             available_on: '6',
             discount: { '3g' => 180 },
+            events: [{ 'type' => '1g2g_rust' }],
           },
           {
             name: '8',
@@ -90,6 +94,7 @@ module Engine
             num: 3,
             price: 800,
             discount: { '6' => 300 },
+            events: [{ 'type' => '5g_available' }],
           },
           {
             name: '5g',
@@ -99,6 +104,7 @@ module Engine
             price: 800,
             available_on: '8',
             discount: { '4g' => 300 },
+            events: [{ 'type' => '1g2g3g_rust' }],
           },
           {
             name: '10',
@@ -106,6 +112,7 @@ module Engine
             num: 20,
             price: 1000,
             discount: { '8' => 400 },
+            events: [{ 'type' => '1g2g3g_rust' }],
           },
         ].freeze
 
@@ -124,7 +131,7 @@ module Engine
             num: 3,
             price: 120,
             available_on: '2',
-            rusts_on: '3g',
+            rusts_on: %w[3g 4g 5g 10],
           },
           {
             name: '3',
@@ -141,7 +148,7 @@ module Engine
             num: 2,
             price: 240,
             available_on: '3',
-            rusts_on: '4g',
+            rusts_on: %w[4g 5g 10],
             discount: { '1g' => 60 },
           },
           {
@@ -160,8 +167,9 @@ module Engine
             num: 2,
             price: 360,
             available_on: '4',
-            rusts_on: '5g',
+            rusts_on: %w[5g 10],
             discount: { '2g' => 120 },
+            events: [{ 'type' => '1g_rust' }],
           },
           {
             name: '5',
@@ -188,6 +196,7 @@ module Engine
             price: 600,
             available_on: '6',
             discount: { '3g' => 180 },
+            events: [{ 'type' => '1g2g_rust' }],
           },
           {
             name: '8',
@@ -204,6 +213,7 @@ module Engine
             price: 800,
             available_on: '8',
             discount: { '4g' => 300 },
+            events: [{ 'type' => '1g2g3g_rust' }],
           },
           {
             name: '10',
@@ -211,6 +221,7 @@ module Engine
             num: 20,
             price: 1000,
             discount: { '8' => 400 },
+            events: [{ 'type' => '1g2g3g_rust' }],
           },
         ].freeze
 
@@ -229,7 +240,7 @@ module Engine
             num: 5,
             price: 120,
             available_on: '2',
-            rusts_on: '3g',
+            rusts_on: %w[3g 4g 5g 10],
           },
           {
             name: '3',
@@ -246,7 +257,7 @@ module Engine
             num: 4,
             price: 240,
             available_on: '3',
-            rusts_on: '4g',
+            rusts_on: %w[4g 5g 10],
             discount: { '1g' => 60 },
           },
           {
@@ -265,8 +276,9 @@ module Engine
             num: 3,
             price: 360,
             available_on: '4',
-            rusts_on: '5g',
+            rusts_on: %w[5g 10],
             discount: { '2g' => 120 },
+            events: [{ 'type' => '1g_rust' }],
           },
           {
             name: '5',
@@ -293,6 +305,7 @@ module Engine
             price: 600,
             available_on: '6',
             discount: { '3g' => 180 },
+            events: [{ 'type' => '1g2g_rust' }],
           },
           {
             name: '8',
@@ -309,6 +322,7 @@ module Engine
             price: 800,
             available_on: '8',
             discount: { '4g' => 300 },
+            events: [{ 'type' => '1g2g3g_rust' }],
           },
           {
             name: '10',
@@ -316,6 +330,7 @@ module Engine
             num: 20,
             price: 1000,
             discount: { '8' => 400 },
+            events: [{ 'type' => '1g2g3g_rust' }],
           },
         ].freeze
       end


### PR DESCRIPTION
This is the trains parts extract from a previous abandoned PR (#8640), slightly rewritten after review comments.

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

1824 is in pre-alpha and is not playable so it should not affect any games.

### Implementation Notes

* **Explanation of Change**
18xx.games do not handle the g-trains of 1824 correctly, so events are used to handle these trains, and the peculiarities connected to them.

* **Screenshots**
Here is how the train table looks like when first 4 train, and first 3g train, has been bought:
![image](https://github.com/tobymao/18xx/assets/2631151/52f9d815-f9cf-470a-be60-c22a50ef9191)

* **Any Assumptions / Hacks**
None