### PR TITLE
[core rendering] fix handling gaps in map axes

### DIFF
--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -31,12 +31,20 @@ module View
       GAP = 25 # GAP between the row/col labels and the map hexes
       SCALE = 0.5 # Scale for the map
 
+      def compute_axes(hexes)
+        min, max = hexes.minmax
+        ((min.next)..(max.next)).to_a
+      end
+
       def render
         return h(:div, []) if (@layout = @game.layout) == :none
 
         @hexes = @show_starting_map ? @game.clone([]).hexes : @game.hexes.dup
-        @cols = @hexes.reject(&:ignore_for_axes).map(&:x).uniq.sort.map(&:next)
-        @rows = @hexes.reject(&:ignore_for_axes).map(&:y).uniq.sort.map(&:next)
+
+        axes_hexes = @hexes.reject(&:ignore_for_axes)
+        @cols = compute_axes(axes_hexes.map(&:x))
+        @rows = compute_axes(axes_hexes.map(&:y))
+
         @start_pos = [@cols.first, @rows.first]
 
         @scale = SCALE * map_zoom


### PR DESCRIPTION
Stop setting `@cols` and `@rows` to sparse arrays. This allows for a row/col to be unused, which is especially useful when incrementally defining the map for a new game.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`