### PR TITLE
Opal 1.8, Ruby 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Ruby 3.0
+    - name: Set up Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0
+        ruby-version: 3.2
     - name: Build and test with Rake
       run: |
         gem install bundler

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+    OPAL_PREFORK_DISABLE: "true"
+
 jobs:
   build:
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 require: rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 3.0.2
+  TargetRubyVersion: 3.2
   NewCops: enable
   SuggestExtensions: false
 
@@ -74,6 +74,10 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Naming/BlockForwarding:
+  EnforcedStyle: explicit
+  BlockForwardingName: block
+
 Naming/MemoizedInstanceVariableName:
   Enabled: false
 
@@ -143,6 +147,11 @@ Style/HashEachMethods:
 # code readibility: case trumps hash-lookup
 Style/HashLikeCase:
   Enabled: false
+
+Style/HashSyntax:
+  Enabled: true
+  EnforcedStyle: no_mixed_keys
+  EnforcedShorthandSyntax: never
 
 Style/NegatedIfElseCondition:
   Enabled: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1
+FROM ruby:3.2
 
 ARG RACK_ENV
 RUN mkdir /18xx

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    argon2 (2.1.1)
-      ffi (~> 1.14)
+    argon2 (2.2.0)
+      ffi (~> 1.15)
       ffi-compiler (~> 1.0)
     ast (2.4.2)
     byebug (11.1.3)
@@ -23,7 +23,7 @@ GEM
     kgio (2.11.4)
     libv8-node (16.10.0.0)
     libv8-node (16.10.0.0-x86_64-linux)
-    listen (3.7.1)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     message_bus (4.2.0)
@@ -32,7 +32,7 @@ GEM
     mini_racer (0.6.2)
       libv8-node (~> 16.10.0.0)
     newrelic_rpm (8.6.0)
-    opal (1.5.0)
+    opal (1.8.2)
       ast (>= 2.3.0)
       parser (~> 3.0, >= 3.0.3.2)
     parallel (1.22.1)
@@ -49,17 +49,17 @@ GEM
       pry (~> 0.13.0)
     raabro (1.4.0)
     racc (1.7.3)
-    rack (3.0.6.1)
+    rack (3.0.8)
     rainbow (3.1.1)
     raindrops (0.20.0)
     rake (13.0.6)
-    rb-fsevent (0.11.1)
+    rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.6.0)
     regexp_parser (2.3.0)
     require_all (3.0.0)
-    rerun (0.13.1)
+    rerun (0.14.0)
       listen (~> 3.0)
     rexml (3.2.5)
     roda (3.55.0)
@@ -147,4 +147,4 @@ DEPENDENCIES
   unicorn-worker-killer
 
 BUNDLED WITH
-   2.3.7
+   2.4.10

--- a/assets/app/view/game/par_chart.rb
+++ b/assets/app/view/game/par_chart.rb
@@ -181,7 +181,7 @@ module View
           },
           style: {
             stroke: 'black',
-            'stroke-width' => '0.1rem',
+            'stroke-width': '0.1rem',
           },
         }
 

--- a/assets/app/view/game/triangular_grid.rb
+++ b/assets/app/view/game/triangular_grid.rb
@@ -15,7 +15,7 @@ module View
         fill: 'none',
         opacity: 0.5,
         stroke: 'black',
-        'stroke-width' => 2,
+        'stroke-width': 2,
       }
 
       h('g.triangular_grid', { attrs: attrs }, children)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,6 +6,7 @@ x-rack: &rack
     DATABASE_URL: postgres://root:password@db:5432/18xx_development
     RACK_ENV: development
     RUBYOPTS: --yjit
+    OPAL_PREFORK_DISABLE: "true"
   build:
     args:
       RACK_ENV: development

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,6 +12,7 @@ x-rack: &rack
     SLACK_WEBHOOK_URL: $SLACK_WEBHOOK_URL
     RUBYOPTS: --yjit
     PORT: 9292
+    OPAL_PREFORK_DISABLE: "true"
   restart: always
   build:
     args:

--- a/queue.rb
+++ b/queue.rb
@@ -54,7 +54,7 @@ scheduler.cron '00 09 * * *' do
   pins.each do |pin|
     where_kwargs = {
       Sequel.pg_jsonb_op(:settings).get_text('pin') => pin,
-      status: %w[active finished],
+      :status => %w[active finished],
     }
     if Game.where(**where_kwargs).count.zero?
       file = "#{PINS_DIR}/#{pin}.js.gz"


### PR DESCRIPTION
* a few gems, as well as configuration for a couple rubocop cops, needed updating for Ruby 3.2
* Opal 1.6+ gives longer in JS  stacktraces 🎉 
* Opal 1.7+ allows use of `Set` in Ruby 🎉 

Fixes #9608 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`