### PR TITLE
add `backtick_javascript` comments

### DIFF
--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'index'
 require 'game_manager'
 require 'user_manager'

--- a/assets/app/game_class_loader.rb
+++ b/assets/app/game_class_loader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 module GameClassLoader
   def self.included(base)
     base.needs :game_classes_loaded, default: {}, store: true if base.respond_to?(:needs)

--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'lib/storage'
 require_relative 'game_class_loader'
 

--- a/assets/app/lib/connection.rb
+++ b/assets/app/lib/connection.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'lib/storage'
 
 module Lib

--- a/assets/app/lib/params.rb
+++ b/assets/app/lib/params.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 module Lib
   module Params
     def self.[](key)

--- a/assets/app/lib/settings.rb
+++ b/assets/app/lib/settings.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require_relative 'color'
 require_relative 'hex'
 

--- a/assets/app/lib/storage.rb
+++ b/assets/app/lib/storage.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 module Lib
   module Storage
     def self.[](key)

--- a/assets/app/view/about.rb
+++ b/assets/app/view/about.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'user_manager'
 
 module View

--- a/assets/app/view/chat.rb
+++ b/assets/app/view/chat.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'lib/settings'
 require 'view/log'
 

--- a/assets/app/view/confirm.rb
+++ b/assets/app/view/confirm.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 module View
   class Confirm < Snabberb::Component
     # confirm_opts can be passed as a string which will default to yellow

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'game_manager'
 require 'lib/whats_this'
 require 'view/form'

--- a/assets/app/view/flash.rb
+++ b/assets/app/view/flash.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 module View
   class Flash < Snabberb::Component
     # flash_opts can be passed as a string which will default to salmon

--- a/assets/app/view/game/actionable.rb
+++ b/assets/app/view/game/actionable.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'game_manager'
 require 'lib/params'
 require 'lib/storage'

--- a/assets/app/view/game/auto.rb
+++ b/assets/app/view/game/auto.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'view/game/auto_action/auction_bid'
 require 'view/game/auto_action/buy_shares'
 require 'view/game/auto_action/share_pass'

--- a/assets/app/view/game/game_data.rb
+++ b/assets/app/view/game/game_data.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'game_manager'
 
 module View

--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'view/game/actionable'
 require 'lib/settings'
 

--- a/assets/app/view/game/tile_manifest.rb
+++ b/assets/app/view/game/tile_manifest.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'lib/settings'
 require 'view/tiles'
 

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'lib/settings'
 require 'lib/truncate'
 require 'lib/profile_link'

--- a/assets/app/view/game_card_page.rb
+++ b/assets/app/view/game_card_page.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'game_manager'
 require 'view/game_row'
 

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'game_manager'
 require 'lib/connection'
 require 'lib/params'

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'game_manager'
 require 'lib/settings'
 require 'lib/storage'

--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'game_manager'
 require 'user_manager'
 require 'lib/settings'

--- a/assets/deps.rb
+++ b/assets/deps.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 `Opal.config.unsupported_features_severity = 'ignore'`
 require 'native'
 require 'json'

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require_relative 'game_error'
 require_relative 'route'
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 if RUBY_ENGINE == 'opal'
   require_tree '../action'
   require_tree '../round'


### PR DESCRIPTION
suppresses this warning from Opal:

```
warning: Backtick operator usage interpreted as intent to embed JavaScript; this
code will break in Opal 2.0; add a magic comment: `# backtick_javascript: true`
-- (file)
```

Still see one instance of the error when running `rake spec_parallel` but it doesn't include a filename. We can worry about that one when Opal 2.0 is available

Fixes #10381 