### PR TITLE
1832 initial dev work by jemiahlee

### DIFF
--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -62,61 +62,72 @@ module Engine
         STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(unlimited: :green, par: :white,
                                                             ignore_one_sale: :red).freeze
 
-        PHASES = [{ name: '2', train_limit: 4, tiles: [:yellow], operating_rounds: 1 },
-                  {
-                    name: '3',
-                    on: '3',
-                    train_limit: 4,
-                    tiles: %i[yellow green],
-                    operating_rounds: 2,
-                    status: ['can_buy_companies'],
-                  },
-                  {
-                    name: '4',
-                    on: '4',
-                    train_limit: 3,
-                    tiles: %i[yellow green],
-                    operating_rounds: 2,
-                    status: %w[can_buy_companies],
-                  },
-                  {
-                    name: '5',
-                    on: '5',
-                    train_limit: 2,
-                    tiles: %i[yellow green brown],
-                    operating_rounds: 3,
-                  },
-                  {
-                    name: '6',
-                    on: '6',
-                    train_limit: 2,
-                    tiles: %i[yellow green brown],
-                    operating_rounds: 3,
-                  },
-                  {
-                    name: '8',
-                    on: '8',
-                    train_limit: 2,
-                    tiles: %i[yellow green brown],
-                    operating_rounds: 3,
-                  },
-                  {
-                    name: '10',
-                    on: '10',
-                    train_limit: 2,
-                    tiles: %i[yellow green brown],
-                    operating_rounds: 3,
-                  },
-                  {
-                    name: '12',
-                    on: '12',
-                    train_limit: 2,
-                    tiles: %i[yellow green brown],
-                    operating_rounds: 3,
-                  }].freeze
+        PHASES = [
+          { name: '2',
+            train_limit: 4,
+            tiles: [:yellow],
+            operating_rounds: 1
+          },
+          {
+            name: '3',
+            on: '3',
+            train_limit: 4,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+            status: %w[can_buy_companies],
+          },
+          {
+            name: '4',
+            on: '4',
+            train_limit: 3,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+            status: %w[can_buy_companies],
+          },
+          {
+            name: '5',
+            on: '5',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+          },
+          {
+            name: '6',
+            on: '6',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+          },
+          {
+            name: '8',
+            on: '8',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+          },
+          {
+            name: '10',
+            on: '10',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+          },
+          {
+            name: '12',
+            on: '12',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+          }].freeze
 
         TRAINS = [
-          { name: '2', distance: 2, price: 80, rusts_on: '4', num: 7 },
+          {
+            name: '2',
+            distance: 2,
+            price: 80,
+            rusts_on: '4',
+            num: 7
+          },
           {
             name: '3',
             distance: 3,
@@ -125,7 +136,13 @@ module Engine
             num: 6,
             events: [{ 'type' => 'companies_buyable' }],
           },
-          { name: '4', distance: 4, price: 300, rusts_on: '8', num: 4 },
+          {
+            name: '4',
+            distance: 4,
+            price: 300,
+            rusts_on: '8',
+            num: 4
+          },
           {
             name: '5',
             distance: 5,
@@ -148,13 +165,23 @@ module Engine
             num: 3,
             events: [{ 'type' => 'remove_key_west_token' }],
           },
-          { name: '10', distance: 10, price: 950, num: 2 },
-          { name: '12', distance: 12, price: 1100, num: 99 },
+          {
+            name: '10',
+            distance: 10,
+            price: 950,
+            num: 2
+          },
+          {
+            name: '12',
+            distance: 12,
+            price: 1100,
+            num: 99
+          },
         ].freeze
 
         def tile_lays(entity)
           return self.class::SYSTEM_TILE_LAYS if system?(entity)
-
+          
           self.class::TILE_LAYS
         end
 
@@ -397,6 +424,7 @@ module Engine
 
         def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
           upgrades = super
+
           return upgrades unless tile_manifest
 
           upgrades |= [@sharp_city, @tile_141, @tile_142, @tile_143] if tile.name == '3' && tile.assigned?('boomtown')

--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require_relative '../g_1870/game'
-require_relative 'meta'
-require_relative 'map'
 require_relative 'entities'
+require_relative 'map'
+require_relative 'market'
+require_relative 'meta'
+require_relative 'phases'
+require_relative 'trains'
 require_relative '../base'
 
 module Engine
@@ -13,6 +16,9 @@ module Engine
         include_meta(G1832::Meta)
         include G1832::Entities
         include G1832::Map
+        include G1832::Market
+        include G1832::Phases
+        include G1832::Trains
 
         attr_accessor :sell_queue, :reissued, :coal_token_counter, :coal_company_sold_or_closed
 
@@ -45,143 +51,9 @@ module Engine
 
         STARTING_CASH = { 2 => 1050, 3 => 700, 4 => 525, 5 => 420, 6 => 350, 7 => 300 }.freeze
 
-        MARKET = [
-          %w[64y 68 72 76 82 90 100p 110 120 140 160 180 200 225 250 275 300 325 350 375 400],
-          %w[60y 64y 68 72 76 82 90p 100 110 120 140 160 180 200 225 250 275 300 325 350 375],
-          %w[55y 60y 64y 68 72 76 82p 90 100 110 120 140 160 180 200 225 250i 275i 300i 325i 350i],
-          %w[50o 55y 60y 64y 68 72 76p 82 90 100 110 120 140 160i 180i 200i 225i 250i 275i 300i 325i],
-          %w[40b 50o 55y 60y 64 68 72p 76 82 90 100 110i 120i 140i 160i 180i],
-          %w[30b 40o 50o 55y 60y 64 68p 72 76 82 90i 100i 110i],
-          %w[20b 30b 40o 50o 55y 60y 64 68 72 76i 82i],
-          %w[10b 20b 30b 40o 50y 55y 60y 64 68i 72i],
-          %w[0c 10b 20b 30b 40o 50y 55y 60i 64i],
-          %w[0c 0c 10b 20b 30b 40o 50y],
-          %w[0c 0c 0c 10b 20b 30b 40o],
-        ].freeze
-
-        STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(unlimited: :green, par: :white,
-                                                            ignore_one_sale: :red).freeze
-
-        PHASES = [
-          { name: '2',
-            train_limit: 4,
-            tiles: [:yellow],
-            operating_rounds: 1
-          },
-          {
-            name: '3',
-            on: '3',
-            train_limit: 4,
-            tiles: %i[yellow green],
-            operating_rounds: 2,
-            status: %w[can_buy_companies],
-          },
-          {
-            name: '4',
-            on: '4',
-            train_limit: 3,
-            tiles: %i[yellow green],
-            operating_rounds: 2,
-            status: %w[can_buy_companies],
-          },
-          {
-            name: '5',
-            on: '5',
-            train_limit: 2,
-            tiles: %i[yellow green brown],
-            operating_rounds: 3,
-          },
-          {
-            name: '6',
-            on: '6',
-            train_limit: 2,
-            tiles: %i[yellow green brown],
-            operating_rounds: 3,
-          },
-          {
-            name: '8',
-            on: '8',
-            train_limit: 2,
-            tiles: %i[yellow green brown],
-            operating_rounds: 3,
-          },
-          {
-            name: '10',
-            on: '10',
-            train_limit: 2,
-            tiles: %i[yellow green brown],
-            operating_rounds: 3,
-          },
-          {
-            name: '12',
-            on: '12',
-            train_limit: 2,
-            tiles: %i[yellow green brown],
-            operating_rounds: 3,
-          }].freeze
-
-        TRAINS = [
-          {
-            name: '2',
-            distance: 2,
-            price: 80,
-            rusts_on: '4',
-            num: 7
-          },
-          {
-            name: '3',
-            distance: 3,
-            price: 180,
-            rusts_on: '6',
-            num: 6,
-            events: [{ 'type' => 'companies_buyable' }],
-          },
-          {
-            name: '4',
-            distance: 4,
-            price: 300,
-            rusts_on: '8',
-            num: 4
-          },
-          {
-            name: '5',
-            distance: 5,
-            price: 450,
-            rusts_on: '12',
-            num: 3,
-            events: [{ 'type' => 'close_companies' }],
-          },
-          {
-            name: '6',
-            distance: 6,
-            price: 630,
-            num: 3,
-            events: [{ 'type' => 'remove_tokens' }],
-          },
-          {
-            name: '8',
-            distance: 8,
-            price: 800,
-            num: 3,
-            events: [{ 'type' => 'remove_key_west_token' }],
-          },
-          {
-            name: '10',
-            distance: 10,
-            price: 950,
-            num: 2
-          },
-          {
-            name: '12',
-            distance: 12,
-            price: 1100,
-            num: 99
-          },
-        ].freeze
-
         def tile_lays(entity)
           return self.class::SYSTEM_TILE_LAYS if system?(entity)
-          
+
           self.class::TILE_LAYS
         end
 

--- a/lib/engine/game/g_1832/map.rb
+++ b/lib/engine/game/g_1832/map.rb
@@ -151,7 +151,7 @@ module Engine
             %w[A7 A21] => 'offboard=revenue:yellow_30|brown_50;path=a:5,b:_0;path=a:0,b:_0',
             ['B2'] => 'offboard=revenue:yellow_30|brown_50|gray_60;path=a:5,b:_0;path=a:4,b:_0',
             ['N16'] => 'offboard=revenue:yellow_20|brown_30|gray_50;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;'\
-                       'icon=image:port,sticky:1,loc:0.5;icon=image:1850/FECR_key_west,loc:2.5',
+                       'icon=image:port,sticky:1,loc:0.5;icon=image:1832/FECR_key_west,loc:2.5',
           },
           yellow: {
             ['F10'] => 'city=revenue:20;city=revenue:20;city=revenue:20;path=a:4,b:_0;path=a:0,b:_1;path=a:2,b:_2;label=Atl;',

--- a/lib/engine/game/g_1832/market.rb
+++ b/lib/engine/game/g_1832/market.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1832
+      module Market
+        MARKET = [
+          %w[64y 68 72 76 82 90 100p 110 120 140 160 180 200 225 250 275 300 325 350 375 400],
+          %w[60y 64y 68 72 76 82 90p 100 110 120 140 160 180 200 225 250 275 300 325 350 375],
+          %w[55y 60y 64y 68 72 76 82p 90 100 110 120 140 160 180 200 225 250i 275i 300i 325i 350i],
+          %w[50o 55y 60y 64y 68 72 76p 82 90 100 110 120 140 160i 180i 200i 225i 250i 275i 300i 325i],
+          %w[40b 50o 55y 60y 64 68 72p 76 82 90 100 110i 120i 140i 160i 180i],
+          %w[30b 40o 50o 55y 60y 64 68p 72 76 82 90i 100i 110i],
+          %w[20b 30b 40o 50o 55y 60y 64 68 72 76i 82i],
+          %w[10b 20b 30b 40o 50y 55y 60y 64 68i 72i],
+          %w[0c 10b 20b 30b 40o 50y 55y 60i 64i],
+          %w[0c 0c 10b 20b 30b 40o 50y],
+          %w[0c 0c 0c 10b 20b 30b 40o],
+        ].freeze
+
+        STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(unlimited: :green, par: :white,
+                                                            ignore_one_sale: :red).freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1832/meta.rb
+++ b/lib/engine/game/g_1832/meta.rb
@@ -13,13 +13,24 @@ module Engine
         DEV_STAGE = :prealpha
 
         GAME_DESIGNER = 'Bill Dixon'
-        GAME_INFO_URL = 'https://google.com'
+        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1832'
         GAME_LOCATION = 'Southern States, USA'
         PUBLISHER = :golden_spike
-        GAME_RULES_URL = 'http://google.com'
+        GAME_RULES_URL = 'https://drive.google.com/file/d/1LQCQbf4r5isUuPqK6mILUz89iNwK0ARx/view?usp=sharing'
 
         PLAYER_RANGE = [3, 7].freeze
-        OPTIONAL_RULES = [].freeze
+        OPTIONAL_RULES = [
+          {
+            sym: :game_end_on_400_stock_price,
+            short_name: 'End game if stock price hits 400',
+            desc: 'Game will end after the operating turn of a company with share value of 400',
+          },
+          {
+            sym: :diesel_trains,
+            short_name: 'Use 1830-style diesels',
+            desc: 'Instead of 8, 10, and 12 trains — use Diesels',
+          },
+        ].freeze
       end
     end
   end

--- a/lib/engine/game/g_1832/phases.rb
+++ b/lib/engine/game/g_1832/phases.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1832
+      module Phases
+        PHASES = [
+          {
+            name: '2',
+            train_limit: 4,
+            tiles: [:yellow],
+            operating_rounds: 1,
+          },
+          {
+            name: '3',
+            on: '3',
+            train_limit: 4,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+            status: %w[can_buy_companies],
+          },
+          {
+            name: '4',
+            on: '4',
+            train_limit: 3,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+            status: %w[can_buy_companies],
+          },
+          {
+            name: '5',
+            on: '5',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+          },
+          {
+            name: '6',
+            on: '6',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+          },
+          {
+            name: '8',
+            on: '8',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+          },
+          {
+            name: '10',
+            on: '10',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+          },
+          {
+            name: '12',
+            on: '12',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+          },
+].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1832/round/merger.rb
+++ b/lib/engine/game/g_1832/round/merger.rb
@@ -7,6 +7,23 @@ module Engine
     module G1832
       module Round
         class Merger < Engine::Round::Merger
+          def self.round_name
+            'Merger and Takeover Round'
+          end
+
+          def self.short_name
+            'MR & T'
+          end
+
+          def select_entities
+            @game.merge_corporations.sort
+          end
+
+          def setup
+            super
+            skip_steps
+            next_entity! if finished?
+          end
         end
       end
     end

--- a/lib/engine/game/g_1832/step/track.rb
+++ b/lib/engine/game/g_1832/step/track.rb
@@ -13,7 +13,7 @@ module Engine
 
             action.hex.remove_assignment!('boomtown') if action.hex.assigned?('boomtown')
 
-            if action.hex.id.include?(Engine::Game::G1832::Game::BOOMTOWN_HEXES) && action.hex::COLOR == 'white'
+            if Engine::Game::G1832::Game::BOOMTOWN_HEXES.include?(action.hex.id) && action.hex.tile.color == :white
               action.hex.assign!('boomtown')
             end
 

--- a/lib/engine/game/g_1832/trains.rb
+++ b/lib/engine/game/g_1832/trains.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1832
+      module Trains
+        TRAINS = [
+          {
+            name: '2',
+            distance: 2,
+            price: 80,
+            rusts_on: '4',
+            num: 7,
+          },
+          {
+            name: '3',
+            distance: 3,
+            price: 180,
+            rusts_on: '6',
+            num: 6,
+            events: [{ 'type' => 'companies_buyable' }],
+          },
+          {
+            name: '4',
+            distance: 4,
+            price: 300,
+            rusts_on: '8',
+            num: 4,
+          },
+          {
+            name: '5',
+            distance: 5,
+            price: 450,
+            rusts_on: '12',
+            num: 3,
+            events: [{ 'type' => 'close_companies' }],
+          },
+          {
+            name: '6',
+            distance: 6,
+            price: 630,
+            num: 3,
+            events: [{ 'type' => 'remove_tokens' }],
+          },
+          {
+            name: '8',
+            distance: 8,
+            price: 800,
+            num: 3,
+            events: [{ 'type' => 'remove_key_west_token' }],
+          },
+          {
+            name: '10',
+            distance: 10,
+            price: 950,
+            num: 2,
+          },
+          {
+            name: '12',
+            distance: 12,
+            price: 1100,
+            num: 99,
+          },
+        ].freeze
+      end
+    end
+  end
+end


### PR DESCRIPTION
Works on #10122 

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` label if this change will break existing games (N/A)
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

@philcampeau did a ton of work here already to get the basic game setup done. This PR mostly just rearranges the files a little bit so that trains, phases, market are in their own files. There was also an issue in laying track that this fixes (I did not examine whether the behavior is truly correct, just that it was breaking tile laying and now it isn't).


***Screenshots**
N/A
* **Any Assumptions / Hacks**
N/A