### PR TITLE
Add myself to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,3 +48,9 @@ lib/engine/game/g_18_sj* @perwestling
 lib/engine/game/g_18_tn* @perwestling
 lib/engine/game/g_1824* @perwestling
 lib/engine/game/g_1893* @perwestling
+
+lib/engine/game/g_1858* @ollybh
+lib/engine/game/g_1861* @ollybh
+lib/engine/game/g_1867* @ollybh
+lib/engine/game/g_18_ardennes* @ollybh
+lib/engine/game/g_18_bf* @ollybh


### PR DESCRIPTION
### Implementation Notes

Add myself to the CODEOWNERS file.

1858 is a game implemented by me. Neither 18Ardennes or 18BF are complete yet, but I've done work on both of these.

Neither 1861 nor 1867 were implemented be me, but the original author (Jen?) is no longer active here. I've been fixing any bugs reported in these games and will continue to do this.

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

