### PR TITLE
[18RoyalGorge] update phase info, implement two more private companies

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/entities.rb
+++ b/lib/engine/game/g_18_royal_gorge/entities.rb
@@ -8,10 +8,9 @@ module Engine
           {
             sym: 'Y1',
             name: 'St. Cloud Hotel (Y1)',
-            desc: 'Special abilities not implemented.',
-            # desc: "Hotel token starts in Silvercliffe (G17). When owned by a corporation, St. Cloud's "\
-            #       'hotel token will generate an additional $20 revenue only for the holding corporation. '\
-            #       'Once in Brown Phase, the hotel is moved to Cañon City (H12). This company never closes.',
+            desc: "Hotel token starts in Silvercliffe (G17). When owned by a corporation, St. Cloud's "\
+                  'hotel token will generate an additional $20 revenue only for the holding corporation. '\
+                  'Once in Brown Phase, the hotel is moved to Cañon City (H12). This company never closes.',
             value: 50,
             revenue: 5,
             abilities: [

--- a/lib/engine/game/g_18_royal_gorge/entities.rb
+++ b/lib/engine/game/g_18_royal_gorge/entities.rb
@@ -205,16 +205,22 @@ module Engine
           {
             sym: 'B2',
             name: 'Sulphur Springs (B2)',
-            desc: 'Special abilities not implemented.',
-            # desc: 'The owning corporation may close this company permanently to turn Sulphur '\
-            #       'Springs (E3) into a city of the same color tile. If owned by a player, once in Brown Phase, '\
-            #       'provides $50 revenue per operating round, only if Sulphur Springs is connected by any rail.',
+            desc: 'The owning corporation may close this company permanently to turn Sulphur '\
+                  'Springs (E3) into a city of the same color tile. If owned by a player, once in Brown Phase, '\
+                  'provides $50 revenue per operating round, only if Sulphur Springs is connected by any rail.',
             value: 50,
             revenue: 0,
             abilities: [
-              { type: 'revenue_change', revenue: 50, on_phase: 'Brown' },
-              # TODO: revenue to player only if rail reaches sulphur springs
-              # TODO: upgrade E3 to a city tile
+              {
+                type: 'tile_lay',
+                when: 'owning_corp_or_turn',
+                hexes: %w[E3],
+                tiles: %w[RG1 RG2 RG3],
+                owner_type: 'corporation',
+                count: 1,
+                closed_when_used_up: true,
+                special: true,
+              },
             ],
           },
           {

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -66,8 +66,9 @@ module Engine
         }.freeze
 
         EVENTS_TEXT = Base::EVENTS_TEXT.merge(
-          green_par: ['Green Par Available'],
-          brown_par: ['Brown Par Available'],
+          green_phase: ['Green Phase Begins'],
+          brown_phase: ['Brown Phase Begins'],
+          gray_phase: ['Gray Phase Begins'],
           treaty_of_boston: ['Treaty of Boston'],
         )
 
@@ -275,21 +276,17 @@ module Engine
           can_start?(corporation) && super
         end
 
-        def event_green_par!
-          @log << "-- Event: #{EVENTS_TEXT[:green_par]} --"
+        def event_green_phase!
           @available_par_groups << :par_1
-          update_cache(:share_prices)
-        end
-
-        def event_brown_par!
-          @log << "-- Event: #{EVENTS_TEXT[:brown_par]} --"
-          @available_par_groups << :par_2
           update_cache(:share_prices)
         end
 
         def event_brown_phase!
           event_st_cloud_moves!
           event_sulphur_springs_revenue!
+
+          @available_par_groups << :par_2
+          update_cache(:share_prices)
         end
 
         def event_st_cloud_moves!

--- a/lib/engine/game/g_18_royal_gorge/step/special_track.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/special_track.rb
@@ -9,6 +9,15 @@ module Engine
         class SpecialTrack < Engine::Step::SpecialTrack
           def actions(entity)
             return [] unless entity.owner == current_entity
+          end
+
+          def legal_tile_rotation?(entity, hex, tile)
+            if entity == @game.sulphur_springs &&
+               hex.id == @game.class::SULPHUR_SPRINGS_HEX &&
+               %w[RG1 RG2 RG3].include?(tile.name)
+
+              return hex.tile.color == tile.color && tile.rotation.zero?
+            end
 
             super
           end

--- a/lib/engine/game/g_18_royal_gorge/trains.rb
+++ b/lib/engine/game/g_18_royal_gorge/trains.rb
@@ -13,7 +13,7 @@ module Engine
             rusts_on: '4+',
             salvage: 20,
             num: 4,
-            events: [{ 'type' => 'green_par', 'when' => 4 }],
+            events: [{ 'type' => 'green_phase', 'when' => 4 }],
           },
           {
             name: '3+',
@@ -31,7 +31,7 @@ module Engine
                        { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
             price: 400,
             num: 3,
-            events: [{ 'type' => 'brown_par', 'when' => 3 }, { 'type' => 'brown_phase', 'when' => 3 }],
+            events: [{ 'type' => 'brown_phase', 'when' => 3 }],
           },
           {
             name: '5+',
@@ -39,6 +39,7 @@ module Engine
                        { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
             price: 500,
             num: 2,
+            events: [{ 'type' => 'gray_phase', 'when' => 2 }],
           },
           {
             name: '6',

--- a/lib/engine/game/g_18_royal_gorge/trains.rb
+++ b/lib/engine/game/g_18_royal_gorge/trains.rb
@@ -31,7 +31,7 @@ module Engine
                        { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
             price: 400,
             num: 3,
-            events: [{ 'type' => 'brown_par', 'when' => 3 }, { 'type' => 'sulphur_springs_revenue', 'when' => 3 }],
+            events: [{ 'type' => 'brown_par', 'when' => 3 }, { 'type' => 'brown_phase', 'when' => 3 }],
           },
           {
             name: '5+',

--- a/lib/engine/game/g_18_royal_gorge/trains.rb
+++ b/lib/engine/game/g_18_royal_gorge/trains.rb
@@ -31,7 +31,7 @@ module Engine
                        { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
             price: 400,
             num: 3,
-            events: [{ 'type' => 'brown_par', 'when' => 3 }],
+            events: [{ 'type' => 'brown_par', 'when' => 3 }, { 'type' => 'sulphur_springs_revenue', 'when' => 3 }],
           },
           {
             name: '5+',


### PR DESCRIPTION
* Y1 St Cloud Hotel - bonus revenue in one hex, then a different hex in brown phase
* B2 Sulphur Springs - can upgrade Sulphur Springs hex from a town to a city; only pays revenue in brown phase if Sulphur Springs hex has track built to it

 #10110

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
