### PR TITLE
Fix shared mount volume designation for podman

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     build:
       context: ./db/
     volumes:
-      - ./db/data:/var/lib/postgresql/data:Z
+      - ./db/data:/var/lib/postgresql/data:z
     ports:
       - 127.0.0.1:5433:5432
     logging:


### PR DESCRIPTION

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

I don't know why this needs to change now, but lowercase z is defined as the "shared volume" flag in https://docs.podman.io/en/latest/markdown/podman-run.1.html#volume-v-source-volume-host-dir-container-dir-options and this fixes my issues building on a fresh reinstall of Fedora 39.  I was coming from Fedora 35 which is really far back, so something must have changed in the meantime.

I did a local test, and a codespace test, which should cover ubunutu/docker.  I didn't see any issues there.

### Screenshots

### Any Assumptions / Hacks
