### PR TITLE
fix looping error for `/fixture` in prod or when fixture doesn't exist

### DIFF
--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -110,6 +110,8 @@ class App < Snabberb::Component
       enter_game(@game_data)
     end
 
+    error = @game_data&.dig('error')
+    return h('div.padded', "Error loading game: #{error}") if error
     return h('div.padded', 'Loading game...') unless @game_data&.dig('loaded')
 
     h(View::GamePage, connection: @connection, user: @user)

--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -47,7 +47,7 @@ module GameManager
   end
 
   def enter_fixture(path)
-    @connection.safe_get("/fixtures/#{path}.json", '') do |data|
+    @connection.get("/fixtures/#{path}.json", '') do |data|
       store(:game_data, data, skip: false)
     end
   end


### PR DESCRIPTION
When the `/fixture` path is used in production, the fixture does not load, but due to the `safe_get` implementation it is retried, triggering a loop:

![fixture loop error](https://github.com/tobymao/18xx/assets/1045173/f3d0a3f8-774b-467c-838c-923621510764)

This also happens in development if path in the URL does not correspond to an actual fixture file.
