### PR TITLE
[1850] Fixes Western Land Grant "Paths must be connected" error

### DIFF
--- a/lib/engine/ability/README.md
+++ b/lib/engine/ability/README.md
@@ -260,7 +260,7 @@ remains open but the discount can no longer be used. Default false.
 - `special`: If true, do not check that the tile upgrade preserves
   labels and city count. Default true.
 - `connect`: If true, and `count` is greater than 1, tiles laid must
-  connect to each other. Default true.
+  connect to each other. Default true unless `count_per_or` is used, in which case `connect` isn't checked by default. 
 - `blocks`: If true and `when` is `sold`, then the step
   `TrackLayWhenCompanySold` will require a tile lay. Default false.
 - `reachable`: If true, when tile laid, a check is done if one of the
@@ -280,6 +280,7 @@ remains open but the discount can no longer be used. Default false.
   the number of green or higher tile upgrades. When these are set, the ability
   cannot be used for both new tile lays and upgrades. With these set, you need
   to make sure the `ability.use!` call includes an `upgrade` kwarg.
+- `count_per_or`: used if private ability limits the amount of tile lays that you can use per OR.
 
 ## train_buy
 

--- a/lib/engine/game/g_1850/entities.rb
+++ b/lib/engine/game/g_1850/entities.rb
@@ -123,7 +123,6 @@ module Engine
             owner_type: 'corporation',
             count: 3,
             count_per_or: 1,
-            connect: false,
             reachable: true,
             special: false,
             when: 'track',

--- a/lib/engine/game/g_1850/entities.rb
+++ b/lib/engine/game/g_1850/entities.rb
@@ -123,6 +123,7 @@ module Engine
             owner_type: 'corporation',
             count: 3,
             count_per_or: 1,
+            connect: false,
             reachable: true,
             special: false,
             when: 'track',

--- a/lib/engine/step/special_track.rb
+++ b/lib/engine/step/special_track.rb
@@ -175,6 +175,7 @@ module Engine
         return unless ability.connect
         return if ability.hexes.size < 2
         return if !ability.start_count || ability.start_count < 2 || ability.start_count == ability.count
+        return if ability.count_per_or == 1
 
         # check to see if at least one path on each laid tile connects to at least one path on one of the others
         #


### PR DESCRIPTION
Tiles don't need to be connected.

Fixes #10033 
Fixes #10334

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Western land grant doesn't require its tiles to be connected, and this defaults to true on tile_lay abilities with more than one tile.

### Screenshots

### Any Assumptions / Hacks
