### PR TITLE
[1850] Corrects Western Land Grant to not require connected lays

### DIFF
--- a/lib/engine/game/g_1850/entities.rb
+++ b/lib/engine/game/g_1850/entities.rb
@@ -121,6 +121,7 @@ module Engine
           abilities: [{
             type: 'tile_lay',
             owner_type: 'corporation',
+            connect: false,
             count: 3,
             count_per_or: 1,
             reachable: true,


### PR DESCRIPTION
Fixes #10033
Fixes #10334 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Western Land Grant was requiring all special lays be contiguous. This isn't required. 

### Screenshots

### Any Assumptions / Hacks
