### PR TITLE
[18RoyalGorge] implement private Y2 Ghost Town Tours

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/entities.rb
+++ b/lib/engine/game/g_18_royal_gorge/entities.rb
@@ -20,13 +20,17 @@ module Engine
           {
             sym: 'Y2',
             name: 'Ghost Town Tour Co. (Y2)',
-            desc: 'Special abilities not implemented.',
-            # desc: 'When the owning corporation ships the last gold from any mine space, they  may put 1 Ghost Town '\
-            #       'Token in that hex. On future turns, Ghost Town Tokens provide $10 revenue for the owning corporation.',
+            desc: 'When the owning corporation ships the last gold from any mine space, they  may put 1 Ghost Town '\
+                  'Token in that hex. On future turns, Ghost Town Tokens provide $10 revenue for the owning corporation.',
             value: 45,
             revenue: 15,
             abilities: [
-              # after last Gold is shipped from a hex, may add a +$10 ghost town
+              {
+                type: 'choose_ability',
+                owner_type: 'corporation',
+                when: %w[dividend],
+                count: 4,
+              },
             ],
           },
           {

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -813,6 +813,10 @@ module Engine
           @st_cloud_hotel ||= company_by_id('Y1')
         end
 
+        def ghost_town_tours
+          @ghost_town_tours ||= company_by_id('Y2')
+        end
+
         def upgrades_to?(from, to, special = false, selected_company: nil)
           if special && from.hex.id == SULPHUR_SPRINGS_HEX && selected_company == sulphur_springs
             return case from.color
@@ -945,15 +949,28 @@ module Engine
           route.corporation == st_cloud_hotel&.owner && stops.any? { |s| s.hex == @st_cloud_hex }
         end
 
+        def ghost_town_bonus(route)
+          bonus = { revenue: 0, description: '' }
+          return bonus  unless route.corporation == ghost_town_tours&.owner
+
+          ghost_towns = route.all_hexes.count { |h| h.tile.icons.find { |i| i.name == 'ghost_town' } }
+
+          return bonus if ghost_towns.zero?
+
+          { revenue: 10 * ghost_towns, description: " (Ghost Town#{ghost_towns == 1 ? '' : 's'})" }
+        end
+
         def revenue_for(route, stops)
           revenue = super
           revenue += ST_CLOUD_BONUS if st_cloud_bonus?(route, stops)
+          revenue += ghost_town_bonus(route)[:revenue]
           revenue
         end
 
         def revenue_str(route)
           str = super
           str += ST_CLOUD_BONUS_STR if st_cloud_bonus?(route, route.visited_stops)
+          str += ghost_town_bonus(route)[:description]
           str
         end
       end


### PR DESCRIPTION
After last gold is shipped from a hex, may place a ghost town marker (from a starting supply of 4) there for +$10 to the owning corporation's routes there.

#10110

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`