### PR TITLE
[18ESP] Fixes interest calculation to round up.

### DIFF
--- a/lib/engine/game/g_18_esp/game.rb
+++ b/lib/engine/game/g_18_esp/game.rb
@@ -1017,7 +1017,7 @@ module Engine
           @bank.spend(loan, player)
 
           loan_amount = loan
-          interest = loan_amount * 0.5
+          interest = (loan_amount * 0.5).ceil
 
           @log << "#{player.name} recieves #{format_currency(loan)} from the bank. \
                     The loan amount is #{format_currency(loan_amount)}.\


### PR DESCRIPTION
Fixes #10404

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Currently loan interest rounds down to nearest whole integer, but according to the rules it should round **up** to the nearest whole integer. 

Changed loan calculation from `interest = loan_amount * 0.5` to `interest = (loan_amount * 0.5).ceil`

This change will break any games where interest calculation was wrong, applied `archive_alpha_games` label.

### Screenshots

### Any Assumptions / Hacks
