### PR TITLE
[18RoyalGorge] implement train-lengthening privates (Y3, G6, B5)

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/entities.rb
+++ b/lib/engine/game/g_18_royal_gorge/entities.rb
@@ -36,15 +36,17 @@ module Engine
           {
             sym: 'Y3',
             name: 'Coal Creek Mines (Y3)',
-            desc: 'Special abilities not implemented.',
-            # desc: 'When any corporation runs through Coal Creek, the owning corporation receives a coal cube '\
-            #       'from the Coal Mine Card. On a future turn, the owning corporation may use up to 2 coal cubes '\
-            #       'to increase their train run by 1 stop for each cube. When used, cubes are removed from the game.',
+            desc: 'When any corporation runs through Coal Creek, the owning corporation receives a coal cube '\
+                  "from the Mine's supply of 12 cubes. On a future turn, the owning corporation may use up to 2 coal cubes "\
+                  'to increase their train run by 1 stop for each cube. When used, cubes are removed from the game.',
             value: 40,
             revenue: 5,
             abilities: [
-              # owning corp gets a coal cube from the coal mine card (supply of
-              # 12) when anyone runs through Coal Creek
+              {
+                type: 'base',
+                desc: 'When any corporation runs through Coal Creek, the owning corporation receives a coal cube.',
+                count: 12,
+              },
             ],
           },
           {
@@ -178,15 +180,11 @@ module Engine
           {
             sym: 'G6',
             name: 'Coal Depot (G6)',
-            desc: 'Special abilities not implemented.',
-            # desc: 'Place one coal cube on this card for every $10 paid for this company in the '\
-            #       'initial auction (rounded down). During operating rounds, the owning corporation may '\
-            #       'spend 1-2 coal cubes to add additional stops on a route, following normal route rules.',
+            desc: 'Place one coal cube on this card for every $10 paid for this company in the '\
+                  'initial auction (rounded down). During operating rounds, the owning corporation may '\
+                  'spend 1-2 coal cubes to add additional stops on a route, following normal route rules.',
             value: 10,
             revenue: 5,
-            abilities: [
-              # 1 coal cube per $10 paid (round down) during auction
-            ],
           },
         ].freeze
 
@@ -259,15 +257,11 @@ module Engine
           },
           {
             sym: 'B5',
-            name: 'Track Engineer (B5)',
-            desc: 'Special abilities not implemented.',
-            # desc: 'Every operating round, this company may treat one train as if it were +1. It may '\
-            #       'be a different train each operating round.',
+            name: 'B5 Track Engineer',
+            desc: 'Every operating round, this company may treat one train as if it were +1. It may '\
+                  'be a different train each operating round.',
             value: 60,
             revenue: 10,
-            abilities: [
-              # extend a train by 1 each OR
-            ],
           },
           {
             sym: 'B6',

--- a/lib/engine/game/g_18_royal_gorge/step/route.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/route.rb
@@ -7,12 +7,54 @@ module Engine
     module G18RoyalGorge
       module Step
         class Route < Engine::Step::Route
+          CHOOSE_STATES = %i[coal_mines coal_depot engineer].freeze
+
+          CHOICE_NAMES = {
+            engineer: "may increase one train's number by 1",
+            coal_mines: "may spend up to 2 coal cubes to increase one train's number 1 per cube",
+            coal_depot: "may spend up to 2 coal cubes to increase one train's number 1 per cube",
+          }.freeze
+
+          MAX_COAL_CUBES = 2
+
           def round_state
             super.merge(
               {
                 hanging_bridge_lease_payment: 0,
               }
             )
+          end
+
+          def setup
+            @choices_already_setup = false
+            @original_variants = {}
+            @chosen_trains = {}
+          end
+
+          def setup_choices
+            @choices_already_setup = true
+
+            @choose_companies = {
+              engineer: @game.track_engineer,
+              coal_mines: @game.coal_creek_mines,
+              coal_depot: @game.coal_depot,
+            }.select { |_, c| c&.owner == current_entity }
+
+            @choose_states = CHOOSE_STATES.select { |s| valid_choose_state?(s) }
+            advance_choose_state!
+
+            @choice_names = @choose_companies.to_h do |choice_sym, company|
+              [choice_sym, "#{company.name} - #{current_entity.name} #{CHOICE_NAMES[choice_sym]}"]
+            end
+          end
+
+          def valid_choose_state?(choose_state)
+            return false unless @choose_companies[choose_state]
+            return false if @chosen_trains.include?(choose_state)
+            return true if choose_state == :engineer
+
+            ability = coal_cube_ability(choose_state)
+            ability.count.positive?
           end
 
           def available_hex(entity, hex)
@@ -24,11 +66,153 @@ module Engine
           def process_run_routes(action)
             super
 
+            restore_original_variants unless @original_variants.empty?
+
+            if @game.coal_creek_mines&.owner&.corporation? &&
+               (route = action.routes.find { |r| r.hexes.any? { |h| h.id == @game.class::COAL_CREEK_MINES_HEX } })
+              @game.move_coal_creek_mines_cube!(action.entity)
+            end
+
             return unless action.entity == @game.hanging_bridge_lease&.owner
             return if action.entity == @game.rio_grande
             return unless (route = action.routes.find { |r| r.hexes.any? { |h| h.id == @game.class::ROYAL_GORGE_TOWN_HEX } })
 
             @round.hanging_bridge_lease_payment = route.revenue / 10
+          end
+
+          def actions(entity)
+            actions = super.dup
+            actions << 'choose' if !actions.empty? && choosing?(entity)
+            actions
+          end
+
+          def choosing?(entity)
+            return false unless entity == current_entity
+
+            setup_choices unless @choices_already_setup
+            @choose_state && !choices.empty?
+          end
+
+          def advance_choose_state!
+            @choose_state = @choose_states.pop
+          end
+
+          def choice_name
+            @choice_names[@choose_state]
+          end
+
+          def choosing_company
+            @choose_companies[@choose_state]
+          end
+
+          def choices
+            return unless @choose_state
+
+            skip_key = "#{@choose_state}/skip/0"
+            init_obj = @choose_states.empty? ? {} : { skip_key => 'Skip' }
+
+            choices = (current_entity.trains - @chosen_trains.values).uniq(&:name).each_with_object(init_obj) do |train, obj|
+              if @choose_state == :engineer
+                obj["engineer/#{train.id}/1"] = "#{train.name} train"
+              else
+                cubes = [MAX_COAL_CUBES, coal_cube_ability(@choose_state).count].min
+                (1..cubes).each do |num_cubes|
+                  obj["#{@choose_state}/#{train.id}/#{num_cubes}"] =
+                    "Spend #{num_cubes} coal cube#{num_cubes == 1 ? '' : 's'} on #{train.name} train"
+                end
+              end
+            end
+
+            if choices.keys == [skip_key]
+              {}
+            else
+              choices
+            end
+          end
+
+          def coal_cube_ability(choose_state)
+            current_entity.abilities.find { |a| a.type =~ /#{choose_state}/ }
+          end
+
+          def spend_coal_cubes!(amount)
+            return if @choose_state == :engineer
+
+            ability = coal_cube_ability(@choose_state)
+            amount.times { ability.use! }
+            ability.description = ability.description.sub(/\d+/, ability.count.to_s)
+          end
+
+          def process_choose(action)
+            choose_state, train_id, amount = action.choice.split('/')
+            unless @choose_state == choose_state.to_sym
+              raise GameError,
+                    "Expected choice for #{@choose_state}, got #{choose_state}"
+            end
+
+            if train_id == 'skip'
+              # move current state to end of queue so undoing is not necessary
+              # if player changes their mind about using this company
+              @choose_states.unshift(@choose_state)
+            else
+              train = @game.train_by_id(train_id)
+              amount = amount.to_i
+
+              spend_coal_cubes!(amount)
+
+              # save train name so it can be restored
+              @original_variants[@choose_state] = train.name
+
+              # upgraded info
+              new_length = train.distance[0]['visit'] + amount
+              new_name = train.name.sub(/\d+/, new_length.to_s)
+
+              # create upgraded variant if necessary
+              unless train.variants.include?(new_name)
+                distance = train.distance.map.with_index do |dist, index|
+                  next { **dist } unless index.zero?
+
+                  {
+                    **dist,
+                    'pay' => dist['pay'] + amount,
+                    'visit' => dist['visit'] + amount,
+                  }
+                end
+                train.add_variant({
+                                    name: new_name,
+                                    distance: distance,
+                                    buyable: false,
+                                  })
+              end
+
+              # use the upgraded variant
+              train.variant = new_name
+
+              # save train so it cannot be upgraded by another company and so it
+              # can be restored
+              @chosen_trains[@choose_state] = train
+
+              extend_str =
+                if @choose_state == :engineer
+                  'extends'
+                else
+                  "spends #{amount} coal cube#{amount == 1 ? '' : 's'} to extend"
+                end
+              @log << "#{@choose_companies[@choose_state].owner.name} "\
+                      "(#{@choose_companies[@choose_state].name}) #{extend_str} a "\
+                      "#{@original_variants[@choose_state]} train to a "\
+                      "#{@chosen_trains[@choose_state].name} train"
+            end
+
+            advance_choose_state!
+          end
+
+          def restore_original_variants
+            @chosen_trains.each do |choose_state, train|
+              train.variant = @original_variants[choose_state]
+            end
+
+            @original_variants.clear
+            @chosen_trains.clear
           end
         end
       end

--- a/lib/engine/game/g_18_royal_gorge/trains.rb
+++ b/lib/engine/game/g_18_royal_gorge/trains.rb
@@ -48,7 +48,7 @@ module Engine
             num: 5,
             events: [{ 'type' => 'trigger_endgame' }],
           },
-        ].freeze
+        ].deep_freeze
 
         PHASES = [
           {
@@ -82,7 +82,7 @@ module Engine
             status: %w[can_buy_companies],
             operating_rounds: 2,
           },
-        ].freeze
+        ].deep_freeze
       end
     end
   end


### PR DESCRIPTION
https://github.com/tobymao/18xx/issues/10110

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

* B5 Track Engineer increase one train's length by one each OR

* Y3 Coal Creek Mines and G6 Coal Depot get coal cubes in different ways, but they are spent in the same way: the owning corporation can spend up to 2 coal cubes to increase one train's length by one per cube

* no train can be lengthened by more than one of these companies per OR; the `choose_state` logic in the route step ensures only one of these companies will be chosen at a time

### Screenshots

### Any Assumptions / Hacks

* Depends on #10435 and #10436, but while in prealpha it doesn't matter if this one is merged first.