### PR TITLE
[core] allow trains to have variants dynamically added

### DIFF
--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -56,6 +56,7 @@ module Engine
         discount: @discount,
         salvage: @salvage,
         track_type: @track_type,
+        buyable: @buyable,
       }
 
       # Primary variant should be at the head of the list.
@@ -71,6 +72,16 @@ module Engine
 
       # Remove the @local variable, this to get the local? method evaluate the new variant
       remove_instance_variable(:@local) if defined?(@local)
+    end
+
+    def add_variant(new_variant)
+      return if @variants.include?(new_variant[:name])
+
+      variant = {
+        **@variant,
+        **new_variant,
+      }
+      @variants[variant[:name]] = variant
     end
 
     # remove unused variants, i.e., the physical train card is not allowed to be


### PR DESCRIPTION
This will be used in 18RoyalGorge with private companies that can increase a train's number. It could also replace (and simplify) the current implementation of other train attachments, such as the pullman cars in 1822.

Split off from #10428 for #10110



<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`