### PR TITLE
[core] abilities can increase in count, and stay open when count hits 0

### DIFF
--- a/lib/engine/ability/base.rb
+++ b/lib/engine/ability/base.rb
@@ -14,7 +14,8 @@ module Engine
                   :on_phase, :after_phase, :use_across_ors
 
       def initialize(type:, description: nil, desc_detail: nil, owner_type: nil, count: nil, remove: nil,
-                     use_across_ors: nil, count_per_or: nil, passive: nil, on_phase: nil, after_phase: nil, **opts)
+                     use_across_ors: nil, count_per_or: nil, passive: nil, on_phase: nil, after_phase: nil,
+                     remove_when_used_up: nil, **opts)
         @type = type&.to_sym
         @description = description&.to_s
         @desc_detail = desc_detail&.to_s
@@ -30,6 +31,7 @@ module Engine
         @remove = remove&.to_s
         @start_count = @count
         @passive = passive.nil? ? @when.empty? : passive
+        @remove_when_used_up = remove_when_used_up.nil? ? true : remove_when_used_up
 
         setup(**opts)
       end
@@ -46,7 +48,7 @@ module Engine
         return unless @count
 
         @count -= 1
-        owner.remove_ability(self) unless @count.positive?
+        owner.remove_ability(self) if !@count.positive? && @remove_when_used_up
       end
 
       def use_up!
@@ -59,6 +61,10 @@ module Engine
 
       def when?(*times)
         !(@when & times).empty?
+      end
+
+      def add_count!(amount)
+        @count += amount
       end
     end
   end


### PR DESCRIPTION
This will be used in 18RoyalGorge for an ability that involves earning and spending cubes; more cubes can still be earned after the corporation hits zero available.

Split off from #10428 for #10110

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
