### PR TITLE
[18 India] Yellow Town / City Upgrades to Green City Tile

### DIFF
--- a/lib/engine/game/g_18_india/game.rb
+++ b/lib/engine/game/g_18_india/game.rb
@@ -410,7 +410,7 @@ module Engine
           Engine::Round::Operating.new(self, [
             Engine::Step::Exchange,
             Engine::Step::HomeToken,
-            Engine::Step::Track,
+            G18India::Step::Track,
             Engine::Step::Token,
             Engine::Step::Route,
             G18India::Step::Dividend,
@@ -583,10 +583,37 @@ module Engine
           hexes
         end
 
-        # Modifed to place share price marker on Market Chart
+        # Modified to place share price marker on Market Chart
         def float_corporation(corporation)
           @log << "#{corporation.name} floats. Share price marker placed at #{corporation.share_price.price}"
           corporation.share_price.corporations << corporation
+        end
+
+        # Modified to allow yellow towns to be upgraded to SINGLE slot city green tiles
+        # > Also modified legal_tile_rotation in STEP::Track or STEP::Tracker
+        # Modified do prevent yellow cities upgrading to SINGLE slot city green tiles
+        def upgrades_to?(from, to, special = false, selected_company: nil)
+          return true if yellow_town_to_city_upgrade?(from, to)
+          return false if yellow_city_upgrade_is_single_slot_green?(from, to)
+
+          super
+        end
+
+        def yellow_town_to_city_upgrade?(from, to)
+          case from.name
+          when '3'
+            %w[12 206 205].include?(to.name)
+          when '4'
+            %w[206 205].include?(to.name)
+          when '58'
+            %w[13 12 206 205].include?(to.name)
+          else
+            false
+          end
+        end
+
+        def yellow_city_upgrade_is_single_slot_green?(from, to)
+          %w[5 6 57].include?(from.name) && %w[12 13 205 206].include?(to.name)
         end
 
         # test using this to control laying yellow tiles from railhead

--- a/lib/engine/game/g_18_india/step/track.rb
+++ b/lib/engine/game/g_18_india/step/track.rb
@@ -7,7 +7,6 @@ module Engine
     module G18India
       module Step
         class Track < Engine::Step::Track
-
           # Bypass some Step::Tracker tests for Town to City upgrade: maintain exits, and check new exits are valid
           def legal_tile_rotation?(entity, hex, tile)
             old_tile = hex.tile

--- a/lib/engine/game/g_18_india/step/track.rb
+++ b/lib/engine/game/g_18_india/step/track.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/track'
+
+module Engine
+  module Game
+    module G18India
+      module Step
+        class Track < Engine::Step::Track
+
+          # Bypass some Step::Tracker tests for Town to City upgrade: maintain exits, and check new exits are valid
+          def legal_tile_rotation?(entity, hex, tile)
+            old_tile = hex.tile
+            if @game.yellow_town_to_city_upgrade?(old_tile, tile)
+              all_new_exits_valid = tile.exits.all? { |edge| hex.neighbors[edge] }
+              return false unless all_new_exits_valid
+
+              return old_tile.paths.all? { |old| tile.paths.any? { |new| old.exits == new.exits } } &&
+                     !(tile.exits & hex_neighbors(entity, hex)).empty?
+            end
+
+            super
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implement upgrade chart differences for Yellow Towns and Yellow Cities to Green Tiles

- [x] Branch is derived from the latest `master`
- n/a Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes
- Yellow towns may upgrade to Single Slot green cities.
- Needed to override legal_tile_rotation in Step:Track / Tracker
- Yellow cites upgrades to Double Slot green cities

### Screenshots
![image](https://github.com/tobymao/18xx/assets/118568589/967f9954-280f-4b62-9de7-66c6c7122788)
![image](https://github.com/tobymao/18xx/assets/118568589/12211a91-f5e1-4654-810d-764fba491a6f)

### Any Assumptions / Hacks
