### PR TITLE
1841: Fix tiebreaker for Tuscan Merge decider

### DIFF
--- a/lib/engine/game/g_1841/game.rb
+++ b/lib/engine/game/g_1841/game.rb
@@ -2471,8 +2471,13 @@ module Engine
           event_tuscan_merge!
         end
 
+        # Return corp first in operating order:
+        # 1. Highest price, then
+        # 2. Rightmost price, then
+        # 3. Highest in stack within a price
+        #
         def best_stock_value(corps)
-          corps.compact.select(&:floated?).max_by { |c| c.share_price.price }
+          corps.compact.select(&:floated?).min
         end
 
         def tuscan_merge_start(sflp, sfma, ssfl, sfli, holding, will_run)
@@ -2481,6 +2486,7 @@ module Engine
           @tuscan_merge_run = will_run
 
           decider = best_stock_value([sflp, sfma, ssfl])
+          @log << "#{decider.name} has best stock value"
           @tuscan_merge_decider = decider.player || @round.current_entity.player
           @log << "#{@tuscan_merge_decider.name} will perform Tuscan Merge operations"
           @tuscan_merge_ssfl = ssfl


### PR DESCRIPTION
Fixes #10389 

This will very likely require pins (there are only 24 active games at the moment)

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Rewrite best_stock_value method to use operating order sort

### Screenshots

### Any Assumptions / Hacks
