### PR TITLE
[1858] Delete private company reservation when token is placed

### DIFF
--- a/lib/engine/game/g_1858/step/home_token.rb
+++ b/lib/engine/game/g_1858/step/home_token.rb
@@ -56,7 +56,7 @@ module Engine
 
             super
 
-            delete_reservations(action.entity)
+            delete_reservations(action.entity, city)
           end
 
           def process_pass(action)
@@ -65,13 +65,20 @@ module Engine
             delete_reservations(action.entity)
           end
 
-          def delete_reservations(corporation)
-            return unless @game.private_closure_round == :in_progress
-
-            # Delete any reservations acquired from a just closed private
-            # railway company. These are only needed for this token step.
-            reservations = Array(@game.abilities(corporation, :reservation))
-            reservations.each { |r| corporation.remove_ability(r) }
+          def delete_reservations(corporation, city = nil)
+            if @game.private_closure_round == :in_progress
+              # Delete any reservations acquired from a just closed private
+              # railway company. These are only needed for this token step.
+              reservations = Array(@game.abilities(corporation, :reservation))
+              reservations.each { |r| corporation.remove_ability(r) }
+            elsif city && !corporation.companies.empty?
+              # Delete the private railway company's reservation for the slot
+              # that the token has just been placed in. If this isn't done
+              # then if the tile is upgraded before the private closes then you
+              # can get an extra slot created to accommodate both the token and
+              # the reservation, https://github.com/tobymao/18xx/issues/10442.
+              city.remove_reservation!(corporation.companies.first)
+            end
           end
         end
       end


### PR DESCRIPTION
## Implementation Notes

### Explanation of Change
An extra slot was being created when Madrid was upgrade to green. The sequence of events that triggered this was:

1. M&A is used to form AVT in stock round 3.
2. AVT places its home token in M&A's slot in the NE Madrid city.
3. In OR 3.1 RP operates before AVT.
4. RP upgrades Madrid to green.

At this point M&A hasn't yet closed and the code for moving tokens and reservations sees both AVT's token and M&A's reservation in the NE Madrid city, and helpfully creates a second slot to accommodate both of these.

The fix is to remove M&A's reservation after AVT places its home token.

Fixes #10442.

I would hope that this doesn't break any existing games, but it's possible that there has been someone who has taken advantage of this extra slot, so I've added the pins label to this pull request.


### Screenshots
#### Broken behaviour – two slots in the NE Madrid city.
![image](https://github.com/tobymao/18xx/assets/11144854/b64d6389-554b-45c6-9515-0dfd5092ed6b)

#### Correct behaviour – a single slot in the NE Madrid city.
![image](https://github.com/tobymao/18xx/assets/11144854/d2c9713b-ad54-4898-bcfe-8e68cb285c57)

### Any Assumptions / Hacks
None.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
