### PR TITLE
[18RoyalGorge] show table for gold market; [core] allow multiple "map legends"

### DIFF
--- a/assets/app/view/game/map_legend.rb
+++ b/assets/app/view/game/map_legend.rb
@@ -10,12 +10,18 @@ module View
       needs :game, store: true
 
       def render
-        table_props, header, *chart = @game.map_legend(
+        h(:div, @game.map_legends.map { |method| render_legend(method) })
+      end
+
+      def render_legend(method)
+        table_props, header, *chart = @game.send(
+          method,
           color_for(:font),
           color_for(:yellow),
           color_for(:green),
           color_for(:brown),
           color_for(:gray),
+          color_for(:red),
           action_processor: ->(a) { process_action(a) },
         )
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -3221,6 +3221,10 @@ module Engine
         false
       end
 
+      def map_legends
+        [:map_legend]
+      end
+
       def train_purchase_name(train)
         train.name
       end

--- a/lib/engine/game/g_18_royal_gorge/entities.rb
+++ b/lib/engine/game/g_18_royal_gorge/entities.rb
@@ -416,15 +416,15 @@ module Engine
             abilities: [
               {
                 type: 'base',
-                description: 'Gold Market Dividends',
-                desc_detail: 'When gold is shipped from the map, it is added to the Gold Market, '\
+                description: 'Gold Dividend',
+                desc_detail: 'When gold is shipped from the map, it is added to the Gold Dividend table, '\
                              'covering the lowest available slot. At the end of each OR set, VGC '\
                              'pays the amount of the lowest uncovered slot as dividends to '\
                              'shareholders. That amount is also tracked here as VGC\'s cash.',
               },
               {
                 type: 'base',
-                description: 'Gold Market Slots',
+                description: 'Gold Slots',
                 desc_detail: 'Yellow: 50, 90. Green: 140, 200. Brown: 270. Red: 350. Availability '\
                              'for filling slots is determined by the current phase.',
               },

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -687,7 +687,7 @@ module Engine
               },
             },
             [
-              { text: 'Gold Market', props: { attrs: { colspan: 10 } } },
+              { text: 'Gold Dividend', props: { attrs: { colspan: 10 } } },
             ],
             cells,
           ]

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -634,13 +634,49 @@ module Engine
           {
             **image_text,
             props: {
-              style: { border: '1px solid', color: 'black', backgroundColor: bg_color, cursor: 'pointer', 'user-select': 'none' },
+              style: {
+                border: '1px solid',
+                color: 'black',
+                backgroundColor: bg_color,
+                cursor: 'pointer',
+                'user-select': 'none',
+                'text-align': 'center',
+              },
               on: { click: onclick },
             },
           }
         end
 
-        def map_legend(font_color, yellow, green, brown, gray, action_processor: nil)
+        def map_legends
+          %i[gold_legend steel_legend]
+        end
+
+        def gold_legend(_font_color, yellow, green, brown, _gray, red, action_processor: nil)
+          cell_style = {
+            border: '1px solid',
+            color: 'black',
+            'font-weight': 'bold',
+            'text-align': 'center',
+            'vertical-align': 'middle',
+            width: '28px',
+            height: '33px',
+          }
+
+          cells = [
+            { text: '50', props: { style: { **cell_style, backgroundColor: yellow } } },
+            { text: '90', props: { style: { **cell_style, backgroundColor: yellow } } },
+            { text: '140', props: { style: { **cell_style, backgroundColor: green } } },
+            { text: '200', props: { style: { **cell_style, backgroundColor: green } } },
+            { text: '270', props: { style: { **cell_style, backgroundColor: brown } } },
+            { text: '350', props: { style: { **cell_style, backgroundColor: red } } },
+          ]
+          cells.take(@gold_shipped).each do |gold_cell|
+            gold_cell.delete(:text)
+            gold_cell[:image] = '/icons/18_royal_gorge/gold_cube.svg'
+            gold_cell[:image_height] = '20px'
+            gold_cell[:props][:style][:'padding-top'] = '0.3rem'
+          end
+
           [
             # table-wide props
             {
@@ -650,7 +686,29 @@ module Engine
                 borderCollapse: 'collapse',
               },
             },
-            # header
+            [
+              { text: 'Gold Market', props: { attrs: { colspan: 10 } } },
+            ],
+            cells,
+          ]
+        end
+
+        def steel_legend(font_color, yellow, green, brown, gray, _red, action_processor: nil)
+          [
+            # table-wide props
+            {
+              style: {
+                margin: '0.5rem 0 0.5rem 0',
+                border: '1px solid',
+                borderCollapse: 'collapse',
+              },
+            },
+            [
+              {
+                text: 'Steel Market',
+                props: { style: { 'text-align': 'center', 'font-weight': 'bold' }, attrs: { colspan: 10 } },
+              },
+            ],
             [
               { text: "(#{format_currency(@steel_corp.cash)})", props: { style: { border: '1px solid' } } },
               { text: 'A', props: { style: { border: '1px solid', **legend_header_style('A', :yellow, yellow) } } },
@@ -663,7 +721,6 @@ module Engine
               { text: 'H', props: { style: { border: '1px solid', **legend_header_style('H', :brown, brown) } } },
               { text: 'I', props: { style: { border: '1px solid', **legend_header_style('I', :gray, gray) } } },
             ],
-            # body
             [
               {
                 text: format_currency(40),

--- a/lib/engine/game/g_18_royal_gorge/step/dividend.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/dividend.rb
@@ -160,6 +160,7 @@ module Engine
             case @choose_state
             when :gold
               gold_shipper?(entity) &&
+                @game.gold_slots_available? &&
                 shippable_gold.include?(hex)
             when :ghost
               hex == @gold_hex

--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -1028,7 +1028,7 @@ module Engine
           true
         end
 
-        def map_legend(font_color, yellow, green, brown, gray)
+        def map_legend(font_color, yellow, green, brown, gray, *_extra_colors)
           [
             # table-wide props
             {


### PR DESCRIPTION
#10110 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

* when a gold is shipped, it occupies a spot in the market
* gold may only be shipped to spaces with colors up to the current phase
* the smallest uncovered number in the gold market is the amount of total dividends that the gold company will pay
* add capability to render multiple "map legends", so that the gold and steel tables can be rendered separately


### Screenshots

![Screenshot 2024-03-04 204456](https://github.com/tobymao/18xx/assets/1045173/505a825d-8adb-49bd-b13f-431d093e40fa)

The shipped gold cube is placed in the next spot on the gold market:

![Screenshot 2024-03-04 204434](https://github.com/tobymao/18xx/assets/1045173/5a7891b5-2ad6-4e3f-b9b6-fae041aa1f1c)

### Any Assumptions / Hacks
