### PR TITLE
[18RoyalGorge, core] allow president sales to market for only specified corporations

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -145,6 +145,7 @@ module Engine
       # many remain?
       CERT_LIMIT_COUNTS_BANKRUPTED = false
 
+      # boolean or a Set<String> of corporation IDs
       PRESIDENT_SALES_TO_MARKET = false
 
       MULTIPLE_BUY_TYPES = %i[multiple_buy].freeze
@@ -1121,8 +1122,19 @@ module Engine
         max_bundle&.price || 0
       end
 
+      def president_sales_to_market?(corporation)
+        case self.class::PRESIDENT_SALES_TO_MARKET
+        when true
+          true
+        when Set
+          self.class::PRESIDENT_SALES_TO_MARKET.include?(corporation.id)
+        else
+          false
+        end
+      end
+
       def value_for_dumpable(player, corporation)
-        return value_for_sellable(player, corporation) if self.class::PRESIDENT_SALES_TO_MARKET
+        return value_for_sellable(player, corporation) if president_sales_to_market?(corporation)
 
         max_bundle = bundles_for_corporation(player, corporation)
           .select { |bundle| bundle.can_dump?(player) && @share_pool&.fit_in_bank?(bundle) }

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -65,6 +65,8 @@ module Engine
           'Silver' => 5,
         }.freeze
 
+        PRESIDENT_SALES_TO_MARKET = Set['CF&I', 'VGC'].freeze
+
         EVENTS_TEXT = Base::EVENTS_TEXT.merge(
           green_phase: ['Green Phase Begins'],
           brown_phase: ['Brown Phase Begins'],
@@ -870,6 +872,10 @@ module Engine
 
           @log << '-- Event: Endgame triggered --'
           @endgame_triggered = true
+        end
+
+        def init_share_pool
+          SharePool.new(self, allow_president_sale: self.class::PRESIDENT_SALES_TO_MARKET, no_rebundle_president_buy: true)
         end
 
         def init_stock_market

--- a/lib/engine/game/g_18_royal_gorge/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/buy_sell_par_shares.rb
@@ -11,6 +11,10 @@ module Engine
             @game.par_prices.select { |p| p.price * 2 <= entity.cash }
           end
 
+          def can_dump?(_entity, bundle)
+            @game.president_sales_to_market?(bundle.corporation) || super
+          end
+
           def visible_corporations
             # * hide debt company
             # * put metal companies always first

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -33,7 +33,10 @@ module Engine
     def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil,
                    allow_president_change: true, silent: nil, borrow_from: nil)
       bundle = shares.is_a?(ShareBundle) ? shares : ShareBundle.new(shares)
-      if @allow_president_sale && !@no_rebundle_president_buy && bundle.presidents_share && bundle.owner == self
+      if allow_president_sale?(bundle.corporation) &&
+         !@no_rebundle_president_buy &&
+         bundle.presidents_share &&
+         bundle.owner == self
         bundle = ShareBundle.new(bundle.shares, bundle.corporation.share_percent)
       end
 
@@ -220,7 +223,7 @@ module Engine
 
       # handle selling president's share to the pool
       # if partial, move shares from pool to old president
-      if @allow_president_sale && max_shares < corporation.presidents_percent && bundle.presidents_share &&
+      if allow_president_sale?(corporation) && max_shares < corporation.presidents_percent && bundle.presidents_share &&
           to_entity == self
         corporation.owner = self
         @log << "President's share sold to pool. #{corporation.name} enters receivership"
@@ -232,7 +235,7 @@ module Engine
 
       # handle buying president's share from the pool
       # swap existing share for it
-      if @allow_president_sale && owner == self && bundle.presidents_share
+      if allow_president_sale?(corporation) && owner == self && bundle.presidents_share
         corporation.owner = to_entity
         @log << "#{to_entity.name} becomes the president of #{corporation.name}"
         @log << "#{corporation.name} exits receivership"
@@ -241,7 +244,7 @@ module Engine
       end
 
       # skip the rest if no player can be president yet
-      return if @allow_president_sale && max_shares < corporation.presidents_percent
+      return if allow_president_sale?(corporation) && max_shares < corporation.presidents_percent
 
       majority_share_holders = presidency_check_shares(corporation).select { |_, p| p == max_shares }.keys
 
@@ -357,6 +360,17 @@ module Engine
       share.owner.shares_by_corporation[corporation].delete(share)
       to_entity.shares_by_corporation[corporation] << share
       share.owner = to_entity
+    end
+
+    def allow_president_sale?(corporation)
+      case @allow_president_sale
+      when true
+        true
+      when Set
+        @allow_president_sale.include?(corporation.id)
+      else
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
The gold and steel corporations don't really have presidencies and all their shares can be in the market.

#10110
<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`