### PR TITLE
[core] Allow companies to provide a discount when buying shares

### DIFF
--- a/assets/app/view/game/button/buy_share.rb
+++ b/assets/app/view/game/button/buy_share.rb
@@ -18,6 +18,7 @@ module View
         needs :action, default: Engine::Action::BuyShares
         needs :purchase_for, default: nil
         needs :borrow_from, default: nil
+        needs :discounter, default: nil
 
         def render
           step = @game.round.active_step
@@ -43,7 +44,8 @@ module View
           process_buy = lambda do
             do_buy = lambda do
               buy_shares(@entity, bundle, share_price: modified_price, swap: @swap_share,
-                                          purchase_for: @purchase_for, borrow_from: @borrow_from)
+                                          purchase_for: @purchase_for, borrow_from: @borrow_from,
+                                          discounter: @discounter)
             end
 
             if (consenter = @game.consenter_for_buy_shares(@entity, bundle))
@@ -56,9 +58,10 @@ module View
           h(:button, { on: { click: process_buy } }, text)
         end
 
-        def buy_shares(entity, bundle, share_price: nil, swap: nil, purchase_for: nil, borrow_from: nil)
+        def buy_shares(entity, bundle, share_price: nil, swap: nil, purchase_for: nil, borrow_from: nil, discounter: nil)
           process_action(@action.new(entity, shares: bundle.shares, swap: swap, purchase_for: purchase_for,
-                                             share_price: share_price, borrow_from: borrow_from))
+                                             share_price: share_price, borrow_from: borrow_from,
+                                             discounter: discounter))
         end
       end
     end

--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -71,8 +71,9 @@ module View
         children.concat(render_other_player_shares)
         children.concat(render_shares_for_others)
         children.concat(render_price_protection)
-        children.concat(render_reduced_price_shares(@ipo_shares, source: @game.ipo_name(@corporation)))
-        children.concat(render_reduced_price_shares(@pool_shares))
+        children.concat(render_swap_shares(@ipo_shares, source: @game.ipo_name(@corporation)))
+        children.concat(render_swap_shares(@pool_shares))
+        children.concat(render_company_discounted_bundles)
 
         children
       end
@@ -233,7 +234,7 @@ module View
         [h(:button, { on: { click: protect } }, 'Protect Shares')]
       end
 
-      def render_reduced_price_shares(shares, source: 'Market')
+      def render_swap_shares(shares, source: 'Market')
         shares.map do |share|
           next unless (swap_share = @step.swap_buy(@current_entity, @corporation, share))
 
@@ -243,6 +244,19 @@ module View
             entity: @current_entity,
             percentages_available: shares.group_by(&:percent).size,
             source: source)
+        end
+      end
+
+      def render_company_discounted_bundles
+        return [] unless @step.respond_to?(:company_discounted_bundles)
+
+        @step.company_discounted_bundles(@corporation).map do |company, bundle|
+          h(Button::BuyShare,
+            share: bundle,
+            entity: @current_entity,
+            prefix: "#{company.name}: ",
+            discounter: company,
+            percentages_available: bundle.num_shares,)
         end
       end
 

--- a/lib/engine/action/buy_shares.rb
+++ b/lib/engine/action/buy_shares.rb
@@ -5,10 +5,10 @@ require_relative 'base'
 module Engine
   module Action
     class BuyShares < Base
-      attr_reader :entity, :bundle, :swap, :purchase_for, :borrow_from, :total_price
+      attr_reader :entity, :bundle, :swap, :purchase_for, :borrow_from, :total_price, :discounter
 
       def initialize(entity, shares:, share_price: nil, percent: nil, swap: nil, purchase_for: nil,
-                     borrow_from: nil, total_price: nil)
+                     borrow_from: nil, total_price: nil, discounter: nil)
         super(entity)
         @bundle = ShareBundle.new(Array(shares), percent)
         @bundle.share_price = share_price
@@ -16,6 +16,7 @@ module Engine
         @purchase_for = purchase_for
         @borrow_from = borrow_from
         @total_price = total_price
+        @discounter = discounter
       end
 
       def self.h_to_args(h, game)
@@ -27,6 +28,7 @@ module Engine
           purchase_for: game.get(h['purchase_for_type'], h['purchase_for']),
           borrow_from: game.get(h['borrow_from_type'], h['borrow_from']),
           total_price: h['total_price'],
+          discounter: game.company_by_id(h['discounter']),
         }
       end
 
@@ -41,6 +43,7 @@ module Engine
           'borrow_from_type' => type_s(@borrow_from),
           'borrow_from' => @borrow_from&.id,
           'total_price' => @total_price,
+          'discounter' => @discounter&.id,
         }
       end
     end

--- a/lib/engine/game/g_18_new_england/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_new_england/step/buy_sell_par_shares.rb
@@ -57,7 +57,8 @@ module Engine
           end
 
           # Overrides method in share_buying
-          def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true, borrow_from: nil)
+          def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true, borrow_from: nil,
+                         discounter: nil)
             corp = shares.corporation
             if corp.type == :major && shares.owner == corp.ipo_owner
               @game.share_pool.buy_shares(entity,

--- a/lib/engine/game/g_18_va/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_va/step/buy_sell_par_shares.rb
@@ -72,7 +72,8 @@ module Engine
             entity.corporation? && entity == @parred&.corporation
           end
 
-          def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true, borrow_from: nil)
+          def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true, borrow_from: nil,
+                         discounter: nil)
             # Pres 5_10 5_10 5_10 10_10!
             # 0    1    2    3    4
             # if shares.to_bundle.shares.find { |s| s.index == 4}

--- a/lib/engine/game/g_21_moon/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_21_moon/step/buy_sell_par_shares.rb
@@ -102,7 +102,8 @@ module Engine
             @round.clear_cache!
           end
 
-          def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true, borrow_from: nil)
+          def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true, borrow_from: nil,
+                         discounter: nil)
             corp = shares.corporation
             if shares.owner == corp.ipo_owner
               # IPO shares pay corporation

--- a/lib/engine/game/g_21_moon/step/corporate_buy_sell_shares.rb
+++ b/lib/engine/game/g_21_moon/step/corporate_buy_sell_shares.rb
@@ -67,7 +67,8 @@ module Engine
           end
 
           # FIXME: move to common location
-          def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true, borrow_from: nil)
+          def buy_shares(entity, shares, exchange: nil, swap: nil, allow_president_change: true, borrow_from: nil,
+                         discounter: nil)
             corp = shares.corporation
             if shares.owner == corp.ipo_owner
               # IPO shares pay corporation

--- a/lib/engine/game/g_rolling_stock/step/buy_sell_shares_bid_companies.rb
+++ b/lib/engine/game/g_rolling_stock/step/buy_sell_shares_bid_companies.rb
@@ -150,7 +150,8 @@ module Engine
             entity.cash >= @game.next_price_to_right(bundle.corporation.share_price).price
           end
 
-          def buy_shares(entity, bundle, exchange: nil, swap: nil, allow_president_change: true, borrow_from: nil)
+          def buy_shares(entity, bundle, exchange: nil, swap: nil, allow_president_change: true, borrow_from: nil,
+                         discounter: nil)
             @game.share_pool.buy_shares(entity,
                                         bundle,
                                         exchange: exchange,

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -31,7 +31,8 @@ module Engine
     end
 
     def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil,
-                   allow_president_change: true, silent: nil, borrow_from: nil)
+                   allow_president_change: true, silent: nil, borrow_from: nil,
+                   discounter: nil)
       bundle = shares.is_a?(ShareBundle) ? shares : ShareBundle.new(shares)
       if @allow_president_sale && !@no_rebundle_president_buy && bundle.presidents_share && bundle.owner == self
         bundle = ShareBundle.new(bundle.shares, bundle.corporation.share_percent)
@@ -91,7 +92,8 @@ module Engine
         borrowed_text = borrowed.positive? ? " by borrowing #{@game.format_currency(borrowed)} from #{borrow_from.name}" : ''
         verb = entity == corporation ? 'redeems' : 'buys'
         unless silent
-          @log << "#{entity.name} #{verb} #{share_str} "\
+          discounter_str = discounter ? "(#{discounter.name}) " : ''
+          @log << "#{entity.name} #{discounter_str}#{verb} #{share_str} "\
                   "from #{from} "\
                   "for #{@game.format_currency(price)}#{swap_text}#{borrowed_text}"
         end

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -173,7 +173,8 @@ module Engine
         @round.bought_from_ipo = true if action.bundle.owner.corporation?
         buy_shares(action.purchase_for || action.entity, action.bundle,
                    swap: action.swap, borrow_from: action.borrow_from,
-                   allow_president_change: allow_president_change?(action.bundle.corporation))
+                   allow_president_change: allow_president_change?(action.bundle.corporation),
+                   discounter: action.discounter)
         track_action(action, action.bundle.corporation)
       end
 

--- a/lib/engine/step/share_buying.rb
+++ b/lib/engine/step/share_buying.rb
@@ -6,7 +6,8 @@ module Engine
   module Step
     module ShareBuying
       def buy_shares(entity, shares, exchange: nil, exchange_price: nil, swap: nil,
-                     allow_president_change: true, borrow_from: nil, silent: nil)
+                     allow_president_change: true, borrow_from: nil, silent: nil,
+                     discounter: nil)
         check_legal_buy(entity,
                         shares,
                         exchange: exchange,
@@ -20,7 +21,8 @@ module Engine
                                     swap: swap,
                                     borrow_from: borrow_from,
                                     allow_president_change: allow_president_change,
-                                    silent: silent)
+                                    silent: silent,
+                                    discounter: discounter)
 
         maybe_place_home_token(shares.corporation)
       end


### PR DESCRIPTION
18RoyalGorge's share-buying step will implement `company_discounted_bundles`, which will be used for multiple private companies; see #10449 for a screenshot.

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`