### PR TITLE
[18RoyalGorge] gold/steel - implement privates G5, B4, B6

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/entities.rb
+++ b/lib/engine/game/g_18_royal_gorge/entities.rb
@@ -163,16 +163,18 @@ module Engine
           {
             sym: 'G5',
             name: 'Metals Investor (G5)',
-            desc: 'Special abilities not implemented.',
-            # desc: 'Each Stock Round, the owning player may purchase 1 CF&I share and/or 1 VGC '\
-            #       'share for one step cheaper than their current value. Once used, the player may '\
-            #       'not sell any of the purchased stocks until the next Stock Round.',
+            desc: 'Each Stock Round, the owning player may purchase 1 CF&I share and/or 1 VGC '\
+                  'share for one step cheaper than their current value. Once used, the player may '\
+                  'not sell any of the purchased stocks until the next Stock Round.',
             value: 25,
             revenue: 5,
             abilities: [
-              # 1 step discount on CF&I/VGC shares; if used, cannot sell the
-              # bought shares till next SR
               { type: 'no_buy' },
+              {
+                type: 'choose_ability',
+                owner_type: 'player',
+                when: %w[owning_player_sr_turn],
+              },
             ],
           },
           {
@@ -245,15 +247,11 @@ module Engine
           {
             sym: 'B4',
             name: 'Gold Miner (B4)',
-            desc: 'Special abilities not implemented.',
-            # desc: 'This card acts as though it were a 20% share of Victor Gold Company. Does not '\
-            #       'count as a certificate. Closes when the first 5+ train is purchased.',
+            desc: 'This card acts as though it were a 20% share of Victor Gold Company. Does not '\
+                  'count as a certificate. Closes when the first 5+ train is purchased.',
             value: 20,
             revenue: 0,
             abilities: [
-              # { type: 'close', on_train: '5+' },
-              # 20% share of gold company
-              # does not count against cert limit
               { type: 'no_buy' },
             ],
           },
@@ -272,14 +270,17 @@ module Engine
           {
             sym: 'B6',
             name: 'U.S. Mint Worker (B6)',
-            desc: 'Special abilities not implemented.',
-            # desc: 'The owning player may close this company to purchase 1-2 Victor Gold Company '\
-            #       'shares at a 50% discount each. These are bought simultaneously.',
+            desc: 'The owning player may close this company to purchase 1-2 Victor Gold Company '\
+                  'shares at a 50% discount each. These are bought simultaneously.',
             value: 40,
             revenue: 5,
             abilities: [
               { type: 'no_buy' },
-              # once per game may buy 1-2 gold shares at 50% discount; closes company
+              {
+                type: 'choose_ability',
+                owner_type: 'player',
+                when: %w[owning_player_sr_turn],
+              },
             ],
           },
         ].freeze

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -70,6 +70,7 @@ module Engine
           brown_phase: ['Brown Phase Begins'],
           gray_phase: ['Gray Phase Begins'],
           treaty_of_boston: ['Treaty of Boston'],
+          close_gold_miner: ['Close Gold Miner (B4)'],
         )
 
         DEBT_PENALTY = {
@@ -167,7 +168,6 @@ module Engine
           @gold_corp = init_metal_corp(corporation_by_id('VGC'))
 
           init_available_steel
-          @steel_corp.cash = 50
 
           @gold_cubes = Hash.new(0)
           @gold_shipped = 0
@@ -244,6 +244,10 @@ module Engine
             status << "Debt-adjusted share price: #{format_currency(price_with_debt)}"
           end
 
+          if corporation == @gold_corp && (player = gold_miner&.owner)
+            status << "#{player.name} has 2 virtual shares (#{gold_miner.sym})"
+          end
+
           status unless status.empty?
         end
 
@@ -288,6 +292,13 @@ module Engine
 
           @available_par_groups << :par_2
           update_cache(:share_prices)
+        end
+
+        def event_close_gold_miner!
+          return unless gold_miner
+
+          @log << "-- Event: #{gold_miner.name} closes --"
+          gold_miner.close!
         end
 
         def event_st_cloud_moves!
@@ -464,6 +475,7 @@ module Engine
           @stock_market.set_par(corporation, price)
           bundle = ShareBundle.new(corporation.shares_of(corporation))
           @share_pool.transfer_shares(bundle, @share_pool)
+          corporation.cash = 50
           corporation
         end
 
@@ -516,7 +528,14 @@ module Engine
           per_share = revenue / 10
           payouts = {}
           @players.each do |payee|
-            amount = payee.num_shares_of(entity) * per_share
+            num_shares = payee.num_shares_of(entity)
+
+            if payee == gold_miner&.owner
+              entity.cash += per_share * 2
+              num_shares += 2
+            end
+
+            amount = num_shares * per_share
             payouts[payee] = amount if amount.positive?
             entity.spend(amount, payee, check_positive: false)
           end
@@ -799,6 +818,14 @@ module Engine
           @rio_grande ||= corporation_by_id('RG')
         end
 
+        def mint_worker
+          @mint_worker ||= company_by_id('B6')
+        end
+
+        def gold_miner
+          @gold_miner ||= company_by_id('B4')
+        end
+
         def sulphur_springs
           @sulphur_springs ||= company_by_id('B2')
         end
@@ -809,6 +836,10 @@ module Engine
 
         def gold_nugget
           @gold_nugget ||= company_by_id('G2')
+        end
+
+        def metals_investor
+          @metals_investor ||= company_by_id('G5')
         end
 
         def hanging_bridge_lease
@@ -949,6 +980,12 @@ module Engine
           else
             super
           end
+        end
+
+        def num_certs(entity)
+          certs = super
+          certs -= 1 if entity == gold_miner&.owner
+          certs
         end
 
         def st_cloud_bonus?(route, stops)

--- a/lib/engine/game/g_18_royal_gorge/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/buy_sell_par_shares.rb
@@ -7,6 +7,19 @@ module Engine
     module G18RoyalGorge
       module Step
         class BuySellParShares < Engine::Step::BuySellParShares
+          def round_state
+            super.merge(
+              {
+                metals_investor_bought: [],
+              }
+            )
+          end
+
+          def setup
+            super
+            @_modify_purchase_price = {}
+          end
+
           def get_par_prices(entity, _corp)
             @game.par_prices.select { |p| p.price * 2 <= entity.cash }
           end
@@ -15,6 +28,74 @@ module Engine
             # * hide debt company
             # * put metal companies always first
             @game.sorted_corporations.reject { |c| c.type == :debt }.sort_by { |c| c.type == :metal ? 0 : 1 }
+          end
+
+          def process_buy_shares(action)
+            super
+            return unless action.discounter
+
+            case action.discounter
+            when @game.mint_worker
+              @log << "#{@game.mint_worker.name} closes"
+              @game.mint_worker.close!
+            when @game.metals_investor
+              @round.metals_investor_bought << action.bundle.corporation
+            end
+          end
+
+          def modify_purchase_price(bundle)
+            @_modify_purchase_price[bundle] || bundle.price
+          end
+
+          def mint_worker_discounted_bundles(corporation)
+            return [] unless current_entity == @game.mint_worker&.owner
+            return [] unless corporation == @game.gold_corp
+
+            (1..2).map do |num_shares|
+              shares = @game.share_pool.shares_by_corporation[corporation].take(num_shares)
+              bundle = ShareBundle.new(shares)
+              @_modify_purchase_price[bundle] = (bundle.price / 2.0).ceil
+              [@game.mint_worker, bundle]
+            end
+          end
+
+          def metal_investor_discounted_bundles(corporation)
+            return [] if @round.metals_investor_bought.include?(corporation)
+            return [] unless current_entity == @game.metals_investor&.owner
+            return [] unless [@game.gold_corp, @game.steel_corp].include?(corporation)
+
+            share = @game.share_pool.shares_by_corporation[corporation][0]
+            bundle = ShareBundle.new(share)
+            @_modify_purchase_price[bundle] = @game.stock_market.find_share_price(corporation, :left).price
+            [[@game.metals_investor, bundle]]
+          end
+
+          def company_discounted_bundles(corporation)
+            case corporation
+            when @game.gold_corp
+              bundles = []
+              bundles.concat(metal_investor_discounted_bundles(corporation))
+              bundles.concat(mint_worker_discounted_bundles(corporation))
+              bundles
+            when @game.steel_corp
+              metal_investor_discounted_bundles(corporation)
+            else
+              []
+            end
+          end
+
+          def can_sell?(entity, bundle)
+            corporation = bundle.corporation
+
+            # must hold the shares bought with the metal investor discount
+            if entity == @game.metals_investor&.owner &&
+               [@game.gold_corp, @game.steel_corp].include?(corporation) &&
+               @round.metals_investor_bought.include?(corporation) &&
+               bundle.num_shares == entity.num_shares_of(corporation)
+              return false
+            end
+
+            super
           end
         end
       end

--- a/lib/engine/game/g_18_royal_gorge/trains.rb
+++ b/lib/engine/game/g_18_royal_gorge/trains.rb
@@ -39,7 +39,7 @@ module Engine
                        { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
             price: 500,
             num: 2,
-            events: [{ 'type' => 'gray_phase', 'when' => 2 }],
+            events: [{ 'type' => 'close_gold_miner' }, { 'type' => 'gray_phase', 'when' => 2 }],
           },
           {
             name: '6',


### PR DESCRIPTION
#10110 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

* implement private G5 Metal Investor - buy gold/steel shares at a discount once per SR

* implement private B4 Gold Miner - virtual 20% share of gold company

* implement private B6 US Mint Worker - close to buy 1-2 gold shares for half price

### Screenshots

Separate buy button to use the private company and get the one-step discount:

![Screenshot 2024-03-05 101411](https://github.com/tobymao/18xx/assets/1045173/42f501eb-34ac-4225-a7b8-993b3b5c38db)

### Any Assumptions / Hacks

* depends on core changes in #10448, but while in prealpha the order of merging these PRs doesn't matter