### PR TITLE
[1880] don't autoskip when corp must buy train

### DIFF
--- a/lib/engine/game/g_1880/step/buy_train.rb
+++ b/lib/engine/game/g_1880/step/buy_train.rb
@@ -17,6 +17,10 @@ module Engine
             @round.bought_trains || (action.train.owner == @game.depot && action.train.name != '2P')
           end
 
+          def pass_if_cannot_buy_train?(_entity)
+            false
+          end
+
           def must_take_player_loan?(entity)
             @game.depot.min_depot_price > (entity.cash + entity.owner.cash)
           end


### PR DESCRIPTION
Fixes #10455

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [Maybe?] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Disables flag "entity is able to pass if unable to buy train"

### Explanation of Change

This flag appears to be included by default in order to cover cases like nationals where they don't need to own a train

Reading 1880 rules, corps must always own a train at the end of its turn, and they will always have space for a train when purchasing one when otherwise trainless

### Screenshots

![image](https://github.com/tobymao/18xx/assets/1711810/dded7d1e-0be2-476f-9843-6bff2870e5c0)

![image](https://github.com/tobymao/18xx/assets/1711810/26a44d3e-3ddd-4ea6-b7b9-b956b8674764)


### Any Assumptions / Hacks
