### PR TITLE
[18Ardennes] Various small changes and fixes

### DIFF
--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -134,6 +134,12 @@ module Engine
           # that they cannot afford to start?
           bankrupt?(player)
         end
+
+        # If a player has gone above 60% holding in a major (by exchanging
+        # minors for shares) they don't have to sell back down.
+        def can_hold_above_corp_limit?(_entity)
+          true
+        end
       end
     end
   end

--- a/lib/engine/game/g_18_ardennes/map.rb
+++ b/lib/engine/game/g_18_ardennes/map.rb
@@ -211,6 +211,12 @@ module Engine
           },
         }.freeze
 
+        MAJOR_TILE_LAYS = [
+          { lay: true, upgrade: true },
+          { lay: :not_if_upgraded, upgrade: false },
+        ].freeze
+        MINOR_TILE_LAYS = [{ lay: true, upgrade: true }].freeze
+
         NORTH_HEXES = %w[B8 B16].freeze
         SOUTH_HEXES = %w[M7 M27].freeze
         EAST_HEXES = %w[D18 E25 G25 H26].freeze
@@ -336,6 +342,10 @@ module Engine
           return to.name == 'X11' if from.name == 'B16'
 
           super
+        end
+
+        def tile_lays(entity)
+          entity.type == :minor ? MINOR_TILE_LAYS : MAJOR_TILE_LAYS
         end
 
         def after_lay_tile(hex, tile, entity)

--- a/lib/engine/game/g_18_ardennes/market.rb
+++ b/lib/engine/game/g_18_ardennes/market.rb
@@ -8,6 +8,7 @@ module Engine
         BANK_CASH = 12_000
         CERT_LIMIT = { 3 => 11, 4 => 8, 5 => 6 }.freeze
         STARTING_CASH = { 3 => 700, 4 => 525, 5 => 420 }.freeze
+        SOLD_OUT_INCREASE = false
 
         STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(
           par_1: :red,

--- a/lib/engine/game/g_18_ardennes/step/decline_tokens.rb
+++ b/lib/engine/game/g_18_ardennes/step/decline_tokens.rb
@@ -83,7 +83,7 @@ module Engine
 
           def close_minor!
             @game.close_corporation(minor)
-            @round.corporations_removing_tokens.clear
+            @round.corporations_removing_tokens = nil
           end
         end
       end

--- a/lib/engine/game/g_18_ardennes/step/track.rb
+++ b/lib/engine/game/g_18_ardennes/step/track.rb
@@ -7,6 +7,17 @@ module Engine
     module G18Ardennes
       module Step
         class Track < Engine::Step::Track
+          MINOR_TILE_COLORS = %w[yellow green].freeze
+
+          def potential_tiles(entity, hex)
+            colors = @game.phase.tiles
+            colors &= MINOR_TILE_COLORS if entity.type == :minor
+            @game.tiles
+                 .select { |tile| colors.include?(tile.color) }
+                 .uniq(&:name)
+                 .select { |tile| @game.upgrades_to?(hex.tile, tile) }
+          end
+
           def legal_tile_rotation?(entity_or_entities, hex, tile)
             # Special case for the Ruhr green tile, which loses a town.
             return tile.rotation.zero? if hex.name == 'B16' && tile.name == 'X11'

--- a/lib/engine/game/g_18_ardennes/trains.rb
+++ b/lib/engine/game/g_18_ardennes/trains.rb
@@ -44,6 +44,7 @@ module Engine
         TRAINS = [
           {
             name: '2',
+            obsolete_on: '4',
             rusts_on: '4',
             distance: [{ 'nodes' => %w[city], 'pay' => 2, 'visit' => 2 },
                        { 'nodes' => %w[offboard], 'pay' => 2, 'visit' => 2 },
@@ -186,6 +187,25 @@ module Engine
           # Minors are not obliged to buy a train, and cannot enter emergency
           # fund raising.
           false
+        end
+
+        # Before rusting, check if this train individual should rust.
+        def rust?(train, purchased_train)
+          return false unless super
+          return true unless train.name == '2'
+
+          operated_this_round?(train.owner)
+        end
+
+        # Before obsoleting, check if this specific train should obsolete.
+        def obsolete?(train, purchased_train)
+          super && !operated_this_round?(train.owner)
+        end
+
+        def operated_this_round?(entity)
+          return false unless entity&.corporation?
+
+          entity.operating_history.include?([@turn, @round.round_num])
         end
       end
     end


### PR DESCRIPTION
## Implementation Notes
### Explanation of Change

Various fixes and small new features for the in-progress 18Ardennes implementation:
- Major companies can lay two yellow tiles.
- Minor companies cannot lay brown tiles.
- If you go above 60% ownership of a major (by exchanging minors) you don't have to sell back down.
- Show unsold shares as 'Treasury' instead of 'IPO'.
- Share price of fully sold companies doesn't increase at the end of a stock round.
- Custom rules for rusting 2-trains.
- Fix a bug from the last batch of code, where it was possible for a minor to remain open after it had been exchanged for a share in a major.

### Any Assumptions / Hacks

The l2-train rusting is the only bit that involves anything unusual. The rule is that when the first 4-train is bought, some 2-trains rust immediately, but others don't.

- 2-trains belonging to companies that have already operated in the current operating round rust.
- 2-trains belonging to companies that have not yet operated don't rust until their owner next operates.

This has been done by having both the 2-trains `rust_on` and `obsolete_on` properties set to `'4'`. The default `rust?` and `obsolete?` methods are overridden to check whether a train's owner has operated, and rust the train if it has, and obsolete it otherwise.

No core code is affected by this pull request.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~~Add the `pins` or `archive_alpha_games` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

