### PR TITLE
[1848] Makes terminal paths always terminal

### DIFF
--- a/lib/engine/game/g_1848/map.rb
+++ b/lib/engine/game/g_1848/map.rb
@@ -69,7 +69,7 @@ module Engine
           '241' => {
             'count' => 1,
             'color' => 'blue',
-            'code' => 'label=TAS;offboard=revenue:50;icon=image:anchor;path=a:2,b:_0;path=a:1,b:_0',
+            'code' => 'label=TAS;offboard=revenue:50;icon=image:anchor;path=a:2,b:_0,terminal:1;path=a:1,b:_0,terminal:1',
           },
           '611' => 4,
           '915' => 1,
@@ -108,11 +108,13 @@ module Engine
         HEXES = {
           red: {
             ['A4'] =>
-                     'offboard=revenue:yellow_10|green_20|brown_40|gray_60;path=a:5,b:_0;path=a:0,b:_0;border=edge:4',
+                     'offboard=revenue:yellow_10|green_20|brown_40|gray_60;path=a:5,b:_0,terminal:1;path=a:0,b:_0,terminal:1;'\
+                     'border=edge:4',
             ['A6'] =>
-                   'offboard=revenue:yellow_10|green_20|brown_40|gray_60;path=a:5,b:_0;path=a:0,b:_0;border=edge:1',
+                   'offboard=revenue:yellow_10|green_20|brown_40|gray_60;path=a:5,b:_0,terminal:1;path=a:0,b:_0,terminal:1;'\
+                   'border=edge:1',
             ['A18'] =>
-                   'offboard=revenue:yellow_10|green_20|brown_30|gray_40;path=a:5,b:_0;path=a:0,b:_0',
+                   'offboard=revenue:yellow_10|green_20|brown_30|gray_40;path=a:5,b:_0,terminal:1;path=a:0,b:_0,terminal:1',
             ['D1'] =>
                    'city=revenue:yellow_20|green_40|brown_60|gray_80;path=a:4,b:_0,terminal:1;' \
                    'path=a:5,b:_0,terminal:1;path=a:3,b:_0,terminal:1;label=K',


### PR DESCRIPTION
Fixes #10468 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Game was tracing connected K cities through the blue tile 241. I made the paths on that tile as well as the offboards along the top of the map all terminal:1. 

### Screenshots

### Any Assumptions / Hacks
