### PR TITLE
[1817] fixes edge case bug with Train Station private

### DIFF
--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -440,7 +440,7 @@ module Engine
 
         def tokens_needed(corporation)
           tokens_needed = { 2 => 1, 5 => 2, 10 => 4 }[corporation.total_shares] - corporation.tokens.size
-          tokens_needed += 1 if corporation.companies.any? { |c| c.id == 'TS' }
+          tokens_needed += 1 if corporation.companies.any? { |c| c.id == TRAIN_STATION_PRIVATE_NAME }
           tokens_needed
         end
 

--- a/lib/engine/game/g_1817/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1817/step/buy_sell_par_shares.rb
@@ -332,8 +332,6 @@ module Engine
               corporation.tokens << Engine::Token.new(corporation)
               ability.use!
               @log << "#{corporation.name} acquires additonal token from #{company.name}"
-              @log << "#{company.name} closes"
-              company.close!
             end
           end
 


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

**How to Reproduce the Bug?**

If a 5 or 10 share corp is started using the Train Station private, instead of getting an additional station token, the game simply doesn't charge the corp for the second token. In the image below, we can see the Train Station was used to form the corp. The corp acquires the "extra" token, Train Station closes, and then the corp starts with 5 shares and $60, and isn't forced to buy a third station. 

![image](https://github.com/tobymao/18xx/assets/26125362/2ab05c23-08be-44bd-af3f-ebe6b1647bac)

The reason this happens is because the code that checks for the amount of tokens needed for the corp to start does this by checking if the corporation owns any companies with the id 'TS', but the current code closes Train Station as soon as it's assigned to the corp and the token is granted. 

https://github.com/tobymao/18xx/blob/a351c8169ad84ac9b5fec5aebb8d662971b8a12f/lib/engine/game/g_1817/game.rb#L441-L445

The reason this is happening is because of the last two lines in this method:

https://github.com/tobymao/18xx/blob/a351c8169ad84ac9b5fec5aebb8d662971b8a12f/lib/engine/game/g_1817/step/buy_sell_par_shares.rb#L331-L337

### Explanation of Change

In the end, those last two lines are unnecessary code, so I removed them. There was already code in /g_1817/round/stock.rb to handle closing the Train Station private at the end of an SR where its acquired by a corp, and its comment even addresses the issue:

https://github.com/tobymao/18xx/blob/a351c8169ad84ac9b5fec5aebb8d662971b8a12f/lib/engine/game/g_1817/round/stock.rb#L19-L21

I also modified line 443 in the first code block I shared above to replace 'TS' with the constant TRAIN_STATION_PRIVATE_NAME, since this constant was already defined as 'TS' elsewhere in the game.rb file.

### Screenshots

### Any Assumptions / Hacks
