### PR TITLE
Removing last backtick warning

### DIFF
--- a/assets/app/mail/turn.rb
+++ b/assets/app/mail/turn.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 class Turn < Snabberb::Component
   needs :game_url
   needs :game_id


### PR DESCRIPTION
## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Remove final backtick warning in test output, adds on to #10382

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
