### PR TITLE
update links to webhook notif instructions on home page

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -44,8 +44,8 @@ module View
       message = <<~MESSAGE
         <p>Check out the <a href='https://github.com/tobymao/18xx/wiki/FAQ'>FAQ</a>, <a href='https://github.com/tobymao/18xx/wiki/Power-User-Features'>keyboard shortcuts</a> and <a href='https://github.com/tobymao/18xx/wiki'>the Wiki</a></p>
         <p>Find games in the chat or <a href='https://github.com/tobymao/18xx/wiki/18xx-Online-Communities%2C-Media%2C-and-Resources#community'>on (unofficial) Discord servers</a></p>
-        <p>Setup <a href='https://github.com/tobymao/18xx/wiki/Notifications'>turn notifications</a> via webhook to Slack, Discord, and Telegram</p>
-        <p>Ask questions in <code>#18xxgames</code> <a href='https://18xxgames.slack.com/join/shared_invite/zt-2evbzlz86-fSip9Zr9W~OSQW_EbP4DGw#/shared-invite/email'>on the 18XX Slack</a></p>
+        <p><a href='https://github.com/tobymao/18xx/wiki/Notifications'>Turn notifications</a> can be enabled via <a href='https://github.com/tobymao/18xx/wiki/Notifications#discord-notifications'>Discord</a>, <a href='https://github.com/tobymao/18xx/wiki/Notifications#slack-notifications'>Slack</a>, or <a href='https://github.com/tobymao/18xx/wiki/Notifications#telegram-notifications'>Telegram</a></p>
+        <p>Ask any questions about the site in <code>#18xxgames</code> <a href='https://18xxgames.slack.com/join/shared_invite/zt-2evbzlz86-fSip9Zr9W~OSQW_EbP4DGw#/shared-invite/email'>on the 18XX Slack</a></p>
         <p>Buy physical copies of 18XX games from publishers:</br> #{Lib::Publisher.link_list.join}.</p>
         <p>Keep the servers running by becoming a member <a href='https://www.patreon.com/18xxgames'>on Patreon</a></p>
       MESSAGE


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Add specific links to notif options so ppl don't have to scroll the whole page

### Explanation of Change

Update the links to the wiki

### Screenshots

![image](https://github.com/tobymao/18xx/assets/1711810/5087db70-2e54-48bf-ac06-ca48c5c2a9c9)


### Any Assumptions / Hacks
