### PR TITLE
[site-wide] corrects 'company' to 'corporation' where relevant

### DIFF
--- a/lib/engine/game/g_1817/entities.rb
+++ b/lib/engine/game/g_1817/entities.rb
@@ -9,9 +9,9 @@ module Engine
             name: 'P4 - Pittsburgh Steel Mill',
             value: 40,
             revenue: 0,
-            desc: 'Owning corp may place a special yellow tile (#X00) on Pittsburgh (F13) during '\
+            desc: 'Owning corporation may place a special yellow tile (#X00) on Pittsburgh (F13) during '\
                   'tile-laying, regardless of connectivity.  The hex is not '\
-                  'reserved, and the power is lost if another corp builds there first.',
+                  'reserved, and the power is lost if another corporation builds there first.',
             sym: 'PSM',
             abilities: [
             {
@@ -32,7 +32,7 @@ module Engine
             name: 'P3 - Mountain Engineers',
             value: 40,
             revenue: 0,
-            desc: 'Owning corp receives $20 after laying a yellow tile in a '\
+            desc: 'Owning corporation receives $20 after laying a yellow tile in a '\
                   'mountain hex.  Any fees must be paid first.',
             sym: 'ME',
             abilities: [
@@ -51,9 +51,9 @@ module Engine
             value: 40,
             revenue: 0,
             desc: 'Comes with one $10 bridge token that may be placed by the '\
-                  'owning corp in Louisville, Cincinnati, or Charleston, max one '\
+                  'owning corporation in Louisville, Cincinnati, or Charleston, max one '\
                   'token per city, regardless of connectivity.  Allows owning '\
-                  'corp to skip $10 river fee when placing yellow tiles.',
+                  'corporation to skip $10 river fee when placing yellow tiles.',
             sym: 'OBC',
             abilities: [
               {
@@ -77,9 +77,9 @@ module Engine
             value: 80,
             revenue: 0,
             desc: 'Comes with two $10 bridge token that may be placed by the '\
-                  'owning corp in Louisville, Cincinnati, or Charleston, max '\
+                  'owning corporation in Louisville, Cincinnati, or Charleston, max '\
                   'one token per city, regardless of connectivity.  Allows '\
-                  'owning corp to skip $10 river fee when placing yellow tiles.',
+                  'owning corporation to skip $10 river fee when placing yellow tiles.',
             sym: 'UBC',
             abilities: [
               {
@@ -235,8 +235,8 @@ module Engine
             name: 'P6 - Minor Mail Contract',
             value: 60,
             revenue: 0,
-            desc: 'Pays owning corp $10 at the start of each operating round, '\
-                  'as long as the corp has at least one train.',
+            desc: 'Pays owning corporation $10 at the start of each operating round, '\
+                  'as long as the corporation has at least one train.',
             sym: 'MINM',
             abilities: [
               {
@@ -252,8 +252,8 @@ module Engine
             name: 'P9 - Mail Contract',
             value: 90,
             revenue: 0,
-            desc: 'Pays owning corp $15 at the start of each operating round, '\
-                  'as long as the corp has at least one train.',
+            desc: 'Pays owning corporation $15 at the start of each operating round, '\
+                  'as long as the corporation has at least one train.',
             sym: 'MAIL',
             abilities: [
               {
@@ -269,8 +269,8 @@ module Engine
             name: 'P11 - Major Mail Contract',
             value: 120,
             revenue: 0,
-            desc: 'Pays owning corp $20 at the start of each operating round, '\
-                  'as long as the corp has at least one train.',
+            desc: 'Pays owning corporation $20 at the start of each operating round, '\
+                  'as long as the corporation has at least one train.',
             sym: 'MAJM',
             abilities: [
               {
@@ -292,8 +292,8 @@ module Engine
             name: 'P12 - Loan Shark',
             value: 60,
             revenue: 0,
-            desc: 'Owning corp receives $60 along with this private company. The owning '\
-                  'corp must pay $10 during the "Pay Loan Interest" phase of each '\
+            desc: 'Owning corporation receives $60 along with this private company. The owning '\
+                  'corporation must pay $10 during the "Pay Loan Interest" phase of each '\
                   'operating round. Failure to pay the $10 results in liquidation. '\
                   'The loan shark remains in force for the entire game, unless the '\
                   "bank purchases the owning corp's assets through liquidation.",
@@ -312,7 +312,7 @@ module Engine
             name: 'P14 - Inventor',
             value: 70,
             revenue: 0,
-            desc: 'The bank pays the owning corp when the first type of each train '\
+            desc: 'The bank pays the owning corporation when the first type of each train '\
                   'is purchased or exported (2: $20, 2+: $0, 3: $30, 4: $40, '\
                   '5: $50, 6: $60, 7: $70, 8: $80).',
             sym: 'P14',
@@ -322,7 +322,7 @@ module Engine
             name: 'P15 - Scrapper',
             value: 40,
             revenue: 0,
-            desc: 'Owning corp receives compensation for each train it owns that become '\
+            desc: 'Owning corporation receives compensation for each train it owns that become '\
                   'obsolete and are eliminated (2: $30, 2+: $30, 3: $75, 4: $150).',
             sym: 'P15',
             abilities: [
@@ -337,9 +337,9 @@ module Engine
             name: 'P16 - Buffalo Rail Center',
             value: 40,
             revenue: 0,
-            desc: 'Owning corp may place a special yellow tile (#X00) on Buffalo (C14) during '\
+            desc: 'Owning corporation may place a special yellow tile (#X00) on Buffalo (C14) during '\
                   'tile-laying, regardless of connectivity.  The hex is not '\
-                  'reserved, and the power is lost if another corp builds there first.',
+                  'reserved, and the power is lost if another corporation builds there first.',
             sym: 'P16',
             abilities: [
               {
@@ -360,9 +360,9 @@ module Engine
             name: 'P17 - Toledo Industry',
             value: 40,
             revenue: 0,
-            desc: 'Owning corp may place a special yellow tile (#X00) on Toledo (D7) during '\
+            desc: 'Owning corporation may place a special yellow tile (#X00) on Toledo (D7) during '\
                   'tile-laying, regardless of connectivity.  The hex is not '\
-                  'reserved, and the power is lost if another corp builds there first.',
+                  'reserved, and the power is lost if another corporation builds there first.',
             sym: 'P17',
             abilities: [
               {
@@ -383,9 +383,9 @@ module Engine
             name: 'P18 - Express Track',
             value: 30,
             revenue: 0,
-            desc: 'Owning corp must pay $10 to perform the first tile operation each '\
-                  'operating round. The corp may perform a second tile operation for '\
-                  'free. The corp may skip all tile operations to avoid the $10 fee. '\
+            desc: 'Owning corporation must pay $10 to perform the first tile operation each '\
+                  'operating round. The corporation may perform a second tile operation for '\
+                  'free. The corporation may skip all tile operations to avoid the $10 fee. '\
                   'If combined with Efficient Track (P19), both first and second track '\
                   'operations are free.',
             sym: 'P18',
@@ -395,7 +395,7 @@ module Engine
             name: 'P19 - Efficient Track',
             value: 40,
             revenue: 0,
-            desc: 'Owning corp may perform a second tile operation for $10, instead of '\
+            desc: 'Owning corporation may perform a second tile operation for $10, instead of '\
                   'the normal $20. If combined with Express Track (P18), both first and '\
                   'second track operations are free.',
             sym: 'P19',
@@ -405,8 +405,8 @@ module Engine
             name: 'P20 - Golden Parachute',
             value: 100,
             revenue: 0,
-            desc: 'The President of the corp owning this private company is paid $100 from the '\
-                  'bank when the Golden Parachute ownership is transferred to a corp '\
+            desc: 'The President of the corporation owning this private company is paid $100 from the '\
+                  'bank when the Golden Parachute ownership is transferred to a corporation '\
                   'with a different player as president, or discarded to the bank.',
             sym: 'P20',
             color: nil,
@@ -415,7 +415,7 @@ module Engine
             name: 'P21 - Station Subsidy',
             value: 70,
             revenue: 0,
-            desc: 'Owning corp receives $50 every time it converts (not merges) to a '\
+            desc: 'Owning corporation receives $50 every time it converts (not merges) to a '\
                   '5-share or 10-share corp.',
             sym: 'P21',
             color: nil,
@@ -478,9 +478,9 @@ module Engine
             name: 'P24 - Indianapolis Market',
             value: 40,
             revenue: 0,
-            desc: 'Owning corp may place a special (#X00) yellow tile on Indianapolis (F3) during '\
+            desc: 'Owning corporation may place a special (#X00) yellow tile on Indianapolis (F3) during '\
                   'tile-laying, regardless of connectivity.  The hex is not '\
-                  'reserved, and the power is lost if another corp builds there first.',
+                  'reserved, and the power is lost if another corporation builds there first.',
             sym: 'P24',
             abilities: [
               {

--- a/lib/engine/game/g_1817_de/entities.rb
+++ b/lib/engine/game/g_1817_de/entities.rb
@@ -28,9 +28,9 @@ module Engine
         name: 'Bridge Company',
         value: 80,
         revenue: 0,
-        desc: 'Comes with two 10 ℳ bridge token that may be placed by the owning corp '\
+        desc: 'Comes with two 10 ℳ bridge token that may be placed by the owning corporation '\
               'in Frankfurt and Dresden, max one token per city, regardless of '\
-              'connectivity. Allows owning corp to skip 10 ℳ river fee when '\
+              'connectivity. Allows owning corporation to skip 10 ℳ river fee when '\
               'placing yellow tiles.',
         sym: 'UBC',
         abilities: [
@@ -133,7 +133,7 @@ module Engine
         name: 'Minor Mail Contract',
         value: 60,
         revenue: 0,
-        desc: 'Pays owning corp 10 ℳ at the start of each operating round, as '\
+        desc: 'Pays owning corporation 10 ℳ at the start of each operating round, as '\
               'long as the corporation has at least one train.',
         sym: 'MINM',
         abilities: [
@@ -150,7 +150,7 @@ module Engine
         name: 'Major Mail Contract',
         value: 120,
         revenue: 0,
-        desc: 'Pays owning corp 20 ℳ at the start of each operating round, as '\
+        desc: 'Pays owning corporation 20 ℳ at the start of each operating round, as '\
               'long as the corporation has at least one train.',
         sym: 'MAJM',
         abilities: [

--- a/lib/engine/game/g_1817_de/entities.rb
+++ b/lib/engine/game/g_1817_de/entities.rb
@@ -10,7 +10,7 @@ module Engine
         name: 'Mountain Engineers',
         value: 40,
         revenue: 0,
-        desc: 'Owning company receives 20 ℳ after laying a yellow tile in a '\
+        desc: 'Owning corporation receives 20 ℳ after laying a yellow tile in a '\
               'mountain hex.  Any fees must be paid first.',
         sym: 'ME',
         abilities: [
@@ -134,7 +134,7 @@ module Engine
         value: 60,
         revenue: 0,
         desc: 'Pays owning corp 10 ℳ at the start of each operating round, as '\
-              'long as the company has at least one train.',
+              'long as the corporation has at least one train.',
         sym: 'MINM',
         abilities: [
           {
@@ -151,7 +151,7 @@ module Engine
         value: 120,
         revenue: 0,
         desc: 'Pays owning corp 20 ℳ at the start of each operating round, as '\
-              'long as the company has at least one train.',
+              'long as the corporation has at least one train.',
         sym: 'MAJM',
         abilities: [
           {

--- a/lib/engine/game/g_1817_na/entities.rb
+++ b/lib/engine/game/g_1817_na/entities.rb
@@ -11,7 +11,7 @@ module Engine
             revenue: 0,
             desc: 'Owning corp may place special Denver yellow tile during tile-laying, '\
                   'regardless of connectivity.  The hex is not reserved, and the '\
-                  'power is lost if another company builds there first.',
+                  'power is lost if another corporation builds there first.',
             sym: 'DTC',
             abilities: [
             {
@@ -32,7 +32,7 @@ module Engine
             name: 'Mountain Engineers',
             value: 40,
             revenue: 0,
-            desc: 'Owning company receives $20 after laying a yellow tile in a '\
+            desc: 'Owning corporation receives $20 after laying a yellow tile in a '\
                   'mountain hex.  Any fees must be paid first.',
             sym: 'ME',
             abilities: [
@@ -166,7 +166,7 @@ module Engine
             value: 60,
             revenue: 0,
             desc: 'Pays owning corp $10 at the start of each operating round, as '\
-                  'long as the company has at least one train.',
+                  'long as the corporation has at least one train.',
             sym: 'MINM',
             abilities: [
               {
@@ -183,7 +183,7 @@ module Engine
             value: 120,
             revenue: 0,
             desc: 'Pays owning corp $20 at the start of each operating round, as '\
-                  'long as the company has at least one train.',
+                  'long as the cocorporationmpany has at least one train.',
             sym: 'MAJM',
             abilities: [
               {

--- a/lib/engine/game/g_1817_na/entities.rb
+++ b/lib/engine/game/g_1817_na/entities.rb
@@ -183,7 +183,7 @@ module Engine
             value: 120,
             revenue: 0,
             desc: 'Pays owning corp $20 at the start of each operating round, as '\
-                  'long as the cocorporationmpany has at least one train.',
+                  'long as the corporation has at least one train.',
             sym: 'MAJM',
             abilities: [
               {

--- a/lib/engine/game/g_1817_na/entities.rb
+++ b/lib/engine/game/g_1817_na/entities.rb
@@ -9,7 +9,7 @@ module Engine
             name: 'Denver Telecommunications',
             value: 40,
             revenue: 0,
-            desc: 'Owning corp may place special Denver yellow tile during tile-laying, '\
+            desc: 'Owning corporation may place special Denver yellow tile during tile-laying, '\
                   'regardless of connectivity.  The hex is not reserved, and the '\
                   'power is lost if another corporation builds there first.',
             sym: 'DTC',
@@ -50,9 +50,9 @@ module Engine
             name: 'Union Bridge Company',
             value: 80,
             revenue: 0,
-            desc: 'Comes with two $10 bridge token that may be placed by the owning corp '\
+            desc: 'Comes with two $10 bridge token that may be placed by the owning corporation '\
                   'in Winnipeg or New Orleans, max one token per city, regardless of '\
-                  'connectivity. Allows owning corp to skip $10 river fee when '\
+                  'connectivity. Allows owning corporation to skip $10 river fee when '\
                   'placing yellow tiles.',
             sym: 'UBC',
             abilities: [
@@ -165,7 +165,7 @@ module Engine
             name: 'Minor Mail Contract',
             value: 60,
             revenue: 0,
-            desc: 'Pays owning corp $10 at the start of each operating round, as '\
+            desc: 'Pays owning corporation $10 at the start of each operating round, as '\
                   'long as the corporation has at least one train.',
             sym: 'MINM',
             abilities: [
@@ -182,7 +182,7 @@ module Engine
             name: 'Major Mail Contract',
             value: 120,
             revenue: 0,
-            desc: 'Pays owning corp $20 at the start of each operating round, as '\
+            desc: 'Pays owning corporation $20 at the start of each operating round, as '\
                   'long as the corporation has at least one train.',
             sym: 'MAJM',
             abilities: [

--- a/lib/engine/game/g_1817_wo/entities.rb
+++ b/lib/engine/game/g_1817_wo/entities.rb
@@ -11,7 +11,7 @@ module Engine
             revenue: 0,
             desc: "Owning corp may place special 'New Pittsburgh' yellow tile "\
                   'during tile-laying, regardless of connectivity.  The hex is not reserved, and the '\
-                  'power is lost if another company builds there first.',
+                  'power is lost if another corporation builds there first.',
             sym: 'PSM',
             abilities: [
             {
@@ -144,7 +144,7 @@ module Engine
             value: 120,
             revenue: 0,
             desc: 'Pays owning corp $20 at the start of each operating round, '\
-                  'as long as the company has at least one train.',
+                  'as long as the corporation has at least one train.',
             sym: 'MAJM',
             abilities: [
               {

--- a/lib/engine/game/g_1817_wo/entities.rb
+++ b/lib/engine/game/g_1817_wo/entities.rb
@@ -9,7 +9,7 @@ module Engine
             name: 'Pittsburgh Steel Mill',
             value: 40,
             revenue: 0,
-            desc: "Owning corp may place special 'New Pittsburgh' yellow tile "\
+            desc: "Owning corporation may place special 'New Pittsburgh' yellow tile "\
                   'during tile-laying, regardless of connectivity.  The hex is not reserved, and the '\
                   'power is lost if another corporation builds there first.',
             sym: 'PSM',
@@ -32,7 +32,7 @@ module Engine
             name: 'Mountain (Ocean) Engineers',
             value: 40,
             revenue: 0,
-            desc: 'Owning corp receives $20 after laying a yellow tile in a '\
+            desc: 'Owning corporation receives $20 after laying a yellow tile in a '\
                   'mountain (ocean) hex.  Any fees must be paid first.',
             sym: 'ME',
             abilities: [
@@ -50,9 +50,9 @@ module Engine
             name: 'Ohio Bridge Company',
             value: 40,
             revenue: 0,
-            desc: 'Comes with one $10 bridge token that may be placed by the owning corp '\
+            desc: 'Comes with one $10 bridge token that may be placed by the owning corporation '\
                   'in Mare Nostrum or Dynasties max one token per city, regardless '\
-                  'of connectivity.  Allows owning corp to skip $10 river fee '\
+                  'of connectivity.  Allows owning corporation to skip $10 river fee '\
                   'when placing yellow tiles.',
             sym: 'OBC',
             abilities: [
@@ -143,7 +143,7 @@ module Engine
             name: 'Major Mail Contract',
             value: 120,
             revenue: 0,
-            desc: 'Pays owning corp $20 at the start of each operating round, '\
+            desc: 'Pays owning corporation $20 at the start of each operating round, '\
                   'as long as the corporation has at least one train.',
             sym: 'MAJM',
             abilities: [

--- a/lib/engine/game/g_1817_wo/entities.rb
+++ b/lib/engine/game/g_1817_wo/entities.rb
@@ -32,7 +32,7 @@ module Engine
             name: 'Mountain (Ocean) Engineers',
             value: 40,
             revenue: 0,
-            desc: 'Owning company receives $20 after laying a yellow tile in a '\
+            desc: 'Owning corp receives $20 after laying a yellow tile in a '\
                   'mountain (ocean) hex.  Any fees must be paid first.',
             sym: 'ME',
             abilities: [

--- a/lib/engine/game/g_1822/entities.rb
+++ b/lib/engine/game/g_1822/entities.rb
@@ -11,9 +11,9 @@ module Engine
             value: 0,
             revenue: 5,
             desc: 'MAJOR, Phase 5. 5-Train. This is a normal 5-train that is subject to all of the normal rules. '\
-                  'Note that a company can acquire this private company at the start of its turn, even if it is '\
+                  'Note that a corporation can acquire this private company at the start of its turn, even if it is '\
                   'already at its train limit as this counts as an acquisition action, not a train buying action. '\
-                  'However, once acquired the acquiring company needs to check whether it is at train limit and '\
+                  'However, once acquired the acquiring corporation needs to check whether it is at train limit and '\
                   'discard any trains held in excess of limit.',
             abilities: [],
             color: nil,
@@ -23,11 +23,11 @@ module Engine
             sym: 'P2',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 2. Remove Small Station. Allows the owning company to place a plain yellow '\
+            desc: 'MAJOR/MINOR, Phase 2. Remove Small Station. Allows the owning corporation to place a plain yellow '\
                   'track tile directly on an undeveloped small station hex location or upgrade a small station tile '\
                   'of one colour to a plain track tile of the next colour. This closes the company and counts as '\
-                  'the company’s normal track laying step. All other normal track laying restrictions apply. Once '\
-                  'acquired, the private company pays its revenue to the owning company until the power is '\
+                  'the corporation’s normal track laying step. All other normal track laying restrictions apply. Once '\
+                  'acquired, the private company pays its revenue to the owning corporation until the power is '\
                   'exercised and the company is closed.',
             abilities: [
               {
@@ -50,13 +50,13 @@ module Engine
             value: 0,
             revenue: 0,
             desc: 'MAJOR, Phase 2. Permanent 2-Train. 2P-train is a permanent 2-train. It can’t be sold to another '\
-                  'company. It does not count against train limit. It does not count as a train for the purpose of '\
-                  'mandatory train ownership and purchase. A company may not own more than one 2P train. '\
-                  'A company cannot own both a permanent L-train and a permanent 2-train. Dividends '\
-                  'can be separated from other trains and may be split, paid in full, or retained. If a company '\
+                  'corporation. It does not count against train limit. It does not count as a train for the purpose of '\
+                  'mandatory train ownership and purchase. A corporation may not own more than one 2P train. '\
+                  'A corporation cannot own both a permanent L-train and a permanent 2-train. Dividends '\
+                  'can be separated from other trains and may be split, paid in full, or retained. If a corporation '\
                   'runs a 2P-train and pays a dividend (split or full), but retains its dividend from other train '\
                   'operations this still counts as a normal dividend for stock price movement purposes. Vice-versa, '\
-                  'if a company pays a dividend (split or full) with its other trains, but retains the dividend '\
+                  'if a corporation pays a dividend (split or full) with its other trains, but retains the dividend '\
                   'from the 2P, this also still counts as a normal dividend for stock price movement purposes. Does '\
                   'not close.',
             abilities: [],
@@ -68,13 +68,13 @@ module Engine
             value: 0,
             revenue: 0,
             desc: 'MAJOR, Phase 2. Permanent 2-Train. 2P-train is a permanent 2-train. It can’t be sold to another '\
-                  'company. It does not count against train limit. It does not count as a train for the purpose of '\
-                  'mandatory train ownership and purchase. A company may not own more than one 2P train. '\
-                  'A company cannot own both a permanent L-train and a permanent 2-train. Dividends '\
-                  'can be separated from other trains and may be split, paid in full, or retained. If a company '\
+                  'corporation. It does not count against train limit. It does not count as a train for the purpose of '\
+                  'mandatory train ownership and purchase. A corporation may not own more than one 2P train. '\
+                  'A corporation cannot own both a permanent L-train and a permanent 2-train. Dividends '\
+                  'can be separated from other trains and may be split, paid in full, or retained. If a corporation '\
                   'runs a 2P-train and pays a dividend (split or full), but retains its dividend from other train '\
                   'operations this still counts as a normal dividend for stock price movement purposes. Vice-versa, '\
-                  'if a company pays a dividend (split or full) with its other trains, but retains the dividend '\
+                  'if a corporation pays a dividend (split or full) with its other trains, but retains the dividend '\
                   'from the 2P, this also still counts as a normal dividend for stock price movement purposes. '\
                   'Does not close.',
             abilities: [],
@@ -85,15 +85,15 @@ module Engine
             sym: 'P5',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 3. English Channel. The owning company may place an exchange station token on the '\
-                  'map, free of charge, in a token space in the English Channel. The company does not need to be '\
-                  'able to trace a route to the English Channel to use this property (i.e. any company can use this '\
+            desc: 'MAJOR, Phase 3. English Channel. The owning corporation may place an exchange station token on the '\
+                  'map, free of charge, in a token space in the English Channel. The corporation does not need to be '\
+                  'able to trace a route to the English Channel to use this property (i.e. any corporation can use this '\
                   'power to place a token in the English Channel). If no token spaces are available, but a space '\
                   'could be created by upgrading the English Channel track then this power may be used to place a '\
-                  'token and upgrade the track simultaneously. This counts as the acquiring company’s tile lay '\
-                  'action and incurs the usual costs for doing so. It does not count as the company’s token placing '\
+                  'token and upgrade the track simultaneously. This counts as the acquiring corporation’s tile lay '\
+                  'action and incurs the usual costs for doing so. It does not count as the corporation’s token placing '\
                   'step. Alternatively, it can move an exchange station token to the available station token section '\
-                  'on its company charter.',
+                  'on its corporation charter.',
             abilities: [
               {
                 type: 'teleport',
@@ -122,9 +122,9 @@ module Engine
             sym: 'P6',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 3. Mail Contract. After running trains, the owning company receives income into its '\
+            desc: 'MAJOR, Phase 3. Mail Contract. After running trains, the owning corporation receives income into its '\
                   'treasury equal to one half of the base value of the start and end stations from one of the '\
-                  'trains operated. Doubled values (for E trains or destination tokens) do not count. The company '\
+                  'trains operated. Doubled values (for E trains or destination tokens) do not count. The corporation '\
                   'is not required to maximise the dividend from its run if it wishes to maximise its revenue from '\
                   'the mail contract by stopping at a large city and not running beyond it to include small '\
                   'stations. Does not close.',
@@ -136,9 +136,9 @@ module Engine
             sym: 'P7',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 3. Mail Contract. After running trains, the owning company receives income into its '\
+            desc: 'MAJOR, Phase 3. Mail Contract. After running trains, the owning corporation receives income into its '\
                   'treasury equal to one half of the base value of the start and end stations from one of the '\
-                  'trains operated. Doubled values (for E trains or destination tokens) do not count. The company '\
+                  'trains operated. Doubled values (for E trains or destination tokens) do not count. The corporation '\
                   'is not required to maximise the dividend from its run if it wishes to maximise its revenue from '\
                   'the mail contract by stopping at a large city and not running beyond it to include small '\
                   'stations. Does not close.',
@@ -150,9 +150,9 @@ module Engine
             sym: 'P8',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 3. Mountain/Hill Discount. Either: The acquiring company receives a discount '\
+            desc: 'MAJOR/MINOR, Phase 3. Mountain/Hill Discount. Either: The acquiring corporation receives a discount '\
                   'token that can be used to pay the full cost of a single track tile lay on a rough terrain, hill '\
-                  'or mountain hex. This closes the company. Or: The acquiring company rejects the token and '\
+                  'or mountain hex. This closes the company. Or: The acquiring corporation rejects the token and '\
                   'receives a £20 discount off the cost of all £60 hill and £80 mountain terrain (i.e. NOT off the cost of '\
                   '£40 rough terrain). The private company does not close. Closes if free token taken when acquired. '\
                   'Otherwise, flips when acquired and does not close. Rough terrain and hills are any hexes including a '\
@@ -196,7 +196,7 @@ module Engine
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 3. Declare 2x Cash Holding. If held by a player, the holding player may '\
                   'declare double their actual cash holding at the end of a stock round to determine player turn '\
-                  'order in the next stock round. If held by a company it pays revenue of '\
+                  'order in the next stock round. If held by a corporation it pays revenue of '\
                   '£20 (green)/£40 (brown)/£60 (grey). Does not close.',
             abilities: [],
             color: nil,
@@ -206,7 +206,7 @@ module Engine
             sym: 'P10',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 3. River/Estuary Discount. The acquiring company receives two discount tokens '\
+            desc: 'MAJOR/MINOR, Phase 3. River/Estuary Discount. The acquiring corporation receives two discount tokens '\
                   'each of which can be used to pay the cost for one track lay over an estuary crossing. They can '\
                   'be used on the same or different tile lays. Use of the second token closes the company. In '\
                   'addition, until the company closes it provides a discount of £10 against the cost of all river '\
@@ -237,13 +237,13 @@ module Engine
             sym: 'P11',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 2. Advanced Tile Lay. The owning company may lay one plain or small station '\
+            desc: 'MAJOR/MINOR, Phase 2. Advanced Tile Lay. The owning corporation may lay one plain or small station '\
                   'track upgrade using the next colour of track to be available, before it is actually made '\
                   'available by phase progression. The normal rules for progression of track lay must be followed '\
                   '(i.e. grey upgrades brown upgrades green upgrades yellow) it is not possible to skip a colour '\
                   'using this private. All other normal track laying restrictions apply. This is in place of its '\
                   'normal track lay action. Once acquired, the private company pays its revenue to the owning '\
-                  'company until the power is exercised and the company closes.',
+                  'corporation until the power is exercised and the company closes.',
             abilities: [
               {
                 type: 'tile_lay',
@@ -264,10 +264,10 @@ module Engine
             sym: 'P12',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 3. Extra Tile Lay. The owning company may lay an additional yellow tile (or '\
-                  'two for major companies), or make one additional tile upgrade in its track laying step. The '\
+            desc: 'MAJOR/MINOR, Phase 3. Extra Tile Lay. The owning corporation may lay an additional yellow tile (or '\
+                  'two for major corporations), or make one additional tile upgrade in its track laying step. The '\
                   'upgrade can be to a tile laid in its normal tile laying step. All other normal track laying '\
-                  'restrictions apply. Once acquired, the private company pays its revenue to the owning company '\
+                  'restrictions apply. Once acquired, the private company pays its revenue to the owning corporation '\
                   'until the power is exercised and the company closes.',
             abilities: [
               {
@@ -292,9 +292,9 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 5. Pullman. A “Pullman” carriage train that can be added to another train '\
-                  'owned by the company. It converts the train into a + train. Does not count against train limit '\
+                  'owned by the corporation. It converts the train into a + train. Does not count against train limit '\
                   'and does not count as a train for the purposes of train ownership. Can’t be sold to another '\
-                  'company. Does not close.',
+                  'corporation. Does not close.',
             abilities: [],
             color: nil,
           },
@@ -304,9 +304,9 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 5. Pullman. A “Pullman” carriage train that can be added to another train '\
-                  'owned by the company. It converts the train into a + train. Does not count against train limit '\
+                  'owned by the corporation. It converts the train into a + train. Does not count against train limit '\
                   'and does not count as a train for the purposes of train ownership. Can’t be sold to another '\
-                  'company. Does not close.',
+                  'corporation. Does not close.',
             abilities: [],
             color: nil,
           },
@@ -317,7 +317,7 @@ module Engine
             revenue: 0,
             desc: 'MAJOR/MINOR, Phase 2. £10x Phase. Pays revenue of £10 x phase number to the player, and pays '\
                   'treasury credits of £10 x phase number to the private company. This credit is retained on the '\
-                  'private company charter. When acquired, the acquiring company receives this treasury money and '\
+                  'private company charter. When acquired, the acquiring corporation receives this treasury money and '\
                   'this private company closes. If not acquired beforehand, this company closes at the start of '\
                   'Phase 7 and all treasury credits are returned to the bank.',
             abilities: [],
@@ -330,12 +330,12 @@ module Engine
             revenue: 0,
             desc: 'CAN NOT BE ACQUIRED. Tax Haven. As a stock round action, under the direction and funded by the '\
                   'owning player, the off-shore Tax Haven may purchase an available share certificate and place it '\
-                  'onto P16’s charter. The certificate is not counted for determining directorship of a company. '\
+                  'onto P16’s charter. The certificate is not counted for determining directorship of a corporation. '\
                   'The share held in the tax haven does NOT count against the 60% share limit for purchasing '\
-                  'shares. If at 60% (or more) in hand in a company, a player can still purchase an additional '\
-                  'share in that company and place it in the tax haven. Similarly, if a player holds 50% of a '\
-                  'company, plus has 10% of the same company in the tax haven, they can buy a further 10% share. '\
-                  'A company with a share in the off-shore tax haven CAN be “all sold out” at the end of a stock '\
+                  'shares. If at 60% (or more) in hand in a corporation, a player can still purchase an additional '\
+                  'share in that corporation and place it in the tax haven. Similarly, if a player holds 50% of a '\
+                  'corporation, plus has 10% of the same corporation in the tax haven, they can buy a further 10% share. '\
+                  'A corporation with a share in the off-shore tax haven CAN be “all sold out” at the end of a stock '\
                   'round. Dividends paid to the share are also placed onto the off-shore tax haven charter. At the '\
                   'end of the game, the player receives the share certificate from the off-shore tax haven charter '\
                   'and includes it in their portfolio for determining final worth. The player also receives the '\
@@ -349,8 +349,8 @@ module Engine
             sym: 'P17',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 2. Move Card. Allows the director of the owning company to select one concession, '\
-                  'private company, or minor company from the relevant stack of certificates, excluding those items '\
+            desc: 'MAJOR, Phase 2. Move Card. Allows the director of the owning corporation to select one concession, '\
+                  'private company, or minor corporation from the relevant stack of certificates, excluding those items '\
                   'currently in the bidding boxes, and move it to the top or the bottom of the stack. Closes when '\
                   'the power is exercised.',
             abilities: [],
@@ -361,7 +361,7 @@ module Engine
             sym: 'P18',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 5. Station Marker Swap. Allows the owning company to move a token from the exchange '\
+            desc: 'MAJOR, Phase 5. Station Marker Swap. Allows the owning corporation to move a token from the exchange '\
                   'token area of its charter to the available token area, or vice versa. This company closes when '\
                   'its power is exercised.',
             abilities: [],
@@ -372,13 +372,13 @@ module Engine
             sym: 'P19',
             value: 0,
             revenue: 0,
-            desc: 'MAJOR/MINOR, Phase 1. Permanent L-Train. An L-train cannot be sold to another company. It does '\
+            desc: 'MAJOR/MINOR, Phase 1. Permanent L-Train. An L-train cannot be sold to another corporation. It does '\
                   'not count as a train for the purposes of mandatory train ownership. It does not count against '\
-                  'train ownership limit. A company cannot own both a permanent L-train and a permanent 2-train. '\
+                  'train ownership limit. A corporation cannot own both a permanent L-train and a permanent 2-train. '\
                   'Dividends can be separated from other trains and may be split, paid in full, or retained. If a '\
-                  'company runs a permanent L-train and pays a dividend (split or full), but retains its dividend '\
+                  'corporation runs a permanent L-train and pays a dividend (split or full), but retains its dividend '\
                   'from other train operations this still counts as a normal dividend for stock price movement '\
-                  'purposes. Vice-versa, if a company pays a dividend (split or full) with its other trains, but '\
+                  'purposes. Vice-versa, if a corporation pays a dividend (split or full) with its other trains, but '\
                   'retains the dividend from the permanent L, this also still counts as a normal dividend for stock '\
                   'price movement purposes. Does not close.',
             abilities: [],
@@ -391,7 +391,7 @@ module Engine
             revenue: 0,
             desc: 'MAJOR/MINOR, Phase 3. £5x Phase. Pays revenue of £5 x phase number to the player, and pays '\
                   'treasury credits of £5 x phase number to the private company. This credit is retained on the '\
-                  'private company charter. When acquired, the acquiring company receives this treasury money and '\
+                  'private company charter. When acquired, the acquiring corporation receives this treasury money and '\
                   'this private company closes. If not acquired beforehand, this company closes at the start of '\
                   'Phase 7 and all treasury credits are returned to the bank.',
             abilities: [],
@@ -402,12 +402,12 @@ module Engine
             sym: 'P21',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 2. Grimsby/Hull Bridge. Allows the owning company to lay yellow tiles in '\
+            desc: 'MAJOR/MINOR, Phase 2. Grimsby/Hull Bridge. Allows the owning corporation to lay yellow tiles in '\
                   'Grimsby and / or Hull, forming a direct track connection between the two cities over the '\
                   'Humber estuary. If one of the cities already has a yellow tile in place, then if used in phase 3 '\
                   'or later, one of the tile lays may be a green upgrade. No terrain costs apply for these tile '\
-                  'lays. These tile lays count as the normal track laying phase for the operating company. The '\
-                  'owning company must have a token in Hull or Grimsby to use this power. Closes when its power is '\
+                  'lays. These tile lays count as the normal track laying phase for the operating corporation. The '\
+                  'owning corporation must have a token in Hull or Grimsby to use this power. Closes when its power is '\
                   'exercised.',
             abilities: [
               {

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -300,17 +300,17 @@ module Engine
 
         EVENTS_TEXT = {
           'close_concessions' =>
-            ['Concessions close', 'All concessions close without compensation, major companies float at 50%'],
+            ['Concessions close', 'All concessions close without compensation, corporations float at 50%'],
           'full_capitalisation' =>
-            ['Full capitalisation', 'Major companies receive full capitalisation when floated'],
+            ['Full capitalisation', 'corporations receive full capitalisation when floated'],
           'phase_revenue' =>
-            ['Phase revenue companies close', 'P15-HR and P20-C&WR close if not owned by a major company'],
+            ['Phase revenue companies close', 'P15-HR and P20-C&WR close if not owned by a major corporation'],
         }.freeze
 
         STATUS_TEXT = Base::STATUS_TEXT.merge(
           'can_buy_trains' => ['Buy trains', 'Can buy trains from other corporations'],
           'can_convert_concessions' => ['Convert concessions',
-                                        'Can float a major company by converting a concession'],
+                                        'Can float a major corporation by converting a concession'],
           'can_acquire_minor_bidbox' => ['Acquire a minor from bidbox',
                                          'Can acquire a minor from bidbox for £200, must have connection '\
                                          'to start location'],
@@ -732,7 +732,7 @@ module Engine
         end
 
         def event_full_capitalisation!
-          @log << '-- Event: Major companies receive full capitalisation when floated --'
+          @log << '-- Event: Corporations receive full capitalisation when floated --'
           @corporations.select { |c| !c.floated? && c.type == :major }.each do |corporation|
             corporation.capitalization = :full
           end

--- a/lib/engine/game/g_1822_africa/entities.rb
+++ b/lib/engine/game/g_1822_africa/entities.rb
@@ -35,9 +35,9 @@ module Engine
           {
             name: 'P4 (Pullman)',
             sym: 'P4',
-            desc: 'MAJOR/MINOR, Phase 3. A "Pullman" carriage that can be added to another train owned by the company.'\
+            desc: 'MAJOR/MINOR, Phase 3. A "Pullman" carriage that can be added to another train owned by the corporation.'\
                   ' It converts the train into a + train. Does not count against train limit and does not count '\
-                  'as a train for the purposes of train ownership. Can’t be sold to another company.',
+                  'as a train for the purposes of train ownership. Can’t be sold to another corporation.',
             value: 0,
             revenue: 10,
             abilities: [],
@@ -46,11 +46,11 @@ module Engine
           {
             name: 'P5 (Add Town)',
             sym: 'P5',
-            desc: 'MAJOR/MINOR, Phase 2. Add Small Station. Allows the owning company to place a yellow track tile '\
+            desc: 'MAJOR/MINOR, Phase 2. Add Small Station. Allows the owning corporation to place a yellow track tile '\
                   'with a small station directly on an undeveloped plain hex or upgrade a plain tile of one colour '\
-                  'to a small station tile of the next colour. This closes the company and counts as the company’s '\
+                  'to a small station tile of the next colour. This closes the company and counts as the corporation’s '\
                   'normal track laying step. All other normal track laying restrictions apply. Once acquired, the '\
-                  'private company pays its revenue to the owning company until the power is exercised and the '\
+                  'private company pays its revenue to the owning corporation until the power is exercised and the '\
                   'company is closed.',
             value: 0,
             revenue: 10,
@@ -82,11 +82,11 @@ module Engine
           {
             name: 'P7 (Extra tile)',
             sym: 'P7',
-            desc: 'MAJOR/MINOR, Phase 3. Extra Tile Lay. The owning company may lay an additional yellow tile '\
-                  '(or two for major companies beginning in Phase 3), or make one additional tile upgrade '\
+            desc: 'MAJOR/MINOR, Phase 3. Extra Tile Lay. The owning corporation may lay an additional yellow tile '\
+                  '(or two for major corporations beginning in Phase 3), or make one additional tile upgrade '\
                   'in its track laying step. The upgrade can be to a tile laid in its normal tile laying step. '\
                   'All other normal track laying restrictions apply. Once acquired, the private company pays '\
-                  'its revenue to the owning company until the power is exercised and the company closes.',
+                  'its revenue to the owning corporation until the power is exercised and the company closes.',
             value: 0,
             revenue: 10,
             abilities: [
@@ -110,10 +110,10 @@ module Engine
           {
             name: 'P8 (Reserve Three Tiles)',
             sym: 'P8',
-            desc: 'MAJOR/MINOR, Phase 1. Upon acquisition, owning company must reserve three tiles from the stock '\
-                  'of unplayed tiles for future placement. No other company may use these tiles held in reserve. '\
+            desc: 'MAJOR/MINOR, Phase 1. Upon acquisition, owning corporation must reserve three tiles from the stock '\
+                  'of unplayed tiles for future placement. No other corporation may use these tiles held in reserve. '\
                   'The revenue of this private company changes to A5x the number of tiles it holds. '\
-                  'Once the owning company reserves tiles, it may not place any other tiles '\
+                  'Once the owning corporation reserves tiles, it may not place any other tiles '\
                   'until those tiles have been placed, even if it becomes impossible to place the reserved tiles.',
             value: 0,
             revenue: 10,
@@ -123,12 +123,12 @@ module Engine
           {
             name: 'P9 (Remove Town)',
             sym: 'P9',
-            desc: 'MAJOR/MINOR, Phase 2. Remove Small Station. Allows the owning company to place '\
+            desc: 'MAJOR/MINOR, Phase 2. Remove Small Station. Allows the owning corporation to place '\
                   'a plain yellow track tile directly on an undeveloped small station hex location '\
                   'or upgrade a small station tile of one colour to a plain track tile of the next colour. '\
-                  'This closes the company and counts as the company’s normal track laying step. '\
+                  'This closes the company and counts as the corporation’s normal track laying step. '\
                   'All other normal track laying restrictions apply. Once acquired, the private company '\
-                  'pays its revenue to the owning company until the power is exercised and the company is closed.',
+                  'pays its revenue to the owning corporation until the power is exercised and the company is closed.',
             value: 0,
             revenue: 10,
             abilities: [
@@ -149,10 +149,10 @@ module Engine
           {
             name: 'P10 (Game Reserve)',
             sym: 'P10',
-            desc: 'MAJOR/MINOR, Phase 3. When this company is acquired, the owning company must place '\
+            desc: 'MAJOR/MINOR, Phase 3. When this company is acquired, the owning corporation must place '\
                   'the striped Game Reserve tile on any empty (and non-desert) hex. '\
                   'Placement must not run track into an unplayable hex edge. This hex becomes a game reserve. '\
-                  'The company immediately receives a bonus equal to A5x the number of hexes between '\
+                  'The corporation immediately receives a bonus equal to A5x the number of hexes between '\
                   'this game reserve and the preprinted game reserve (excluding the reserve hexes).',
             value: 0,
             revenue: 10,
@@ -176,7 +176,7 @@ module Engine
           {
             name: 'P11 (Mountain Rebate)',
             sym: 'P11',
-            desc: 'MAJOR/MINOR, Phase 3. The owning company may close this company when it lays a yellow tile '\
+            desc: 'MAJOR/MINOR, Phase 3. The owning corporation may close this company when it lays a yellow tile '\
                   'in a mountain hex to earn A50 into its treasury.',
             value: 0,
             revenue: 10,
@@ -205,7 +205,7 @@ module Engine
           {
             name: 'P12 (Fast Sahara Building)',
             sym: 'P12',
-            desc: 'MAJOR/MINOR, Phase 1. The owning company may place any amount of yellow tiles in the hexes marked '\
+            desc: 'MAJOR/MINOR, Phase 1. The owning corporation may place any amount of yellow tiles in the hexes marked '\
                   'with desert terrain as their normal tile laying step at normal cost. '\
                   'Using this ability closes the private company.',
             value: 0,
@@ -233,7 +233,7 @@ module Engine
           {
             name: 'P13 (Station Swap)',
             sym: 'P13',
-            desc: 'MAJOR, Phase 5. Station Marker Swap. Allows the owning company to move a token from the exchange '\
+            desc: 'MAJOR, Phase 5. Station Marker Swap. Allows the owning corporation to move a token from the exchange '\
                   'token area of its charter to the available token area, or vice versa. '\
                   'This company closes when its power is exercised.',
             value: 0,
@@ -244,7 +244,7 @@ module Engine
           {
             name: 'P14 (Gold Mine)',
             sym: 'P14',
-            desc: 'MAJOR, Phase 3. Owning company close this company to place the +20 gold mine token in any city '\
+            desc: 'MAJOR, Phase 3. Owning corporation close this company to place the +20 gold mine token in any city '\
                   'with an open city slot. This token adds 20 to the value of that city for all corporations. '\
                   'The gold mine token occupies a city slot and blocks routes through that city '\
                   'if the city is otherwise full.',
@@ -270,9 +270,9 @@ module Engine
           {
             name: 'P15 (Coffee Plantation)',
             sym: 'P15',
-            desc: 'MAJOR/MINOR, Phase 1. Owning company may close this private company to place the coffee '\
+            desc: 'MAJOR/MINOR, Phase 1. Owning corporation may close this private company to place the coffee '\
                   'plantation token on any hex with mountainous terrain and no tile. '\
-                  'The company immediately receives into its treasury A30. When a tile is placed in that hex, '\
+                  'The corporation immediately receives into its treasury A30. When a tile is placed in that hex, '\
                   'the coffee plantation token is placed on it and prevents upgrading this tile. '\
                   'All routes that use this tile earn an extra A20.',
             value: 0,
@@ -295,7 +295,7 @@ module Engine
             desc: 'MAJOR/MINOR, Phase 2. A10x Phase. Pays revenue of A10 x the phase number to the player, '\
                   'and pays treasury credits of A10 x phase number to the private company. '\
                   'This credit is retained on the private company charter. '\
-                  'When acquired, the acquiring company receives this treasury money and this private company closes. '\
+                  'When acquired, the acquiring corporation receives this treasury money and this private company closes. '\
                   'If not acquired beforehand, this company closes at the start of Phase 6 and all treasury credits '\
                   'are returned to the bank.',
             value: 0,
@@ -306,7 +306,7 @@ module Engine
           {
             name: 'P17 (Bank Share Buy)',
             sym: 'P17',
-            desc: 'MAJOR, Phase 2. Owning company may close this private company for the bank to purchase a share '\
+            desc: 'MAJOR, Phase 2. Owning corporation may close this private company for the bank to purchase a share '\
                   'it owns for the current market value. The share is moved to the bank pool. This does not count '\
                   'as a share issuance and does not affect the stock price.',
             value: 0,
@@ -317,10 +317,10 @@ module Engine
           {
             name: 'P18 (Safari Bonus)',
             sym: 'P18',
-            desc: 'MAJOR/MINOR, Phase 3. The Safari Bonus can be added to a train owned by the company. '\
+            desc: 'MAJOR/MINOR, Phase 3. The Safari Bonus can be added to a train owned by the corporation. '\
                   'It converts the train into a safari train that counts an extra 20 to the earnings for reaching '\
                   'each of the game reserves. Does not count against train limit and does not count as a train '\
-                  'for the purposes of train ownership. Can’t be sold to another company.',
+                  'for the purposes of train ownership. Can’t be sold to another corporation.',
             value: 0,
             revenue: 10,
             abilities: [],

--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -182,11 +182,11 @@ module Engine
 
         EVENTS_TEXT = {
           'close_concessions' =>
-            ['Concessions close', 'All concessions close without compensation, major companies float at 50%'],
+            ['Concessions close', 'All concessions close without compensation, corporations float at 50%'],
           'full_capitalisation' =>
-            ['Full capitalisation', 'Major companies receive full capitalisation when floated'],
+            ['Full capitalisation', 'Corporations receive full capitalisation when floated'],
           'phase_revenue' =>
-            ['Phase revenue company closes', 'P16 closes if not owned by a major company'],
+            ['Phase revenue company closes', 'P16 closes if not owned by a corporation'],
         }.freeze
 
         STATUS_TEXT = G1822::Game::STATUS_TEXT.merge(

--- a/lib/engine/game/g_1822_ca/entities.rb
+++ b/lib/engine/game/g_1822_ca/entities.rb
@@ -15,10 +15,10 @@ module Engine
             value: 0,
             revenue: 5,
             desc: 'MAJOR, Phase 5. Montréal Locomotive Works. This is a normal 5-train that is '\
-                  'subject to all of the normal rules. Note that a company can acquire this '\
+                  'subject to all of the normal rules. Note that a corporation can acquire this '\
                   'private company at the start of its turn, even if it is already at its train '\
                   'limit as this counts as an acquisition action, not a train buying action. '\
-                  'However, once acquired the acquiring company needs to check whether it is at '\
+                  'However, once acquired the acquiring corporation needs to check whether it is at '\
                   'train limit and discard any trains held in excess of limit.',
             abilities: [],
             color: PRIVATE_RED,
@@ -29,13 +29,13 @@ module Engine
             value: 0,
             revenue: 0,
             desc: 'MAJOR/MINOR, Phase 1. Robert Stephenson & Company. An L-train cannot be sold to '\
-                  'another company. It does not count as a train for the purposes of mandatory '\
-                  'train ownership. It does not count against train ownership limit. A company '\
+                  'another corporation. It does not count as a train for the purposes of mandatory '\
+                  'train ownership. It does not count against train ownership limit. A corporation '\
                   'cannot own both a permanent L-train and a permanent 2-train. Dividends can be '\
                   'separated from other trains and may be split, paid in full, or retained. If a '\
-                  'company runs a permanent L-train and pays a dividend (split or full), but '\
+                  'corporation runs a permanent L-train and pays a dividend (split or full), but '\
                   'retains its dividend from other train operations this still counts as a normal '\
-                  'dividend for stock price movement purposes. Vice-versa, if a company pays a '\
+                  'dividend for stock price movement purposes. Vice-versa, if a corporation pays a '\
                   'dividend (split or full) with its other trains, but retains the dividend from '\
                   'the permanent L, this also still counts as a normal dividend for stock price '\
                   'movement purposes. Does not close.',
@@ -48,14 +48,14 @@ module Engine
             value: 0,
             revenue: 0,
             desc: 'MAJOR, Phase 2. Toronto Locomotive Works. 2P-train is a permanent 2-train. It '\
-                  'can’t be sold to another company. It does not count against train limit. It '\
+                  'can’t be sold to another corporation. It does not count against train limit. It '\
                   'does not count as a train for the purpose of mandatory train ownership and '\
-                  'purchase. A company may not own more than one 2P train. A company cannot own '\
+                  'purchase. A corporation may not own more than one 2P train. A corporation cannot own '\
                   'both a permanent L-train and a permanent 2-train. Dividends can be separated '\
-                  'from other trains and may be split, paid in full, or retained. If a company '\
+                  'from other trains and may be split, paid in full, or retained. If a corporation '\
                   'runs a 2P-train and pays a dividend (split or full), but retains its dividend '\
                   'from other train operations this still counts as a normal dividend for stock '\
-                  'price movement purposes. Vice-versa, if a company pays a dividend (split or '\
+                  'price movement purposes. Vice-versa, if a corporation pays a dividend (split or '\
                   'full) with its other trains, but retains the dividend from the 2P, this also '\
                   'still counts as a normal dividend for stock price movement purposes. Does not '\
                   'close.',
@@ -68,14 +68,14 @@ module Engine
             value: 0,
             revenue: 0,
             desc: 'MAJOR, Phase 2. The Countess of Dufferin. 2P-train is a permanent 2-train. It '\
-                  'can’t be sold to another company. It does not count against train limit. It '\
+                  'can’t be sold to another corporation. It does not count against train limit. It '\
                   'does not count as a train for the purpose of mandatory train ownership and '\
-                  'purchase. A company may not own more than one 2P train. A company cannot own '\
+                  'purchase. A corporation may not own more than one 2P train. A corporation cannot own '\
                   'both a permanent L-train and a permanent 2-train. Dividends can be separated '\
-                  'from other trains and may be split, paid in full, or retained. If a company '\
+                  'from other trains and may be split, paid in full, or retained. If a corporation '\
                   'runs a 2P-train and pays a dividend (split or full), but retains its dividend '\
                   'from other train operations this still counts as a normal dividend for stock '\
-                  'price movement purposes. Vice-versa, if a company pays a dividend (split or '\
+                  'price movement purposes. Vice-versa, if a corporation pays a dividend (split or '\
                   'full) with its other trains, but retains the dividend from the 2P, this also '\
                   'still counts as a normal dividend for stock price movement purposes. Does not '\
                   'close.',
@@ -88,9 +88,9 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR, Phase 5. Pullman Car Company. A “Pullman” carriage train that can be '\
-                  'added to another train owned by the company. It converts the train into a + '\
+                  'added to another train owned by the corporation. It converts the train into a + '\
                   'train. Does not count against train limit and does not count as a train for the '\
-                  'purposes of train ownership. Can’t be sold to another company. Does not close. '\
+                  'purposes of train ownership. Can’t be sold to another corporation. Does not close. '\
                   'May include a maximum of [2 × the train size] number of towns.',
             abilities: [],
             color: PRIVATE_RED,
@@ -101,9 +101,9 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR, Phase 5. Fulton Car Works. A “Pullman” carriage train that can be added '\
-                  'to another train owned by the company. It converts the train into a + train. '\
+                  'to another train owned by the corporation. It converts the train into a + train. '\
                   'Does not count against train limit and does not count as a train for the '\
-                  'purposes of train ownership. Can’t be sold to another company. Does not close. '\
+                  'purposes of train ownership. Can’t be sold to another corporation. Does not close. '\
                   'May include a maximum of [2 × the train size] number of towns.',
             abilities: [],
             color: PRIVATE_RED,
@@ -115,7 +115,7 @@ module Engine
             revenue: 10,
             desc: 'MAJOR, Phase 3. Toronto Stock Exchange. If held by a player, the holding player '\
                   'may declare double their actual cash holding at the end of a stock round to '\
-                  'determine player turn order in the next stock round. If held by a company it '\
+                  'determine player turn order in the next stock round. If held by a corporation it '\
                   'pays revenue of $20 (green)/$40 (brown)/$60 (grey). Does not close.',
             abilities: [],
             color: PRIVATE_RED,
@@ -128,7 +128,7 @@ module Engine
             desc: 'MAJOR/MINOR, Phase 2. Stratford & Huron Railway revenue of $10 x phase number '\
                   'to the player, and pays treasury credits of $10 x phase number to the private '\
                   'company. This credit is retained on the private company charter. When acquired, '\
-                  'the acquiring company receives this treasury money and this private company '\
+                  'the acquiring corporation receives this treasury money and this private company '\
                   'closes. If not acquired beforehand, this company closes at the start of Phase 7 '\
                   'and all treasury credits are returned to the bank.',
             abilities: [],
@@ -142,7 +142,7 @@ module Engine
             desc: 'MAJOR/MINOR, Phase 2. General Mining Assoication. Pays revenue of $5 x phase '\
                   'number to the player, and pays treasury credits of $5 x phase number to the '\
                   'private company. This credit is retained on the private company charter. When '\
-                  'acquired, the acquiring company receives this treasury money and this private '\
+                  'acquired, the acquiring corporation receives this treasury money and this private '\
                   'company closes. If not acquired beforehand, this company closes at the start of '\
                   'Phase 7 and all treasury credits are returned to the bank.',
             abilities: [],
@@ -153,12 +153,12 @@ module Engine
             sym: 'P10',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 3. Manitoba South-Western Colonization Railway. The owning company '\
+            desc: 'MAJOR, Phase 3. Manitoba South-Western Colonization Railway. The owning corporation '\
                   'may place an exchange station token on the map, free of charge, in a token '\
-                  'space in Winnipeg (N16). The company does NOT need to be able to trace a route to the '\
+                  'space in Winnipeg (N16). The corporation does NOT need to be able to trace a route to the '\
                   'station in Winnipeg. Token must be specifically conjoined to one of the five '\
-                  'Station slots. Pays company $10 until used. The company does not need to be '\
-                  'able to trace a route to Winnipeg to use this property (i.e. any company can '\
+                  'Station slots. Pays corporation $10 until used. The corporation does not need to be '\
+                  'able to trace a route to Winnipeg to use this property (i.e. any corporation can '\
                   'use this power to place a token in the Winnipeg hex).',
             abilities: [
               {
@@ -189,11 +189,11 @@ module Engine
                   'action, under the direction and funded by the owning player, the off-shore Tax '\
                   'Haven may purchase an available share certificate and place it onto P7’s '\
                   'charter. The certificate is not counted for determining directorship of a '\
-                  'company. The share held in the tax haven does NOT count against the 60% share '\
-                  'limit for purchasing shares. If at 60% (or more) in hand in a company, a player '\
-                  'can still purchase an additional share in that company and place it in the tax '\
-                  'haven. Similarly, if a player holds 50% of a company, plus has 10% of the same '\
-                  'company in the tax haven, they can buy a further 10% share. A company with a '\
+                  'corporation. The share held in the tax haven does NOT count against the 60% share '\
+                  'limit for purchasing shares. If at 60% (or more) in hand in a corporation, a player '\
+                  'can still purchase an additional share in that corporation and place it in the tax '\
+                  'haven. Similarly, if a player holds 50% of a corporation, plus has 10% of the same '\
+                  'corporation in the tax haven, they can buy a further 10% share. A corporation with a '\
                   'share in the off-shore tax haven CAN be “all sold out” at the end of a stock '\
                   'round. Dividends paid to the share are also placed onto the off-shore tax haven '\
                   'charter. At the end of the game, the player receives the share certificate from '\
@@ -209,14 +209,14 @@ module Engine
             sym: 'P12',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 1. Sir Sanford Fleming. The owning company may lay one plain '\
+            desc: 'MAJOR/MINOR, Phase 1. Sir Sanford Fleming. The owning corporation may lay one plain '\
                   'or town track upgrade using the next colour of track to be available, before it '\
                   'is actually made available by phase progression. The normal rules for '\
                   'progression of track lay must be followed (i.e. grey upgrades brown upgrades '\
                   'green upgrades yellow) it is not possible to skip a colour using this private. '\
                   'All other normal track laying restrictions apply. This is in place of its '\
                   'normal track lay action. Once acquired, the private company pays its revenue to '\
-                  'the owning company until the power is exercised and the company closes. May be '\
+                  'the owning corporation until the power is exercised and the company closes. May be '\
                   'used in conjunction with P29 and/or P30 as part of the same tile placement step.',
             abilities: [
               {
@@ -242,12 +242,12 @@ module Engine
             desc: 'MAJOR, Phase 3. John Rudolphus Booth. Close this company to place a +$10 ('\
                   'closed) or +$20 (open to all) token in a town or city. Token placement is '\
                   'restricted and may not be placed in a grey pre-printed hex nor any labeled '\
-                  'city (A, B, L, M, O, Q, T, W, Y). The placing company does not have to have a '\
+                  'city (A, B, L, M, O, Q, T, W, Y). The placing corporation does not have to have a '\
                   'route to the city where the token is placed. The token increases the value of '\
                   'the revenue center by the indicated amount when running a train there. If the '\
-                  'token is “open” then all companies receive the +20 bonus; if “closed” only the '\
-                  'owning company receives the +10 bonus. Destination runs and E-trains both '\
-                  'double the value of this token. A company may only include the token bonus to '\
+                  'token is “open” then all corporations receive the +20 bonus; if “closed” only the '\
+                  'owning corporation receives the +10 bonus. Destination runs and E-trains both '\
+                  'double the value of this token. A corporation may only include the token bonus to '\
                   'the run of one train per operating round. A town with a sawmill may not be '\
                   'removed by P29 or P30.',
             abilities: [
@@ -273,9 +273,9 @@ module Engine
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 1. Ontario, Simcoe & Huron Union Railroad. Owner pays no '\
                   'upgrade fee or terrain costs for tile lays and upgrades to Toronto (AC21). This is in '\
-                  'addition to the company’s normal tile placement(s), but happens during the '\
-                  'company’s tile laying step. Does not close. Minor may place yellow or green '\
-                  'only. The company upgrading the city must be connected to it in order to '\
+                  'addition to the corporation’s normal tile placement(s), but happens during the '\
+                  'corporation’s tile laying step. Does not close. Minor may place yellow or green '\
+                  'only. The corporation upgrading the city must be connected to it in order to '\
                   'exercise the private company.',
             abilities: [
               {
@@ -299,9 +299,9 @@ module Engine
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 1. Pontiac Pacific Junction Railway. Owner pays no upgrade '\
                   'fee or terrain costs for tile lays and upgrades to Ottawa (AE15). This is in addition '\
-                  'to the company’s normal tile placement(s), but happens during the company’s '\
+                  'to the corporation’s normal tile placement(s), but happens during the corporation’s '\
                   'tile laying step. Does not close. Minor may place yellow or green only. The '\
-                  'company upgrading the city must be connected to it in order to exercise the '\
+                  'corporation upgrading the city must be connected to it in order to exercise the '\
                   'private company.',
             abilities: [
               {
@@ -325,8 +325,8 @@ module Engine
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 1. South Eastern Railway. Owner pays no upgrade fee or '\
                   'terrain costs for tile lays and upgrades to Montréal (AF12). This is in addition to the '\
-                  'company’s normal tile placement(s), but happens during the company’s tile '\
-                  'laying step. Does not close. Minor may place yellow or green only. The company '\
+                  'company’s normal tile placement(s), but happens during the corporation’s tile '\
+                  'laying step. Does not close. Minor may place yellow or green only. The corporation '\
                   'upgrading the city must be connected to it in order to exercise the private '\
                   'company.',
             abilities: [
@@ -351,8 +351,8 @@ module Engine
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 1. Québec & Richmond Railway. Owner pays no upgrade fee or '\
                   'terrain costs for tile lays and upgrades to Québec (AH8). This is in addition to the '\
-                  'company’s normal tile placement(s), but happens during the company’s tile '\
-                  'laying step. Does not close. Minor may place yellow or green only. The company '\
+                  'corporation’s normal tile placement(s), but happens during the corporation’s tile '\
+                  'laying step. Does not close. Minor may place yellow or green only. The corporation '\
                   'upgrading the city must be connected to it in order to exercise the private '\
                   'company.',
             abilities: [
@@ -377,9 +377,9 @@ module Engine
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 1. Winnipeg & Prince Albert Railway. Owner pays no upgrade '\
                   'fee or terrain costs for the tile placement. This is in addition '\
-                  'to the company’s normal tile placement(s), but happens during the company’s '\
+                  'to the corporation’s normal tile placement(s), but happens during the corporation’s '\
                   'tile laying step. Does not close. Minor may place yellow or green only. The '\
-                  'company upgrading the city must be connected to it in order to exercise the '\
+                  'corporation upgrading the city must be connected to it in order to exercise the '\
                   'private company.',
             abilities: [
               {
@@ -401,10 +401,10 @@ module Engine
             sym: 'P19',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 3. The Crowsnest Pass. Allows the owning company to place a tile '\
+            desc: 'MAJOR, Phase 3. The Crowsnest Pass. Allows the owning corporation to place a tile '\
                   'into the Crowsnest Pass (F16) and ignore the terrain fee. This tile placement '\
-                  'counts as the company’s full track laying step. Closed when used. The CP hex is '\
-                  'not reserved; any company may pay to lay a tile there irrespective of the '\
+                  'counts as the corporation’s full track laying step. Closed when used. The CP hex is '\
+                  'not reserved; any corporation may pay to lay a tile there irrespective of the '\
                   'ownership of P19.',
             abilities: [
               {
@@ -428,10 +428,10 @@ module Engine
             sym: 'P20',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 3. The Yellowhead Pass. Allows the owning company to place a tile '\
+            desc: 'MAJOR, Phase 3. The Yellowhead Pass. Allows the owning corporation to place a tile '\
                   'into the Yellowhead Pass (E11) and ignore the terrain fee. This tile placement '\
-                  'counts as the company’s full track laying step. Closed when used. The YP hex is '\
-                  'not reserved; any company may pay to lay a tile there irrespective of the '\
+                  'counts as the corporation’s full track laying step. Closed when used. The YP hex is '\
+                  'not reserved; any corporation may pay to lay a tile there irrespective of the '\
                   'ownership of P20.',
             abilities: [
               {
@@ -455,9 +455,9 @@ module Engine
             sym: 'P21',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 3. The National Dream. The owning company may close this company '\
+            desc: 'MAJOR, Phase 3. The National Dream. The owning corporation may close this company '\
                   'to place three yellow tiles in addition to its normal track lay. The owning '\
-                  'company’s normal track lay and each of the three extra yellow tile lays may be '\
+                  'corporation’s normal track lay and each of the three extra yellow tile lays may be '\
                   'done in any order. These lays are exempt from terrain fees, but may not be used '\
                   'to build on hexes with mountainous terrain costing $120 or in Montréal, Ottawa, '\
                   'Québec, Toronto or Winnipeg.',
@@ -500,13 +500,13 @@ module Engine
             sym: 'P22',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 3. National Mail Service. After running trains, the owning company '\
+            desc: 'MAJOR, Phase 3. National Mail Service. After running trains, the owning corporation '\
                   'receives income into its treasury equal to one half of the base value of the '\
                   'start and end stations from one of the trains operated. Doubled values (for E '\
-                  'trains or destination tokens) do not count. The company is not required to '\
+                  'trains or destination tokens) do not count. The corporation is not required to '\
                   'maximise the dividend from its run if it wishes to maximise its revenue from '\
                   'the mail contract by stopping at a large city and not running beyond it to '\
-                  'include towns. A company may own multiple Large Mail Contracts, but may only '\
+                  'include towns. A corporation may own multiple Large Mail Contracts, but may only '\
                   'use one per train. Does not close.',
             abilities: [],
             color: PRIVATE_RED,
@@ -516,13 +516,13 @@ module Engine
             sym: 'P23',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 3. National Mail Service. After running trains, the owning company '\
+            desc: 'MAJOR, Phase 3. National Mail Service. After running trains, the owning corporation '\
                   'receives income into its treasury equal to one half of the base value of the '\
                   'start and end stations from one of the trains operated. Doubled values (for E '\
-                  'trains or destination tokens) do not count. The company is not required to '\
+                  'trains or destination tokens) do not count. The corporation is not required to '\
                   'maximise the dividend from its run if it wishes to maximise its revenue from '\
                   'the mail contract by stopping at a large city and not running beyond it to '\
-                  'include towns. A company may own multiple Large Mail Contracts, but may only '\
+                  'include towns. A corporation may own multiple Large Mail Contracts, but may only '\
                   'use one per train. Does not close.',
             abilities: [],
             color: PRIVATE_RED,
@@ -533,7 +533,7 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR, Phase 3. Regional Mail Service. Pay phase-based rate of $10 (yellow)/$'\
-                  '20 (green)/$30 (brown)/$40 (grey) to the treasury of the company. The company '\
+                  '20 (green)/$30 (brown)/$40 (grey) to the treasury of the corporation. The corporation '\
                   'must operate a train to claim the mail income. Does not close.',
             abilities: [],
             color: PRIVATE_RED,
@@ -544,7 +544,7 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR, Phase 3. Regional Mail Service. Pay phase-based rate of $10 (yellow)/$'\
-                  '20 (green)/$30 (brown)/$40 (grey) to the treasury of the company. The company '\
+                  '20 (green)/$30 (brown)/$40 (grey) to the treasury of the corporation. The corporation '\
                   'must operate a train to claim the mail income. Does not close.',
             abilities: [],
             color: PRIVATE_RED,
@@ -555,11 +555,11 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR, Phase 3. Saskatchewan Wheat Pool. A grain train can be added to a train '\
-                  'owned by the company. It converts the train into a grain train, which can '\
+                  'owned by the corporation. It converts the train into a grain train, which can '\
                   'deliver grain from the grain elevators to a port city. Does not count against '\
                   'the train limit and does not count as a train for the purposes of train '\
-                  'ownership. Does not close. Cannot be sold to another company. Adds $10 to '\
-                  'company revenue for each grain elevator on the run. Does not count the town '\
+                  'ownership. Does not close. Cannot be sold to another corporation. Adds $10 to '\
+                  'corporation revenue for each grain elevator on the run. Does not count the town '\
                   'revenue. Towns with grain elevators do not count as stops. Runs may extend '\
                   'beyond the start and end city. If the route run by the grain train '\
                   'includes at least one grain elevator and a port city, the port city adds $20 to '\
@@ -573,10 +573,10 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR, Phase 3. Alberta Wheat Pool. A grain train can be added to a train owned '\
-                  'by the company. It converts the train into a grain train, which can deliver '\
+                  'by the corporation. It converts the train into a grain train, which can deliver '\
                   'grain from the grain elevators to a port city. Does not count against the train '\
                   'limit and does not count as a train for the purposes of train ownership. Does '\
-                  'not close. Cannot be sold to another company. Adds $10 to company revenue for '\
+                  'not close. Cannot be sold to another corporation. Adds $10 to corporation revenue for '\
                   'each grain elevator on the run. Does not count the town revenue. Towns with '\
                   'grain elevators do not count as stops. Runs may extend beyond the start and end '\
                   'city. If the route run by the grain train includes at least one grain '\
@@ -589,7 +589,7 @@ module Engine
             sym: 'P28',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 3. Great Southern Railway. Allows the owning company to move '\
+            desc: 'MAJOR/MINOR, Phase 3. Great Southern Railway. Allows the owning corporation to move '\
                   'a token from the exchange token area of its charter to the available token '\
                   'area, or vice versa. This company closes when its power is exercised.',
             abilities: [],
@@ -600,12 +600,12 @@ module Engine
             sym: 'P29',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 1. Charles Melville Hays. Allows the owning company to place '\
+            desc: 'MAJOR/MINOR, Phase 1. Charles Melville Hays. Allows the owning corporation to place '\
                   'a plain yellow track tile directly on an undeveloped single town hex location '\
                   'or upgrade a single town tile of one colour to a plain track tile of the next '\
-                  'colour. This closes the company and counts as the company’s normal track laying '\
+                  'colour. This closes the company and counts as the corporation’s normal track laying '\
                   'step. All other normal track laying restrictions apply. Once acquired, the '\
-                  'private company pays its revenue to the owning company until the power is '\
+                  'private company pays its revenue to the owning corporation until the power is '\
                   'exercised and the company is closed. May be used in conjunction with P12 '\
                   'as part of the same tile placement step. May not be used to remove a town '\
                   'with a sawmill token (placed by P13).',
@@ -632,11 +632,11 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 1. Sir William Cornelius Van Horne. Allows the owning '\
-                  'company to place a plain yellow track tile directly on an undeveloped single '\
+                  'corporation to place a plain yellow track tile directly on an undeveloped single '\
                   'town hex location or upgrade a single town tile of one colour to a plain track '\
-                  'tile of the next colour. This closes the company and counts as the company’s '\
+                  'tile of the next colour. This closes the company and counts as the corporation’s '\
                   'normal track laying step. All other normal track laying restrictions apply. '\
-                  'Once acquired, the private company pays its revenue to the owning company until '\
+                  'Once acquired, the private company pays its revenue to the owning corporation until '\
                   'the power is exercised and the company is closed. May be used in conjunction '\
                   'with P12 as part of the same tile placement step. May not be used to '\
                   'remove a town with a sawmill token (placed by P13).',

--- a/lib/engine/game/g_1822_mx/entities.rb
+++ b/lib/engine/game/g_1822_mx/entities.rb
@@ -10,11 +10,11 @@ module Engine
             sym: 'P1',
             value: 0,
             revenue: 5,
-            desc: 'MAJOR, Phase 5. 5-Train. Once a company acquires it, this is a normal 5-train that is subject to '\
+            desc: 'MAJOR, Phase 5. 5-Train. Once a corporation acquires it, this is a normal 5-train that is subject to '\
                   'all of the normal rules.  It is not a "special train" and is not subject to the rules that are '\
-                  'specific to special trains.  A company can acquire this private company at the start of its turn, '\
+                  'specific to special trains.  A corporation can acquire this private company at the start of its turn, '\
                   'even if it is already at it\'s train limit, as this counts as an acquisition action, not a train '\
-                  'buying action.  However, once acquired the acquiring company must check whether it as at the '\
+                  'buying action.  However, once acquired the acquiring corporation must check whether it as at the '\
                   'train limit and must discard any trains held in excess of limit.',
             abilities: [],
             color: nil,
@@ -25,13 +25,13 @@ module Engine
             value: 0,
             revenue: 0,
             desc: 'MAJOR, Phase 2. Permanent 2-Train. The 2P-train is a permanent 2-train. It is a “special train.” '\
-                  'It cannot be sold to another company. It does not count against the train limit. '\
+                  'It cannot be sold to another corporation. It does not count against the train limit. '\
                   'It does not count as a train for the purpose of mandatory train ownership and '\
-                  'purchase. A company cannot own more than one special train. Dividends can '\
+                  'purchase. A corporation cannot own more than one special train. Dividends can '\
                   'be separated from other trains and may be split, paid in full, or retained. If '\
-                  'a company runs a 2P-train and pays a dividend (split or full), but retains its '\
+                  'a corporation runs a 2P-train and pays a dividend (split or full), but retains its '\
                   'dividend from other train operations, this still counts as a normal dividend '\
-                  'for share price movement purposes. Vice-versa, if a company pays a dividend '\
+                  'for share price movement purposes. Vice-versa, if a corporation pays a dividend '\
                   '(split or full) with its other trains, but retains the dividend from the 2P-train, '\
                   'this also still counts as a normal dividend for share price movement purposes. '\
                   'Does not close.',
@@ -44,15 +44,15 @@ module Engine
             value: 0,
             revenue: 0,
             desc: 'MAJOR/MINOR, Phase 1. Permanent 3/2-Train. It is a “special train.” '\
-                  'It cannot be sold to another company. It does not count against the train limit. '\
+                  'It cannot be sold to another corporation. It does not count against the train limit. '\
                   'It does not count as a train for the purpose of mandatory train ownership and '\
-                  'purchase. A company cannot own more than one special train. Dividends can '\
+                  'purchase. A corporation cannot own more than one special train. Dividends can '\
                   'be separated from other trains and may be split, paid in full, or retained. Runs like a '\
                   'normal 3-train, but its earnings are halved after all bonuses/Pullman revenue are '\
                   'included (round up to a multiple of $10). '\
-                  'If a company runs a 3/2-train and pays a dividend (split or full), but retains its '\
+                  'If a corporation runs a 3/2-train and pays a dividend (split or full), but retains its '\
                   'dividend from other train operations, this still counts as a normal dividend '\
-                  'for share price movement purposes. Vice-versa, if a company pays a dividend '\
+                  'for share price movement purposes. Vice-versa, if a corporation pays a dividend '\
                   '(split or full) with its other trains, but retains the dividend from the 3/2-train, '\
                   'this also still counts as a normal dividend for share price movement purposes. '\
                   'Does not close.',
@@ -65,13 +65,13 @@ module Engine
             value: 0,
             revenue: 0,
             desc: 'MAJOR/MINOR, Phase 1. Permanent L-Train.  It is a “special train.” '\
-                  'It cannot be sold to another company. It does not count against the train limit. '\
+                  'It cannot be sold to another corporation. It does not count against the train limit. '\
                   'It does not count as a train for the purpose of mandatory train ownership and '\
-                  'purchase. A company cannot own more than one special train. Dividends can '\
+                  'purchase. A corporation cannot own more than one special train. Dividends can '\
                   'be separated from other trains and may be split, paid in full, or retained. If '\
-                  'a company runs a LP-train and pays a dividend (split or full), but retains its '\
+                  'a corporation runs a LP-train and pays a dividend (split or full), but retains its '\
                   'dividend from other train operations, this still counts as a normal dividend '\
-                  'for share price movement purposes. Vice-versa, if a company pays a dividend '\
+                  'for share price movement purposes. Vice-versa, if a corporation pays a dividend '\
                   '(split or full) with its other trains, but retains the dividend from the LP-train, '\
                   'this also still counts as a normal dividend for share price movement purposes. '\
                   'Does not close.',
@@ -84,10 +84,10 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 3. Pullman. A “Pullman” car that can be attached to another train owned by the '\
-                  'company. It is not a train. A train with a Pullman attached to it counts any '\
+                  'corporation. It is not a train. A train with a Pullman attached to it counts any '\
                   'number of towns in addition to its standard number of large stations. Does '\
-                  'not count toward the train limit. Cannot be sold to another company. Does '\
-                  'not close. No company may own more than one Pullman.',
+                  'not count toward the train limit. Cannot be sold to another corporation. Does '\
+                  'not close. No corporation may own more than one Pullman.',
             abilities: [],
             color: nil,
           },
@@ -97,10 +97,10 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 3. Pullman. A “Pullman” car that can be attached to another train owned by the '\
-                  'company. It is not a train. A train with a Pullman attached to it counts any '\
+                  'corporation. It is not a train. A train with a Pullman attached to it counts any '\
                   'number of towns in addition to its standard number of large stations. Does '\
-                  'not count toward the train limit. Cannot be sold to another company. Does '\
-                  'not close. No company may own more than one Pullman.',
+                  'not count toward the train limit. Cannot be sold to another corporation. Does '\
+                  'not close. No corporation may own more than one Pullman.',
             abilities: [],
             color: nil,
           },
@@ -111,7 +111,7 @@ module Engine
             revenue: 10,
             desc: 'MAJOR, Phase 3. Declare 2x Cash Holding. If held by a player, the holding player may declare '\
                   'double their actual cash holding at the end of a stock round to determine '\
-                  'player turn order in the next stock round. If held by a company it pays '\
+                  'player turn order in the next stock round. If held by a corporation it pays '\
                   'revenue of $20 (green)/$40 (brown)/$60 (gray). Does not close.',
             abilities: [],
             color: nil,
@@ -121,13 +121,13 @@ module Engine
             sym: 'P8',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 1. Advanced Non-City Tile Lay. The owning company may lay one plain '\
+            desc: 'MAJOR/MINOR, Phase 1. Advanced Non-City Tile Lay. The owning corporation may lay one plain '\
                   'or town track upgrade using the next color of track to be available, before '\
                   'it is actually made available by phase progression. The normal rules for '\
                   'progression of track lay must be followed; it is not possible to skip a color '\
                   'using this private. All other normal track laying restrictions apply. This is '\
                   'in place of its normal track lay action. Once acquired, the private company '\
-                  'pays its revenue to the owning company until the power is exercised and '\
+                  'pays its revenue to the owning corporation until the power is exercised and '\
                   'the company closes. A minor company may not use this power to upgrade '\
                   'beyond green.',
             abilities: [
@@ -150,11 +150,11 @@ module Engine
             sym: 'P9',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 3. Extra Tile Lay. The owning company may lay an additional yellow tile (or '\
-                  'two for major companies beginning in Phase 3), or make one additional '\
+            desc: 'MAJOR/MINOR, Phase 3. Extra Tile Lay. The owning corporation may lay an additional yellow tile (or '\
+                  'two for major corporation beginning in Phase 3), or make one additional '\
                   'tile upgrade in its track laying step. The upgrade can be to a tile laid in its '\
                   'normal tile laying step. All other normal track laying restrictions apply. Once '\
-                  'acquired, the private company pays its revenue to the owning company until '\
+                  'acquired, the private company pays its revenue to the owning corporation until '\
                   'the power is exercised and the company closes.',
             abilities: [
               {
@@ -179,9 +179,9 @@ module Engine
             sym: 'P10',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 1. Three Builder Cubes. When acquired by a company, the private company '\
+            desc: 'MAJOR/MINOR, Phase 1. Three Builder Cubes. When acquired by a corporation, the private company '\
                   'closes and is exchanged for three of the builder cubes from the cube pool. '\
-                  'The company may spend one or more of the cubes to place them on the '\
+                  'The corporation may spend one or more of the cubes to place them on the '\
                   'board during their lay track action. These placements are in addition to the '\
                   'tile placement. These cube placements may occur at any time during the '\
                   'action and can be split among turns.',
@@ -204,9 +204,9 @@ module Engine
             sym: 'P11',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 1. Three Builder Cubes. When acquired by a company, the private company '\
+            desc: 'MAJOR/MINOR, Phase 1. Three Builder Cubes. When acquired by a corporation, the private company '\
                   'closes and is exchanged for three of the builder cubes from the cube pool. '\
-                  'The company may spend one or more of the cubes to place them on the '\
+                  'The corporation may spend one or more of the cubes to place them on the '\
                   'board during their lay track action. These placements are in addition to the '\
                   'tile placement. These cube placements may occur at any time during the '\
                   'action and can be split among turns.',
@@ -229,13 +229,13 @@ module Engine
             sym: 'P12',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 1. Remove Town. Allows the owning company to place a plain yellow track '\
+            desc: 'MAJOR/MINOR, Phase 1. Remove Town. Allows the owning corporation to place a plain yellow track '\
                   'tile directly on an undeveloped town hex location or upgrade a town tile '\
                   'of one color to a plain track tile of the next color. This closes the company '\
-                  'and counts as the company’s normal track laying step. All other normal '\
+                  'and counts as the corporation’s normal track laying step. All other normal '\
                   'track laying restrictions apply. Cannot be used in hexes with two small '\
                   'towns. Once acquired, the private company pays its revenue to the owning '\
-                  'company until the power is exercised and the company is closed.',
+                  'corporation until the power is exercised and the company is closed.',
             abilities: [
               {
                 type: 'tile_lay',
@@ -256,13 +256,13 @@ module Engine
             sym: 'P13',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 1. Remove Town. Allows the owning company to place a plain yellow track '\
+            desc: 'MAJOR/MINOR, Phase 1. Remove Town. Allows the owning corporation to place a plain yellow track '\
                   'tile directly on an undeveloped town hex location or upgrade a town tile '\
                   'of one color to a plain track tile of the next color. This closes the company '\
-                  'and counts as the company’s normal track laying step. All other normal '\
+                  'and counts as the corporation’s normal track laying step. All other normal '\
                   'track laying restrictions apply. Cannot be used in hexes with two small '\
                   'towns. Once acquired, the private company pays its revenue to the owning '\
-                  'company until the power is exercised and the company is closed.',
+                  'corporation until the power is exercised and the company is closed.',
             abilities: [
               {
                 type: 'tile_lay',
@@ -283,14 +283,14 @@ module Engine
             sym: 'P14',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 3. Mail Contract. After running trains, the owning company receives income '\
+            desc: 'MAJOR, Phase 3. Mail Contract. After running trains, the owning corporation receives income '\
                   'into its treasury equal to one half of the base value of the start and end '\
                   'stations from one of the trains operated. Modifications to values (for '\
                   'E-trains, a 3/2-train, or destination tokens) do not apply. An L-train may '\
-                  'deliver mail within a single city. The company is not required to maximize '\
+                  'deliver mail within a single city. The corporation is not required to maximize '\
                   'the dividend from its run if it wishes to maximize its revenue from the mail '\
                   'contract by stopping at a large city and not running beyond it to include '\
-                  'towns. A company that owns more than one Mail Contract may not use '\
+                  'towns. A corporation that owns more than one Mail Contract may not use '\
                   'more than one on any train.',
             abilities: [],
             color: nil,
@@ -300,14 +300,14 @@ module Engine
             sym: 'P15',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 3. Mail Contract. After running trains, the owning company receives income '\
+            desc: 'MAJOR, Phase 3. Mail Contract. After running trains, the owning corporation receives income '\
                   'into its treasury equal to one half of the base value of the start and end '\
                   'stations from one of the trains operated. Modifications to values (for '\
                   'E-trains, a 3/2-train, or destination tokens) do not apply. An L-train may '\
-                  'deliver mail within a single city. The company is not required to maximize '\
+                  'deliver mail within a single city. The corporation is not required to maximize '\
                   'the dividend from its run if it wishes to maximize its revenue from the mail '\
                   'contract by stopping at a large city and not running beyond it to include '\
-                  'towns. A company that owns more than one Mail Contract may not use '\
+                  'towns. A corporation that owns more than one Mail Contract may not use '\
                   'more than one on any train.',
             abilities: [],
             color: nil,
@@ -317,10 +317,10 @@ module Engine
             sym: 'P16',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 2.  Stock Drop. Pays $10 while owned by a player. A company must pay the '\
-                  'bank $10 while owned by a company. A major company may close this '\
-                  'company during its operating turn, but that makes its stock drop one space. '\
-                  'If the company ever cannot pay the $10, this private company closes and the '\
+            desc: 'MAJOR, Phase 2.  Stock Drop. Pays $10 while owned by a player. The owning corporation must pay the '\
+                  'bank $10 while owned by a corporation. The owning corporation may close this '\
+                  'company during its operating turn, but this makes its stock drop one space. '\
+                  'If the corporation ever cannot pay the $10, this private company closes and the '\
                   'stock drops immediately.',
             abilities: [
               {
@@ -339,10 +339,10 @@ module Engine
             desc: 'MAJOR/MINOR, Phase 2. Small Port. Replace a spike going to water with this tile. Lay this tile on '\
                   'a spike that does not already have a port. The spike now counts as a 30 '\
                   '(yellow)/40 (green and later) and is treated like a gray off-board area for '\
-                  'counting train runs for all companies. This is in addition to the company’s '\
-                  'normal tile placement and the company does not need a route to the '\
+                  'counting train runs for all corporations. This tile lay is in addition to the corporation’s '\
+                  'normal tile placement and the corporation does not need a route to the '\
                   'spike. Once acquired, the private company pays its revenue to the owning '\
-                  'company until the power is exercised and the company is closed.',
+                  'corporation until the power is exercised and the company is closed.',
             abilities: [
               {
                 type: 'tile_lay',
@@ -366,10 +366,10 @@ module Engine
             desc: 'MAJOR, Phase 3. Replace a spike going to water with this tile. Lay this tile on '\
                   'a spike that does not already have a port. The spike now counts as a 40 '\
                   '(green)/50 (brown)/60 (gray) and is treated like a gray off-board area for '\
-                  'counting train runs for all companies. This is in addition to the company’s '\
-                  'normal tile placement and the company does not need a route to the '\
+                  'counting train runs for all corporations. This tile lay is in addition to the corporation’s '\
+                  'normal tile placement and the corporation does not need a route to the '\
                   'spike. Once acquired, the private company pays its revenue to the owning '\
-                  'company until the power is exercised and the company is closed.',
+                  'corporation until the power is exercised and the company is closed.',
             abilities: [
               {
                 type: 'tile_lay',

--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -296,9 +296,9 @@ module Engine
 
         EVENTS_TEXT = {
           'close_concessions' =>
-            ['Concessions close', 'All concessions close without compensation, major companies float at 50%'],
+            ['Concessions close', 'All concessions close without compensation, corporations float at 50%'],
           'full_capitalisation' =>
-            ['Full capitalisation', 'Major companies receive full capitalisation when floated'],
+            ['Full capitalisation', 'Corporations receive full capitalisation when floated'],
           'close_ndem' =>
             ['NdeM privatization', 'NdeM privatized, runs one last time, auctions token'],
         }.freeze

--- a/lib/engine/game/g_1822_pnw/entities.rb
+++ b/lib/engine/game/g_1822_pnw/entities.rb
@@ -10,12 +10,12 @@ module Engine
             sym: 'P1',
             value: 0,
             revenue: 5,
-            desc: 'MAJOR, Phase 5. 5-Train. Once a company acquires it, this is a normal 5-train that is subject to '\
+            desc: 'MAJOR, Phase 5. 5-Train. Once a corporation acquires it, this is a normal 5-train that is subject to '\
                   'all of the normal rules.  It is not a "special train" and is not subject to the rules that are '\
-                  'specific to special trains.  A company can acquire this private company at the start of its turn, '\
+                  'specific to special trains.  A corporation can acquire this private company at the start of its turn, '\
                   'even if it is already at it\'s train limit, as this counts as an acquisition action, not a train '\
-                  'buying action.  However, once acquired the acquiring company must check whether it as at the '\
-                  'train limit and must discard any trains held in excess of limit.',
+                  'buying action.  However, once acquired, the acquiring corporation must check whether it is at the '\
+                  'train limit, and must discard any trains held in excess of limit.',
             abilities: [],
             color: nil,
           },
@@ -25,13 +25,13 @@ module Engine
             value: 0,
             revenue: 0,
             desc: 'MAJOR, Phase 2. Permanent 2-Train. The 2P-train is a permanent 2-train. It is a “special train.” '\
-                  'It cannot be sold to another company. It does not count against the train limit. '\
+                  'It cannot be sold to another corporation. It does not count against the train limit. '\
                   'It does not count as a train for the purpose of mandatory train ownership and '\
-                  'purchase. A company cannot own more than one special train. Dividends can '\
+                  'purchase. A corporation cannot own more than one special train. Dividends can '\
                   'be separated from other trains and may be split, paid in full, or retained. If '\
-                  'a company runs a 2P-train and pays a dividend (split or full), but retains its '\
+                  'a corporation runs a 2P-train and pays a dividend (split or full), but retains its '\
                   'dividend from other train operations, this still counts as a normal dividend '\
-                  'for share price movement purposes. Vice-versa, if a company pays a dividend '\
+                  'for share price movement purposes. Vice-versa, if a corporation pays a dividend '\
                   '(split or full) with its other trains, but retains the dividend from the 2P-train, '\
                   'this also still counts as a normal dividend for share price movement purposes. '\
                   'Does not close.',
@@ -44,13 +44,13 @@ module Engine
             value: 0,
             revenue: 0,
             desc: 'MAJOR/MINOR, Phase 1. Permanent L-Train.  It is a “special train.” '\
-                  'It cannot be sold to another company. It does not count against the train limit. '\
+                  'It cannot be sold to another corporation. It does not count against the train limit. '\
                   'It does not count as a train for the purpose of mandatory train ownership and '\
-                  'purchase. A company cannot own more than one special train. Dividends can '\
+                  'purchase. A corporation cannot own more than one special train. Dividends can '\
                   'be separated from other trains and may be split, paid in full, or retained. If '\
-                  'a company runs a LP-train and pays a dividend (split or full), but retains its '\
+                  'a corporation runs a LP-train and pays a dividend (split or full), but retains its '\
                   'dividend from other train operations, this still counts as a normal dividend '\
-                  'for share price movement purposes. Vice-versa, if a company pays a dividend '\
+                  'for share price movement purposes. Vice-versa, if a corporation pays a dividend '\
                   '(split or full) with its other trains, but retains the dividend from the LP-train, '\
                   'this also still counts as a normal dividend for share price movement purposes. '\
                   'Does not close.',
@@ -63,13 +63,13 @@ module Engine
             value: 0,
             revenue: 0,
             desc: 'MAJOR/MINOR, Phase 1. Permanent L-Train.  It is a “special train.” '\
-                  'It cannot be sold to another company. It does not count against the train limit. '\
+                  'It cannot be sold to another corporation. It does not count against the train limit. '\
                   'It does not count as a train for the purpose of mandatory train ownership and '\
-                  'purchase. A company cannot own more than one special train. Dividends can '\
+                  'purchase. A corporation cannot own more than one special train. Dividends can '\
                   'be separated from other trains and may be split, paid in full, or retained. If '\
-                  'a company runs a LP-train and pays a dividend (split or full), but retains its '\
+                  'a corporation runs a LP-train and pays a dividend (split or full), but retains its '\
                   'dividend from other train operations, this still counts as a normal dividend '\
-                  'for share price movement purposes. Vice-versa, if a company pays a dividend '\
+                  'for share price movement purposes. Vice-versa, if a corporation pays a dividend '\
                   '(split or full) with its other trains, but retains the dividend from the LP-train, '\
                   'this also still counts as a normal dividend for share price movement purposes. '\
                   'Does not close.',
@@ -82,10 +82,10 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 3. Pullman. A “Pullman” car that can be attached to another train owned by the '\
-                  'company. It is not a train. A train with a Pullman attached to it counts any '\
+                  'corporation. It is not a train. A train with a Pullman attached to it counts any '\
                   'number of towns in addition to its standard number of large stations. Does '\
-                  'not count toward the train limit. Cannot be sold to another company. Does '\
-                  'not close. No company may own more than one Pullman.',
+                  'not count toward the train limit. Cannot be sold to another corporation. Does '\
+                  'not close. No corporation may own more than one Pullman.',
             abilities: [],
             color: nil,
           },
@@ -95,10 +95,10 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 3. Pullman. A “Pullman” car that can be attached to another train owned by the '\
-                  'company. It is not a train. A train with a Pullman attached to it counts any '\
+                  'corporation. It is not a train. A train with a Pullman attached to it counts any '\
                   'number of towns in addition to its standard number of large stations. Does '\
-                  'not count toward the train limit. Cannot be sold to another company. Does '\
-                  'not close. No company may own more than one Pullman.',
+                  'not count toward the train limit. Cannot be sold to another corporation. Does '\
+                  'not close. No corporation may own more than one Pullman.',
             abilities: [],
             color: nil,
           },
@@ -107,13 +107,13 @@ module Engine
             sym: 'P7',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 1. Remove Town. Allows the owning company to place a plain yellow track '\
+            desc: 'MAJOR/MINOR, Phase 1. Remove Town. Allows the owning corporation to place a plain yellow track '\
                   'tile directly on an undeveloped town hex location or upgrade a town tile '\
                   'of one color to a plain track tile of the next color. This closes the company '\
-                  'and counts as the company’s normal track laying step. All other normal '\
+                  'and counts as the corporation’s normal track laying step. All other normal '\
                   'track laying restrictions apply. Cannot be used in hexes with two small '\
                   'towns. Once acquired, the private company pays its revenue to the owning '\
-                  'company until the power is exercised and the company is closed.',
+                  'corporation until the power is exercised and the company is closed.',
             abilities: [
             {
               type: 'tile_lay',
@@ -134,13 +134,13 @@ module Engine
             sym: 'P8',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 1. Remove Town. Allows the owning company to place a plain yellow track '\
+            desc: 'MAJOR/MINOR, Phase 1. Remove Town. Allows the owning corporation to place a plain yellow track '\
                   'tile directly on an undeveloped town hex location or upgrade a town tile '\
                   'of one color to a plain track tile of the next color. This closes the company '\
-                  'and counts as the company’s normal track laying step. All other normal '\
+                  'and counts as the corporation’s normal track laying step. All other normal '\
                   'track laying restrictions apply. Cannot be used in hexes with two small '\
                   'towns. Once acquired, the private company pays its revenue to the owning '\
-                  'company until the power is exercised and the company is closed.',
+                  'corporation until the power is exercised and the company is closed.',
             abilities: [
               {
                 type: 'tile_lay',
@@ -161,14 +161,14 @@ module Engine
             sym: 'P9',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR, Phase 3. Mail Contract. After running trains, the owning company receives income '\
+            desc: 'MAJOR, Phase 3. Mail Contract. After running trains, the owning corporation receives income '\
                   'into its treasury equal to one half of the base value of the start and end '\
                   'stations from one of the trains operated. Modifications to values (for '\
                   'E-trains or destination tokens) do not apply. An L-train may '\
-                  'deliver mail within a single city. The company is not required to maximize '\
+                  'deliver mail within a single city. The corporation is not required to maximize '\
                   'the dividend from its run if it wishes to maximize its revenue from the mail '\
                   'contract by stopping at a large city and not running beyond it to include '\
-                  'towns. A company that owns more than one Mail Contract may not use '\
+                  'towns. A corporation that owns more than one Mail Contract may not use '\
                   'more than one on any train.',
             abilities: [],
             color: nil,
@@ -178,9 +178,9 @@ module Engine
             sym: 'P10',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 1. Three Builder Cubes. When acquired by a company, the private company '\
+            desc: 'MAJOR/MINOR, Phase 1. Three Builder Cubes. When acquired by a corporation, the private company '\
                   'closes and is exchanged for three of the builder cubes from the cube pool. '\
-                  'The company may spend one or more of the cubes to place them on the '\
+                  'The corporation may spend one or more of the cubes to place them on the '\
                   'board during their lay track action. These placements are in addition to the '\
                   'tile placement. These cube placements may occur at any time during the '\
                   'action and can be split among turns.',
@@ -203,11 +203,11 @@ module Engine
             sym: 'P11',
             value: 0,
             revenue: 10,
-            desc: 'MAJOR/MINOR, Phase 3. Extra Tile Lay. The owning company may lay an additional yellow tile (or '\
-                  'two for major companies beginning in Phase 3), or make one additional '\
+            desc: 'MAJOR/MINOR, Phase 3. Extra Tile Lay. The owning corporation may lay an additional yellow tile (or '\
+                  'two for major corporation beginning in Phase 3), or make one additional '\
                   'tile upgrade in its track laying step. The upgrade can be to a tile laid in its '\
                   'normal tile laying step. All other normal track laying restrictions apply. Once '\
-                  'acquired, the private company pays its revenue to the owning company until '\
+                  'acquired, the private company pays its revenue to the owning corporation until '\
                   'the power is exercised and the company closes.',
             abilities: [
               {
@@ -234,10 +234,10 @@ module Engine
             desc: 'MAJOR/MINOR, Phase 2. Small Port. Replace a spike going to water with this tile. Lay this tile on '\
                   'a spike that does not already have a port. The spike now counts as a 30 '\
                   '(yellow)/40 (green and later) and is treated like a gray off-board area for '\
-                  'counting train runs for all companies. This is in addition to the company’s '\
-                  'normal tile placement and the company does not need a route to the '\
+                  'counting train runs for all corporations. This is in addition to the corporation’s '\
+                  'normal tile placement and the corporation does not need a route to the '\
                   'spike. Once acquired, the private company pays its revenue to the owning '\
-                  'company until the power is exercised and the company is closed.',
+                  'corporation until the power is exercised and the company is closed.',
             abilities: [
               {
                 type: 'tile_lay',
@@ -261,10 +261,10 @@ module Engine
             desc: 'MAJOR, Phase 3. Replace a spike going to water with this tile. Lay this tile on '\
                   'a spike that does not already have a port. The spike now counts as a 40 '\
                   '(green)/50 (brown)/60 (gray) and is treated like a gray off-board area for '\
-                  'counting train runs for all companies. This is in addition to the company’s '\
-                  'normal tile placement and the company does not need a route to the '\
+                  'counting train runs for all corporations. This is in addition to the corporation’s '\
+                  'normal tile placement and the corporation does not need a route to the '\
                   'spike. Once acquired, the private company pays its revenue to the owning '\
-                  'company until the power is exercised and the company is closed.',
+                  'corporation until the power is exercised and the company is closed.',
             abilities: [
               {
                 type: 'tile_lay',
@@ -288,7 +288,7 @@ module Engine
             desc: 'MAJOR/MINOR, Phase 3. The Lumber Baron private increases '\
                   'the payout of each timber track traversed by a single '\
                   'train from $10 to $20. Maintains all of the timber trade '\
-                  'connection requirements. Once acquired by a company '\
+                  'connection requirements. Once acquired by a corporation '\
                   'this private no longer pays its revenue.',
             abilities: [],
             color: nil,
@@ -324,13 +324,13 @@ module Engine
             desc: 'MAJOR/MINOR, Phase 2. Use this private to place '\
                   'one or both special tiles (PNW1, PNW2) in any blue '\
                   'water hex on the map. This tile lay replaces a '\
-                  'company\'s normal tile lay. The owning company may '\
+                  'corporation\'s normal tile lay. The owning corporation may '\
                   'run a train across the special tiles for free. If any other '\
-                  'train company uses the tiles, they subtract $10 from '\
+                  'corporation uses the tiles, they subtract $10 from '\
                   'their run for each special tile crossed. The owning '\
-                  'company receives $10 per special track used from the '\
+                  'corporation receives $10 per special track used from the '\
                   'bank. Once used, this private no longer pays revenue '\
-                  'to the company.',
+                  'to the corporation.',
             abilities: [
               {
                 type: 'tile_lay',
@@ -398,15 +398,15 @@ module Engine
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 3. Use this private to use a yellow track '\
                   'placement to place the Rockport Coal special tile (PNW4) in '\
-                  'any mountain hex. The owning company must be able to trace to '\
-                  'the hex the mine is placed on. Only the owning company can run a '\
+                  'any mountain hex. The owning corporation must be able to trace to '\
+                  'the hex the mine is placed on. Only the owning corporation can run a '\
                   'train through the city spot on the Rockport Coal special tile '\
-                  '(PNW4). Any company can pay the upgrade cost or use '\
+                  '(PNW4). Any corporation can pay the upgrade cost or use '\
                   'building cubes to upgrade the Rockport Coal Special tile '\
                   '(PNW4) to include the pass around route tile (PNW5). No '\
                   'other private bonus can combine with this one. Once '\
                   'used, this private no longer pays revenue to the '\
-                  'company.',
+                  'corporation.',
             abilities: [
               {
                 type: 'tile_lay',
@@ -433,7 +433,7 @@ module Engine
                   'associated minor for the major associated with the '\
                   'discarded minor. The owning minor must still abide by all '\
                   'merge requirements when forming the associated major '\
-                  'company and its location becomes the major’s new home '\
+                  'corporation and its location becomes the major’s new home '\
                   'token location.',
             abilities: [],
             color: nil,
@@ -444,11 +444,11 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 2. Allows the director of the '\
-                  'owning company to select one private company or minor '\
+                  'owning corporation to select one private company or minor '\
                   'company from the relevant stack of certificates, excluding '\
                   'those items currently in the bidding boxes, and move it to '\
                   'the top or the bottom of the stack OR allows the director of '\
-                  'a major company to move a station token from exchange to '\
+                  'a major corporation to move a station token from exchange to '\
                   'available. Closes when the power is exercised.',
             abilities: [],
             color: nil,

--- a/lib/engine/game/g_1826/entities.rb
+++ b/lib/engine/game/g_1826/entities.rb
@@ -28,9 +28,9 @@ module Engine
             sym: 'P2',
             value: 40,
             revenue: 10,
-            desc: 'This company allows a Corporation to increase the value of a City by F10 for all its runs. Once chosen,'\
-                  ' the corp and city cannot be changed. This closes the private company. Bonus is removed when the first E'\
-                  ' train is purchased.',
+            desc: 'This company allows a corporation to increase the value of a city by F10 for all its runs. Once chosen,'\
+                  ' the corporation and city cannot be changed. This closes the private company. Bonus is removed when the '\
+                  ' first E train is purchased.',
             abilities: [
               {
                 type: 'assign_hexes',

--- a/lib/engine/game/g_1828/entities.rb
+++ b/lib/engine/game/g_1828/entities.rb
@@ -97,7 +97,7 @@ module Engine
             revenue: 20,
             desc: 'Blocks Adrian & Ann Arbor (E7) while owned by a player. ' \
                   'A yellow track tile is placed at E7 when purchased by a corporation. ' \
-                  'Owning corp may (once) place one additional yellow track tile ' \
+                  'Owning corporation may (once) place one additional yellow track tile ' \
                   'at $20 as part of its normal track build.',
             sym: 'E&K',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['E7'] },

--- a/lib/engine/game/g_1828/entities.rb
+++ b/lib/engine/game/g_1828/entities.rb
@@ -80,7 +80,7 @@ module Engine
             value: 120,
             revenue: 20,
             desc: 'Blocks D22 while owned by a player. ' \
-                  'Owning player may exchange for a share of any company from the market or IPO.',
+                  'Owning player may exchange for a share of any corporation from the market or IPO.',
             sym: 'M&H',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['D22'] },
                         {
@@ -96,8 +96,8 @@ module Engine
             value: 120,
             revenue: 20,
             desc: 'Blocks Adrian & Ann Arbor (E7) while owned by a player. ' \
-                  'A yellow track tile is placed at E7 when purchased by a company. ' \
-                  'Owning company may (once) place one additional yellow track tile ' \
+                  'A yellow track tile is placed at E7 when purchased by a corporation. ' \
+                  'Owning corp may (once) place one additional yellow track tile ' \
                   'at $20 as part of its normal track build.',
             sym: 'E&K',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['E7'] },

--- a/lib/engine/game/g_1829/entities.rb
+++ b/lib/engine/game/g_1829/entities.rb
@@ -48,7 +48,7 @@ module Engine
             type: 'steam',
             value: 315,
             revenue: 25,
-            desc: 'Steam. Pays £40 to corp with token in B17',
+            desc: 'Steam. Pays £40 to corporation with token in B17',
           },
           {
             name: 'Preston',
@@ -56,7 +56,7 @@ module Engine
             value: 435,
             revenue: 30,
             type: 'steam',
-            desc: 'Steam. Pays £40 to corp with token in B7',
+            desc: 'Steam. Pays £40 to corporation with token in B7',
           },
           {
             name: 'Holyhead',
@@ -64,7 +64,7 @@ module Engine
             value: 570,
             type: 'steam',
             revenue: 35,
-            desc: 'Steam. Pays £40 to corp with token in D1',
+            desc: 'Steam. Pays £40 to corporation with token in D1',
           },
           {
             name: 'Harwich',
@@ -72,7 +72,7 @@ module Engine
             type: 'steam',
             value: 720,
             revenue: 40,
-            desc: 'Steam. Pays £40 to corp with token in I22',
+            desc: 'Steam. Pays £40 to corporation with token in I22',
           },
           {
             name: 'Dover',
@@ -80,7 +80,7 @@ module Engine
             value: 900,
             revenue: 45,
             type: 'steam',
-            desc: 'Steam. Pays £40 to corp with token in K22',
+            desc: 'Steam. Pays £40 to corporation with token in K22',
           },
         ].freeze
 

--- a/lib/engine/game/g_1829/entities.rb
+++ b/lib/engine/game/g_1829/entities.rb
@@ -48,7 +48,7 @@ module Engine
             type: 'steam',
             value: 315,
             revenue: 25,
-            desc: 'Steam. pays 40$ to company with token in B17',
+            desc: 'Steam. Pays £40 to corp with token in B17',
           },
           {
             name: 'Preston',
@@ -56,7 +56,7 @@ module Engine
             value: 435,
             revenue: 30,
             type: 'steam',
-            desc: 'Steam. pays 40$ to company with token in B7',
+            desc: 'Steam. Pays £40 to corp with token in B7',
           },
           {
             name: 'Holyhead',
@@ -64,7 +64,7 @@ module Engine
             value: 570,
             type: 'steam',
             revenue: 35,
-            desc: 'Steam. pays 40$ to company with token in D1',
+            desc: 'Steam. Pays £40 to corp with token in D1',
           },
           {
             name: 'Harwich',
@@ -72,7 +72,7 @@ module Engine
             type: 'steam',
             value: 720,
             revenue: 40,
-            desc: 'Steam. pays 40$ to company with token in I22',
+            desc: 'Steam. Pays £40 to corp with token in I22',
           },
           {
             name: 'Dover',
@@ -80,7 +80,7 @@ module Engine
             value: 900,
             revenue: 45,
             type: 'steam',
-            desc: 'Steam. pays 40$ to company with token in K22',
+            desc: 'Steam. Pays £40 to corp with token in K22',
           },
         ].freeze
 

--- a/lib/engine/game/g_1832/entities.rb
+++ b/lib/engine/game/g_1832/entities.rb
@@ -232,7 +232,7 @@ module Engine
             revenue: 10,
             desc: 'This company has a $10 token which may be placed in any non-coastal city'\
                   ' (Atlantic or Gulf Coast) as an extra token lay during the'\
-                  ' token placement step of an owning public company\'s operating round.',
+                  ' token placement step of an owning corp\'s operating round.',
             sym: 'P2',
             abilities: [
               {
@@ -257,9 +257,9 @@ module Engine
             revenue: 10,
             desc: 'This company has a Port token which may be placed on any city'\
                   ' on the coasts as an extra token lay during the token placement'\
-                  ' step of an owning public company\'s operating round. All eligible cities are marked with an anchor symbol.'\
+                  ' step of an owning public corp\'s operating round. All eligible cities are marked with an anchor symbol.'\
                   ' This token increases the value of the selected city by $20'\
-                  ' for the owning company and by $10 for all other companies.',
+                  ' for the owning corporation and by $10 for all other corps.',
             sym: 'P3',
             abilities: [
               {
@@ -284,8 +284,8 @@ module Engine
             revenue: 10,
             desc: 'This company represents those shrewd investors in London. They have hired'\
                   ' you to invest their money in the new Southern railways.'\
-                  ' They will purchase a share of your choice in any newly started company.'\
-                  ' You get the share. After the company pays its first dividend, '\
+                  ' They will purchase a share of your choice in any newly started corporation.'\
+                  ' You get the share. After the corp pays its first dividend, '\
                   'the London Investment Company is closed, as they realize they have paid you'\
                   ' for nothing and you spent the money for yourself.',
             sym: 'P4',
@@ -310,8 +310,8 @@ module Engine
                 hexes: %w[B12 B16 C13 C15],
               },
             ],
-            desc: 'This private company gives the owning company a Coal token for free.'\
-                  ' When other companies connect to the Coalfields, '\
+            desc: 'This private company gives the owning corporation a Coal token for free.'\
+                  ' When other corporations connect to the Coalfields, '\
                   'they may buy a Coal token (if available) during their operating round for $80'\
                   ' ($40 goes to the corporation owning the Coal private company).',
           },

--- a/lib/engine/game/g_1832/entities.rb
+++ b/lib/engine/game/g_1832/entities.rb
@@ -285,8 +285,8 @@ module Engine
             desc: 'This company represents those shrewd investors in London. They have hired'\
                   ' you to invest their money in the new Southern railways.'\
                   ' They will purchase a share of your choice in any newly started corporation.'\
-                  ' You get the share. After the corp pays its first dividend, '\
-                  'the London Investment Company is closed, as they realize they have paid you'\
+                  ' You get the share. After the corporation pays its first dividend,'\
+                  ' the London Investment Company is closed, as they realize they have paid you'\
                   ' for nothing and you spent the money for yourself.',
             sym: 'P4',
             abilities: [{

--- a/lib/engine/game/g_1835/entities.rb
+++ b/lib/engine/game/g_1835/entities.rb
@@ -195,7 +195,7 @@ module Engine
             type: 'low',
             float_percent: 60,
             shares: [20, 10, 20, 20, 10, 10, 10],
-            # the shares order creates a 10 share company, but the first 3 sold papers are 20%
+            # the shares order creates a 10-share corporation, but the first 3 sold papers are 20%
             coordinates: 'C13',
             color: :violet,
           },
@@ -208,7 +208,7 @@ module Engine
             float_percent: 60,
             type: 'low',
             shares: [20, 10, 20, 20, 10, 10, 10],
-            # the shares order creates a 10 share company, but the first 3 sold papers are 20%
+            # the shares order creates a 10-share corporation, but the first 3 sold papers are 20%
             coordinates: 'D6',
             color: '#6e6966',
           },

--- a/lib/engine/game/g_1846/entities.rb
+++ b/lib/engine/game/g_1846/entities.rb
@@ -11,7 +11,7 @@ module Engine
             discount: -80,
             revenue: 0,
             desc: 'Starts with $60, a 2 train, and a token in Detroit (C15). Always operates first. Its train may run in OR1. '\
-                  'Splits dividends equally with owner. Purchasing company receives its cash, train and token '\
+                  'Splits dividends equally with owner. Purchasing corporation receives its cash, train and token '\
                   'but cannot run this 2 train in the same OR in which the MS operated. ',
             sym: 'MS',
             color: nil,
@@ -24,7 +24,7 @@ module Engine
             desc: 'Starts with $40, a 2 train, and a token in Indianapolis (G9). '\
                   'Always operates after the MS and before other corporations. '\
                   'Its train may run in OR1. '\
-                  'Splits dividends equally with owner. Purchasing company receives its cash, train and token '\
+                  'Splits dividends equally with owner. Purchasing corporation receives its cash, train and token '\
                   'but cannot run this 2 train in the same OR in which the BIG4 operated. ',
             sym: 'BIG4',
             color: nil,
@@ -112,7 +112,7 @@ module Engine
             desc: 'Add a bonus to the value of one port city, either a $40 bonus to Wheeling (G19) / Holland (B8) '\
                   'or a $20 bonus to Chicago Conn. (C5) / Toledo (D14) / St. Louis (I1). '\
                   'At the beginning of each OR, this company\'s owner may reassign this bonus '\
-                  'to a different port city and/or train company (including minors). '\
+                  'to a different port city and/or corporation (including minors). '\
                   'Once purchased by a corporation, it becomes permanently assigned to that corporation. '\
                   'Bonus persists after this company closes in Phase III but is removed in Phase IV.',
             sym: 'SC',

--- a/lib/engine/game/g_1847_ae/entities.rb
+++ b/lib/engine/game/g_1847_ae/entities.rb
@@ -367,7 +367,7 @@ module Engine
             float_percent: 50,
             max_ownership_percent: 100,
             coordinates: 'G15',
-            # the shares order creates a 10 share company, but the first 2 sold certs are 20%
+            # the shares order creates a 10 share corporation, but the first 2 sold certs are 20%
             shares: [20, 10, 20, 10, 10, 10, 20],
             second_share_double: true,
             last_share_double: true,
@@ -433,7 +433,7 @@ module Engine
             float_percent: 50,
             max_ownership_percent: 100,
             coordinates: 'F12',
-            # the shares order creates a 10 share company, but the first 2 sold certs are 20%
+            # the shares order creates a 10 share corporation, but the first 2 sold certs are 20%
             shares: [20, 10, 20, 10, 10, 10, 20],
             second_share_double: true,
             last_share_double: true,
@@ -467,7 +467,7 @@ module Engine
             float_percent: 50,
             max_ownership_percent: 100,
             coordinates: 'C13',
-            # the shares order creates a 10 share company, but the first 2 sold certs are 20%
+            # the shares order creates a 10 share corporation, but the first 2 sold certs are 20%
             shares: [20, 10, 20, 10, 10, 10, 20],
             second_share_double: true,
             last_share_double: true,

--- a/lib/engine/game/g_1848/entities.rb
+++ b/lib/engine/game/g_1848/entities.rb
@@ -21,7 +21,7 @@ module Engine
             min_price: 1,
             max_price: 80,
             revenue: 10,
-            desc: 'Owning Public Company or its Director may build one (1) free tile on a desert hex (marked by'\
+            desc: 'Owning corporation or its Director may build one (1) free tile on a desert hex (marked by'\
                   ' a cactus icon). This power does not go away after a 5/5+ train is purchased. Can be bought for £1-£80 ',
             abilities: [
                     {
@@ -55,8 +55,8 @@ module Engine
             min_price: 1,
             max_price: 140,
             revenue: 15,
-            desc: 'The Tasmania tile can be placed by a Public Company on one of the two blue hexes (I8, I10). This is in'\
-                  " addition to the company's normal build that turn. Can be bought for £1-£140",
+            desc: 'The Tasmania tile can be placed by a corporation on one of the two blue hexes (I8, I10). This is in'\
+                  " addition to the corporation's normal build that turn. Can be bought for £1-£140",
             abilities: [
                     {
                       type: 'tile_lay',
@@ -79,7 +79,7 @@ module Engine
             min_price: 1,
             max_price: 220,
             revenue: 20,
-            desc: 'Owning Public Company or its Director may receive a one-time discount of £100 on the purchase'\
+            desc: 'Owning corporation or its Director may receive a one-time discount of £100 on the purchase'\
                   ' of a 2E (Ghan) train. This power does not go away after a 5/5+ train is purchased. Can be bought for £1-£220',
             abilities: [
                     {

--- a/lib/engine/game/g_1850/entities.rb
+++ b/lib/engine/game/g_1850/entities.rb
@@ -44,10 +44,10 @@ module Engine
           name: 'Mississippi River Bridge Company',
           value: 40,
           revenue: 10,
-          desc: 'This private company gives the purchasing company a free bridge over the Mississippi River at'\
+          desc: 'This private company gives the purchasing corporation a free bridge over the Mississippi River at'\
                 ' St. Louis (i.e: a free track lay in the St. Louis hex. For the Missouri Pacific this track lay'\
                 ' is in addition to and may be performed before its normal track lay/upgrade.'\
-                ' This private company may be sold during phase two for from half to full face value. If a company'\
+                ' This private company may be sold during phase two for from half to full face value. If a corporation'\
                 ' uses this private to lay the St. Louis hex, it may not upgrade that hex in the same operating turn.',
           sym: 'MRB',
           abilities: [

--- a/lib/engine/game/g_1856/entities.rb
+++ b/lib/engine/game/g_1856/entities.rb
@@ -19,7 +19,7 @@ module Engine
             sym: 'WSRC',
             value: 40,
             revenue: 10,
-            desc: 'The public company that owns this private company may place a free station marker and/or '\
+            desc: 'The corporation that owns this private company may place a free station marker and/or '\
                   'green #59 tile on the Kitchener hex (I12). This action closes the private company.',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['I12'] },
                         {
@@ -47,9 +47,9 @@ module Engine
             sym: 'TCC',
             value: 50,
             revenue: 10,
-            desc: 'During its operating turn, the public company owning this private company may place a '\
+            desc: 'During its operating turn, the corporation owning this private company may place a '\
                   'track tile in the hex occupied by this private company (H11). This track lay is in addition to '\
-                  'the public company\'s normal track lay. This action does not close the private company.',
+                  'the corporation\'s normal track lay. This action does not close the private company.',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['H11'] },
                         {
                           type: 'tile_lay',
@@ -67,7 +67,7 @@ module Engine
             sym: 'GLSC',
             value: 70,
             revenue: 15,
-            desc: 'At any time during its operating turn, the owning public company may place the port marker in '\
+            desc: 'At any time during its operating turn, the owning corporation may place the port marker in '\
                   'any one hex with the port symbol. The port marker raises the value of all revenue locations in that hex '\
                   'by $20 for that corporation. This marker may not be moved and will be removed when the first '\
                   '6 train is purchased. Placement of this marker closes the Great Lakes Shipping Company.',
@@ -105,8 +105,8 @@ module Engine
             sym: 'NFSBC',
             value: 100,
             revenue: 20,
-            desc: 'The public company that owns this private company may add a $10 bonus when running '\
-                  'to Buffalo (P17/P19). Other public companies may purchase the right for $50.',
+            desc: 'The corporation that owns this private company may add a $10 bonus when running '\
+                  'to Buffalo (P17/P19). Other corporations may purchase the right for $50.',
             color: nil,
           },
           {
@@ -114,8 +114,8 @@ module Engine
             sym: 'SCFTC',
             value: 100,
             revenue: 20,
-            desc: 'The public company that owns this private company may add a $10 Port Huron bonus when running '\
-                  'to Sarnia (B13). Other public companies may purchase the right for $50.',
+            desc: 'The corporation that owns this private company may add a $10 Port Huron bonus when running '\
+                  'to Sarnia (B13). Other corporations may purchase the right for $50.',
             color: nil,
           },
         ].freeze

--- a/lib/engine/game/g_1858/entities.rb
+++ b/lib/engine/game/g_1858/entities.rb
@@ -117,7 +117,7 @@ module Engine
             sym: 'H&G',
             name: 'Havana and Güines Railway',
             desc: 'P1. Revenue 10, face value 30. ' \
-                  'Cannot be used to start a public company or exchanged for a share.',
+                  'Cannot be used to start a corporation or exchanged for a share.',
             value: 30,
             discount: 0,
             revenue: 10,
@@ -129,7 +129,7 @@ module Engine
             sym: 'B&M',
             name: 'Barcelona and Mataró Railway',
             desc: 'P2. Revenue 23/35, face value 115. Home hex is O8. ' \
-                  'Can be used to start a public company in Barcelona.',
+                  'Can be used to start a corporation in Barcelona.',
             value: 115,
             discount: 25,
             revenue: 23,
@@ -152,7 +152,7 @@ module Engine
             sym: 'M&A',
             name: 'Madrid and Aranjuez Railway',
             desc: 'P3. Revenue 25/38, face value 125. Home hexes are H11 and H13. ' \
-                  'Can be used to start a public company in Madrid.',
+                  'Can be used to start a corporation in Madrid.',
             value: 125,
             discount: 25,
             revenue: 25,
@@ -176,7 +176,7 @@ module Engine
             sym: 'P&L',
             name: 'Porto and Lisbon Railway',
             desc: 'P4. Revenue 22/33, face value 110. Home hexes are B9 and B11. ' \
-                  'Can be used to start a public company in Porto.',
+                  'Can be used to start a corporation in Porto.',
             value: 110,
             discount: 20,
             revenue: 22,
@@ -199,7 +199,7 @@ module Engine
             sym: 'V&J',
             name: 'Valencia and Jativa Railway',
             desc: 'P5. Revenue 20/30, face value 100. Home hex is L13. ' \
-                  'Can be used to start a public company in Valencia.',
+                  'Can be used to start a corporation in Valencia.',
             value: 100,
             discount: 20,
             revenue: 20,
@@ -222,7 +222,7 @@ module Engine
             sym: 'R&T',
             name: 'Reus and Tarragona Railway',
             desc: 'P6. Revenue 12/18, face value 60. Home hex is N9. ' \
-                  'Cannot be used to start a public company.',
+                  'Cannot be used to start a corporation.',
             value: 60,
             discount: 10,
             revenue: 12,
@@ -237,7 +237,7 @@ module Engine
             sym: 'L&C',
             name: 'Lisbon and Carregado Railway',
             desc: 'P7. Revenue 18/27, face value 90. Home hexes are A14 and B13. ' \
-                  'Can be used to start a public company in Lisboa.',
+                  'Can be used to start a corporation in Lisboa.',
             value: 90,
             discount: 20,
             revenue: 18,
@@ -260,7 +260,7 @@ module Engine
             sym: 'M&V',
             name: 'Madrid and Valladolid Railway',
             desc: 'P8. Revenue 24/36, face value 120. Home hexes are G8, G10 and H11. ' \
-                  'Can be used to start a public company in either Madrid or Valladolid.',
+                  'Can be used to start a corporation in either Madrid or Valladolid.',
             value: 120,
             discount: 25,
             revenue: 24,
@@ -285,7 +285,7 @@ module Engine
             sym: 'M&Z',
             name: 'Madrid and Zaragoza Railway',
             desc: 'P9. Revenue 19/29, face value 95. Home hexes are I10, J9, K8 and L7. ' \
-                  'Can be used to start a public company in Zaragoza.',
+                  'Can be used to start a corporation in Zaragoza.',
             value: 95,
             discount: 20,
             revenue: 19,
@@ -308,7 +308,7 @@ module Engine
             sym: 'C&S',
             name: 'Córdoba and Seville Railway',
             desc: 'P10. Revenue 21/32, face value 105. Home hexes are E18, F17 and G18. ' \
-                  'Can be used to start a public company in either Sevilla or Córdoba.',
+                  'Can be used to start a corporation in either Sevilla or Córdoba.',
             value: 105,
             discount: 20,
             revenue: 21,
@@ -332,7 +332,7 @@ module Engine
             sym: 'SJ&C',
             name: 'Seville, Jerez and Cadiz Railway',
             desc: 'P11. Revenue 14/21, face value 70. Home hexes are E18 and E20. ' \
-                  'Can be used to start a public company in either Sevilla or Cádiz.',
+                  'Can be used to start a corporation in either Sevilla or Cádiz.',
             value: 70,
             discount: 15,
             revenue: 14,
@@ -356,7 +356,7 @@ module Engine
             sym: 'Z&P',
             name: 'Zaragoza and Pamplona Railway',
             desc: 'P12. Revenue 16/24, face value 80. Home hexes are K4, K6 and L7. ' \
-                  'Can be used to start a public company in Zaragoza.',
+                  'Can be used to start a corporation in Zaragoza.',
             value: 80,
             discount: 15,
             revenue: 16,
@@ -379,7 +379,7 @@ module Engine
             sym: 'C&B',
             name: 'Castejón and Bilbao Railway',
             desc: 'P13. Revenue 15/23, face value 75. Home hex is I2. ' \
-                  'Can be used to start a public company in Bilbao.',
+                  'Can be used to start a corporation in Bilbao.',
             value: 75,
             discount: 15,
             revenue: 15,
@@ -402,7 +402,7 @@ module Engine
             sym: 'C&M',
             name: 'Córdoba and Málaga Railway',
             desc: 'P14. Revenue 17/26, face value 85. Home hexes are G18 and G20. ' \
-                  'Can be used to start a public company in either Córdoba or Málaga.',
+                  'Can be used to start a corporation in either Córdoba or Málaga.',
             value: 85,
             discount: 15,
             revenue: 17,
@@ -426,7 +426,7 @@ module Engine
             sym: 'M&C',
             name: 'Murcia and Cartagena Railway',
             desc: 'P15. Revenue 14/21, face value 70. Home hexes are K18 and L19. ' \
-                  'Can be used to start a public company in Murcia.',
+                  'Can be used to start a corporation in Murcia.',
             value: 70,
             discount: 15,
             revenue: 14,
@@ -449,7 +449,7 @@ module Engine
             sym: 'A&S',
             name: 'Alar and Santander Railway',
             desc: 'P16. Revenue 16/24, face value 80. Home hexes are G4 and H3. ' \
-                  'Can be used to start a public company in Santander.',
+                  'Can be used to start a corporation in Santander.',
             value: 80,
             discount: 15,
             revenue: 16,
@@ -472,7 +472,7 @@ module Engine
             sym: 'B&CR',
             name: 'Badajoz and Ciudad Real Railway',
             desc: 'P17. Revenue 13/20, face value 65. Home hexes are D15, E14 and F15. ' \
-                  'Cannot be used to start a public company.',
+                  'Cannot be used to start a corporation.',
             value: 65,
             discount: 15,
             revenue: 13,
@@ -487,7 +487,7 @@ module Engine
             sym: 'S&C',
             name: 'Santiago and La Coruña Railway',
             desc: 'P18. Revenue 30, face value 100. Home hexes are C2 and C4. ' \
-                  'Can be used to start a public company in La Coruña.',
+                  'Can be used to start a corporation in La Coruña.',
             value: 100,
             discount: 0,
             revenue: 30,
@@ -509,7 +509,7 @@ module Engine
             sym: 'M&S',
             name: 'Medina and Salamanca Railway',
             desc: 'P19. Revenue 27, face value 90. Home hex is F9. ' \
-                  'Cannot be used to start a public company.',
+                  'Cannot be used to start a corporation.',
             value: 90,
             discount: 0,
             revenue: 27,
@@ -521,7 +521,7 @@ module Engine
             sym: 'CM&P',
             name: 'Cáceres, Madrid and Portugal Railway',
             desc: 'P20. Revenue 40, face value 135. Home hexes are D13, E12, F13, G12 and H11. ' \
-                  'Can be used to start a public company in Madrid.',
+                  'Can be used to start a corporation in Madrid.',
             value: 135,
             discount: -30,
             revenue: 40,
@@ -544,7 +544,7 @@ module Engine
             sym: 'O&V',
             name: 'Orense and Vigo Railway',
             desc: 'P21. Revenue 33, face value 110. Home hexes are B5 and C4. ' \
-                  'Can be used to start a public company in Vigo.',
+                  'Can be used to start a corporation in Vigo.',
             value: 110,
             discount: 0,
             revenue: 33,
@@ -566,7 +566,7 @@ module Engine
             sym: 'L&G',
             name: 'León and Gijón Railway',
             desc: 'P22. Revenue 36, face value 120. Home hexes are F1, F3 and F5. ' \
-                  'Can be used to start a public company in Gijón.',
+                  'Can be used to start a corporation in Gijón.',
             value: 120,
             discount: 0,
             revenue: 36,

--- a/lib/engine/game/g_1860/entities.rb
+++ b/lib/engine/game/g_1860/entities.rb
@@ -9,7 +9,7 @@ module Engine
             name: 'Brading Harbour Company',
             value: 30,
             revenue: 5,
-            desc: 'Can be exchanged for a share in the BHI&R public company',
+            desc: 'Can be exchanged for a share in the BHI&R corporation',
             sym: 'BHC',
             abilities: [
             {
@@ -25,7 +25,7 @@ module Engine
             name: 'Yarmouth Harbour Company',
             value: 50,
             revenue: 10,
-            desc: 'Can be exchanged for a share in the FYN public company.',
+            desc: 'Can be exchanged for a share in the FYN corporation.',
             sym: 'YHC',
             abilities: [
               {
@@ -41,7 +41,7 @@ module Engine
             name: 'Cowes Marina and Harbour',
             value: 90,
             revenue: 20,
-            desc: 'Can be exchanged for a share in the C&N public company.',
+            desc: 'Can be exchanged for a share in the C&N corporation.',
             sym: 'CMH',
             abilities: [
               {
@@ -57,7 +57,7 @@ module Engine
             name: 'Ryde Pier & Shipping Company',
             value: 130,
             revenue: 30,
-            desc: 'Can be exchanged for a share in the IOW public company.',
+            desc: 'Can be exchanged for a share in the IOW corporation.',
             sym: 'RPSC',
             abilities: [
               {

--- a/lib/engine/game/g_1868_wy/entities.rb
+++ b/lib/engine/game/g_1868_wy/entities.rb
@@ -43,7 +43,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Credit Mobilier',
-                desc_detail: 'After yellow track is laid by any Railroad Company in the Credit Mobilier region (row J and south, column 23 and west, outlined in brown) which either extends track west from Omaha or east from Ogden, UP shareholders are paid the total terrain costs of the hex as dividends, even if the track was laid by the Railroad Company for free via a private company ability. Credit Mobilier closes at phase 5, or when the Golden Spike bonus is collected, whichever comes first.',
+                desc_detail: 'After yellow track is laid by any Corporation in the Credit Mobilier region (row J and south, column 23 and west, outlined in brown) which either extends track west from Omaha or east from Ogden, UP shareholders are paid the total terrain costs of the hex as dividends, even if the track was laid by the Corporation for free via a private company ability. Credit Mobilier closes at phase 5, or when the Golden Spike bonus is collected, whichever comes first.',
                 remove: '5',
               },
             ]
@@ -80,7 +80,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Purple Home Hex',
-                desc_detail: 'No other Railroad Company may run routes to Chadron (G27).',
+                desc_detail: 'No other Corporation may run routes to Chadron (G27).',
               },
 
             ],
@@ -118,7 +118,7 @@ module Engine
               {
                 type: 'base',
                 description: 'Purple Home Hex',
-                desc_detail: 'No other Railroad Company may run routes to Rapid City (C27).',
+                desc_detail: 'No other corporation may run routes to Rapid City (C27).',
               },
 
             ],
@@ -157,7 +157,7 @@ module Engine
             desc: 'Buyer or auction winner chooses one of Wylie Permanent Camping Company '\
                   '($10 bonus for running routes to Yellowstone--C5 or D4), Trabing Brothers Frontier Fort Resupply '\
                   '($10 bonus for running routes to Forts), or Midwest Oil Refinery '\
-                  '($10 bonus for any train owned by any Railroad Company running a route to Casper--H18)',
+                  '($10 bonus for any train owned by any Corporation running a route to Casper--H18)',
           },
           {
             name: 'P2a Wylie Permanent Camping Company',
@@ -166,7 +166,7 @@ module Engine
             revenue: 10,
             abilities: [{ type: 'close', on_phase: '5' },
                         { type: 'manual_close_company', when: %w[owning_player_sr_turn owning_player_or_turn] }],
-            desc: 'Provides its owning Railroad Company a +$10 revenue bonus for routes '\
+            desc: 'Provides its owning Corporation a +$10 revenue bonus for routes '\
                   'starting or ending at either of the accessible Yellowstone entrances. '\
                   'Closes at phase 5.',
           },
@@ -177,7 +177,7 @@ module Engine
             revenue: 10,
             abilities: [{ type: 'close', on_phase: '5' },
                         { type: 'manual_close_company', when: %w[owning_player_sr_turn owning_player_or_turn] }],
-            desc: 'Owning Railroad Company receives a +$10 revenue bonus for each fort served. Closes at phase 5.',
+            desc: 'Owning Corporation receives a +$10 revenue bonus for each fort served. Closes at phase 5.',
           },
           {
             name: 'P2c Midwest Oil Refinery',
@@ -274,7 +274,7 @@ module Engine
                           discount: 15,
                         },
                         { type: 'manual_close_company', when: %w[owning_player_sr_turn owning_player_or_turn] }],
-            desc: 'Gives owning Railroad Company a $15 discount to terrain costs for '\
+            desc: 'Gives owning Corporation a $15 discount to terrain costs for '\
                   'each tile lay. Closes at phase 6.',
           },
           {
@@ -295,7 +295,7 @@ module Engine
                           tiles: [],
                         },
                         { type: 'manual_close_company', when: %w[owning_player_sr_turn owning_player_or_turn] }],
-            desc: 'Gives owning Railroad Company a $60 discount for one tile lay per OR. Closes at phase 6.',
+            desc: 'Gives owning Corporation a $60 discount for one tile lay per OR. Closes at phase 6.',
           },
           {
             name: 'P5 Surveyor II',
@@ -328,7 +328,7 @@ module Engine
                           reachable: true,
                         },
                         { type: 'manual_close_company', when: %w[owning_player_sr_turn owning_player_or_turn] }],
-            desc: 'Grants owning Railroad Company one extra tile lay/upgrade. '\
+            desc: 'Grants owning Corporation one extra tile lay/upgrade. '\
                   'May be used 3 times, then closes. Terrain or upgrade costs '\
                   'for this action are ignored. Closes at phase 6.',
           },
@@ -340,7 +340,7 @@ module Engine
             abilities: [{ type: 'close', on_phase: '6' },
                         { type: 'revenue_change', revenue: 0o0, when: 'sold' },
                         { type: 'manual_close_company', when: %w[owning_player_sr_turn owning_player_or_turn] }],
-            desc: 'Owning Railroad Company is paid per yellow tile it places: $40/city, $30/Boomtown or '\
+            desc: 'Owning Corporation is paid per yellow tile it places: $40/city, $30/Boomtown or '\
                   'Boom City, $10/town. $20 revenue is only paid while owned by a player. Closes at phase 6.',
           },
           {
@@ -351,7 +351,7 @@ module Engine
             abilities: [{ type: 'close', on_phase: '6' },
                         { type: 'base', description: 'P5c 50% terrain/upgrade discount', when: 'sold' },
                         { type: 'manual_close_company', when: %w[owning_player_sr_turn owning_player_or_turn] }],
-            desc: 'While player-owned, DT terrain costs are halved; while Railroad Company-owned, tile placement '\
+            desc: 'While player-owned, DT terrain costs are halved; while Corporation-owned, tile placement '\
                   'terrain or upgrade costs are halved. Closes at phase 6.',
           },
           {
@@ -418,7 +418,7 @@ module Engine
             abilities: [{ type: 'close', on_phase: '8' },
                         { type: 'manual_close_company', when: %w[owning_player_sr_turn owning_player_or_turn] }],
             desc: '[+1+1] token extends a train by 1 city and 1 town. The token '\
-                  'is assigned to a train when a Railroad Company buys this '\
+                  'is assigned to a train when a Corporation buys this '\
                   'private company, and may be moved to another train during the '\
                   'train purchasing phase. Closes at phase 8.',
           },
@@ -452,7 +452,7 @@ module Engine
             ],
             desc: 'Comes with a Boomtown token that may be placed (when owned by a Railroad) '\
                   'during any OR anywhere track may be placed. Once it\'s a Boom City, it may '\
-                  'only be tokened by the owning Railroad Company. Closes at '\
+                  'only be tokened by the owning Corporation. Closes at '\
                   'phase 7, removing Boomtown/City and station token, and tile '\
                   'becomes a Ghost Town.',
           },
@@ -468,7 +468,7 @@ module Engine
             desc: 'Pays $40 revenue ONLY in green phases. Closes, becomes '\
                   'LHP train (permanent 2+1) at phase 5. If owned by a player at '\
                   'the start of phase 5, the LHP train may be immediately assigned '\
-                  'to a Railroad Company for no compensation.',
+                  'to a Corporation for no compensation.',
           },
           {
             name: 'P10 Thomas C. Durant',

--- a/lib/engine/game/g_1870/entities.rb
+++ b/lib/engine/game/g_1870/entities.rb
@@ -17,14 +17,14 @@ module Engine
             name: 'Mississippi River Bridge Company',
             value: 40,
             revenue: 10,
-            desc: 'Until this company is closed or sold to a public company, no company may bridge the Mississippi'\
-                  ' River. A company may lay track along the river, but may not lay track to cross the river, or do an'\
-                  ' upgrade that would cause track to cross the river. The public company that purchases the Mississippi'\
+            desc: 'Until this company is closed or sold to a corporation, no corporation may bridge the Mississippi'\
+                  ' River. A corporation may lay track along the river, but may not lay track to cross the river, or do an'\
+                  ' upgrade that would cause track to cross the river. The corporation that purchases the Mississippi'\
                   ' River Bridge Company may build in one of the hexes along the Mississippi River for a $40 discount.'\
-                  ' This company may be purchased by one of the two companies on the Mississippi River (Missouri Pacific'\
-                  ' or St.Louis Southwestern) in phase one for $20 to $40. If one of these two public companies purchases'\
-                  ' this private company during their first operating round, that company can lay a tile at its starting'\
-                  ' city for no cost and in addition to its normal tile lay(s). The company cannot lay a tile in their'\
+                  ' This company may be purchased by one of the two corps on the Mississippi River (Missouri Pacific'\
+                  ' or St.Louis Southwestern) in phase one for $20 to $40. If one of these two corps purchases'\
+                  ' this private company during their first operating round, that corporation can lay a tile at its starting'\
+                  ' city for no cost and in addition to its normal tile lay(s). The corp cannot lay a tile in their'\
                   ' starting city and upgrade it during the same operating round.',
             sym: 'MRBC',
             abilities: [
@@ -53,7 +53,7 @@ module Engine
             revenue: 10,
             desc: 'This company has a token that may be placed on any city west of the Mississippi River. Cities'\
                   ' located in the same hex as any portion of the Mississippi are not eligible for this placement. This'\
-                  ' increases the value of that city by $10 for that company only. Placing the token does not close the'\
+                  ' increases the value of that city by $10 for that corporation only. Placing the token does not close the'\
                   ' company.',
             sym: 'SCC',
             abilities: [
@@ -80,10 +80,10 @@ module Engine
             desc: 'This company has two tokens. One represents an open port and the other is a closed port. One (but'\
                   ' not both) of these tokens may be placed on one of the cities: Memphis (H17), Baton Rouge (M14), Mobile'\
                   ' (M20), Galveston (N7) and New Orleans (N17). Either token increases the value of the city for the owning'\
-                  ' company by $20. The open port token also increases the value of the city for all other companies by $10.'\
-                  ' If the president of the owning company places the closed port token, the private company is closed. If'\
-                  ' the open port token is placed, it may be replaced in a later operating round by the closed port token,'\
-                  ' closing the company.',
+                  ' corporation by $20. The open port token also increases the value of the city for all other corporations by'\
+                  ' $10. If the president of the owning corporation places the closed port token, the private company is'\
+                  ' closed. If the open port token is placed, it may be replaced in a later operating round by the closed'\
+                  ' port token, closing the company.',
             sym: 'GSC',
             abilities: [
               {
@@ -107,8 +107,8 @@ module Engine
             value: 140,
             revenue: 0,
             desc: "This is the President's certificate of the St.Louis-San Francisco Railway. The purchaser sets the"\
-                  ' par value of the railway. Unlike other companies, this company may operate with just 20% sold. It may'\
-                  ' not be purchased by another public company.',
+                  ' par value of the railway. Unlike other corporations, the St.Louis-San Francisco Railway may operate'\
+                  ' with just 20% sold. This private company may not be purchased by a corporation.',
             sym: 'SLSF',
             abilities: [{ type: 'shares', shares: 'SLSF_0' }, { type: 'no_buy' }],
             color: nil,

--- a/lib/engine/game/g_1870/entities.rb
+++ b/lib/engine/game/g_1870/entities.rb
@@ -24,7 +24,7 @@ module Engine
                   ' This company may be purchased by one of the two corps on the Mississippi River (Missouri Pacific'\
                   ' or St.Louis Southwestern) in phase one for $20 to $40. If one of these two corps purchases'\
                   ' this private company during their first operating round, that corporation can lay a tile at its starting'\
-                  ' city for no cost and in addition to its normal tile lay(s). The corp cannot lay a tile in their'\
+                  ' city for no cost and in addition to its normal tile lay(s). The corporation cannot lay a tile in their'\
                   ' starting city and upgrade it during the same operating round.',
             sym: 'MRBC',
             abilities: [

--- a/lib/engine/game/g_1880/entities.rb
+++ b/lib/engine/game/g_1880/entities.rb
@@ -27,7 +27,7 @@ module Engine
             sym: 'P2',
             value: 25,
             revenue: 10,
-            desc: 'The owner may use all ferries for free with all their companies',
+            desc: 'The owner may use all ferries for free with all their corporations',
             color: nil,
           },
           {
@@ -35,7 +35,7 @@ module Engine
             sym: 'P3',
             value: 45,
             revenue: 15,
-            desc: 'For the owner, the value of Taiwan is +20 (with all their companies)',
+            desc: 'For the owner, the value of Taiwan is +20 with all their corporations',
             abilities: [
               {
                 type: 'hex_bonus',
@@ -52,7 +52,7 @@ module Engine
             sym: 'P4',
             value: 70,
             revenue: 20,
-            desc: 'Reduce the cost of laying a tile in a river hex by ¥20 (for all their companies)',
+            desc: 'Reduce the cost of laying a tile in a river hex by ¥20 (for all their corporations)',
             abilities: [{
               type: 'tile_discount',
               discount: 20,
@@ -68,7 +68,7 @@ module Engine
             sym: 'P5',
             value: 100,
             revenue: 25,
-            desc: 'Building permit for Phase D (for one of their companies)',
+            desc: 'Building permit for Phase D (for one of their corporations)',
             abilities: [{
               type: 'assign_corporation',
               owner_type: 'player',
@@ -93,7 +93,7 @@ module Engine
             value: 50,
             revenue: 0,
             desc: 'The owner may exchange the Rocket of China for a currently available train, '\
-                  'for one of their companies, during that company’s turn in an Operating Round. '\
+                  'for one of their corporations, during that corporation’s turn in an Operating Round. '\
                   'Forced exchange into second 4-train.',
             abilities: [{
               type: 'purchase_train',

--- a/lib/engine/game/g_1888/entities.rb
+++ b/lib/engine/game/g_1888/entities.rb
@@ -17,7 +17,7 @@ module Engine
             name: 'Terracotta Army',
             value: 50,
             revenue: 10,
-            desc: 'Comes with the red Xi’an tile which shows higher value for this off-board location. A company owning this private may lay this tile in addition to it’s normal tile lay step. No connection is required. This does not close the company. If it wasn’t laid when the company closes the red tile is out of the game.',
+            desc: 'Comes with the red Xi’an tile which shows higher value for this off-board location. A corporation owning this private may lay this tile in addition to it’s normal tile lay step. No connection is required. This does not close the company. If it wasn’t laid when the company closes the red tile is out of the game.',
             sym: 'TA',
             abilities: [{
               type: 'tile_lay',
@@ -35,7 +35,7 @@ module Engine
             name: 'Heng Shan',
             value: 75,
             revenue: 15,
-            desc: 'Comes with the yellow mountain tile.  A company owning this private may lay the mine on hex C5 in addition to it’s normal tile laying step. No connection is required. If it wasn’t laid when the company closes the mountain tile is out of the game. If a train runs to or through the mine the company treasury gets ¥40 from the bank. It counts against the range of a train.  Any company may lay a normal tile on hex C5 after this private company was sold to a company or closed at the cost of ¥40. Then the yellow mountain tile can’t be placed.',
+            desc: 'Comes with the yellow mountain tile.  A corporation owning this private may lay the mine on hex C5 in addition to it’s normal tile laying step. No connection is required. If it wasn’t laid when the company closes the mountain tile is out of the game. If a train runs to or through the mine the owning corporation\'s treasury gets ¥40 from the bank. It counts against the range of a train.  Any corporation may lay a normal tile on hex C5 after this private company was sold to a corporation or closed at the cost of ¥40. Then the yellow mountain tile can’t be placed.',
             sym: 'HS',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['C5'] },
                         {
@@ -53,7 +53,7 @@ module Engine
             name: 'Great Wall of China',
             value: 100,
             revenue: 20,
-            desc: 'A company owning this private may lay one or two yellow tiles for free onto hexes with the Great Wall in addition to the normal tile lay step. No connection is required. This does not close the company. If laying two tiles, both tiles must be laid during the same turn and must be connected.',
+            desc: 'A corporation owning this private may lay one or two yellow tiles for free onto hexes with the Great Wall in addition to the normal tile lay step. No connection is required. This does not close the company. If laying two tiles, both tiles must be laid during the same turn and must be connected.',
             sym: 'CW',
             abilities: [{
               type: 'tile_lay',
@@ -71,7 +71,7 @@ module Engine
             name: 'Yanda Railway Ferry',
             value: 125,
             revenue: 25,
-            desc: 'Comes with the blue ferry tiles. A company owning this private may lay these tiles in addition to it’s normal tile laying step on both of the Dalian and Yantai hexes. No connection is required. If they are not laid when the company closes the ferry tiles are out of the game.',
+            desc: 'Comes with the blue ferry tiles. A corporation owning this private may lay these tiles in addition to it’s normal tile laying step on both of the Dalian and Yantai hexes. No connection is required. If they are not laid when the company closes the ferry tiles are out of the game.',
             sym: 'YRF',
             abilities: [{
               type: 'tile_lay',
@@ -92,7 +92,7 @@ module Engine
             name: 'Forbidden City',
             value: 150,
             revenue: 30,
-            desc: 'A player owning this private company may exchange it into an IPO share of a company with a token in Beijing (at the time of exchange). If sold to a company this ability is lost.',
+            desc: 'A player owning this private company may exchange it into an IPO share of a corporation with a token in Beijing (at the time of exchange). If sold to a corporation this ability is lost.',
             sym: 'FC',
             abilities: [{
               type: 'exchange',

--- a/lib/engine/game/g_1889/entities.rb
+++ b/lib/engine/game/g_1889/entities.rb
@@ -107,8 +107,8 @@ module Engine
             value: 150,
             revenue: 30,
             desc: 'Does not close while owned by a player. If owned by a player '\
-                  'when the first 5-train is purchased it may no longer be sold '\
-                  'to a public company and the revenue is increased to 50.',
+                  'when the first 5-train is purchased, it may no longer be sold '\
+                  'to a corporation, and the revenue is increased to 50.',
             sym: 'UTF',
             min_players: 4,
             abilities: [{ type: 'close', on_phase: 'never', owner_type: 'player' },

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -338,7 +338,7 @@ module Engine
         def company_header(company)
           case company.type
           when :minor then 'MINOR COMPANY'
-          when :concession then 'PUBLIC COMPANY'
+          when :concession then 'CORPORATION'
           else raise GameError, 'Unknown type of private company'
           end
         end

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -21,7 +21,7 @@ module Engine
         include Tiles
         include Trains
 
-        # Minors that have been pledged in bids to start public companies.
+        # Minors that have been pledged in bids to start corporations.
         # Used by {Step::MajorAuction} to pass this information to
         # {Step::BuySellParSharesCompanies}. This is a hash whose keys are
         # the major corporations and the values are the minor corporations.

--- a/lib/engine/game/g_18_ardennes/map.rb
+++ b/lib/engine/game/g_18_ardennes/map.rb
@@ -365,7 +365,7 @@ module Engine
         end
 
         def place_home_token(corporation)
-          # Public companies get their starting tokens by exchange.
+          # Corporations get their starting tokens by exchange.
           return unless corporation.type == :minor
 
           super

--- a/lib/engine/game/g_18_ardennes/market.rb
+++ b/lib/engine/game/g_18_ardennes/market.rb
@@ -16,7 +16,7 @@ module Engine
         ).freeze
         MARKET_TEXT = Base::MARKET_TEXT.merge(
           par_1: 'Minor company starting values',
-          par_2: 'Major company starting values',
+          par_2: 'Corporation starting values',
           repar: 'Minor companies cannot merge'
         )
         MARKET = [%w[0r 50x 55x 60x 70x 80x 90x 100 110 120 140z 160z 180z 200z 220z 240 260 280 300 320 340 360 380 400]].freeze

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -79,14 +79,14 @@ module Engine
             end
           end
 
-          # Valid par prices for public companies.
+          # Valid par prices for corporationss.
           def get_par_prices(_player, _corporation)
             @game.stock_market.par_prices.select { |pp| pp.types.include?(:par_2) }
           end
 
           # This function is called from View::Game::Par to calculate how many
           # shares can be bought at each possible par price. In 18Ardennes you
-          # get an extra share when floating a public company, part paid for by
+          # get an extra share when floating a corporation, part paid for by
           # exchanging the pledged minor, so pretend that the player has extra
           # cash to pay for this extra share.
           def available_par_cash(player, corporation, share_price: nil)
@@ -122,7 +122,7 @@ module Engine
 
           private
 
-          # Has the player won any auctions for public companies in the
+          # Has the player won any auctions for corporations in the
           # preceding auction round? If they have then they must start these
           # majors before they can buy any other shares or pass.
           def under_obligation?(player)

--- a/lib/engine/game/g_18_ardennes/step/major_auction.rb
+++ b/lib/engine/game/g_18_ardennes/step/major_auction.rb
@@ -21,7 +21,7 @@ module Engine
           end
 
           def description
-            'Bid on public companies'
+            'Bid on corporations'
           end
 
           def setup
@@ -29,8 +29,8 @@ module Engine
             @concessions = @game.companies.select do |company|
               company.type == :concession && company.owner.nil? && !company.closed?
             end
-            # Hash showing which minors can be used to start a public company.
-            # The public companies are the has keys, each value is an array of
+            # Hash showing which minors can be used to start a corporation.
+            # The corporations are the hash keys, each value is an array of
             # minor companies.
             @eligible_minors = {}
           end
@@ -152,9 +152,9 @@ module Engine
             @game.corporation_by_id(concession.id)
           end
 
-          # If no public companies have yet been started then there are
+          # If no corporations have yet been started then there are
           # geographical restrictions on which minor companies can be used to
-          # start a public company.
+          # start a corporation.
           def restricted?
             if @restricted.nil?
               @restricted = @game.corporations.none? do |corporation|
@@ -164,7 +164,7 @@ module Engine
             @restricted
           end
 
-          # Finds all the minors that can be used to start the public company
+          # Finds all the minors that can be used to start the corporation
           # associated with the concession. If this isn't the first auction
           # round then any minor can be used.
           def eligible_minors(concession)

--- a/lib/engine/game/g_18_bf/entities.rb
+++ b/lib/engine/game/g_18_bf/entities.rb
@@ -98,7 +98,7 @@ module Engine
             value: 60,
             revenue: 20,
             discount: 20,
-            desc: 'P6. Gives a £10 revenue bonus for Newcastle (G17) when owned by a public company or a system.',
+            desc: 'P6. Gives a £10 revenue bonus for Newcastle (G17) when owned by a corporation or a system.',
             color: 'yellow',
             abilities: [
               {
@@ -116,7 +116,7 @@ module Engine
             value: 75,
             revenue: 25,
             discount: 25,
-            desc: 'P7. Gives a £10 revenue bonus for London when owned by a public company or a system.',
+            desc: 'P7. Gives a £10 revenue bonus for London when owned by a corporation or a system.',
             color: 'yellow',
             abilities: [
               {
@@ -134,7 +134,7 @@ module Engine
             value: 75,
             revenue: 25,
             discount: 25,
-            desc: 'P8. Gives a £10 revenue bonus for London when owned by a public company or a system.',
+            desc: 'P8. Gives a £10 revenue bonus for London when owned by a corporation or a system.',
             color: 'yellow',
             abilities: [
               {
@@ -153,7 +153,7 @@ module Engine
             value: 75,
             revenue: 25,
             discount: 25,
-            desc: 'P9. Gives a £10 revenue bonus for London when owned by a public company or a system.',
+            desc: 'P9. Gives a £10 revenue bonus for London when owned by a corporation or a system.',
             color: 'yellow',
             abilities: [
               {
@@ -172,7 +172,7 @@ module Engine
             revenue: 30,
             discount: 30,
             desc: 'P10. Gives a £10 revenue bonus for Liverpool (M11) ' \
-                  'when owned by a public company or a system.',
+                  'when owned by a corporation or a system.',
             color: 'yellow',
             abilities: [
               {
@@ -190,7 +190,7 @@ module Engine
             value: 50,
             revenue: 10,
             desc: 'F1. Gives a £10 revenue bonus for one of the Ireland off-board areas ' \
-                  'when owned by a public company or a system.',
+                  'when owned by a corporation or a system.',
             color: 'aqua',
             abilities: [
               { type: 'revenue_change', revenue: 15, on_phase: '3' },
@@ -211,7 +211,7 @@ module Engine
             value: 50,
             revenue: 10,
             desc: 'F2. Gives a £10 revenue bonus for one of the Ireland off-board areas ' \
-                  'when owned by a public company or a system.',
+                  'when owned by a corporation or a system.',
             color: 'aqua',
             abilities: [
               { type: 'revenue_change', revenue: 15, on_phase: '3' },
@@ -232,7 +232,7 @@ module Engine
             value: 50,
             revenue: 10,
             desc: 'F3. Gives a £10 revenue bonus for one of the Ireland off-board areas ' \
-                  'when owned by a public company or a system.',
+                  'when owned by a corporation or a system.',
             color: 'aqua',
             abilities: [
               { type: 'revenue_change', revenue: 15, on_phase: '3' },
@@ -253,7 +253,7 @@ module Engine
             value: 100,
             revenue: 20,
             desc: 'F4. Gives a £10 revenue bonus for the Hull off-board area (L22) ' \
-                  'when owned by a public company or a system.',
+                  'when owned by a corporation or a system.',
             color: 'aqua',
             abilities: [
               { type: 'revenue_change', revenue: 30, on_phase: '3' },
@@ -274,7 +274,7 @@ module Engine
             value: 100,
             revenue: 20,
             desc: 'F5. Gives a £10 revenue bonus for the Harwich off-board area (S29) ' \
-                  'when owned by a public company or a system.',
+                  'when owned by a corporation or a system.',
             color: 'aqua',
             abilities: [
               { type: 'revenue_change', revenue: 30, on_phase: '3' },
@@ -295,7 +295,7 @@ module Engine
             value: 100,
             revenue: 20,
             desc: 'F6. Gives a £10 revenue bonus for the Plymouth off-board area (X8) ' \
-                  'when owned by a public company or a system.',
+                  'when owned by a corporation or a system.',
             color: 'aqua',
             abilities: [
               { type: 'revenue_change', revenue: 30, on_phase: '3' },
@@ -316,7 +316,7 @@ module Engine
             value: 150,
             revenue: 30,
             desc: 'F7. Gives a £10 revenue bonus for the Dover off-board area (V30) ' \
-                  'when owned by a public company or a system.',
+                  'when owned by a corporation or a system.',
             color: 'aqua',
             abilities: [
               { type: 'revenue_change', revenue: 45, on_phase: '3' },
@@ -337,7 +337,7 @@ module Engine
             value: 150,
             revenue: 30,
             desc: 'F8. Gives a £10 revenue bonus for the Aberdeen off-board area (A13) ' \
-                  'when owned by a public company or a system.',
+                  'when owned by a corporation or a system.',
             color: 'aqua',
             abilities: [
               { type: 'revenue_change', revenue: 45, on_phase: '3' },
@@ -357,7 +357,7 @@ module Engine
             type: 'underground',
             value: 100,
             revenue: 40,
-            desc: 'U1. Gives a £10 revenue bonus for London when owned by a public company or a system.',
+            desc: 'U1. Gives a £10 revenue bonus for London when owned by a corporation or a system.',
             color: '#9b0056',
             text_color: 'white',
             abilities: [
@@ -376,7 +376,7 @@ module Engine
             type: 'underground',
             value: 150,
             revenue: 75,
-            desc: 'U2. Gives a £10 revenue bonus for London when owned by a public company or a system.',
+            desc: 'U2. Gives a £10 revenue bonus for London when owned by a corporation or a system.',
             color: 'black',
             text_color: 'white',
             abilities: [

--- a/lib/engine/game/g_18_bf/trains.rb
+++ b/lib/engine/game/g_18_bf/trains.rb
@@ -24,7 +24,7 @@ module Engine
           'minors_convert' => ['Minors convert',
                                'Minor companies may merge, convert or be taken over.'],
           'systems_form' => ['Systems form',
-                             'Systems may form by merging major companies.'],
+                             'Systems may form by merging corporations.'],
           'double_jump' => ['Double jumps',
                             'Systems may double-jump.'],
           'train_export' => ['Train exported',
@@ -269,7 +269,7 @@ module Engine
             'Twelve minor companies are available from the first stock round.',
             'Another six minor companies become available for purchase in stock round 2.',
             'The last six minor companes are available once the first 3-train is bought.',
-            'Minors can be merged or converted into major companies from phase 3.',
+            'Minors can be merged or converted into corporations from phase 3.',
             'Majors can be merged to form systems from phase 6.',
             '2+2 and 5+5E trains are available after a 4+4 or 6G train has been purchased.',
           ]

--- a/lib/engine/game/g_18_christmas_eve/entities.rb
+++ b/lib/engine/game/g_18_christmas_eve/entities.rb
@@ -47,7 +47,7 @@ module Engine
             name: 'Egg Nog Express',
             value: 80,
             revenue: 15,
-            desc: 'The owning company adds $40 to any train run that includes both the Bar (F7) and the DC hex (C10).',
+            desc: 'The owning corporation adds $40 to any train run that includes both the Bar (F7) and the DC hex (C10).',
             sym: 'ENX',
             color: nil,
           },

--- a/lib/engine/game/g_18_cuba/entities.rb
+++ b/lib/engine/game/g_18_cuba/entities.rb
@@ -70,7 +70,7 @@ module Engine
             sym: 'M2',
             value: 140,
             revenue: 0,
-            desc: '1 Wagon. Must be assigned to a major company.',
+            desc: '1 Wagon. Must be assigned to a corporation.',
             color: nil,
           },
           {
@@ -95,7 +95,7 @@ module Engine
             sym: 'M5',
             value: 180,
             revenue: 0,
-            desc: 'Mail contract. Must be assigned to a major company. Gives the company at the start of '\
+            desc: 'Mail contract. Must be assigned to a corporation. Gives the corporation at the start of '\
                   'their turn during an OR if they own at least one train '\
                   'an income of +10/20/30/40 (depending on the phase).',
             color: nil,

--- a/lib/engine/game/g_18_ireland/entities.rb
+++ b/lib/engine/game/g_18_ireland/entities.rb
@@ -9,8 +9,8 @@ module Engine
             name: 'Dalkey Atmospheric Railway',
             value: 20,
             revenue: 5,
-            desc: 'No Corporation can build in the Wicklow hex until this company is either bought by'\
-                  ' any Corporation or closed.',
+            desc: 'No corporation can build in the Wicklow hex until this company is either bought by'\
+                  ' any corporation or closed.',
             sym: 'DAR',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['J14'] }],
           },
@@ -18,7 +18,7 @@ module Engine
             name: 'Donegal Railway',
             value: 30,
             revenue: 7,
-            desc: 'The owning Corporation can place two connected narrow gauge yellow tiles in the Donegal'\
+            desc: 'The owning corporation can place two connected narrow gauge yellow tiles in the Donegal'\
                   ' hex and one adjacent hex. This action closes the company.',
             sym: 'DR',
             abilities: [
@@ -39,7 +39,7 @@ module Engine
             name: 'Board of Works',
             value: 40,
             revenue: 9,
-            desc: 'The owning Corporation can place a yellow tile without payment of terrain costs.'\
+            desc: 'The owning corporation can place a yellow tile without payment of terrain costs.'\
                   ' The company closes once this ability has been used twice.',
             sym: 'BoW',
             abilities: [
@@ -60,8 +60,8 @@ module Engine
             name: 'City of Dublin Steam Packet Company',
             value: 45,
             revenue: 10,
-            desc: 'The owning Corporation can place the +£10 token on any port (Belfast, Londonderry or Rosslare).'\
-                  ' This action closes the company, but the Corporation adds £10 to the' \
+            desc: 'The owning corporation can place the +£10 token on any port (Belfast, Londonderry or Rosslare).'\
+                  ' This action closes the company, but the corporation adds £10 to the' \
                   " port's revenue until the end of the game.",
             sym: 'CDSPC',
             abilities: [
@@ -84,7 +84,7 @@ module Engine
             name: 'Tralee & Dingle Railway',
             value: 50,
             revenue: 10,
-            desc: 'The owning Corporation can place two connected narrow gauge yellow tiles in the'\
+            desc: 'The owning corporation can place two connected narrow gauge yellow tiles in the'\
                   ' Tralee and Dingle hexes. This action closes the company.',
             sym: 'TDR',
             abilities: [
@@ -105,8 +105,8 @@ module Engine
             name: 'Drumglass Colliery Railway',
             value: 60,
             revenue: 12,
-            desc: 'No Corporation can build in the DCR hex (H4) until this company is bought by any Corporation'\
-                  ' or closed. The owning Corporation may place a yellow tile, subject to normal track laying rules,'\
+            desc: 'No corporation can build in the DCR hex (H4) until this company is bought by any corporation'\
+                  ' or closed. The owning corporation may place a yellow tile, subject to normal track laying rules,'\
                   ' on that hex (H4) without using a tile action or paying terrain costs.',
             sym: 'DCR',
             abilities: [
@@ -130,8 +130,8 @@ module Engine
             name: 'Trans-Atlantic Steam Packet Station',
             value: 75,
             revenue: 15,
-            desc: 'The owning Corporation can place the +£20 token on Galway. This action closes the company,'\
-                  " but the Corporation adds £20 to the city's revenue until the end of the game.",
+            desc: 'The owning corporation can place the +£20 token on Galway. This action closes the company,'\
+                  " but the corporation adds £20 to the city's revenue until the end of the game.",
             sym: 'TASPS',
             abilities: [
               {
@@ -153,7 +153,7 @@ module Engine
             name: 'River Shannon Shipping Co',
             value: 80,
             revenue: 10,
-            desc: 'The owning Corporation controls a river link between Dromod and Limerick and adds the value of the'\
+            desc: 'The owning corporation controls a river link between Dromod and Limerick and adds the value of the'\
                   ' other city to one train ending at either Dromod or Limerick.',
             sym: 'RSSC',
           },
@@ -161,17 +161,17 @@ module Engine
             name: 'William Dargan Esq.',
             value: 90,
             revenue: 10,
-            desc: 'The owning Corporation can upgrade a second track tile during each'\
-                  " OR at a cost of £30 from the Corporation's Treasury.",
+            desc: 'The owning corporation can upgrade a second track tile during each'\
+                  " OR at a cost of £30 from the corporation's Treasury.",
             sym: 'WDE',
           },
           {
             name: 'The Irish Mail',
             value: 110,
             revenue: 20,
-            desc: 'The owning Corporation can place an off-board location tile adjacent'\
+            desc: 'The owning corporation can place an off-board location tile adjacent'\
                   ' to one of: Londonderry, Kingstown, or Waterford. This action closes the company,'\
-                  ' but any Corporation may run to the tile for the rest of the game.',
+                  ' but any corporation may run to the tile for the rest of the game.',
             sym: 'TIM',
             abilities: [
               {

--- a/lib/engine/game/g_18_ireland/entities.rb
+++ b/lib/engine/game/g_18_ireland/entities.rb
@@ -9,8 +9,8 @@ module Engine
             name: 'Dalkey Atmospheric Railway',
             value: 20,
             revenue: 5,
-            desc: 'No company can build in the Wicklow hex until this company is either bought by'\
-                  ' any company or closed.',
+            desc: 'No Corporation can build in the Wicklow hex until this company is either bought by'\
+                  ' any Corporation or closed.',
             sym: 'DAR',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['J14'] }],
           },
@@ -189,7 +189,7 @@ module Engine
             name: 'Dublin & Kingstown Railway',
             value: 120,
             revenue: 0,
-            desc: 'The owner of this company: Takes the DKR directorship; sets the share'\
+            desc: 'The buyer of this company: Takes the DKR directorship; sets the share'\
                   ' price at half bid; places a 2H-Train on the charter; places the winning bid'\
                   ' in the DKR treasury less the cost of the train and discards this card.',
             sym: 'DK',

--- a/lib/engine/game/g_18_nl/entities.rb
+++ b/lib/engine/game/g_18_nl/entities.rb
@@ -10,7 +10,7 @@ module Engine
             sym: 'P1',
             value: 20,
             revenue: 0,
-            desc: 'Company may build an extra tile on F5 with a ƒ40 discount. Blocks F5 while owned by a player.',
+            desc: 'Owning corp may build an extra tile on F5 with a ƒ40 discount. Blocks F5 while owned by a player.',
             abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['F5'] },
                         {
                           type: 'tile_lay',

--- a/lib/engine/game/g_18_sj/entities.rb
+++ b/lib/engine/game/g_18_sj/entities.rb
@@ -49,7 +49,7 @@ module Engine
             value: 45,
             revenue: 15,
             desc: 'May lay or shift port token in Halmstad (A6), Ystad(C2), Kalmar (D5), Sundsvall (F19), Umeå (F23), '\
-                  'and Luleå (G26).  Add 30 kr/symbol to all routes run to this location by owning company.',
+                  'and Luleå (G26).  Add 30 kr/symbol to all routes run to this location by owning corp.',
             sym: 'SB',
             abilities:
             [

--- a/lib/engine/game/g_18_usa/entities.rb
+++ b/lib/engine/game/g_18_usa/entities.rb
@@ -164,13 +164,13 @@ module Engine
             name: 'P8 - Express Freight Service',
             value: 40,
             revenue: 0,
-            desc: 'Place an extra station marker from the owning company in one red area. The company receives +10 ' \
+            desc: 'Place an extra station marker from the owning corporation in one red area. The corp receives +10 ' \
                   'revenue for each train which runs to that red area for the remainder of the game. The station ' \
                   'marker in the red area is not a normal station. It is only an indicator of which area the ' \
-                  'company receives the +10 revenue bonus. During a merger or acquisition, the station marker in ' \
-                  'the red area must be replaced by a station from the acquiring company if one is available. If ' \
-                  'during a merger or acquisition, the new company has more than 8 station markers (counting the ' \
-                  'station marker in the red area), the new company may choose to either keep or remove the station ' \
+                  'corporation receives the +10 revenue bonus. During a merger or acquisition, the station marker in ' \
+                  'the red area must be replaced by a station from the acquiring corp if one is available. If ' \
+                  'during a merger or acquisition, the new corporation has more than 8 station markers (counting the ' \
+                  'station marker in the red area), the new corp may choose to either keep or remove the station ' \
                   'marker from the red area. If the station marker is removed during a M&A action the Express ' \
                   'Freight Service private company is discarded.',
             sym: 'P8',
@@ -264,9 +264,9 @@ module Engine
             revenue: 0,
             desc: 'Discard when the first 4, 6, or 8-train is purchased or exported to prevent one train from ' \
                   'rusting. The train is instead treated as an obsolete train and will be discarded at the end ' \
-                  'of the corporation’s next Run Trains step. Obsolete trains may not be sold to another company ' \
-                  'and do not count against the company’s train limit. This ability may only be used on a train ' \
-                  'which is owned by the same company that owns Pennsy Boneyard. May not be used on 2+, 3+, or 4+ ' \
+                  'of the corporation’s next Run Trains step. Obsolete trains may not be sold to another corporation ' \
+                  'and do not count against the corporation’s train limit. This ability may only be used on a train ' \
+                  'which is owned by the same corporation that owns Pennsy Boneyard. May not be used on 2+, 3+, or 4+ ' \
                   'trains.',
             sym: 'P13',
             abilities: [], # Implemented in game class and a custom step
@@ -381,7 +381,7 @@ module Engine
             desc: 'Discard during the lay or upgrade track step to place an available station token into any city ' \
                   'which currently has no available open station circles. The station token will immediately fill ' \
                   'a station circle in the city if one becomes available later. This is an extra station token ' \
-                  'placement. A company may use this to place two station tokens in the same round.',
+                  'placement. A corporation may use this to place two station tokens in the same round.',
             sym: 'P20',
             abilities: [
               type: 'token',
@@ -506,8 +506,8 @@ module Engine
             name: 'P25 - American Locomotive Co.',
             value: 90,
             revenue: 0,
-            desc: 'The owning corporation receives a 10% discount on all trains from the bank. During the owning company’s ' \
-                  'turn, this company may be discarded prior to the Run Trains step to buy a train from the bank at a 10% ' \
+            desc: 'The owning corporation receives a 10% discount on all trains from the bank. During the owning corporation’s '\
+                  'turn, this company may be discarded prior to the Run Trains step to buy a train from the bank at a 10% '\
                   'discount. This company is discarded when the first 6-train is purchased.',
             sym: 'P25',
             abilities: [
@@ -556,11 +556,11 @@ module Engine
             desc: 'Comes with 3 company town tiles, only one of which may be played. The owning corporation may place one '\
                   'Company Town tile on any empty hex not adjacent to a metropolis. When placed, the owning corporation '\
                   'receives one bonus station marker which must be placed on the Company Town tile. No other corporations may '\
-                  'place a token on the Company Town hex and receive $10 less for the city than the company with the station '\
-                  'marker in the city. The Company Town can be placed on any hex, city circle or not, as long as it is not '\
-                  'adjacent to a metropolis and has no track or station marker in it. If the Company Town tile is placed on a '\
-                  '$10 river hex, a bridge token may be used. Coal / Oil / Ore markers may not be used with the Company Town. '\
-                  'If the station marker in the Company Town hex is ever removed, no token may ever replace it',
+                  'place a token on the Company Town hex and receive $10 less for the city than the corporation with the ' \
+                  'station marker in the city. The Company Town can be placed on any hex, city circle or not, as long as it is '\
+                  'not adjacent to a metropolis and has no track or station marker in it. If the Company Town tile is placed '\
+                  'on a $10 river hex, a bridge token may be used. Coal / Oil / Ore markers may not be used with the '\
+                  'Company Town. If the station marker in the Company Town hex is ever removed, no token may ever replace it.',
             sym: 'P27',
             abilities: [
               {

--- a/lib/engine/game/g_18_usa/entities.rb
+++ b/lib/engine/game/g_18_usa/entities.rb
@@ -41,8 +41,8 @@ module Engine
             value: 40,
             revenue: 0,
             desc: 'Comes with one $10 bridge token that may be placed by the owning '\
-                  'corp in a city with $10 water cost, max one token '\
-                  'per city. Allows owning corp to '\
+                  'corporation in a city with $10 water cost, max one token '\
+                  'per city. Allows owning corporation to '\
                   'skip $10 river fee when placing track.',
             sym: 'P2',
             abilities: [
@@ -164,13 +164,13 @@ module Engine
             name: 'P8 - Express Freight Service',
             value: 40,
             revenue: 0,
-            desc: 'Place an extra station marker from the owning corporation in one red area. The corp receives +10 ' \
+            desc: 'Place an extra station marker from the owning corporation in one red area. The corporation receives +10 ' \
                   'revenue for each train which runs to that red area for the remainder of the game. The station ' \
                   'marker in the red area is not a normal station. It is only an indicator of which area the ' \
                   'corporation receives the +10 revenue bonus. During a merger or acquisition, the station marker in ' \
-                  'the red area must be replaced by a station from the acquiring corp if one is available. If ' \
+                  'the red area must be replaced by a station from the acquiring corporation if one is available. If ' \
                   'during a merger or acquisition, the new corporation has more than 8 station markers (counting the ' \
-                  'station marker in the red area), the new corp may choose to either keep or remove the station ' \
+                  'station marker in the red area), the new corporation may choose to either keep or remove the station ' \
                   'marker from the red area. If the station marker is removed during a M&A action the Express ' \
                   'Freight Service private company is discarded.',
             sym: 'P8',
@@ -400,8 +400,8 @@ module Engine
             value: 80,
             revenue: 0,
             desc: 'Comes with one $10 bridge token that may be placed by the owning '\
-                  'corp in a city with $10 water cost, max one token '\
-                  'per city. Allows owning corp to '\
+                  'corporation in a city with $10 water cost, max one token '\
+                  'per city. Allows owning corporation to '\
                   'skip $10 river fee when placing track. '\
                   'Also comes with one coal token and one ore token. (see rules on coal and ore) '\
                   'You can only ever use one of these two; using one means you forfeit the other',
@@ -439,8 +439,8 @@ module Engine
             value: 80,
             revenue: 0,
             desc: 'Comes with two $10 bridge tokens that may be placed by the owning '\
-                  'corp in a city with $10 water cost, max one token '\
-                  'per city. Allows owning corp to '\
+                  'corporation in a city with $10 water cost, max one token '\
+                  'per city. Allows owning corporation to '\
                   'skip $10 river fee when placing track.',
             sym: 'P22',
             abilities: [

--- a/lib/engine/game/g_18_zoo/entities.rb
+++ b/lib/engine/game/g_18_zoo/entities.rb
@@ -9,7 +9,7 @@ module Engine
             sym: 'DAYS_OFF',
             name: 'Days off',
             value: 3,
-            desc: 'During the SR you can choose a family (company), and its reputation mark (share value) increases!'\
+            desc: 'During the SR you can choose a family (corporation), and its reputation mark (share value) increases!'\
                   ' It goes one space to the right',
             abilities: [{ type: 'no_buy', owner_type: 'player' }],
           },
@@ -41,14 +41,14 @@ module Engine
             name: 'It’s all greek to me',
             value: 1,
             desc: 'After your turn in an SR, you get another turn - it means you can play twice in a row in a SR:'\
-                  ' “who said you can steal a company?”',
+                  ' “who said you can steal a corporation?”',
             abilities: [{ type: 'no_buy', owner_type: 'player' }],
           },
           {
             sym: 'WHATSUP',
             name: 'Whatsup',
             value: 3,
-            desc: 'During the SR, a family (company) can buy the first available squirrel (train), deactivated.'\
+            desc: 'During the SR, a family (corporation) can buy the first available squirrel (train), deactivated.'\
                   ' Reputation (share value) moves one space to the right',
             abilities: [{ type: 'no_buy', owner_type: 'player' }],
           },
@@ -56,7 +56,7 @@ module Engine
             sym: 'RABBITS',
             name: 'Rabbits',
             value: 3,
-            desc: 'The family (company) gets two bonus upgrades, that can be placed even illegally'\
+            desc: 'The family (corporation) gets two bonus upgrades, that can be placed even illegally'\
                   ' (mountains and water pool) or before the correct phase',
             abilities: [
               {
@@ -78,7 +78,7 @@ module Engine
             sym: 'MOLES',
             name: 'Moles',
             value: 2,
-            desc: 'The family (company) gets 4 special tiles, that can be used to upgrade any plain tiles,'\
+            desc: 'The family (corporation) gets 4 special tiles, that can be used to upgrade any plain tiles,'\
                   ' even illegally (mountains and water pool)',
             abilities: [
               {
@@ -100,7 +100,7 @@ module Engine
             sym: 'ANCIENT_MAPS',
             name: 'Ancient maps',
             value: 2,
-            desc: 'The family (company) can build two additional yellow tiles',
+            desc: 'The family (corporation) can build two additional yellow tiles',
             abilities: [
               {
                 type: 'tile_lay',
@@ -136,7 +136,7 @@ module Engine
             sym: 'ON_A_DIET',
             name: 'On a diet',
             value: 1,
-            desc: 'The family (company) can place a station in addition to the allowed spaces'\
+            desc: 'The family (corporation) can place a station in addition to the allowed spaces'\
                   ' - no one can block you out',
             abilities: [
               {
@@ -155,7 +155,7 @@ module Engine
             sym: 'SHINING_GOLD',
             name: 'Shining gold',
             value: 1,
-            desc: 'The family (company) gets 2$N / 1$N when it builds on a M / MM tile',
+            desc: 'The family (corporation) gets 2$N / 1$N when it builds on a M / MM tile',
             abilities: [
               {
                 type: 'tile_discount',
@@ -182,7 +182,7 @@ module Engine
             sym: 'THAT_S_MINE',
             name: "That's mine!",
             value: 2,
-            desc: 'The family (company) reserves an open place on a station tile anywhere'\
+            desc: 'The family (corporation) reserves an open place on a station tile anywhere'\
                   ' (irrespective of connectivity) - it is reserved and open for all to run through,'\
                   ' until the family puts a token there',
             abilities: [
@@ -198,7 +198,7 @@ module Engine
             sym: 'WORK_IN_PROGRESS',
             name: 'Work in progress',
             value: 2,
-            desc: 'The family (company) blocks a free place on a station tile anywhere'\
+            desc: 'The family (corporation) blocks a free place on a station tile anywhere'\
                   ' (irrespective of connectivity)',
             abilities: [
               {
@@ -213,7 +213,7 @@ module Engine
             sym: 'WHEAT',
             name: 'Wheat',
             value: 2,
-            desc: 'The family (company) chooses a tile with its own station; the station is worth +30',
+            desc: 'The family (corporation) chooses a tile with its own station; the station is worth +30',
             abilities: [
               {
                 type: 'assign_hexes',
@@ -232,7 +232,7 @@ module Engine
             sym: 'TWO_BARRELS',
             name: 'Two barrels',
             value: 2,
-            desc: 'The family (company) can use this power on two separate occasions to double the value of all'\
+            desc: 'The family (corporation) can use this power on two separate occasions to double the value of all'\
                   ' O tiles – but the downside is that family doesn\'t collect in treasury the usual 1$N for each O',
             abilities: [
               {
@@ -249,7 +249,7 @@ module Engine
             sym: 'A_SQUEEZE',
             name: 'A squeeze',
             value: 3,
-            desc: 'The family (company) gets an additional 3$N if at least one of its squirrels (train)'\
+            desc: 'The family (corporation) gets an additional 3$N if at least one of its squirrels (train)'\
                   ' runs through or to a O',
           },
           {
@@ -258,7 +258,7 @@ module Engine
             value: 2,
             desc: 'Save from rust: at the phase change the player or the family can choose to mark a squirrel'\
                   ' (train) so that it won\'t rust; it becomes, and run as, a 1S. The 1S cannot be sold.'\
-                  ' The PATCH on 1S can be discarded anytime. If the PATCH stays on, the family (company)'\
+                  ' The PATCH on 1S can be discarded anytime. If the PATCH stays on, the family (corporation)'\
                   ' cannot purchase new squirrels (trains)',
           },
           {

--- a/lib/engine/game/g_21_moon/entities.rb
+++ b/lib/engine/game/g_21_moon/entities.rb
@@ -29,7 +29,7 @@ module Engine
             revenue: 5,
             min_price: 1,
             max_price: 45,
-            desc: 'When this private is bought by a company, the president of the company may choose to add or remove '\
+            desc: 'When this private is bought by a corporation, the president of the corporation may choose to add or remove '\
                   'a 2/3/4/5/6 train to/from the depot. If a train is added, it must be of the '\
                   'current phase or later. This will close the company. Can be sold to a corporation for ₡1-₡45.',
             abilities: [],
@@ -43,7 +43,7 @@ module Engine
             min_price: 1,
             max_price: 60,
             desc: 'The corporation owning the SBC can build and upgrade road tiles crossing the rift. '\
-                  'The owning company receives a bonus of 60 credits after the connection across the rift is '\
+                  'The owning corporation receives a bonus of 60 credits after the connection across the rift is '\
                   'made and the SBC will close. Can be sold to a corporation for ₡1-₡60.',
             abilities: [],
             color: nil,

--- a/lib/engine/game/g_steam_over_holland/entities.rb
+++ b/lib/engine/game/g_steam_over_holland/entities.rb
@@ -47,7 +47,7 @@ module Engine
             sym: 'VES',
             value: 75,
             revenue: 15,
-            desc: 'Fl. 20 bonus revenue for the owning company if it uses the ferry across the Zuiderzee at Enkhuizen (D9).',
+            desc: 'Fl. 20 bonus revenue for the owning corporation if it uses the ferry across the Zuiderzee at Enkhuizen (D9).',
             abilities: [
               {
                 type: 'hex_bonus',
@@ -62,7 +62,7 @@ module Engine
             sym: 'VVL',
             value: 75,
             revenue: 15,
-            desc: 'Fl. 20 bonus for the owning company each time it starts or ends a route in Vlissingen (J1).',
+            desc: 'Fl. 20 bonus for the owning corporation each time it starts or ends a route in Vlissingen (J1).',
             abilities: [
               {
                 type: 'hex_bonus',
@@ -77,7 +77,7 @@ module Engine
             sym: 'RW',
             value: 80,
             revenue: 20,
-            desc: 'Allows the owning company to lay one station token for free. Closes after use.',
+            desc: 'Allows the owning corporation to lay one station token for free. Closes after use.',
             abilities: [
               {
                 type: 'token',
@@ -94,7 +94,7 @@ module Engine
             sym: 'W',
             value: 100,
             revenue: 20,
-            desc: 'Gives a 10% discount on all trains the owning company buys from the bank.',
+            desc: 'Gives a 10% discount on all trains the owning corporation buys from the bank.',
             abilities: [
               {
                 type: 'train_discount',


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

I went through all the private company descriptions and changed the word company to corporation where applicable to keep in line with the terminology on the site.

No changes to game code, only text descriptions. 

### Screenshots

### Any Assumptions / Hacks
