### PR TITLE
[Core] Add comment about suppressing backtick warning

### DIFF
--- a/assets/app/mail/turn.rb
+++ b/assets/app/mail/turn.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# This file generates a backtick warning when running tests, but resolving it by adding
+# the same warning suppression comment as other files breaks the e-mail notifications.
+# See: https://github.com/tobymao/18xx/pull/10382
+#      https://github.com/tobymao/18xx/pull/10479
+#      https://github.com/tobymao/18xx/pull/10531
+
 class Turn < Snabberb::Component
   needs :game_url
   needs :game_id


### PR DESCRIPTION
<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
Add comments explaining that suppressing the backtick warning will break the email notifications, hopefully prevent someone else from doing the same thing

### Screenshots

### Any Assumptions / Hacks
