### PR TITLE
[1822PNW] Fix typo in tile name

### DIFF
--- a/lib/engine/game/g_1822_pnw/map.rb
+++ b/lib/engine/game/g_1822_pnw/map.rb
@@ -24,7 +24,7 @@ module Engine
           'F23' => 'Spokane',
           'G2' => 'Clearwater',
           'G8' => 'Quilcene',
-          'G12' => 'Mikilteo',
+          'G12' => 'Mukilteo',
           'G14' => 'Snohomish',
           'G16' => 'Park Place',
           'G24' => 'Spokane',


### PR DESCRIPTION
It's Mukilteo.

<img width="780" alt="Screen Shot 2024-03-20 at 10 22 41 PM" src="https://github.com/tobymao/18xx/assets/880413/56b046a0-7c10-49a2-b51b-6f83d67010a1">
