### PR TITLE
[21Moon] fix terminal tile placement

### DIFF
--- a/lib/engine/game/g_21_moon/entities.rb
+++ b/lib/engine/game/g_21_moon/entities.rb
@@ -81,7 +81,7 @@ module Engine
               {
                 type: 'teleport',
                 owner_type: 'corporation',
-                tiles: ['X30'],
+                tiles: ['X29'],
                 hexes: ['F8'],
               },
             ],

--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -192,7 +192,7 @@ module Engine
         SP_TILES = %w[X22 X23].freeze
         T_HEX = 'F8'
         T_BONUS = 30
-        T_TILE = 'X30'
+        T_TILE = 'X29'
         RIFT_BONUS = 60
         EW_BONUS = 80
         NE_HEXES = %w[K1 L2 L4].freeze


### PR DESCRIPTION
Fixes #10547

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Updates the tile for Terminal that was changed in https://github.com/tobymao/18xx/pull/10527

### Explanation of Change

Likely needs pins since games could have laid the incorrect tile before

### Screenshots

![image](https://github.com/tobymao/18xx/assets/1711810/17e5e72f-2f90-4408-9bec-2ba881120ed7)

![image](https://github.com/tobymao/18xx/assets/1711810/aa9f27d3-5b25-455c-bdc0-c464d30e92a5)

![image](https://github.com/tobymao/18xx/assets/1711810/79cb879f-b534-4f09-a6ce-8e9ebd60f0ed)


### Any Assumptions / Hacks
