### PR TITLE
[21Moon] Terminal private revenue s.b. 15 space bucks

### DIFF
--- a/lib/engine/game/g_21_moon/entities.rb
+++ b/lib/engine/game/g_21_moon/entities.rb
@@ -72,7 +72,7 @@ module Engine
             name: 'Terminal',
             sym: 'T',
             value: 80,
-            revenue: 20,
+            revenue: 15,
             min_price: 1,
             max_price: 120,
             desc: 'The owning corporation may teleport place the T tile, then may place its cheapest supply '\


### PR DESCRIPTION
The BGG-hosted rules indicate Terminal revenue is 15, Scott confirmed
https://boardgamegeek.com/filepage/263361/21moon-rules

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

Definitely needs pins