### PR TITLE
[21Moon] allow Terminal to optionally place token

### DIFF
--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -542,6 +542,7 @@ module Engine
             G21Moon::Step::Assign,
             Engine::Step::HomeToken,
             G21Moon::Step::SpecialTrack,
+            G21Moon::Step::SpecialToken,
             G21Moon::Step::TrainMod,
             G21Moon::Step::Track,
             G21Moon::Step::Token,

--- a/lib/engine/game/g_21_moon/step/special_token.rb
+++ b/lib/engine/game/g_21_moon/step/special_token.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/special_token'
+
+module Engine
+  module Game
+    module G21Moon
+      module Step
+        class SpecialToken < Engine::Step::SpecialToken
+          def teleport_complete
+            @log << "#{@round.teleported.name} closes"
+            @round.teleported.close!
+            @game.lb_graph.clear
+            @game.sp_graph.clear
+            @game.graph.clear
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_21_moon/step/special_track.rb
+++ b/lib/engine/game/g_21_moon/step/special_track.rb
@@ -11,23 +11,6 @@ module Engine
             super
 
             @round.num_laid_track -= 1
-
-            entity = @game.token_owner(action.entity)
-            hex = action.hex
-            city = action.tile.cities.first
-            token = entity.find_token_by_type
-            return unless token
-
-            tokener = "#{entity.name} (#{action.entity.sym})"
-
-            city.place_token(entity, token, free: true)
-            @log << "#{tokener} places a token on #{hex.name} (#{hex.location_name})"
-            @log << "#{action.entity.name} Company closes"
-            action.entity.close!
-
-            @game.lb_graph.clear
-            @game.sp_graph.clear
-            @game.graph.clear
           end
 
           def track_upgrade?(_from, _to, _hex)


### PR DESCRIPTION
Fixes #10552

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Adds a SpecialToken step after SpecialTrack (the latter is necessary to allow laying two tiles after the Terminal)

There was a bunch of custom logic in SpecialTrack that is now covered by SpecialToken, but I kept the logic to close the private and regenerate the graph after the player has finished choosing.

This also fixes a related (unticketed) bug where if the corp had no tokens left, the private would not close. I double-checked in the rules that laying the Terminal is what closes the corp, not the choice to token or not

### Explanation of Change

### Screenshots

SpecialToken step firing (same as C&OC)
![image](https://github.com/tobymao/18xx/assets/1711810/7f5fc1a2-0ecd-468e-b21c-83c39a04e1ec)

Laying a token
![image](https://github.com/tobymao/18xx/assets/1711810/f3c5fbf2-e682-43ef-88aa-2ef147734ad1)

Choosing not to lay a token
![image](https://github.com/tobymao/18xx/assets/1711810/5cba6496-3dce-45c9-a8f6-3356f89288f3)


### Any Assumptions / Hacks
