### PR TITLE
Adds hotkeys for speeding up operations, especially end of game runs.

### DIFF
--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -71,7 +71,11 @@ module View
             process_action(Engine::Action::Dividend.new(@step.current_entity, kind: type))
             cleanup
           end
-          button = h('td.no_padding', [h(:button, { style: { margin: '0.2rem 0' }, on: { click: click } }, text)])
+          button_id = text.downcase.gsub(' ', '_') # Generate an ID based on the value of 'text'
+
+          button = h('td.no_padding', [
+            h(:button, { style: { margin: '0.2rem 0' }, on: { click: click }, attrs: { id: button_id } }, text)
+          ])
 
           h(:tr, [
             button,

--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -71,10 +71,10 @@ module View
             process_action(Engine::Action::Dividend.new(@step.current_entity, kind: type))
             cleanup
           end
-          button_id = text.downcase.gsub(' ', '_') # Generate an ID based on the value of 'text'
+          button_id = text.downcase.tr(' ', '_') # Generate an ID based on the value of 'text'
 
           button = h('td.no_padding', [
-            h(:button, { style: { margin: '0.2rem 0' }, on: { click: click }, attrs: { id: button_id } }, text)
+            h(:button, { style: { margin: '0.2rem 0' }, on: { click: click }, attrs: { id: button_id } }, text),
           ])
 
           h(:tr, [

--- a/assets/app/view/game/pass_button.rb
+++ b/assets/app/view/game/pass_button.rb
@@ -21,7 +21,7 @@ module View
         }
 
         for_text = @for_player ? " (#{@for_player.name})" : ''
-        h(:button, props, "#{@game.round.pass_description}#{for_text}")
+        h('button#pass', props, "#{@game.round.pass_description}#{for_text}")
       end
     end
   end

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -319,11 +319,11 @@ module View
 
         buttons = [
           h('button.small', { on: { click: clear } }, 'Clear Train'),
-          h('button.small', { on: { click: clear_all } }, 'Clear All'),
+          h('button.small', { attrs: { id: 'clearall' }, on: { click: clear_all } }, 'Clear All'),
           h('button.small', { on: { click: reset_all } }, 'Reset'),
         ]
         if @game_data.dig('settings', 'auto_routing') || @game_data['mode'] == :hotseat
-          buttons << h('button.small', { on: { click: auto } }, 'Auto')
+          buttons << h('button.small', { attrs: { id: 'autoroute' }, on: { click: auto } }, 'Auto')
         end
         if @game.adjustable_train_list?(current_entity)
           buttons << h('button.small', { on: { click: add_train } }, "+#{@game.adjustable_train_label(current_entity)}")
@@ -335,7 +335,7 @@ module View
         end
         h(:div, { style: { overflow: 'auto', marginBottom: '1rem' } }, [
           h(:div, buttons),
-          h(:button, { style: submit_style, on: { click: submit } }, 'Submit ' + revenue_str),
+          h(:button, { style: submit_style, attrs: { id: 'submit' }, on: { click: submit } }, 'Submit ' + revenue_str),
         ])
       end
 

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -260,6 +260,15 @@ module View
           change_anchor('#tools')
         when 'a'
           change_anchor('#auto')
+        when '1'
+          button_click('pass')
+        when '2'
+          button_click('clearall')
+        when '3'
+          button_click('autoroute')
+        when 'Enter'
+          button_click('submit')
+          button_click('pay_out')
         when 'c'
           if (chatbar = Native(`document.getElementById('chatbar')`))
             chatbar.focus


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

I've added a few hotkeys that will allow players to quickly speed through the final ORs of a game

[1] - handles all passing (Skip track/skip token/skip trains/skip companies)
[2] - clears all saved runs
[3] - hits the auto route button
[Enter] - Selects 'Pay Out' option, and also 'Submit' for the run

I find this really helpful with everyone agrees the game is over but still want to see a final score. One player enables master mode, goes through one OR where they maximize each route (if desired) and then it's just 1 and Enter for the rest of the game

### Screenshots

### Any Assumptions / Hacks
