### PR TITLE
Revert "[21Moon] Terminal private revenue s.b. 15 space bucks"

### DIFF
--- a/lib/engine/game/g_21_moon/entities.rb
+++ b/lib/engine/game/g_21_moon/entities.rb
@@ -72,7 +72,7 @@ module Engine
             name: 'Terminal',
             sym: 'T',
             value: 80,
-            revenue: 15,
+            revenue: 20,
             min_price: 1,
             max_price: 120,
             desc: 'The owning corporation may teleport place the T tile, then may place its cheapest supply '\


### PR DESCRIPTION
Temporarily reverting so 21Moon breaking changes can all come in together.