### PR TITLE
Prevent spurious exchange buttons appearing in stock round

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -272,7 +272,7 @@ module View
       # Allow privates or minors to be exchanged for shares if they have the ability
       def render_exchanges
         children = []
-        source_entities = @game.companies + @game.minors + @game.corporations
+        source_entities = @game.exchange_entities
 
         source_entities.each do |entity|
           @game.abilities(entity, :exchange) do |ability|

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2134,6 +2134,11 @@ module Engine
         nil
       end
 
+      # Entities that can own an exchange ability.
+      def exchange_entities
+        companies + minors
+      end
+
       def exchange_corporations(exchange_ability)
         candidates = case exchange_ability.corporations
                      when 'any'

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -412,6 +412,11 @@ module Engine
           (min_par.price * 3) - minor_sale_value(minor, min_par)
         end
 
+        # Entities that can own an exchange ability.
+        def exchange_entities
+          minor_corporations
+        end
+
         def exchange_corporations(exchange_ability)
           minor = exchange_ability.owner
           super.select do |major|


### PR DESCRIPTION
### Explanation of Change
Bugs tobymao#10537 and tobymao#10563 were reports of spurious exchange buttons appearing in stock rounds, in 1871 and 1858.

These buttons were appearing when the active player owned a private company that could be exchanged for a share in a corporation. As well as the button to exchange the private for a share, one or more extra buttons were appearing, offering to exchange corporations for a share.

This was caused by commit bc6fa7d, which added `@game.corporations` to the entities that are checked for exchange abilities. This was needed for 18Ardennes, which has corporations with exchange abilities.

Neither 1858 or 1871 have corporations with exchange abilities, but `Corporation.all_abilities` will also pick up any abilities owned by the corporation's president which have an owning_player-type timing. This caused these corporations to appear as an option to be exchanged.

This is fixed by removing `@game.corporations` from the default entities that are checked for exchange abilities. To allow 18Ardennes to still check those, a new method `@game.exchange_entities` is added which defines which entities are examined for the exchange abilities. The default implementation returns all companies and minors, and so reverts to the behaviour before commit bc6fa7d. 18Ardennes has its own version of this method added, which checks the minor-type corporations.

Fixes #10537. Fixes #10563.

This won't need any pins. The spurious buttons never did anything other than throw an error, so no illegal exchanges were possible.

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~~Add the `pins` or `archive_alpha_games` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`