### PR TITLE
[18Uruguay] Only auto withhold when nationalized

### DIFF
--- a/lib/engine/game/g_18_uruguay/step/dividend.rb
+++ b/lib/engine/game/g_18_uruguay/step/dividend.rb
@@ -39,9 +39,10 @@ module Engine
           end
 
           def auto_actions(entity)
-            return [Engine::Action::Dividend.new(current_entity, kind: 'withhold')] if entity.loans.size.positive?
+            return [] unless @game.nationalized?
+            return [] if entity.loans.empty?
 
-            []
+            [Engine::Action::Dividend.new(current_entity, kind: 'withhold')]
           end
 
           def dividend_options(entity)


### PR DESCRIPTION
[18Uruguay] Only auto withhold when nationalized

Corrected a bug and only withhold when nationalized

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
