### PR TITLE
[18Neb] t'aint no train discounts

### DIFF
--- a/lib/engine/game/g_18_neb/game.rb
+++ b/lib/engine/game/g_18_neb/game.rb
@@ -148,7 +148,6 @@ module Engine
             price: 900,
             num: 20,
             available_on: '6',
-            discount: { '4' => 300, '5' => 300, '6' => 300 },
           },
         ].freeze
 


### PR DESCRIPTION
Fixes #10576

Rules don't indicate there's a discount

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [no, since alpha] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
