### PR TITLE
[18Rhl] Remove duplicated E8 definition from map.rb

### DIFF
--- a/lib/engine/game/g_18_rhl/map.rb
+++ b/lib/engine/game/g_18_rhl/map.rb
@@ -421,7 +421,7 @@ module Engine
                         'border=edge:5,type:impassable,color:blue',
               ['B9'] => 'city=revenue:0',
               %w[B11 D3 D5 E4 F3 F7 G4 G8 H3 H5 H7 I2 I8 J5 J7 K8] => '',
-              %w[B13 E8 F5 J3] => 'town=revenue:0;town=revenue:0',
+              %w[B13 F5 J3] => 'town=revenue:0;town=revenue:0',
               %w[C4 I6 K4] => 'town=revenue:0',
               ['C6'] => 'town=revenue:0;border=edge:3,type:impassable,color:blue',
               ['C8'] => 'stub=edge:3;upgrade=cost:30,terrain:water;border=edge:2,type:impassable,color:blue;'\


### PR DESCRIPTION
Fixes #[PUT_ISSUE_NUMBER_HERE]

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Remove duplicated E8 definition from the map.rb which resulted in two visible layers in some moments of the Operating Round:

![image](https://github.com/tobymao/18xx/assets/10097748/61086f52-1feb-432c-955c-89365f7f9e95)

The correct E8 definition is several lines further in the file.

