### PR TITLE
[18Ardennes] 4D trains

### DIFF
--- a/lib/engine/game/g_18_ardennes/trains.rb
+++ b/lib/engine/game/g_18_ardennes/trains.rb
@@ -136,7 +136,7 @@ module Engine
         end
 
         def revenue_for(route, stops)
-          # TODO (maybe): I suspect that the calculation of the revenue for a
+          # TODO: (maybe) I suspect that the calculation of the revenue for a
           # long 4D route is inefficient, and might cause slow auto-routing.
           # It might be worth pruning out some of the stops from the route
           # to avoid calling this method so often.

--- a/lib/engine/game/g_18_ardennes/trains.rb
+++ b/lib/engine/game/g_18_ardennes/trains.rb
@@ -136,6 +136,10 @@ module Engine
         end
 
         def revenue_for(route, stops)
+          # TODO (maybe): I suspect that the calculation of the revenue for a
+          # long 4D route is inefficient, and might cause slow auto-routing.
+          # It might be worth pruning out some of the stops from the route
+          # to avoid calling this method so often.
           super +
             ferry_bonus(route, stops) +
             mine_bonus(route, stops) +

--- a/lib/engine/game/g_18_ardennes/trains.rb
+++ b/lib/engine/game/g_18_ardennes/trains.rb
@@ -111,6 +111,13 @@ module Engine
           '4D': 80,
         }.freeze
 
+        def visited_stops(route)
+          return super unless route.train.name == '4D'
+
+          # 4D trains ignore towns completely.
+          super.reject(&:town?)
+        end
+
         def route_distance_str(route)
           towns = route.visited_stops.count(&:town?)
           cities = route.visited_stops.count(&:city?)

--- a/lib/engine/game/g_18_ardennes/trains.rb
+++ b/lib/engine/game/g_18_ardennes/trains.rb
@@ -118,7 +118,7 @@ module Engine
 
           distance = port ? '⚓' : ''
           distance += cities.to_s
-          distance += "+#{towns}" if towns.positive? && route.train.name != '5D'
+          distance += "+#{towns}" if towns.positive? && route.train.name != '4D'
           distance
         end
 
@@ -164,7 +164,8 @@ module Engine
 
           tokens = route.train.owner.placed_tokens
                    .map(&:city).intersection(stops)
-          tokens.size * (north_south && east_west ? 60 : 30)
+          token_bonus = (north_south && east_west ? 60 : 30)
+          tokens.size * token_bonus * route.train.multiplier
         end
 
         def extra_revenue(_entity, routes)

--- a/lib/engine/game/g_18_ardennes/trains.rb
+++ b/lib/engine/game/g_18_ardennes/trains.rb
@@ -165,7 +165,7 @@ module Engine
           tokens = route.train.owner.placed_tokens
                    .map(&:city).intersection(stops)
           token_bonus = (north_south && east_west ? 60 : 30)
-          tokens.size * token_bonus * route.train.multiplier
+          tokens.size * token_bonus * (route.train.multiplier || 1)
         end
 
         def extra_revenue(_entity, routes)


### PR DESCRIPTION
## Implementation Notes

The 4D trains in 18Ardennes can run a route of any length, earning revenue for four cities and doubling this revenue and any bonuses earned. They can share track with other trains.

This pull request has the bits of code needed to implement 4D trains correctly:

- They can only be bought be 10-share public companies, and these can only each own a single 4D train.
- Sharing track with normal trains.
- Calculating the ferry and Trans-Europa Express bonuses.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~~Add the `pins` or `archive_alpha_games` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`