### PR TITLE
Adding support for stackable assignments

### DIFF
--- a/assets/app/view/game/part/assignments.rb
+++ b/assets/app/view/game/part/assignments.rb
@@ -37,7 +37,7 @@ module View
           @assignments_to_show = []
           stack_group_count = {}
           stack_group_img = {}
-          @assignments.keys.each do |assignment|
+          @assignments.each_key do |assignment|
             stack_group = @game.assignment_stack_group(assignment)
             img = @game.assignment_tokens(assignment, setting_for(:simple_logos, @game))
 

--- a/assets/app/view/game/part/assignments.rb
+++ b/assets/app/view/game/part/assignments.rb
@@ -17,7 +17,7 @@ module View
 
         def preferred_render_locations
           if layout == :pointy
-            case @assignments&.size
+            case @assignments_to_show&.size
             when 1
               POINTY_SMALL_ITEM_LOCATIONS
             when 2
@@ -25,7 +25,7 @@ module View
             else
               POINTY_WIDE_ITEM_LOCATIONS
             end
-          elsif @assignments.one?
+          elsif @assignments_to_show&.one?
             SMALL_ITEM_LOCATIONS
           else
             WIDE_ITEM_LOCATIONS
@@ -34,6 +34,55 @@ module View
 
         def load_from_tile
           @assignments = @tile.hex&.assignments || {}
+          @stack_groups = @tile.hex&.assignment_stack_groups || {}
+          @assignments_to_show = []
+          @stack_groups.each do |key, assignemnts|
+            if key == 'NONE'
+              assignemnts.each do |assignemnt, _value|
+                @assignments_to_show.append({
+                                              'img' => @game.assignment_tokens(assignemnt, setting_for(:simple_logos, @game)),
+                                              'count' => 1,
+                                            })
+              end
+            else
+              @assignments_to_show.append({
+                                            'img' => @game.assignment_tokens(assignemnts.keys.last,
+                                                                             setting_for(:simple_logos, @game)),
+                                            'count' => assignemnts.size,
+                                          })
+            end
+          end
+        end
+
+        def stack_count_background_props(axis, axis_value)
+          props = {
+            attrs: {
+              href: '/icons/stack_background.svg',
+              width: "#{ICON_RADIUS * 2}px",
+              height: "#{ICON_RADIUS * 2}px",
+            },
+          }
+
+          props[:attrs][axis] = axis_value + 10
+          axis2 = (POINTY_TALL_ITEM_LOCATIONS.any?(render_location) ? :x : :y)
+          props[:attrs][axis2] = -5
+          props
+        end
+
+        def stack_count_props(axis, axis_value)
+          props = {
+            attrs: {
+              'dominant-baseline': 'central',
+              fill: 'black',
+            },
+            style: {
+              fontSize: '20px',
+            },
+          }
+          props[:attrs][axis] = axis_value + 35
+          axis2 = (POINTY_TALL_ITEM_LOCATIONS.any?(render_location) ? :x : :y)
+          props[:attrs][axis2] = 8
+          props
         end
 
         def render_part
@@ -41,22 +90,31 @@ module View
           multiplyer = (POINTY_WIDER_ITEM_LOCATIONS.any?(render_location) ? 3 : 1)
 
           if @game
-            children = @assignments.keys.map.with_index do |assignment, index|
-              img = @game.assignment_tokens(assignment, setting_for(:simple_logos, @game))
+            children = []
+            @assignments_to_show.each.with_index do |assignment, index|
+              count = assignment[:count]
 
               props = {
                 attrs: {
-                  href: img,
+                  href: assignment[:img],
                   width: "#{ICON_RADIUS * 2}px",
                   height: "#{ICON_RADIUS * 2}px",
                 },
               }
-              props[:attrs][axis] = ((index - ((@assignments.size - 1) / 2)) * multiplyer * DELTA).round(2)
 
-              h(:image, props)
+              axis_value = ((index - ((@assignments_to_show.size - 1) / 2)) * multiplyer * DELTA).round(2)
+              props[:attrs][axis] = axis_value
+
+              children.append(h(:image, props))
+              if count > 1
+                props = stack_count_background_props(axis, axis_value)
+                children.append(h(:image, props))
+
+                props = stack_count_props(axis, axis_value)
+                children.append(h(:text, props, count))
+              end
             end
           end
-
           h(:g, { attrs: { transform: "#{rotation_for_layout} translate(#{-ICON_RADIUS} #{-ICON_RADIUS})" } },
             [h(:g, { attrs: { transform: translate } }, children)])
         end

--- a/assets/app/view/game/part/assignments.rb
+++ b/assets/app/view/game/part/assignments.rb
@@ -46,8 +46,8 @@ module View
             @assignments_to_show.append({ 'img' => img, 'count' => 1 }) if stack_group.nil?
           end
 
-          stack_group_count.keys.each do |group|
-            @assignments_to_show.append({ 'img' => stack_group_img[group], 'count' => stack_group_count[group] })
+          stack_group_count.each do |group, count|
+            @assignments_to_show.append({ 'img' => stack_group_img[group], 'count' => count })
           end
         end
 

--- a/assets/app/view/game/part/assignments.rb
+++ b/assets/app/view/game/part/assignments.rb
@@ -41,9 +41,12 @@ module View
             stack_group = @game.assignment_stack_group(assignment)
             img = @game.assignment_tokens(assignment, setting_for(:simple_logos, @game))
 
-            stack_group_count[stack_group] = (stack_group_count[stack_group] || 0) + 1 unless stack_group.nil?
-            stack_group_img[stack_group] = img unless stack_group.nil?
-            @assignments_to_show.append({ 'img' => img, 'count' => 1 }) if stack_group.nil?
+            if stack_group
+              stack_group_count[stack_group] += 1
+              stack_group_img[stack_group] = img
+            else
+              @assignments_to_show.append({ 'img' => img, 'count' => 1 })
+            end
           end
 
           stack_group_count.each do |group, count|

--- a/assets/app/view/game/part/assignments.rb
+++ b/assets/app/view/game/part/assignments.rb
@@ -34,23 +34,20 @@ module View
 
         def load_from_tile
           @assignments = @tile.hex&.assignments || {}
-          @stack_groups = @tile.hex&.assignment_stack_groups || {}
           @assignments_to_show = []
-          @stack_groups.each do |key, assignemnts|
-            if key == 'NONE'
-              assignemnts.each do |assignemnt, _value|
-                @assignments_to_show.append({
-                                              'img' => @game.assignment_tokens(assignemnt, setting_for(:simple_logos, @game)),
-                                              'count' => 1,
-                                            })
-              end
-            else
-              @assignments_to_show.append({
-                                            'img' => @game.assignment_tokens(assignemnts.keys.last,
-                                                                             setting_for(:simple_logos, @game)),
-                                            'count' => assignemnts.size,
-                                          })
-            end
+          stack_group_count = {}
+          stack_group_img = {}
+          @assignments.keys.each do |assignment|
+            stack_group = @game.assignment_stack_group(assignment)
+            img = @game.assignment_tokens(assignment, setting_for(:simple_logos, @game))
+
+            stack_group_count[stack_group] = (stack_group_count[stack_group] || 0) + 1 unless stack_group.nil?
+            stack_group_img[stack_group] = img unless stack_group.nil?
+            @assignments_to_show.append({ 'img' => img, 'count' => 1 }) if stack_group.nil?
+          end
+
+          stack_group_count.keys.each do |group|
+            @assignments_to_show.append({ 'img' => stack_group_img[group], 'count' => stack_group_count[group] })
           end
         end
 

--- a/assets/app/view/game/part/assignments.rb
+++ b/assets/app/view/game/part/assignments.rb
@@ -35,7 +35,7 @@ module View
         def load_from_tile
           @assignments = @tile.hex&.assignments || {}
           @assignments_to_show = []
-          stack_group_count = {}
+          stack_group_count = Hash.new(0)
           stack_group_img = {}
           @assignments.each_key do |assignment|
             stack_group = @game.assignment_stack_group(assignment)

--- a/lib/engine/assignable.rb
+++ b/lib/engine/assignable.rb
@@ -6,16 +6,23 @@ module Engine
       @assignments ||= {}
     end
 
+    def assignment_stack_groups
+      @assignment_stack_groups ||= {}
+    end
+
     def assigned?(key)
       assignments.key?(key)
     end
 
-    def assign!(key, value = true)
+    def assign!(key, value = true, stack_group: 'NONE')
       assignments[key] = value
+      assignment_stack_groups[stack_group] ||= {}
+      assignment_stack_groups[stack_group][key] = value
     end
 
     def remove_assignment!(key)
       assignments.delete(key)
+      assignment_stack_groups.each { |groups| groups.delete(key) }
     end
 
     def self.remove_from_all!(assignables, key)

--- a/lib/engine/assignable.rb
+++ b/lib/engine/assignable.rb
@@ -6,23 +6,16 @@ module Engine
       @assignments ||= {}
     end
 
-    def assignment_stack_groups
-      @assignment_stack_groups ||= {}
-    end
-
     def assigned?(key)
       assignments.key?(key)
     end
 
-    def assign!(key, value = true, stack_group: 'NONE')
+    def assign!(key, value = true)
       assignments[key] = value
-      assignment_stack_groups[stack_group] ||= {}
-      assignment_stack_groups[stack_group][key] = value
     end
 
     def remove_assignment!(key)
       assignments.delete(key)
-      assignment_stack_groups.each { |groups| groups.delete(key) }
     end
 
     def self.remove_from_all!(assignables, key)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -358,6 +358,7 @@ module Engine
       }.freeze
 
       ASSIGNMENT_TOKENS = {}.freeze
+      ASSIGNMENT_STACK_GROUPS = {}.freeze
 
       OPERATING_ROUND_NAME = 'Operating'
       OPERATION_ROUND_SHORT_NAME = 'ORs'
@@ -2228,8 +2229,11 @@ module Engine
 
           return assignment.logo
         end
-
         self.class::ASSIGNMENT_TOKENS[assignment]
+      end
+
+      def assignment_stack_group(assignment)
+        self.class::ASSIGNMENT_STACK_GROUPS[assignment]
       end
 
       def bankruptcy_limit_reached?

--- a/lib/engine/game/g_18_uruguay/farm.rb
+++ b/lib/engine/game/g_18_uruguay/farm.rb
@@ -78,7 +78,7 @@ module Engine
           end
           target = action.target
           good = retreive_goods!(@farm_id)
-          target.assign!(good, stack_group: 'GOODS')
+          target.assign!(good)
 
           if (ability = goods)
             ability.use!

--- a/lib/engine/game/g_18_uruguay/farm.rb
+++ b/lib/engine/game/g_18_uruguay/farm.rb
@@ -78,8 +78,7 @@ module Engine
           end
           target = action.target
           good = retreive_goods!(@farm_id)
-
-          target.assign!(good)
+          target.assign!(good, stack_group: 'GOODS')
 
           if (ability = goods)
             ability.use!

--- a/lib/engine/game/g_18_uruguay/game.rb
+++ b/lib/engine/game/g_18_uruguay/game.rb
@@ -108,6 +108,8 @@ module Engine
           'GOODS_CATTLE10' => '/icons/18_uruguay/cow.svg',
         }.freeze
 
+        ASSIGNMENT_STACK_GROUPS = ASSIGNMENT_TOKENS.transform_values { |_str| 'GOODS' }
+
         PORTS = %w[E1 G1 I1 J4 K5 K7 K13].freeze
         MARKET = [
           %w[70 75 80 90 100p 110 125 150 175 200 225 250 275 300 325 350 375 400 425 450],

--- a/public/icons/stack_background.svg
+++ b/public/icons/stack_background.svg
@@ -4,5 +4,5 @@
 <svg version="1.0" xmlns="http://www.w3.org/2000/svg"
  width="512.000000pt" height="512.000000pt" viewBox="0 0 512.000000 512.000000"
  preserveAspectRatio="xMidYMid meet">
-<circle stroke="#000000" stroke-width="20" cx="325" cy="190" r="170" fill="#ffffffff"/>
+<circle stroke="#000000" stroke-width="20" cx="325" cy="190" r="170" fill="#ffffffff" fill-opacity="0.8"/>
 </svg>

--- a/public/icons/stack_background.svg
+++ b/public/icons/stack_background.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
+ "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg"
+ width="512.000000pt" height="512.000000pt" viewBox="0 0 512.000000 512.000000"
+ preserveAspectRatio="xMidYMid meet">
+<circle stroke="#000000" stroke-width="20" cx="325" cy="190" r="170" fill="#ffffffff"/>
+</svg>


### PR DESCRIPTION
In 18 Uruguay there is a need to assigne multiple assignments to one tile. 
In current framework the tile quickly gets overloaded with the assignments

This is a proposal for a possibility to stack assignments

In this proposal you can tag an assignment with stackable like this

`          target.assign!(good, Engine::Assignable::STACKABLE)
`

When drawing the framework will then stack all stackable assignments and add a counter if the number of elements are 2 or larger

![image](https://github.com/tobymao/18xx/assets/8018982/6621fc1c-5fcf-47e7-b74f-b8de337c9d41)

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
