### PR TITLE
[18NL] Fixes token blocking step

### DIFF
--- a/lib/engine/game/g_18_nl/step/token.rb
+++ b/lib/engine/game/g_18_nl/step/token.rb
@@ -14,7 +14,7 @@ module Engine
               !actions.empty? ||
               @game.p2_company.owner != entity ||
               # checks to see if P2's token ability still exists. The game removes the ability after its use.
-              @game.p2_company.abilities.none? { |ability| ability.type == 'token' } ||
+              @game.p2_company.abilities.none? { |ability| ability.type == :token } ||
               available_tokens(entity).empty?
 
             %w[pass]


### PR DESCRIPTION
Fixes #10584 
Fixes #10184 

## Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

User was getting _Blocking step Run Routes_ cannot process action 130_ error in their browser. 

This was being caused in the Token step of my code. In the Ruby, the ability.type is :token, not 'token'. @michaeljb discovered a similar issue ages ago with his pull request #7392

### Screenshots

### Any Assumptions / Hacks
