### PR TITLE
[1848] fix train export on 2nd/5th receivership

### DIFF
--- a/lib/engine/game/g_1848/depot.rb
+++ b/lib/engine/game/g_1848/depot.rb
@@ -7,10 +7,10 @@ module Engine
     module G1848
       class Depot < Engine::Depot
         def export!
-          train = @upcoming.first
-          return if train.rusts_on # only export if upcoming train is permanent
+          # remove next permanent train, no matter what phase we're in
+          train = @upcoming.reject { |t| t.rusts_on || t.name == '2E' }.first
 
-          @game.log << "-- Event: A #{train.name} train exports --"
+          @game.log << "-- Event: Permanent #{train.name} train exports --"
           remove_train(train)
           @game.phase.buying_train!(nil, train, self)
         end

--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -738,6 +738,13 @@ module Engine
 
         # recievership
 
+        def timeline
+          @timeline = [
+            'On the 2nd and 5th corporations to enter receivership, the next permanent train is removed as if purchased \
+            (may trigger a phase change)',
+          ]
+        end
+
         def close_corporation(corporation, quiet: false)
           @close_corp_count += 1
           @player_corp_close_count[corporation.owner] += 1

--- a/public/fixtures/1848/101.json
+++ b/public/fixtures/1848/101.json
@@ -1,0 +1,6302 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "assign",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1692887850,
+      "target": "P1",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1692887851,
+      "target": "P3",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1692887853,
+      "target": "P5",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1692887856,
+      "target": "P3",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1692887857,
+      "target": "P6",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1692887859,
+      "target": "P3",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1692887860,
+      "target": "P2",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1692887862,
+      "target": "P5",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1692887863,
+      "target": "P4",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1692887866,
+      "target": "P1",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1692887868,
+      "target": "P6",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1692887870,
+      "target": "P3",
+      "target_type": "company"
+    },
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1692887873,
+      "company": "P1",
+      "price": 20
+    },
+    {
+      "type": "assign",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1692887877,
+      "target": "P4",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1692887879,
+      "target": "P4",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1692887882,
+      "target": "P2",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1692887885,
+      "target": "P4",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1692887886,
+      "target": "P5",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1692887888,
+      "target": "P6",
+      "target_type": "company"
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1692887893,
+      "company": "P4",
+      "price": 150
+    },
+    {
+      "type": "assign",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1692887895,
+      "target": "P3",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1692887897,
+      "target": "P5",
+      "target_type": "company"
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 23,
+      "created_at": 1692887902,
+      "company": "P3",
+      "price": 85
+    },
+    {
+      "type": "assign",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 24,
+      "created_at": 1692887906,
+      "target": "P6",
+      "target_type": "company"
+    },
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1692887911,
+      "company": "P5",
+      "price": 150
+    },
+    {
+      "type": "assign",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 26,
+      "created_at": 1692887915,
+      "target": "P6",
+      "target_type": "company"
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1692887917,
+      "company": "P6",
+      "price": 205
+    },
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 28,
+      "created_at": 1692887922,
+      "company": "P2",
+      "price": 60
+    },
+    {
+      "type": "par",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 29,
+      "created_at": 1692887941,
+      "corporation": "VR",
+      "share_price": "100,1,5"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 30,
+      "created_at": 1692887952,
+      "shares": [
+        "CAR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 31,
+      "created_at": 1692887975,
+      "corporation": "SAR",
+      "share_price": "70,4,5"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 32,
+      "created_at": 1692887979,
+      "shares": [
+        "VR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 33,
+      "created_at": 1692887981,
+      "shares": [
+        "CAR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1692887983,
+      "shares": [
+        "SAR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1692887985,
+      "shares": [
+        "VR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1692887986,
+      "shares": [
+        "CAR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 37,
+      "created_at": 1692887988,
+      "shares": [
+        "SAR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 38,
+      "created_at": 1692887990,
+      "shares": [
+        "VR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 39,
+      "created_at": 1692887991,
+      "shares": [
+        "CAR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 40,
+      "created_at": 1692887993,
+      "shares": [
+        "SAR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 41,
+      "created_at": 1692887994,
+      "shares": [
+        "VR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 42,
+      "created_at": 1692887998,
+      "shares": [
+        "SAR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 43,
+      "created_at": 1692888011,
+      "shares": [
+        "CAR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 44,
+      "created_at": 1692888020,
+      "shares": [
+        "VR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 45,
+      "created_at": 1692888024,
+      "auto_actions": [
+        {
+          "type": "dividend",
+          "entity": "BOE",
+          "entity_type": "corporation",
+          "created_at": 1692888024,
+          "kind": "payout"
+        }
+      ],
+      "shares": [
+        "VR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 46,
+      "created_at": 1692888033,
+      "hex": "E4",
+      "tile": "57-0",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 47,
+      "created_at": 1692888040,
+      "train": "2-0",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 48,
+      "created_at": 1692888045
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 49,
+      "created_at": 1692888081,
+      "hex": "H11",
+      "tile": "5-0",
+      "rotation": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 50,
+      "created_at": 1692888085,
+      "train": "2-1",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 51,
+      "created_at": 1692888086
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 52,
+      "created_at": 1692888092,
+      "hex": "G6",
+      "tile": "57-1",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 53,
+      "created_at": 1692888096,
+      "train": "2-2",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 54,
+      "created_at": 1692888096,
+      "train": "2-3",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 55,
+      "created_at": 1692888098
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 56,
+      "created_at": 1692888103
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 57,
+      "created_at": 1692888110,
+      "shares": [
+        "SAR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 58,
+      "created_at": 1692888114,
+      "shares": [
+        "SAR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 59,
+      "created_at": 1692888116
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 60,
+      "created_at": 1692888116
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 61,
+      "created_at": 1692888117,
+      "auto_actions": [
+        {
+          "type": "dividend",
+          "entity": "BOE",
+          "entity_type": "corporation",
+          "created_at": 1692888117,
+          "kind": "payout"
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 62,
+      "created_at": 1692888143,
+      "hex": "D3",
+      "tile": "69-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 63,
+      "created_at": 1692888147,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "E4",
+              "D3"
+            ],
+            [
+              "D3",
+              "D1"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "D3",
+            "D1"
+          ],
+          "revenue": 50,
+          "revenue_str": "E4-D3-D1",
+          "nodes": [
+            "E4-0",
+            "D3-1",
+            "D1-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 64,
+      "created_at": 1692888148,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 65,
+      "created_at": 1692888152,
+      "train": "2-4",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 66,
+      "created_at": 1692888153
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 67,
+      "created_at": 1692888165,
+      "hex": "G10",
+      "tile": "235-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 68,
+      "created_at": 1692888167
+    },
+    {
+      "type": "run_routes",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 69,
+      "created_at": 1692888171,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "H11",
+            "G10"
+          ],
+          "revenue": 50,
+          "revenue_str": "H11-G10",
+          "nodes": [
+            "H11-0",
+            "G10-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 70,
+      "created_at": 1692888172,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 71,
+      "created_at": 1692888177,
+      "train": "2-5",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 72,
+      "created_at": 1692888178,
+      "train": "3-0",
+      "price": 200,
+      "variant": "3"
+    },
+    {
+      "type": "undo",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 73,
+      "created_at": 1692888186
+    },
+    {
+      "type": "buy_train",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 74,
+      "created_at": 1692888188,
+      "train": "3-0",
+      "price": 230,
+      "variant": "3+"
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 75,
+      "created_at": 1692888189
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 76,
+      "created_at": 1692888191
+    },
+    {
+      "type": "undo",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 77,
+      "created_at": 1692888194
+    },
+    {
+      "type": "buy_company",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 78,
+      "created_at": 1692888208,
+      "company": "P3",
+      "price": 140
+    },
+    {
+      "type": "buy_company",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 79,
+      "created_at": 1692888212,
+      "company": "P4",
+      "price": 220
+    },
+    {
+      "type": "lay_tile",
+      "entity": "P3",
+      "entity_type": "company",
+      "id": 80,
+      "created_at": 1692888229,
+      "hex": "I10",
+      "tile": "241-0",
+      "rotation": 1
+    },
+    {
+      "type": "undo",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 81,
+      "created_at": 1692888244,
+      "action_id": 66
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 82,
+      "created_at": 1692888246,
+      "hex": "G10",
+      "tile": "235-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 83,
+      "created_at": 1692888248
+    },
+    {
+      "type": "run_routes",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 84,
+      "created_at": 1692888250,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "H11",
+            "G10"
+          ],
+          "revenue": 50,
+          "revenue_str": "H11-G10",
+          "nodes": [
+            "H11-0",
+            "G10-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 85,
+      "created_at": 1692888251,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 86,
+      "created_at": 1692888252,
+      "train": "2-5",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 87,
+      "created_at": 1692888253,
+      "train": "3-0",
+      "price": 200,
+      "variant": "3"
+    },
+    {
+      "type": "buy_company",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 88,
+      "created_at": 1692888280,
+      "company": "P4",
+      "price": 220
+    },
+    {
+      "type": "buy_company",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 89,
+      "created_at": 1692888282,
+      "company": "P3",
+      "price": 140
+    },
+    {
+      "type": "lay_tile",
+      "entity": "P3",
+      "entity_type": "company",
+      "id": 90,
+      "created_at": 1692888287,
+      "hex": "I10",
+      "tile": "241-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 91,
+      "created_at": 1692888289
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 92,
+      "created_at": 1692888292
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 93,
+      "created_at": 1692888315,
+      "hex": "H7",
+      "tile": "6-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 94,
+      "created_at": 1692888319
+    },
+    {
+      "type": "place_token",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 95,
+      "created_at": 1692888320,
+      "city": "6-0-0",
+      "slot": 0,
+      "tokener": "SAR"
+    },
+    {
+      "type": "undo",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 96,
+      "created_at": 1692888327,
+      "action_id": 92
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 97,
+      "created_at": 1692888331,
+      "hex": "F5",
+      "tile": "57-2",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 98,
+      "created_at": 1692888337,
+      "hex": "H7",
+      "tile": "6-0",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 99,
+      "created_at": 1692888345,
+      "city": "57-2-0",
+      "slot": 0,
+      "tokener": "SAR"
+    },
+    {
+      "type": "run_routes",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 100,
+      "created_at": 1692888350,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "F5",
+              "G6"
+            ]
+          ],
+          "hexes": [
+            "F5",
+            "G6"
+          ],
+          "revenue": 40,
+          "revenue_str": "F5-G6",
+          "nodes": [
+            "F5-0",
+            "G6-0"
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "G6",
+              "H7"
+            ]
+          ],
+          "hexes": [
+            "G6",
+            "H7"
+          ],
+          "revenue": 40,
+          "revenue_str": "G6-H7",
+          "nodes": [
+            "G6-0",
+            "H7-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 101,
+      "created_at": 1692888352,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 102,
+      "created_at": 1692888355,
+      "train": "3-1",
+      "price": 230,
+      "variant": "3+"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 103,
+      "created_at": 1692888358,
+      "train": "3-2",
+      "price": 200,
+      "variant": "3"
+    },
+    {
+      "type": "take_loan",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 104,
+      "created_at": 1692888360,
+      "loan": 0
+    },
+    {
+      "type": "buy_company",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 105,
+      "created_at": 1692888367,
+      "company": "P2",
+      "price": 80
+    },
+    {
+      "type": "buy_company",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 106,
+      "created_at": 1692888369,
+      "company": "P1",
+      "price": 40
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 107,
+      "created_at": 1692888373
+    },
+    {
+      "type": "par",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 108,
+      "created_at": 1692888938,
+      "corporation": "FT",
+      "share_price": "70,4,5"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 109,
+      "created_at": 1692888950,
+      "shares": [
+        "SAR_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 110,
+      "created_at": 1692888961,
+      "shares": [
+        "BOE_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 111,
+      "created_at": 1692888969,
+      "shares": [
+        "FT_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 112,
+      "created_at": 1692888972
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 113,
+      "created_at": 1692888974,
+      "shares": [
+        "BOE_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 114,
+      "created_at": 1692888976,
+      "shares": [
+        "FT_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 115,
+      "created_at": 1692888977
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 116,
+      "created_at": 1692888979,
+      "shares": [
+        "BOE_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 117,
+      "created_at": 1692888981
+    },
+    {
+      "type": "undo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 118,
+      "created_at": 1692888986
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 119,
+      "created_at": 1692888991,
+      "shares": [
+        "FT_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 120,
+      "created_at": 1692888993
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 121,
+      "created_at": 1692888993
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 122,
+      "created_at": 1692888995,
+      "shares": [
+        "FT_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 123,
+      "created_at": 1692888996
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 124,
+      "created_at": 1692888997
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 125,
+      "created_at": 1692888997,
+      "auto_actions": [
+        {
+          "type": "dividend",
+          "entity": "BOE",
+          "entity_type": "corporation",
+          "created_at": 1692888997,
+          "kind": "payout"
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 126,
+      "created_at": 1692889022,
+      "hex": "E4",
+      "tile": "14-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 127,
+      "created_at": 1692889026,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "E4",
+              "F5"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "F5"
+          ],
+          "revenue": 50,
+          "revenue_str": "E4-F5",
+          "nodes": [
+            "E4-0",
+            "F5-0"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "E4",
+              "D3"
+            ],
+            [
+              "D3",
+              "D1"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "D3",
+            "D1"
+          ],
+          "revenue": 80,
+          "revenue_str": "E4-D3-D1",
+          "nodes": [
+            "E4-0",
+            "D3-1",
+            "D1-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 128,
+      "created_at": 1692889031,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 129,
+      "created_at": 1692889035,
+      "train": "3-3",
+      "price": 200,
+      "variant": "3"
+    },
+    {
+      "type": "buy_train",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 130,
+      "created_at": 1692889036,
+      "train": "3-4",
+      "price": 200,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 131,
+      "created_at": 1692889042
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 132,
+      "created_at": 1692889053,
+      "hex": "H11",
+      "tile": "238-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 133,
+      "created_at": 1692889071,
+      "city": "235-0-0",
+      "slot": 0,
+      "tokener": "VR"
+    },
+    {
+      "type": "run_routes",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 134,
+      "created_at": 1692889075,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "H11",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "H11",
+            "I10"
+          ],
+          "revenue": 90,
+          "revenue_str": "H11-I10",
+          "nodes": [
+            "H11-0",
+            "I10-1"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "H11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "H11",
+            "G10"
+          ],
+          "revenue": 70,
+          "revenue_str": "H11-G10",
+          "nodes": [
+            "H11-0",
+            "G10-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 135,
+      "created_at": 1692889078,
+      "kind": "payout"
+    },
+    {
+      "type": "take_loan",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 136,
+      "created_at": 1692889081,
+      "loan": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 137,
+      "created_at": 1692889084,
+      "train": "4-0",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 138,
+      "created_at": 1692889093
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 139,
+      "created_at": 1692889097
+    },
+    {
+      "type": "lay_tile",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 140,
+      "created_at": 1692889107,
+      "hex": "G14",
+      "tile": "6-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 141,
+      "created_at": 1692889131,
+      "hex": "G12",
+      "tile": "2-0",
+      "rotation": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 142,
+      "created_at": 1692889141,
+      "train": "4-1",
+      "price": 340,
+      "variant": "4+"
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 143,
+      "created_at": 1692889143
+    },
+    {
+      "type": "undo",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 144,
+      "created_at": 1692889146
+    },
+    {
+      "type": "take_loan",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 145,
+      "created_at": 1692889154,
+      "loan": 2
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 146,
+      "created_at": 1692889162
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 147,
+      "created_at": 1692889165
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 148,
+      "created_at": 1692889173,
+      "hex": "H9",
+      "tile": "6-2",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 149,
+      "created_at": 1692889183
+    },
+    {
+      "type": "run_routes",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 150,
+      "created_at": 1692889194,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "G6",
+              "H7"
+            ],
+            [
+              "H7",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "G6",
+            "H7",
+            "H9"
+          ],
+          "revenue": 60,
+          "revenue_str": "G6-H7-H9",
+          "nodes": [
+            "G6-0",
+            "H7-0",
+            "H9-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "F5",
+              "E4"
+            ],
+            [
+              "E4",
+              "D3"
+            ],
+            [
+              "D3",
+              "D1"
+            ]
+          ],
+          "hexes": [
+            "F5",
+            "E4",
+            "D3",
+            "D1"
+          ],
+          "revenue": 100,
+          "revenue_str": "F5-E4-D3-D1",
+          "nodes": [
+            "F5-0",
+            "E4-0",
+            "D3-1",
+            "D1-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 151,
+      "created_at": 1692889199,
+      "kind": "payout"
+    },
+    {
+      "type": "take_loan",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 152,
+      "created_at": 1692889201,
+      "loan": 3
+    },
+    {
+      "type": "undo",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 153,
+      "created_at": 1692889205,
+      "action_id": 147
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 154,
+      "created_at": 1692889209,
+      "hex": "H9",
+      "tile": "6-2",
+      "rotation": 5
+    },
+    {
+      "type": "take_loan",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 155,
+      "created_at": 1692889210,
+      "loan": 3
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 156,
+      "created_at": 1692889212
+    },
+    {
+      "type": "place_token",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 157,
+      "created_at": 1692889213,
+      "city": "6-2-0",
+      "slot": 0,
+      "tokener": "SAR"
+    },
+    {
+      "type": "undo",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 158,
+      "created_at": 1692889222,
+      "action_id": 147
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 159,
+      "created_at": 1692889225,
+      "hex": "H9",
+      "tile": "57-0",
+      "rotation": 1
+    },
+    {
+      "type": "take_loan",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 160,
+      "created_at": 1692889227,
+      "loan": 3
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 161,
+      "created_at": 1692889227
+    },
+    {
+      "type": "place_token",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 162,
+      "created_at": 1692889229,
+      "city": "238-0-0",
+      "slot": 1,
+      "tokener": "SAR"
+    },
+    {
+      "type": "run_routes",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 163,
+      "created_at": 1692889241,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "F5",
+              "E4"
+            ],
+            [
+              "E4",
+              "D3"
+            ],
+            [
+              "D3",
+              "D1"
+            ]
+          ],
+          "hexes": [
+            "F5",
+            "E4",
+            "D3",
+            "D1"
+          ],
+          "revenue": 100,
+          "revenue_str": "F5-E4-D3-D1",
+          "nodes": [
+            "F5-0",
+            "E4-0",
+            "D3-1",
+            "D1-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "I10",
+              "H11"
+            ],
+            [
+              "H11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "I10",
+            "H11",
+            "G10"
+          ],
+          "revenue": 120,
+          "revenue_str": "I10-H11-G10",
+          "nodes": [
+            "I10-1",
+            "H11-0",
+            "G10-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 164,
+      "created_at": 1692889243,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 165,
+      "created_at": 1692889248
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 166,
+      "created_at": 1692889252,
+      "auto_actions": [
+        {
+          "type": "dividend",
+          "entity": "BOE",
+          "entity_type": "corporation",
+          "created_at": 1692889252,
+          "kind": "payout"
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 167,
+      "created_at": 1692889262,
+      "hex": "F5",
+      "tile": "15-0",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 168,
+      "created_at": 1692889263,
+      "city": "15-0-0",
+      "slot": 1,
+      "tokener": "CAR"
+    },
+    {
+      "type": "undo",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 169,
+      "created_at": 1692889276,
+      "action_id": 166
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 170,
+      "created_at": 1692889279,
+      "hex": "E2",
+      "tile": "6-2",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 171,
+      "created_at": 1692889283
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 172,
+      "created_at": 1692889286
+    },
+    {
+      "type": "run_routes",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 173,
+      "created_at": 1692889289,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "E4",
+              "E2"
+            ],
+            [
+              "E2",
+              "D1"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E2",
+            "D1"
+          ],
+          "revenue": 90,
+          "revenue_str": "E4-E2-D1",
+          "nodes": [
+            "E4-0",
+            "E2-0",
+            "D1-0"
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "D1",
+              "D3"
+            ],
+            [
+              "D3",
+              "E4"
+            ],
+            [
+              "E4",
+              "F5"
+            ]
+          ],
+          "hexes": [
+            "D1",
+            "D3",
+            "E4",
+            "F5"
+          ],
+          "revenue": 100,
+          "revenue_str": "D1-D3-E4-F5",
+          "nodes": [
+            "D1-0",
+            "D3-1",
+            "E4-0",
+            "F5-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 174,
+      "created_at": 1692889290,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 175,
+      "created_at": 1692889293
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 176,
+      "created_at": 1692889295
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 177,
+      "created_at": 1692889310,
+      "hex": "H9",
+      "tile": "14-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 178,
+      "created_at": 1692889317,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G10",
+              "H11"
+            ],
+            [
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H11",
+            "H9",
+            "I10"
+          ],
+          "revenue": 150,
+          "revenue_str": "G10-H11-H9-I10",
+          "nodes": [
+            "G10-0",
+            "H11-0",
+            "H9-0",
+            "I10-1"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "H11",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "H11",
+            "I10"
+          ],
+          "revenue": 90,
+          "revenue_str": "H11-I10",
+          "nodes": [
+            "H11-0",
+            "I10-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 179,
+      "created_at": 1692889318,
+      "kind": "payout"
+    },
+    {
+      "type": "undo",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 180,
+      "created_at": 1692889325
+    },
+    {
+      "type": "undo",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 181,
+      "created_at": 1692889328
+    },
+    {
+      "type": "undo",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 182,
+      "created_at": 1692889330
+    },
+    {
+      "type": "take_loan",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 183,
+      "created_at": 1692889333,
+      "loan": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 184,
+      "created_at": 1692889340,
+      "hex": "H9",
+      "tile": "14-1",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 185,
+      "created_at": 1692889342,
+      "city": "14-1-0",
+      "slot": 0,
+      "tokener": "VR"
+    },
+    {
+      "type": "run_routes",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 186,
+      "created_at": 1692889354,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "H11",
+            "H9",
+            "I10"
+          ],
+          "revenue": 120,
+          "revenue_str": "H11-H9-I10",
+          "nodes": [
+            "H11-0",
+            "H9-0",
+            "I10-1"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "G10",
+              "H11"
+            ],
+            [
+              "H11",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H11",
+            "I10"
+          ],
+          "revenue": 120,
+          "revenue_str": "G10-H11-I10",
+          "nodes": [
+            "G10-0",
+            "H11-0",
+            "I10-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 187,
+      "created_at": 1692889355,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 188,
+      "created_at": 1692889357
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 189,
+      "created_at": 1692889359
+    },
+    {
+      "type": "lay_tile",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 190,
+      "created_at": 1692889369,
+      "hex": "F15",
+      "tile": "235-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 191,
+      "created_at": 1692889371
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 192,
+      "created_at": 1692889378
+    },
+    {
+      "type": "run_routes",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 193,
+      "created_at": 1692889381,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "F15",
+              "G14"
+            ],
+            [
+              "G14",
+              "G12"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "G14",
+            "G12"
+          ],
+          "revenue": 60,
+          "revenue_str": "F15-G14-G12",
+          "nodes": [
+            "F15-0",
+            "G14-0",
+            "G12-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 194,
+      "created_at": 1692889382,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 195,
+      "created_at": 1692889383
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 196,
+      "created_at": 1692889385
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 197,
+      "created_at": 1692889400,
+      "hex": "G10",
+      "tile": "59-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 198,
+      "created_at": 1692889404,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "F5",
+              "E4"
+            ],
+            [
+              "E4",
+              "D3"
+            ],
+            [
+              "D3",
+              "D1"
+            ]
+          ],
+          "hexes": [
+            "F5",
+            "E4",
+            "D3",
+            "D1"
+          ],
+          "revenue": 100,
+          "revenue_str": "F5-E4-D3-D1",
+          "nodes": [
+            "F5-0",
+            "E4-0",
+            "D3-1",
+            "D1-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "I10",
+              "H11"
+            ],
+            [
+              "H11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "I10",
+            "H11",
+            "G10"
+          ],
+          "revenue": 130,
+          "revenue_str": "I10-H11-G10",
+          "nodes": [
+            "I10-1",
+            "H11-0",
+            "G10-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 199,
+      "created_at": 1692889405,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 200,
+      "created_at": 1692889407
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 201,
+      "created_at": 1692889408
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 202,
+      "created_at": 1692889444,
+      "shares": [
+        "SAR_4",
+        "SAR_5",
+        "SAR_7"
+      ],
+      "percent": 30
+    },
+    {
+      "type": "par",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 203,
+      "created_at": 1692889460,
+      "corporation": "NSW",
+      "share_price": "80,3,5"
+    },
+    {
+      "type": "par",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 204,
+      "created_at": 1692889494,
+      "corporation": "WA",
+      "share_price": "70,4,5"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 205,
+      "created_at": 1692889500,
+      "shares": [
+        "BOE_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 206,
+      "created_at": 1692889505,
+      "shares": [
+        "NSW_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 207,
+      "created_at": 1692889507,
+      "shares": [
+        "WA_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 208,
+      "created_at": 1692889509,
+      "shares": [
+        "BOE_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 209,
+      "created_at": 1692889510,
+      "shares": [
+        "NSW_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 210,
+      "created_at": 1692889512,
+      "shares": [
+        "WA_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 211,
+      "created_at": 1692889529,
+      "shares": [
+        "SAR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 212,
+      "created_at": 1692889535,
+      "shares": [
+        "NSW_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 213,
+      "created_at": 1692889537,
+      "shares": [
+        "WA_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 214,
+      "created_at": 1692889540,
+      "shares": [
+        "SAR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 215,
+      "created_at": 1692889542,
+      "shares": [
+        "NSW_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 216,
+      "created_at": 1692889544,
+      "shares": [
+        "WA_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 217,
+      "created_at": 1692889546
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 218,
+      "created_at": 1692889549
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 219,
+      "created_at": 1692889552,
+      "shares": [
+        "SAR_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 220,
+      "created_at": 1692889565
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 221,
+      "created_at": 1692889565
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 222,
+      "created_at": 1692889565,
+      "auto_actions": [
+        {
+          "type": "dividend",
+          "entity": "BOE",
+          "entity_type": "corporation",
+          "created_at": 1692889565,
+          "kind": "payout"
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 223,
+      "created_at": 1692889595,
+      "hex": "E2",
+      "tile": "15-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 224,
+      "created_at": 1692889598
+    },
+    {
+      "type": "run_routes",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 225,
+      "created_at": 1692889600,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "E4",
+              "E2"
+            ],
+            [
+              "E2",
+              "D1"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E2",
+            "D1"
+          ],
+          "revenue": 100,
+          "revenue_str": "E4-E2-D1",
+          "nodes": [
+            "E4-0",
+            "E2-0",
+            "D1-0"
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "D1",
+              "D3"
+            ],
+            [
+              "D3",
+              "E4"
+            ],
+            [
+              "E4",
+              "F5"
+            ]
+          ],
+          "hexes": [
+            "D1",
+            "D3",
+            "E4",
+            "F5"
+          ],
+          "revenue": 100,
+          "revenue_str": "D1-D3-E4-F5",
+          "nodes": [
+            "D1-0",
+            "D3-1",
+            "E4-0",
+            "F5-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 226,
+      "created_at": 1692889602,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 227,
+      "created_at": 1692889603
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 228,
+      "created_at": 1692889605
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 229,
+      "created_at": 1692889612,
+      "hex": "F17",
+      "tile": "6-3",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 230,
+      "created_at": 1692889616,
+      "hex": "E18",
+      "tile": "57-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 231,
+      "created_at": 1692889619
+    },
+    {
+      "type": "buy_train",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 232,
+      "created_at": 1692889621,
+      "train": "4-2",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 233,
+      "created_at": 1692889622
+    },
+    {
+      "type": "pass",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 234,
+      "created_at": 1692889624
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 235,
+      "created_at": 1692889645
+    },
+    {
+      "type": "run_routes",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 236,
+      "created_at": 1692889649,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "H11",
+            "H9",
+            "I10"
+          ],
+          "revenue": 120,
+          "revenue_str": "H11-H9-I10",
+          "nodes": [
+            "H11-0",
+            "H9-0",
+            "I10-1"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "G10",
+              "H11"
+            ],
+            [
+              "H11",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H11",
+            "I10"
+          ],
+          "revenue": 130,
+          "revenue_str": "G10-H11-I10",
+          "nodes": [
+            "G10-1",
+            "H11-0",
+            "I10-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 237,
+      "created_at": 1692889653,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 238,
+      "created_at": 1692889655
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 239,
+      "created_at": 1692889657
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 240,
+      "created_at": 1692889669,
+      "hex": "F5",
+      "tile": "15-1",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 241,
+      "created_at": 1692889671,
+      "city": "15-1-0",
+      "slot": 1,
+      "tokener": "WA"
+    },
+    {
+      "type": "buy_train",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 242,
+      "created_at": 1692889692,
+      "train": "4-3",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "take_loan",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 243,
+      "created_at": 1692889694,
+      "loan": 5
+    },
+    {
+      "type": "pass",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 244,
+      "created_at": 1692889695
+    },
+    {
+      "type": "pass",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 245,
+      "created_at": 1692889697
+    },
+    {
+      "type": "lay_tile",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 246,
+      "created_at": 1692889705,
+      "hex": "F15",
+      "tile": "59-1",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 247,
+      "created_at": 1692889708,
+      "city": "59-1-0",
+      "slot": 0,
+      "tokener": "FT"
+    },
+    {
+      "type": "undo",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 248,
+      "created_at": 1692889721
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 249,
+      "created_at": 1692889724
+    },
+    {
+      "type": "run_routes",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 250,
+      "created_at": 1692889727,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "F15",
+              "G14"
+            ],
+            [
+              "G14",
+              "G12"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "G14",
+            "G12"
+          ],
+          "revenue": 70,
+          "revenue_str": "F15-G14-G12",
+          "nodes": [
+            "F15-0",
+            "G14-0",
+            "G12-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 251,
+      "created_at": 1692889728,
+      "kind": "payout"
+    },
+    {
+      "type": "take_loan",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 252,
+      "created_at": 1692889730,
+      "loan": 6
+    },
+    {
+      "type": "buy_train",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 253,
+      "created_at": 1692889733,
+      "train": "5-0",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 254,
+      "created_at": 1692889734
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 255,
+      "created_at": 1692889794,
+      "hex": "G10",
+      "tile": "65-0",
+      "rotation": 3
+    },
+    {
+      "type": "undo",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 256,
+      "created_at": 1692889798
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 257,
+      "created_at": 1692889814,
+      "hex": "G10",
+      "tile": "65-0",
+      "rotation": 3
+    },
+    {
+      "type": "run_routes",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 258,
+      "created_at": 1692889827,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "F5",
+              "E4"
+            ],
+            [
+              "E4",
+              "D3"
+            ],
+            [
+              "D3",
+              "D1"
+            ]
+          ],
+          "hexes": [
+            "F5",
+            "E4",
+            "D3",
+            "D1"
+          ],
+          "revenue": 130,
+          "revenue_str": "F5-E4-D3-D1",
+          "nodes": [
+            "F5-0",
+            "E4-0",
+            "D3-1",
+            "D1-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "I10",
+              "H11"
+            ],
+            [
+              "H11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "I10",
+            "H11",
+            "G10"
+          ],
+          "revenue": 140,
+          "revenue_str": "I10-H11-G10",
+          "nodes": [
+            "I10-1",
+            "H11-0",
+            "G10-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 259,
+      "created_at": 1692889828,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 260,
+      "created_at": 1692889838,
+      "auto_actions": [
+        {
+          "type": "dividend",
+          "entity": "BOE",
+          "entity_type": "corporation",
+          "created_at": 1692889838,
+          "kind": "payout"
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 261,
+      "created_at": 1692889844,
+      "hex": "E4",
+      "tile": "611-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 262,
+      "created_at": 1692889847
+    },
+    {
+      "type": "run_routes",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 263,
+      "created_at": 1692889851,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "E4",
+              "E2"
+            ],
+            [
+              "E2",
+              "D1"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E2",
+            "D1"
+          ],
+          "revenue": 130,
+          "revenue_str": "E4-E2-D1",
+          "nodes": [
+            "E4-0",
+            "E2-0",
+            "D1-0"
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "D1",
+              "D3"
+            ],
+            [
+              "D3",
+              "E4"
+            ],
+            [
+              "E4",
+              "F5"
+            ]
+          ],
+          "hexes": [
+            "D1",
+            "D3",
+            "E4",
+            "F5"
+          ],
+          "revenue": 140,
+          "revenue_str": "D1-D3-E4-F5",
+          "nodes": [
+            "D1-0",
+            "D3-1",
+            "E4-0",
+            "F5-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 264,
+      "created_at": 1692889853,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 265,
+      "created_at": 1692889857,
+      "train": "2E-0",
+      "price": 200,
+      "variant": "2E"
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 266,
+      "created_at": 1692889861
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 267,
+      "created_at": 1692889868,
+      "hex": "G8",
+      "tile": "7-0",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 268,
+      "created_at": 1692889872,
+      "hex": "F11",
+      "tile": "7-1",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 269,
+      "created_at": 1692889877,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "I10",
+              "H9"
+            ],
+            [
+              "H9",
+              "G8",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "I10",
+            "H9",
+            "G10"
+          ],
+          "revenue": 130,
+          "revenue_str": "I10-H9-G10",
+          "nodes": [
+            "I10-1",
+            "H9-0",
+            "G10-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "G10",
+              "H11"
+            ],
+            [
+              "H11",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H11",
+            "I10"
+          ],
+          "revenue": 140,
+          "revenue_str": "G10-H11-I10",
+          "nodes": [
+            "G10-1",
+            "H11-0",
+            "I10-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 270,
+      "created_at": 1692889879,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 271,
+      "created_at": 1692889900
+    },
+    {
+      "type": "undo",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 272,
+      "created_at": 1692889902
+    },
+    {
+      "type": "buy_train",
+      "entity": "P4",
+      "entity_type": "company",
+      "id": 273,
+      "created_at": 1692889908,
+      "train": "2E-1",
+      "price": 100,
+      "variant": "2E"
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 274,
+      "created_at": 1692889910
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 275,
+      "created_at": 1692889921,
+      "hex": "F15",
+      "tile": "64-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 276,
+      "created_at": 1692889930
+    },
+    {
+      "type": "run_routes",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 277,
+      "created_at": 1692889934,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "F15",
+              "F17"
+            ],
+            [
+              "F17",
+              "E18"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "F17",
+            "E18"
+          ],
+          "revenue": 90,
+          "revenue_str": "F15-F17-E18",
+          "nodes": [
+            "F15-0",
+            "F17-0",
+            "E18-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 278,
+      "created_at": 1692889935,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 279,
+      "created_at": 1692889936,
+      "train": "5-1",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "pass",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 280,
+      "created_at": 1692889937
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 281,
+      "created_at": 1692889956,
+      "hex": "G6",
+      "tile": "237-0",
+      "rotation": 5
+    },
+    {
+      "type": "undo",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 282,
+      "created_at": 1692889962,
+      "action_id": 280
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 283,
+      "created_at": 1692889968,
+      "hex": "H11",
+      "tile": "239-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 284,
+      "created_at": 1692890000,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "F5",
+              "E4"
+            ],
+            [
+              "E4",
+              "D3"
+            ],
+            [
+              "D3",
+              "D1"
+            ]
+          ],
+          "hexes": [
+            "F5",
+            "E4",
+            "D3",
+            "D1"
+          ],
+          "revenue": 140,
+          "revenue_str": "F5-E4-D3-D1",
+          "nodes": [
+            "F5-0",
+            "E4-0",
+            "D3-1",
+            "D1-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "I10",
+              "H11"
+            ],
+            [
+              "H11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "I10",
+            "H11",
+            "G10"
+          ],
+          "revenue": 160,
+          "revenue_str": "I10-H11-G10",
+          "nodes": [
+            "I10-1",
+            "H11-0",
+            "G10-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 285,
+      "created_at": 1692890001,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 286,
+      "created_at": 1692890003
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 287,
+      "created_at": 1692890021,
+      "hex": "F7",
+      "tile": "9-0",
+      "rotation": 1
+    },
+    {
+      "type": "undo",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 288,
+      "created_at": 1692890027
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 289,
+      "created_at": 1692890031,
+      "hex": "F7",
+      "tile": "8-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 290,
+      "created_at": 1692890033
+    },
+    {
+      "type": "pass",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 291,
+      "created_at": 1692890034
+    },
+    {
+      "type": "run_routes",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 292,
+      "created_at": 1692890036,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "D1",
+              "D3"
+            ],
+            [
+              "D3",
+              "E4"
+            ],
+            [
+              "E4",
+              "F5"
+            ],
+            [
+              "F5",
+              "G6"
+            ]
+          ],
+          "hexes": [
+            "D1",
+            "D3",
+            "E4",
+            "F5",
+            "G6"
+          ],
+          "revenue": 210,
+          "revenue_str": "D1-D3-E4-F5-G6 + k-k",
+          "nodes": [
+            "D1-0",
+            "D3-1",
+            "E4-0",
+            "F5-0",
+            "G6-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 293,
+      "created_at": 1692890037,
+      "kind": "payout"
+    },
+    {
+      "type": "take_loan",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 294,
+      "created_at": 1692890039,
+      "loan": 7
+    },
+    {
+      "type": "buy_train",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 295,
+      "created_at": 1692890040,
+      "train": "5-2",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "pass",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 296,
+      "created_at": 1692890041
+    },
+    {
+      "type": "lay_tile",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 297,
+      "created_at": 1692890056,
+      "hex": "G14",
+      "tile": "15-2",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 298,
+      "created_at": 1692890064,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G14",
+              "G12"
+            ]
+          ],
+          "hexes": [
+            "G14",
+            "G12"
+          ],
+          "revenue": 40,
+          "revenue_str": "G14-G12",
+          "nodes": [
+            "G14-0",
+            "G12-0"
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G14",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "G14",
+            "F15"
+          ],
+          "revenue": 80,
+          "revenue_str": "G14-F15",
+          "nodes": [
+            "G14-0",
+            "F15-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 299,
+      "created_at": 1692890065,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 300,
+      "created_at": 1692890067
+    },
+    {
+      "type": "par",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 301,
+      "created_at": 1692890075,
+      "corporation": "COM",
+      "share_price": "100,1,5"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 302,
+      "created_at": 1692890094,
+      "shares": [
+        "CAR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 303,
+      "created_at": 1692890097,
+      "corporation": "QR",
+      "share_price": "100,1,5"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 304,
+      "created_at": 1692890101,
+      "shares": [
+        "COM_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 305,
+      "created_at": 1692890110,
+      "shares": [
+        "BOE_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 306,
+      "created_at": 1692890119,
+      "shares": [
+        "QR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 307,
+      "created_at": 1692890121,
+      "shares": [
+        "COM_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 308,
+      "created_at": 1692890122,
+      "shares": [
+        "BOE_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 309,
+      "created_at": 1692890124,
+      "shares": [
+        "QR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 310,
+      "created_at": 1692890125,
+      "shares": [
+        "COM_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 311,
+      "created_at": 1692890132
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 312,
+      "created_at": 1692890170,
+      "shares": [
+        "BOE_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 313,
+      "created_at": 1692890176,
+      "shares": [
+        "QR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 314,
+      "created_at": 1692890181,
+      "shares": [
+        "COM_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 315,
+      "created_at": 1692890214
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 316,
+      "created_at": 1692890251
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 317,
+      "created_at": 1692890251,
+      "auto_actions": [
+        {
+          "type": "dividend",
+          "entity": "BOE",
+          "entity_type": "corporation",
+          "created_at": 1692890251,
+          "kind": "payout"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 318,
+      "created_at": 1692890251
+    },
+    {
+      "type": "undo",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 319,
+      "created_at": 1692890254
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 320,
+      "created_at": 1692890263,
+      "hex": "C4",
+      "tile": "9-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 321,
+      "created_at": 1692890265,
+      "hex": "B5",
+      "tile": "8-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 322,
+      "created_at": 1692890273
+    },
+    {
+      "type": "undo",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 323,
+      "created_at": 1692890284
+    },
+    {
+      "type": "place_token",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 324,
+      "created_at": 1692890287,
+      "city": "15-0-0",
+      "slot": 1,
+      "tokener": "CAR"
+    },
+    {
+      "type": "run_routes",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 325,
+      "created_at": 1692890295,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "E4",
+              "E2"
+            ],
+            [
+              "E2",
+              "D1"
+            ]
+          ],
+          "hexes": [
+            "E4",
+            "E2",
+            "D1"
+          ],
+          "revenue": 130,
+          "revenue_str": "E4-E2-D1",
+          "nodes": [
+            "E4-0",
+            "E2-0",
+            "D1-0"
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "D1",
+              "D3"
+            ],
+            [
+              "D3",
+              "E4"
+            ],
+            [
+              "E4",
+              "F5"
+            ]
+          ],
+          "hexes": [
+            "D1",
+            "D3",
+            "E4",
+            "F5"
+          ],
+          "revenue": 140,
+          "revenue_str": "D1-D3-E4-F5",
+          "nodes": [
+            "D1-0",
+            "D3-1",
+            "E4-0",
+            "F5-0"
+          ]
+        },
+        {
+          "train": "2E-0",
+          "connections": [
+            [
+              "A4",
+              "B5",
+              "C4",
+              "D3"
+            ],
+            [
+              "D3",
+              "E2"
+            ],
+            [
+              "E2",
+              "F3"
+            ]
+          ],
+          "hexes": [
+            "A4",
+            "D3",
+            "E2",
+            "F3"
+          ],
+          "revenue": 70,
+          "revenue_str": "A4-D3-E2-F3",
+          "nodes": [
+            "A4-0",
+            "D3-0",
+            "E2-0",
+            "F3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 326,
+      "created_at": 1692890296,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 327,
+      "created_at": 1692890298
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 328,
+      "created_at": 1692890310,
+      "hex": "F13",
+      "tile": "57-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 329,
+      "created_at": 1692890313,
+      "auto_actions": [
+        {
+          "type": "destination_connection",
+          "entity": "VR",
+          "entity_type": "corporation",
+          "created_at": 1692890313
+        }
+      ],
+      "hex": "E14",
+      "tile": "5-1",
+      "rotation": 5
+    },
+    {
+      "type": "undo",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 330,
+      "created_at": 1692890321,
+      "action_id": 327
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 331,
+      "created_at": 1692890333,
+      "hex": "G8",
+      "tile": "26-0",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 332,
+      "created_at": 1692890338,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "H11",
+            "H9",
+            "I10"
+          ],
+          "revenue": 140,
+          "revenue_str": "H11-H9-I10",
+          "nodes": [
+            "H11-0",
+            "H9-0",
+            "I10-1"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "G10",
+              "H11"
+            ],
+            [
+              "H11",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H11",
+            "I10"
+          ],
+          "revenue": 160,
+          "revenue_str": "G10-H11-I10",
+          "nodes": [
+            "G10-1",
+            "H11-0",
+            "I10-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 333,
+      "created_at": 1692890343,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 334,
+      "created_at": 1692890346
+    },
+    {
+      "type": "undo",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 335,
+      "created_at": 1692890363,
+      "action_id": 327
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 336,
+      "created_at": 1692890368,
+      "hex": "F13",
+      "tile": "57-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 337,
+      "created_at": 1692890371,
+      "auto_actions": [
+        {
+          "type": "destination_connection",
+          "entity": "VR",
+          "entity_type": "corporation",
+          "created_at": 1692890371
+        }
+      ],
+      "hex": "E14",
+      "tile": "5-1",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 338,
+      "created_at": 1692890384,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "H11",
+            "H9",
+            "I10"
+          ],
+          "revenue": 140,
+          "revenue_str": "H11-H9-I10",
+          "nodes": [
+            "H11-0",
+            "H9-0",
+            "I10-1"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "G10",
+              "H11"
+            ],
+            [
+              "H11",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H11",
+            "I10"
+          ],
+          "revenue": 160,
+          "revenue_str": "G10-H11-I10",
+          "nodes": [
+            "G10-1",
+            "H11-0",
+            "I10-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 339,
+      "created_at": 1692890387,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 340,
+      "created_at": 1692890853
+    },
+    {
+      "type": "lay_tile",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 341,
+      "created_at": 1692890867,
+      "hex": "F17",
+      "tile": "236-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 342,
+      "created_at": 1692890869,
+      "city": "64-0-0",
+      "slot": 0,
+      "tokener": "COM"
+    },
+    {
+      "type": "buy_train",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 343,
+      "created_at": 1692890875,
+      "train": "6-0",
+      "price": 660,
+      "variant": "6+"
+    },
+    {
+      "type": "pass",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 344,
+      "created_at": 1692890886
+    },
+    {
+      "type": "pass",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 345,
+      "created_at": 1692890888
+    },
+    {
+      "type": "lay_tile",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 346,
+      "created_at": 1692890898,
+      "hex": "B19",
+      "tile": "6-2",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 347,
+      "created_at": 1692890902,
+      "hex": "B17",
+      "tile": "235-2",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 348,
+      "created_at": 1692890906
+    },
+    {
+      "type": "buy_train",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 349,
+      "created_at": 1692890909,
+      "train": "6-1",
+      "price": 660,
+      "variant": "6+"
+    },
+    {
+      "type": "pass",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 350,
+      "created_at": 1692890911
+    },
+    {
+      "type": "pass",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 351,
+      "created_at": 1692890913
+    },
+    {
+      "type": "take_loan",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 352,
+      "created_at": 1692890921,
+      "loan": 8
+    },
+    {
+      "type": "undo",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 353,
+      "created_at": 1692890932
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 354,
+      "created_at": 1692890937,
+      "hex": "D19",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 355,
+      "created_at": 1692890943,
+      "hex": "C20",
+      "tile": "6-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 356,
+      "created_at": 1692890948,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "F17",
+              "E18"
+            ],
+            [
+              "E18",
+              "D19",
+              "C20"
+            ],
+            [
+              "C20",
+              "B19"
+            ]
+          ],
+          "hexes": [
+            "F17",
+            "E18",
+            "C20",
+            "B19"
+          ],
+          "revenue": 150,
+          "revenue_str": "F17-E18-C20-B19 + k-k",
+          "nodes": [
+            "F17-0",
+            "E18-0",
+            "C20-0",
+            "B19-0"
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "F17",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "F17",
+            "F15"
+          ],
+          "revenue": 90,
+          "revenue_str": "F17-F15",
+          "nodes": [
+            "F17-0",
+            "F15-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 357,
+      "created_at": 1692890949,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 358,
+      "created_at": 1692890951
+    },
+    {
+      "type": "lay_tile",
+      "entity": "P2",
+      "entity_type": "company",
+      "id": 359,
+      "created_at": 1692890968,
+      "hex": "E6",
+      "tile": "7-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 360,
+      "created_at": 1692890974,
+      "hex": "D5",
+      "tile": "9-2",
+      "rotation": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 361,
+      "created_at": 1692890992,
+      "loan": 8
+    },
+    {
+      "type": "buy_train",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 362,
+      "created_at": 1692891001,
+      "train": "8-0",
+      "price": 800,
+      "variant": "8"
+    },
+    {
+      "type": "take_loan",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 363,
+      "created_at": 1692891071,
+      "loan": 10
+    },
+    {
+      "type": "lay_tile",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 364,
+      "created_at": 1692891080,
+      "hex": "F13",
+      "tile": "15-3",
+      "rotation": 3
+    },
+    {
+      "type": "place_token",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 365,
+      "created_at": 1692891081,
+      "city": "65-0-0",
+      "slot": 0,
+      "tokener": "FT"
+    },
+    {
+      "type": "run_routes",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 366,
+      "created_at": 1692891087,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "F15",
+              "E14"
+            ],
+            [
+              "E14",
+              "F13"
+            ],
+            [
+              "F13",
+              "G14"
+            ],
+            [
+              "G14",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "E14",
+            "F13",
+            "G14",
+            "F15"
+          ],
+          "revenue": 180,
+          "revenue_str": "F15-E14-F13-G14-F15",
+          "nodes": [
+            "F15-0",
+            "E14-0",
+            "F13-0",
+            "G14-0",
+            "F15-1"
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G10",
+              "G8",
+              "H9"
+            ],
+            [
+              "H9",
+              "H11"
+            ],
+            [
+              "H11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H9",
+            "H11",
+            "G10"
+          ],
+          "revenue": 190,
+          "revenue_str": "G10-H9-H11-G10",
+          "nodes": [
+            "G10-0",
+            "H9-0",
+            "H11-0",
+            "G10-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 367,
+      "created_at": 1692891088,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 368,
+      "created_at": 1692891091
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 369,
+      "created_at": 1692891098,
+      "hex": "G8",
+      "tile": "26-0",
+      "rotation": 5
+    },
+    {
+      "type": "undo",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 370,
+      "created_at": 1692891103
+    },
+    {
+      "type": "take_loan",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 371,
+      "created_at": 1692891108,
+      "auto_actions": [
+        {
+          "type": "dividend",
+          "entity": "BOE",
+          "entity_type": "corporation",
+          "created_at": 1692891108,
+          "kind": "payout"
+        }
+      ],
+      "loan": 11
+    },
+    {
+      "type": "undo",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 372,
+      "created_at": 1692891113
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 373,
+      "created_at": 1692891119,
+      "hex": "G8",
+      "tile": "26-0",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 374,
+      "created_at": 1692891123,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "F5",
+              "F7",
+              "G8",
+              "H9"
+            ],
+            [
+              "H9",
+              "H11"
+            ],
+            [
+              "H11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "F5",
+            "H9",
+            "H11",
+            "G10"
+          ],
+          "revenue": 170,
+          "revenue_str": "F5-H9-H11-G10",
+          "nodes": [
+            "F5-0",
+            "H9-0",
+            "H11-0",
+            "G10-1"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "D1",
+              "D3"
+            ],
+            [
+              "D3",
+              "E4"
+            ],
+            [
+              "E4",
+              "F5"
+            ],
+            [
+              "F5",
+              "G6"
+            ]
+          ],
+          "hexes": [
+            "D1",
+            "D3",
+            "E4",
+            "F5",
+            "G6"
+          ],
+          "revenue": 210,
+          "revenue_str": "D1-D3-E4-F5-G6 + k-k",
+          "nodes": [
+            "D1-0",
+            "D3-1",
+            "E4-0",
+            "F5-0",
+            "G6-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 375,
+      "created_at": 1692891126,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 376,
+      "created_at": 1692891128,
+      "auto_actions": [
+        {
+          "type": "dividend",
+          "entity": "BOE",
+          "entity_type": "corporation",
+          "created_at": 1692891128,
+          "kind": "payout"
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 377,
+      "created_at": 1692891158,
+      "hex": "E6",
+      "tile": "28-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 378,
+      "created_at": 1692891162,
+      "routes": [
+        {
+          "train": "2E-0",
+          "connections": [
+            [
+              "A4",
+              "B5",
+              "C4",
+              "D3"
+            ],
+            [
+              "D3",
+              "E2"
+            ],
+            [
+              "E2",
+              "F3"
+            ]
+          ],
+          "hexes": [
+            "A4",
+            "D3",
+            "E2",
+            "F3"
+          ],
+          "revenue": 70,
+          "revenue_str": "A4-D3-E2-F3",
+          "nodes": [
+            "A4-0",
+            "D3-0",
+            "E2-0",
+            "F3-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 379,
+      "created_at": 1692891164,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 380,
+      "created_at": 1692891173,
+      "train": "5-1",
+      "price": 1
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 381,
+      "created_at": 1692891183
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 382,
+      "created_at": 1692891185
+    },
+    {
+      "type": "lay_tile",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 383,
+      "created_at": 1692891196,
+      "hex": "F7",
+      "tile": "24-0",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 384,
+      "created_at": 1692891200,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G10",
+              "H11"
+            ],
+            [
+              "H11",
+              "I10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H11",
+            "I10"
+          ],
+          "revenue": 160,
+          "revenue_str": "G10-H11-I10",
+          "nodes": [
+            "G10-1",
+            "H11-0",
+            "I10-1"
+          ]
+        },
+        {
+          "train": "2E-1",
+          "connections": [
+            [
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "G8",
+              "F7",
+              "E6",
+              "E4"
+            ],
+            [
+              "E4",
+              "E2"
+            ],
+            [
+              "E2",
+              "D3"
+            ],
+            [
+              "D3",
+              "C4",
+              "B5",
+              "A4"
+            ]
+          ],
+          "hexes": [
+            "H11",
+            "H9",
+            "E4",
+            "E2",
+            "D3",
+            "A4"
+          ],
+          "revenue": 100,
+          "revenue_str": "H11-H9-E4-E2-D3-A4",
+          "nodes": [
+            "H11-0",
+            "H9-0",
+            "E4-0",
+            "E2-0",
+            "D3-0",
+            "A4-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 385,
+      "created_at": 1692891201,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 386,
+      "created_at": 1692891213
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 387,
+      "created_at": 1692891215
+    },
+    {
+      "type": "pass",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 388,
+      "created_at": 1692891225
+    },
+    {
+      "type": "undo",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 389,
+      "created_at": 1692891230
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 390,
+      "created_at": 1692891234,
+      "hex": "E18",
+      "tile": "15-4",
+      "rotation": 0
+    },
+    {
+      "type": "undo",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 391,
+      "created_at": 1692891237
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 392,
+      "created_at": 1692891241,
+      "hex": "F17",
+      "tile": "239-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 393,
+      "created_at": 1692891248,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "F15",
+              "F17"
+            ],
+            [
+              "F17",
+              "E18"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "F17",
+            "E18"
+          ],
+          "revenue": 130,
+          "revenue_str": "F15-F17-E18",
+          "nodes": [
+            "F15-0",
+            "F17-0",
+            "E18-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 394,
+      "created_at": 1692891249,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 395,
+      "created_at": 1692891253
+    },
+    {
+      "type": "pass",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 396,
+      "created_at": 1692891254
+    },
+    {
+      "type": "lay_tile",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 397,
+      "created_at": 1692891302,
+      "hex": "E14",
+      "tile": "14-2",
+      "rotation": 2
+    },
+    {
+      "type": "undo",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 398,
+      "created_at": 1692891306
+    },
+    {
+      "type": "lay_tile",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 399,
+      "created_at": 1692891313,
+      "hex": "F11",
+      "tile": "29-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 400,
+      "created_at": 1692891325
+    },
+    {
+      "type": "run_routes",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 401,
+      "created_at": 1692891328,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G10",
+              "H11"
+            ],
+            [
+              "H11",
+              "H9"
+            ],
+            [
+              "H9",
+              "H7"
+            ],
+            [
+              "H7",
+              "G6"
+            ],
+            [
+              "G6",
+              "F5"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H11",
+            "H9",
+            "H7",
+            "G6",
+            "F5"
+          ],
+          "revenue": 260,
+          "revenue_str": "G10-H11-H9-H7-G6-F5 + k-k",
+          "nodes": [
+            "G10-1",
+            "H11-0",
+            "H9-0",
+            "H7-0",
+            "G6-0",
+            "F5-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 402,
+      "created_at": 1692891328,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 403,
+      "created_at": 1692891330
+    },
+    {
+      "type": "pass",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 404,
+      "created_at": 1692891332
+    },
+    {
+      "type": "lay_tile",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 405,
+      "created_at": 1692891337,
+      "hex": "B19",
+      "tile": "237-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 406,
+      "created_at": 1692891339
+    },
+    {
+      "type": "run_routes",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 407,
+      "created_at": 1692891341,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "F15",
+              "F17"
+            ],
+            [
+              "F17",
+              "E18"
+            ],
+            [
+              "E18",
+              "D19",
+              "C20"
+            ],
+            [
+              "C20",
+              "B19"
+            ],
+            [
+              "B19",
+              "B17"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "F17",
+            "E18",
+            "C20",
+            "B19",
+            "B17"
+          ],
+          "revenue": 270,
+          "revenue_str": "F15-F17-E18-C20-B19-B17 + k-k",
+          "nodes": [
+            "F15-0",
+            "F17-0",
+            "E18-0",
+            "C20-0",
+            "B19-0",
+            "B17-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "undo",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 408,
+      "created_at": 1692891344
+    },
+    {
+      "type": "undo",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 409,
+      "created_at": 1692891348
+    },
+    {
+      "type": "place_token",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 410,
+      "created_at": 1692891358,
+      "city": "239-1-0",
+      "slot": 2,
+      "tokener": "QR"
+    },
+    {
+      "type": "run_routes",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 411,
+      "created_at": 1692891363,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "F15",
+              "F17"
+            ],
+            [
+              "F17",
+              "E18"
+            ],
+            [
+              "E18",
+              "D19",
+              "C20"
+            ],
+            [
+              "C20",
+              "B19"
+            ],
+            [
+              "B19",
+              "B17"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "F17",
+            "E18",
+            "C20",
+            "B19",
+            "B17"
+          ],
+          "revenue": 270,
+          "revenue_str": "F15-F17-E18-C20-B19-B17 + k-k",
+          "nodes": [
+            "F15-0",
+            "F17-0",
+            "E18-0",
+            "C20-0",
+            "B19-0",
+            "B17-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 412,
+      "created_at": 1692891422,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 413,
+      "created_at": 1692891424
+    },
+    {
+      "type": "pass",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 414,
+      "created_at": 1692891425
+    },
+    {
+      "type": "lay_tile",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 415,
+      "created_at": 1692891451,
+      "hex": "G8",
+      "tile": "42-0",
+      "rotation": 5
+    },
+    {
+      "type": "undo",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 416,
+      "created_at": 1692891453
+    },
+    {
+      "type": "take_loan",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 417,
+      "created_at": 1692891455,
+      "loan": 11
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 418,
+      "created_at": 1692891458,
+      "hex": "G8",
+      "tile": "42-0",
+      "rotation": 5
+    },
+    {
+      "type": "undo",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 419,
+      "created_at": 1692891472
+    },
+    {
+      "type": "undo",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 420,
+      "created_at": 1692891475
+    },
+    {
+      "type": "lay_tile",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 421,
+      "created_at": 1692891484,
+      "hex": "G8",
+      "tile": "42-0",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 422,
+      "created_at": 1692891489,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "F15",
+              "E14"
+            ],
+            [
+              "E14",
+              "F13"
+            ],
+            [
+              "F13",
+              "G14"
+            ],
+            [
+              "G14",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "E14",
+            "F13",
+            "G14",
+            "F15"
+          ],
+          "revenue": 180,
+          "revenue_str": "F15-E14-F13-G14-F15",
+          "nodes": [
+            "F15-0",
+            "E14-0",
+            "F13-0",
+            "G14-0",
+            "F15-1"
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G10",
+              "G8",
+              "H9"
+            ],
+            [
+              "H9",
+              "H11"
+            ],
+            [
+              "H11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H9",
+            "H11",
+            "G10"
+          ],
+          "revenue": 190,
+          "revenue_str": "G10-H9-H11-G10",
+          "nodes": [
+            "G10-0",
+            "H9-0",
+            "H11-0",
+            "G10-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 423,
+      "created_at": 1692891490,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 424,
+      "created_at": 1692891492
+    },
+    {
+      "type": "undo",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 425,
+      "created_at": 1692891526,
+      "action_id": 414
+    },
+    {
+      "type": "undo",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 426,
+      "created_at": 1692891528,
+      "action_id": 404
+    },
+    {
+      "type": "undo",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 427,
+      "created_at": 1692891529,
+      "action_id": 396
+    },
+    {
+      "type": "undo",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 428,
+      "created_at": 1692891530,
+      "action_id": 387
+    },
+    {
+      "type": "redo",
+      "entity": "NSW",
+      "entity_type": "corporation",
+      "id": 429,
+      "created_at": 1692891536
+    },
+    {
+      "type": "redo",
+      "entity": "COM",
+      "entity_type": "corporation",
+      "id": 430,
+      "created_at": 1692891547
+    },
+    {
+      "type": "redo",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 431,
+      "created_at": 1692891548
+    },
+    {
+      "type": "redo",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 432,
+      "created_at": 1692891550
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 433,
+      "created_at": 1692891578,
+      "hex": "H9",
+      "tile": "611-1",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 434,
+      "created_at": 1692891580,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "F5",
+              "F7",
+              "G8",
+              "H9"
+            ],
+            [
+              "H9",
+              "H11"
+            ],
+            [
+              "H11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "F5",
+            "H9",
+            "H11",
+            "G10"
+          ],
+          "revenue": 180,
+          "revenue_str": "F5-H9-H11-G10",
+          "nodes": [
+            "F5-0",
+            "H9-0",
+            "H11-0",
+            "G10-1"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "D1",
+              "D3"
+            ],
+            [
+              "D3",
+              "E4"
+            ],
+            [
+              "E4",
+              "F5"
+            ],
+            [
+              "F5",
+              "G6"
+            ]
+          ],
+          "hexes": [
+            "D1",
+            "D3",
+            "E4",
+            "F5",
+            "G6"
+          ],
+          "revenue": 210,
+          "revenue_str": "D1-D3-E4-F5-G6 + k-k",
+          "nodes": [
+            "D1-0",
+            "D3-1",
+            "E4-0",
+            "F5-0",
+            "G6-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 435,
+      "created_at": 1692891581,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 436,
+      "created_at": 1692891583,
+      "auto_actions": [
+        {
+          "type": "dividend",
+          "entity": "BOE",
+          "entity_type": "corporation",
+          "created_at": 1692891583,
+          "kind": "payout"
+        }
+      ]
+    },
+    {
+      "type": "undo",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 437,
+      "created_at": 1692891642,
+      "action_id": 424
+    },
+    {
+      "type": "undo",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 438,
+      "created_at": 1692891643,
+      "action_id": 414
+    },
+    {
+      "type": "undo",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 439,
+      "created_at": 1692891644,
+      "action_id": 404
+    },
+    {
+      "type": "take_loan",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 440,
+      "created_at": 1692891646,
+      "loan": 11
+    },
+    {
+      "type": "lay_tile",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 441,
+      "created_at": 1692891821,
+      "hex": "B19",
+      "tile": "237-0",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 442,
+      "created_at": 1692891824,
+      "city": "239-1-0",
+      "slot": 2,
+      "tokener": "QR"
+    },
+    {
+      "type": "run_routes",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 443,
+      "created_at": 1692891827,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "F15",
+              "F17"
+            ],
+            [
+              "F17",
+              "E18"
+            ],
+            [
+              "E18",
+              "D19",
+              "C20"
+            ],
+            [
+              "C20",
+              "B19"
+            ],
+            [
+              "B19",
+              "B17"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "F17",
+            "E18",
+            "C20",
+            "B19",
+            "B17"
+          ],
+          "revenue": 270,
+          "revenue_str": "F15-F17-E18-C20-B19-B17 + k-k",
+          "nodes": [
+            "F15-0",
+            "F17-0",
+            "E18-0",
+            "C20-0",
+            "B19-0",
+            "B17-0"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 444,
+      "created_at": 1692891828,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 445,
+      "created_at": 1692891829
+    },
+    {
+      "type": "pass",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 446,
+      "created_at": 1692891830
+    },
+    {
+      "type": "lay_tile",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 447,
+      "created_at": 1692891851,
+      "hex": "G8",
+      "tile": "42-0",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 448,
+      "created_at": 1692891856,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "F15",
+              "E14"
+            ],
+            [
+              "E14",
+              "F13"
+            ],
+            [
+              "F13",
+              "G14"
+            ],
+            [
+              "G14",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "E14",
+            "F13",
+            "G14",
+            "F15"
+          ],
+          "revenue": 180,
+          "revenue_str": "F15-E14-F13-G14-F15",
+          "nodes": [
+            "F15-0",
+            "E14-0",
+            "F13-0",
+            "G14-0",
+            "F15-1"
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G10",
+              "G8",
+              "H9"
+            ],
+            [
+              "H9",
+              "H11"
+            ],
+            [
+              "H11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H9",
+            "H11",
+            "G10"
+          ],
+          "revenue": 190,
+          "revenue_str": "G10-H9-H11-G10",
+          "nodes": [
+            "G10-0",
+            "H9-0",
+            "H11-0",
+            "G10-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 449,
+      "created_at": 1692891857,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 450,
+      "created_at": 1692891859
+    },
+    {
+      "type": "undo",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 451,
+      "created_at": 1692891882,
+      "action_id": 446
+    },
+    {
+      "type": "undo",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 452,
+      "created_at": 1692891884
+    },
+    {
+      "type": "undo",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 453,
+      "created_at": 1692891893
+    },
+    {
+      "type": "buy_train",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 454,
+      "created_at": 1692891901,
+      "train": "5-2",
+      "price": 1
+    },
+    {
+      "type": "pass",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 455,
+      "created_at": 1692891911
+    },
+    {
+      "type": "pass",
+      "entity": "QR",
+      "entity_type": "corporation",
+      "id": 456,
+      "created_at": 1692891913
+    },
+    {
+      "type": "lay_tile",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 457,
+      "created_at": 1692891918,
+      "hex": "G8",
+      "tile": "42-0",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 458,
+      "created_at": 1692891922,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "F15",
+              "E14"
+            ],
+            [
+              "E14",
+              "F13"
+            ],
+            [
+              "F13",
+              "G14"
+            ],
+            [
+              "G14",
+              "F15"
+            ]
+          ],
+          "hexes": [
+            "F15",
+            "E14",
+            "F13",
+            "G14",
+            "F15"
+          ],
+          "revenue": 180,
+          "revenue_str": "F15-E14-F13-G14-F15",
+          "nodes": [
+            "F15-0",
+            "E14-0",
+            "F13-0",
+            "G14-0",
+            "F15-1"
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "G10",
+              "G8",
+              "H9"
+            ],
+            [
+              "H9",
+              "H11"
+            ],
+            [
+              "H11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H9",
+            "H11",
+            "G10"
+          ],
+          "revenue": 190,
+          "revenue_str": "G10-H9-H11-G10",
+          "nodes": [
+            "G10-0",
+            "H9-0",
+            "H11-0",
+            "G10-1"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "dividend",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 459,
+      "created_at": 1692891923,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 460,
+      "created_at": 1692891924
+    },
+    {
+      "type": "take_loan",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 461,
+      "created_at": 1712251565,
+      "auto_actions": [
+        {
+          "type": "dividend",
+          "entity": "BOE",
+          "entity_type": "corporation",
+          "created_at": 1712251565,
+          "kind": "payout"
+        }
+      ],
+      "loan": 12
+    },
+    {
+      "type": "undo",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 462,
+      "created_at": 1712251598
+    },
+    {
+      "type": "take_loan",
+      "entity": "WA",
+      "entity_type": "corporation",
+      "id": 463,
+      "created_at": 1712251685,
+      "auto_actions": [
+        {
+          "type": "dividend",
+          "entity": "BOE",
+          "entity_type": "corporation",
+          "created_at": 1712251685,
+          "kind": "payout"
+        }
+      ],
+      "loan": 12
+    },
+    {
+      "type": "undo",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 464,
+      "created_at": 1712251720,
+      "action_id": 360
+    },
+    {
+      "type": "undo",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 465,
+      "created_at": 1712251857,
+      "action_id": 139
+    },
+    {
+      "type": "take_loan",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 466,
+      "created_at": 1712251898,
+      "loan": 2
+    },
+    {
+      "type": "undo",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 467,
+      "created_at": 1712251900
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 468,
+      "created_at": 1712251902
+    },
+    {
+      "type": "buy_train",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 469,
+      "created_at": 1712251907,
+      "train": "3-0",
+      "price": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 470,
+      "created_at": 1712251908,
+      "train": "4-0",
+      "price": 1
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 471,
+      "created_at": 1712251914
+    },
+    {
+      "type": "pass",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 472,
+      "created_at": 1712251915
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 473,
+      "created_at": 1712251917
+    },
+    {
+      "type": "run_routes",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 474,
+      "created_at": 1712251919,
+      "routes": [],
+      "extra_revenue": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 475,
+      "created_at": 1712251921
+    },
+    {
+      "type": "take_loan",
+      "entity": "SAR",
+      "entity_type": "corporation",
+      "id": 476,
+      "created_at": 1712251933,
+      "auto_actions": [
+        {
+          "type": "dividend",
+          "entity": "BOE",
+          "entity_type": "corporation",
+          "created_at": 1712251933,
+          "kind": "payout"
+        }
+      ],
+      "loan": 2
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 477,
+      "created_at": 1712251965
+    },
+    {
+      "type": "run_routes",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 478,
+      "created_at": 1712251967,
+      "routes": [],
+      "extra_revenue": 0
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 479,
+      "created_at": 1712251969
+    },
+    {
+      "type": "pass",
+      "entity": "CAR",
+      "entity_type": "corporation",
+      "id": 480,
+      "created_at": 1712251973
+    },
+    {
+      "type": "take_loan",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 481,
+      "created_at": 1712251979,
+      "loan": 3
+    },
+    {
+      "type": "pass",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 482,
+      "created_at": 1712251980
+    },
+    {
+      "type": "buy_train",
+      "entity": "VR",
+      "entity_type": "corporation",
+      "id": 483,
+      "created_at": 1712252105,
+      "train": "4-1",
+      "price": 340,
+      "variant": "4+"
+    },
+    {
+      "type": "end_game",
+      "entity": "FT",
+      "entity_type": "corporation",
+      "id": 484,
+      "created_at": 1712257104
+    }
+  ],
+  "id": "hs_bjivkacy_1692887846",
+  "players": [
+    {
+      "name": "Player 1",
+      "id": 0
+    },
+    {
+      "name": "Player 2",
+      "id": 1
+    },
+    {
+      "name": "Player 3",
+      "id": 2
+    }
+  ],
+  "title": "1848",
+  "description": "Cloned from game hs_pqanpxrt_1692887846",
+  "min_players": "3",
+  "max_players": "3",
+  "settings": {
+    "optional_rules": [],
+    "seed": 1692887846
+  },
+  "mode": "hotseat",
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "created_at": "2024-04-04",
+  "loaded": true,
+  "result": {
+    "0": 634,
+    "1": 501,
+    "2": 1010
+  },
+  "manually_ended": true,
+  "turn": 3,
+  "round": "Operating Round",
+  "acting": [
+    1
+  ],
+  "updated_at": 1712257104
+}

--- a/spec/game_state_spec.rb
+++ b/spec/game_state_spec.rb
@@ -186,6 +186,18 @@ module Engine
       end
     end
 
+    describe '1848' do
+      describe 101 do
+        it '2nd receivership removes the next permanent and triggers phase change' do
+          game = game_at_action(game_file, 483)
+
+          expect(game.phase.name).to eq('5')
+
+          expect(game.depot.upcoming.count { |train| train.name == '5' }).to eq(2)
+        end
+      end
+    end
+
     describe '1836Jr30' do
       describe 2809 do
         it 'CFLV blocks I3 and J4' do


### PR DESCRIPTION
Fixes #10603

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [yes] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Export the next permanent rather than the next upcoming train. Typically happens if 2nd corp is thrown into receivership early

Adds test case

### Screenshots

### Any Assumptions / Hacks
