### PR TITLE
Adds instructions for scrubbing passwords to import_game info.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -182,13 +182,7 @@ You may want example games in your development environment to test. One way to d
 2. Execute `load "scripts/import_game.rb"`
 3. Execute `import_game(<product_game_id>)`
 
-A copy of that game is now available locally. If you need to 
-take actions as a user in the imported game:
-
-1. Run `scrub_passwords!`
-
-This will reset all account passwords on your local environment
-to "password". 
+A copy of that game is now available locally. All accounts in the imported games will have their passwords scrubbed and will be assigned "password" as their new default one. You can use this to login as any active user in the game. 
 
 #### Pinning a game in your local test enviornment
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -182,7 +182,13 @@ You may want example games in your development environment to test. One way to d
 2. Execute `load "scripts/import_game.rb"`
 3. Execute `import_game(<product_game_id>)`
 
-A copy of that game is now available locally.
+A copy of that game is now available locally. If you need to 
+take actions as a user in the imported game:
+
+1. Run `scrub_passwords!`
+
+This will reset all account passwords on your local environment
+to "password". 
 
 #### Pinning a game in your local test enviornment
 


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

~~Added details about how to reset passwords in the local dev environment to the section on importing games, since that's most likely when you're going to want that information.~~

Apparently I misunderstood something about the import script, and this is already done automatically. I modified the DEVELOPMENT.rb file instead to just explicitly say that the passwords are scrubbed and reset to "password".

### Screenshots

### Any Assumptions / Hacks
