### PR TITLE
18NL Typo fixes

### DIFF
--- a/lib/engine/game/g_18_nl/entities.rb
+++ b/lib/engine/game/g_18_nl/entities.rb
@@ -123,7 +123,7 @@ module Engine
           },
           {
             sym: 'DV',
-            name: 'De Vuluwe',
+            name: 'De Veluwe',
             logo: '18_nl/DV',
             tokens: [0, 40, 100, 100],
             coordinates: 'G8',
@@ -140,7 +140,7 @@ module Engine
           },
           {
             sym: 'HIS',
-            name: 'Hollandsche Ijzeren Spoorweg',
+            name: 'Hollandsche IJzeren Spoorweg',
             logo: '18_nl/HIS',
             tokens: [0, 40, 100],
             coordinates: 'E6',


### PR DESCRIPTION
Directly fixes two small typos in 18NL


"De Vuluwe" -> "De Veluwe"
"Hollandsche Ijzeren" -> "Hollandsche IJzeren"
(in Dutch 'IJ' is a single character and thus must be capitalised this way)