### PR TITLE
1849 usability improvements (Timeline, AFG start spaces)

### DIFF
--- a/lib/engine/game/g_1849/entities.rb
+++ b/lib/engine/game/g_1849/entities.rb
@@ -108,6 +108,15 @@ module Engine
             shares: [20, 10, 10, 10, 10, 10, 10, 20],
             always_market_price: true,
             color: '#ff0000',
+            abilities: [
+              {
+                type: 'description',
+                description: 'Choose home token location',
+                desc_detail: 'When this corporation floats, president must select location for its home token among '\
+                             'Caltanissetta (H8), Messina (B14), Ragusa (M11), Terranova (M9) or Trapani (C1). '\
+                             'If no token slots are available in these cities, AFG cannot be started.',
+              },
+            ],
           },
           {
             float_percent: 20,

--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -381,6 +381,26 @@ module Engine
           G1849::SharePool.new(self)
         end
 
+        def bank_corporations
+          @corporations.select do |c|
+            !c.owner || c.owner == @bank
+          end
+        end
+
+        def timeline
+          timeline = []
+
+          corporations = bank_corporations.map do |c|
+            name = c.name.to_s
+            name += ' (cannot be started now)' if c == afg && home_token_locations(afg).empty?
+            name
+          end
+
+          timeline << corporations.join(', ') unless corporations.empty?
+
+          timeline
+        end
+
         def update_garibaldi
           return if !afg || afg.slot_open || home_token_locations(afg).empty?
 


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Explanation of Change

1. After playing a lot of 1822* here I found myself looking for the random corporation order in the Timeline section.
2. Also I played with people new to 1849 and they found it hard to remember where AFG can start so I added a description to the company.


## Screenshots
1
![Screenshot 2024-04-16 at 11 30 42](https://github.com/tobymao/18xx/assets/576786/dcf6f544-edac-483f-867e-95f2ecce3489)
2
![Screenshot 2024-04-17 at 11 40 30](https://github.com/tobymao/18xx/assets/576786/f9299ab2-f984-4cf5-86e6-58e0d0fcb99c)

<details><summary>Rejected</summary>
<p>
3. I also added markers to the map hexes where AFG can start (small red circles with AFG letters).
<img src="https://github.com/tobymao/18xx/assets/576786/860767a4-f9b7-4853-a8f7-1296bb816010"/>
</p>
</details> 