### PR TITLE
[info page] added a space between the event name and '(on Xth train)'

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -223,7 +223,7 @@ module View
               event_text << if index.zero?
                               event_name
                             else
-                              "#{event_name}(on #{ordinal(train2.index + 1)} train)"
+                              "#{event_name} (on #{ordinal(train2.index + 1)} train)"
                             end
             end
           end


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Just a minor tweak, adding a space after the Event name.

Here's what it used to look like:
![image](https://github.com/tobymao/18xx/assets/26125362/944e7ca7-24d6-499f-b717-c539ed669013)

and here's how it looks after the change: 
![image](https://github.com/tobymao/18xx/assets/26125362/82000ae1-b559-4735-9bb4-abe0ab001820)


### Screenshots

### Any Assumptions / Hacks
