### PR TITLE
[Steam Over Holland] cannot lay a token in corps first operating turn

### DIFF
--- a/lib/engine/game/g_steam_over_holland/game.rb
+++ b/lib/engine/game/g_steam_over_holland/game.rb
@@ -251,7 +251,7 @@ module Engine
             Engine::Step::BuyCompany,
             GSteamOverHolland::Step::IssueShares,
             GSteamOverHolland::Step::Track,
-            Engine::Step::Token,
+            GSteamOverHolland::Step::Token,
             Engine::Step::Route,
             GSteamOverHolland::Step::Dividend,
             Engine::Step::DiscardTrain,

--- a/lib/engine/game/g_steam_over_holland/step/token.rb
+++ b/lib/engine/game/g_steam_over_holland/step/token.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/token'
+
+module Engine
+  module Game
+    module GSteamOverHolland
+      module Step
+        class Token < Engine::Step::Token
+          def can_place_token?(entity)
+            return if entity.operating_history.size.zero?
+
+            super
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Odd rule but confirmed by the designer: https://boardgamegeek.com/thread/1034408/article/13330784#13330784

### Screenshots

### Any Assumptions / Hacks
