### PR TITLE
[18 Hiawatha] apparently this title has a space in its name

### DIFF
--- a/lib/engine/game/g_18_hiawatha/meta.rb
+++ b/lib/engine/game/g_18_hiawatha/meta.rb
@@ -11,7 +11,7 @@ module Engine
         DEV_STAGE = :alpha
         DEPENDS_ON = '1817'
 
-        GAME_DESIGNER = 'Anthony Fryer & Nick Neylon'
+        GAME_DESIGNER = 'Michael Carter, Anthony Fryer, & Nick Neylon'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Hiawatha'
         GAME_LOCATION = 'Midwest USA'
         GAME_TITLE = '18 Hiawatha'

--- a/lib/engine/game/g_18_hiawatha/meta.rb
+++ b/lib/engine/game/g_18_hiawatha/meta.rb
@@ -14,7 +14,7 @@ module Engine
         GAME_DESIGNER = 'Anthony Fryer & Nick Neylon'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Hiawatha'
         GAME_LOCATION = 'Midwest USA'
-        GAME_TITLE = '18Hiawatha'
+        GAME_TITLE = '18 Hiawatha'
 
         PLAYER_RANGE = [3, 6].freeze
 


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Fixed title to include a space. 

### Screenshots

### Any Assumptions / Hacks
