### PR TITLE
[18 Hiawatha] change the description of a couple of market spaces

### DIFF
--- a/lib/engine/game/g_18_hiawatha/game.rb
+++ b/lib/engine/game/g_18_hiawatha/game.rb
@@ -40,12 +40,12 @@ module Engine
              55p
              60p
              65p
-             70s
+             70p
              80p
              90p
              100p
              110p
-             120s
+             120p
              135p
              150p
              165p


### PR DESCRIPTION
Fixes #10660

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Removed the "safe par" notation for this game, since selling and shortselling is allowed on unoperated corps, so the information is irrelevant.

### Screenshots

### Any Assumptions / Hacks
