### PR TITLE
[1822] improves description of 1822+ variant

### DIFF
--- a/lib/engine/game/g_1822/meta.rb
+++ b/lib/engine/game/g_1822/meta.rb
@@ -37,8 +37,8 @@ module Engine
           {
             sym: :plus_expansion,
             short_name: '1822+',
-            desc: '6 more minors and 3 more privates. The privates are categorized into blue (bidbox 1), '\
-                  'dark grey (bidbox 2) and gold (bidbox 3) stacks.',
+            desc: '6 more minors and 3 more privates. The privates are categorized into trains (bidbox 1), track '\
+                  '(bidbox 2) and other (bidbox 3) stacks.',
           },
           {
             sym: :tax_haven_multiple,


### PR DESCRIPTION
Fixes #10560

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
As pointed out in the report, saying that the privates are sorted into the blue, dark grey, and gold piles doesn't really mean anything for online play, while explaining what unites the cards in each pile does.

### Screenshots

### Any Assumptions / Hacks
