### PR TITLE
support "ping all" keywords and remove self-pings

### DIFF
--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -72,7 +72,7 @@ module View
                   title: 'hotkey: c – esc to leave',
                   type: 'text',
                   value: @chat_input,
-                  placeholder: 'Use @player command to ping a player',
+                  placeholder: 'Ping with @player_name or @all',
                 },
                 style: {
                   marginLeft: '0.5rem',

--- a/routes/game.rb
+++ b/routes/game.rb
@@ -115,11 +115,16 @@ class Api
               end
             end
 
+            other_users = users.reject { |u| u.id == user&.id }
             type, user_ids, force =
               if action['type'] == 'message'
-                pinged = users.select do |user|
-                  action['message'].include?("@#{user.name}")
-                end
+                pinged = if action['message'].include?('@all')
+                           other_users
+                         else
+                           other_users.select do |u|
+                             action['message'].include?("@#{u.name}")
+                           end
+                         end
                 ['Received Message', pinged.map(&:id), false]
               elsif game.status == 'finished'
                 ['Game Finished', users.map(&:id), true]


### PR DESCRIPTION
Fixes #10674

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Implements common slack/discord style keywords for pinging everybody in a game

Also removes yourself from that list, and removes the ability to ping yourself in general

### Explanation of Change

I used the community discord for testing:
https://discord.com/channels/692794539169284186/747222914419523644

I had two users locally, each w/ the same webhook setup pointing to my Discord userID 

Before I added the "don't ping yourself" check under the `@all` handling, it pinged both users

### Screenshots

![image](https://github.com/tobymao/18xx/assets/1711810/64b086ce-7b50-4377-ae77-d2b61060fa75)

![image](https://github.com/tobymao/18xx/assets/1711810/f123ddce-47d8-478e-a568-f5fdb2c3db6e)


### Any Assumptions / Hacks

