### PR TITLE
[Core] Fix lane connections with 4 lanes per hex edge

### DIFF
--- a/assets/app/view/game/part/track_node_path.rb
+++ b/assets/app/view/game/part/track_node_path.rb
@@ -23,7 +23,7 @@ module View
         STRAIGHT_CROSSOVER = '1 55 63 56'
         GENTLE_CROSSOVER = '1 55 47 56'
 
-        PARALLEL_SPACING = [8, 7, 6].freeze
+        PARALLEL_SPACING = [8, 7, 6, 5].freeze
 
         EDGE_PERP_ANGLES = [90, 30, -30, -90, -150, 150].freeze
 

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -17,7 +17,7 @@ module Engine
 
       def self.decode_lane_spec(x_lane)
         if x_lane
-          [x_lane.to_i, ((x_lane.to_f - x_lane.to_i) * 10).to_i]
+          [x_lane.to_i, ((x_lane.to_f - x_lane.to_i) * 10).round.to_i]
         else
           [1, 0]
         end


### PR DESCRIPTION
Fix rendering of 4 lanes going into specific exits on hex edge and add possibility to render 5.
This is needed to implement 22Mars

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Explanation

Formula to decode lane spec is:
```ruby
[x_lane.to_i, ((x_lane.to_f - x_lane.to_i) * 10).to_i]
```
which is transpiled to this javascript
```js
[x_lane.$to_i(), $rb_times($rb_minus(x_lane.$to_f(), x_lane.$to_i()), 10).$to_i()]
```
so when lane is odd, there are rounding issues in code generated by Opal:
1. `x_lane.to_d` = `4.3`
2. `x_lane.to_i` = `4`
3. `(x_lane.to_f - x_lane.to_i) * 10` = `2.9999999999999982``
4. `((x_lane.to_f - x_lane.to_i) * 10).to_i` = `2` (while it should be 3)

This only starts happening when trying to use 4 lanes on a hex edge.

## Before
<img width="326" alt="Screenshot 2024-04-27 at 23 34 30" src="https://github.com/tobymao/18xx/assets/576786/8e575af6-c108-45f4-838e-44133afc8780">

## After
<img width="344" alt="Screenshot 2024-04-27 at 23 34 46" src="https://github.com/tobymao/18xx/assets/576786/38486187-4aaa-4a51-b529-17618f438573">
