### PR TITLE
[18 Hiawatha] signal_end_game text and fixes Liquidation section of the market

### DIFF
--- a/lib/engine/game/g_18_hiawatha/game.rb
+++ b/lib/engine/game/g_18_hiawatha/game.rb
@@ -30,7 +30,7 @@ module Engine
         ALWAYS_BUY_TRAINS_AT_FACE_VALUE = true
 
         MARKET = [
-          %w[0
+          %w[0l
              0a
              0a
              0a

--- a/lib/engine/game/g_18_hiawatha/game.rb
+++ b/lib/engine/game/g_18_hiawatha/game.rb
@@ -115,7 +115,7 @@ module Engine
 
         EVENTS_TEXT = G1817::Game::EVENTS_TEXT.merge(
           'remove_blocking_token' => ['Remove Blocking Token', "Blocking token in Milwaukee (#{MILWAUKEE_HEX}) is removed."],
-          'signal_end_game' => ['Signal End Game', 'First 4 train bought/exported, ending game at the end of the next OR set.'],
+          'signal_end_game' => ['Signal End Game', 'Game Ends at the end of the OR set after purchase/export of first 4 train.'],
         ).freeze
 
         ASSIGNMENT_TOKENS = {

--- a/lib/engine/game/g_18_hiawatha/game.rb
+++ b/lib/engine/game/g_18_hiawatha/game.rb
@@ -115,6 +115,7 @@ module Engine
 
         EVENTS_TEXT = G1817::Game::EVENTS_TEXT.merge(
           'remove_blocking_token' => ['Remove Blocking Token', "Blocking token in Milwaukee (#{MILWAUKEE_HEX}) is removed."],
+          'signal_end_game' => ['Signal End Game', 'First 4 train bought/exported, ending game at the end of the next OR set.'],
         ).freeze
 
         ASSIGNMENT_TOKENS = {

--- a/lib/engine/game/g_18_hiawatha/step/loan.rb
+++ b/lib/engine/game/g_18_hiawatha/step/loan.rb
@@ -19,7 +19,6 @@ module Engine
             raise GameError, 'Cannot pay off loans taken this OR.' unless @round.payable_loans.positive?
 
             super
-            print action.entity.id
 
             @round.payable_loans -= 1
             return if @round.payable_loans.positive?


### PR DESCRIPTION
Fixes #10687 
Fixes #10689

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
First commit:
forgot to add the changed signal_end_game to EVENTS_TEXT

Second commit:
improved the text from the first commit.

Third commit:
The far left market space wasn't coded as Liquidation as it should be. This will likely break some games. since we're in alpha, they should just be archived.



### Screenshots

### Any Assumptions / Hacks
