### PR TITLE
[18RoyalGorge] fix starting DEBT value

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -889,7 +889,7 @@ module Engine
         def init_debt_corp(corporation)
           corporation.ipoed = true
           corporation.floated = true
-          price = @stock_market.share_price([0, 1])
+          price = @stock_market.share_price([0, 6])
           @stock_market.set_par(corporation, price)
           bundle = ShareBundle.new(corporation.shares_of(corporation))
           @share_pool.transfer_shares(bundle, @share_pool)


### PR DESCRIPTION
DEBT should start at $60, not $35.

In theory this could break games, but so far I don't see any that have gone far enough for DEBT to actually be a factor.