### PR TITLE
[18Ardennes] Exchange approvals

### DIFF
--- a/assets/app/view/game/buy_sell_shares.rb
+++ b/assets/app/view/game/buy_sell_shares.rb
@@ -289,7 +289,14 @@ module View
                                                     source: 'Presidency'))
             end
 
-            children.concat(render_share_exchange(@pool_shares, entity)) if ability.from.include?(:market)
+            if ability.from.include?(:market)
+              pool_shares = if @step.respond_to?(:exchangeable_pool_shares)
+                              @step.exchangeable_pool_shares(@corporation, ability)
+                            else
+                              @pool_shares
+                            end
+              children.concat(render_share_exchange(pool_shares, entity))
+            end
             if ability.from.include?(:reserved)
               children.concat(render_share_exchange(@reserved_shares[0, 1], entity,
                                                     source: 'Reserved'))

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -100,6 +100,7 @@ module Engine
         def stock_round
           Round::Stock.new(self, [
             G18Ardennes::Step::Exchange,
+            G18Ardennes::Step::ExchangeApproval,
             G18Ardennes::Step::DeclineTokens,
             G18Ardennes::Step::DeclineTrains,
             Engine::Step::DiscardTrain,

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -107,7 +107,7 @@ module Engine
             concession = major.par_via_exchange
 
             concession.close!
-            exchange_minor(minor, major.treasury_shares.first.to_bundle, false)
+            exchange_minor(minor, major.treasury_shares.first.to_bundle, :all)
           end
 
           def process_bankrupt(action)

--- a/lib/engine/game/g_18_ardennes/step/exchange.rb
+++ b/lib/engine/game/g_18_ardennes/step/exchange.rb
@@ -41,9 +41,12 @@ module Engine
                                "#{action.bundle.corporation.id}"
             end
 
+            bundle = action.bundle
+            share = bundle.shares.first
             @round.minor = action.entity
-            @round.major = action.bundle.shares.first.corporation
-            exchange_minor(action.entity, action.bundle, true)
+            @round.major = share.corporation
+            transfer_assets = @round.major.shares.include?(share) ? :choose : :none
+            exchange_minor(@round.minor, bundle, transfer_assets)
             @round.current_actions << action if @round.is_a?(Round::Stock)
           end
         end

--- a/lib/engine/game/g_18_ardennes/step/exchange.rb
+++ b/lib/engine/game/g_18_ardennes/step/exchange.rb
@@ -45,9 +45,37 @@ module Engine
             share = bundle.shares.first
             @round.minor = action.entity
             @round.major = share.corporation
-            transfer_assets = @round.major.shares.include?(share) ? :choose : :none
-            exchange_minor(@round.minor, bundle, transfer_assets)
-            @round.current_actions << action if @round.is_a?(Round::Stock)
+            if approval_needed?(@round.minor, share)
+              log_request(@round.minor, @round.major)
+              @round.pending_approval = @round.major
+              @round.bundle = bundle
+            else
+              transfer = treasury_share?(share) ? :choose : :none
+              exchange_minor(@round.minor, bundle, transfer)
+              @round.current_actions << action if @round.is_a?(Round::Stock)
+            end
+          end
+
+          private
+
+          # Does this bundle contain a treasury share, or one from the bank pool?
+          def treasury_share?(share)
+            share.corporation.shares.include?(share)
+          end
+
+          def approval_needed?(minor, share)
+            corporation = share.corporation
+
+            !corporation.operating_history.empty? &&
+              minor.owner != corporation.owner &&
+              treasury_share?(share)
+          end
+
+          def log_request(minor, major)
+            msg = "#{minor.owner.name} requested #{major.owner.name}’s " \
+                  "permission to exchange minor #{minor.name} for a " \
+                  "#{major.id} treasury share."
+            @round.process_action(Engine::Action::Log.new(minor.owner, message: msg))
           end
         end
       end

--- a/lib/engine/game/g_18_ardennes/step/exchange.rb
+++ b/lib/engine/game/g_18_ardennes/step/exchange.rb
@@ -52,7 +52,7 @@ module Engine
             else
               transfer = treasury_share?(share) ? :choose : :none
               exchange_minor(@round.minor, bundle, transfer)
-              @round.current_actions << action if @round.is_a?(Engine::Round::Stock)
+              @round.current_actions << action if @round.stock?
             end
           end
 

--- a/lib/engine/game/g_18_ardennes/step/exchange.rb
+++ b/lib/engine/game/g_18_ardennes/step/exchange.rb
@@ -52,7 +52,7 @@ module Engine
             else
               transfer = treasury_share?(share) ? :choose : :none
               exchange_minor(@round.minor, bundle, transfer)
-              @round.current_actions << action if @round.is_a?(Round::Stock)
+              @round.current_actions << action if @round.is_a?(Engine::Round::Stock)
             end
           end
 

--- a/lib/engine/game/g_18_ardennes/step/exchange_approval.rb
+++ b/lib/engine/game/g_18_ardennes/step/exchange_approval.rb
@@ -59,6 +59,10 @@ module Engine
             }
           end
 
+          def ipo_type(_entity)
+            nil
+          end
+
           def process_choose(action)
             approved = (action.choice == 'approve')
             log_response(minor, major, approved)

--- a/lib/engine/game/g_18_ardennes/step/exchange_approval.rb
+++ b/lib/engine/game/g_18_ardennes/step/exchange_approval.rb
@@ -15,8 +15,8 @@ module Engine
               {
                 minor: nil,
                 bundle: nil,
-                approvals: {},
                 pending_approval: nil,
+                refusals: Hash.new { |h, k| h[k] = [] },
               }
             )
           end
@@ -65,9 +65,9 @@ module Engine
             if approved
               exchange_minor(@round.minor, bundle, :choose)
             else
-              @round.approvals[major] = :denied
+              @round.refusals[major] << minor
               if major.num_market_shares.positive?
-                @game.log << "#{minor.name} may now be exchanged for a " \
+                @game.log << "Minor #{minor.name} may now be exchanged for a " \
                              "#{major.id} market share."
               end
             end
@@ -102,8 +102,8 @@ module Engine
 
           def log_response(minor, major, approved)
             msg = "#{approver.name} #{approved ? 'approved' : 'denied'} " \
-                  "#{requester.name}’s request to exchange #{minor.name} " \
-                  "for a #{major.id} treasury share."
+                  "#{requester.name}’s request to exchange minor " \
+                  "#{minor.name} for a #{major.id} treasury share."
             @round.process_action(Engine::Action::Log.new(approver, message: msg))
           end
         end

--- a/lib/engine/game/g_18_ardennes/step/exchange_approval.rb
+++ b/lib/engine/game/g_18_ardennes/step/exchange_approval.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative 'minor_exchange'
+
+module Engine
+  module Game
+    module G18Ardennes
+      module Step
+        class ExchangeApproval < Engine::Step::Base
+          include MinorExchange
+
+          def round_state
+            super.merge(
+              {
+                minor: nil,
+                bundle: nil,
+                approvals: {},
+                pending_approval: nil,
+              }
+            )
+          end
+
+          def actions(entity)
+            return [] unless entity == major
+
+            ['choose']
+          end
+
+          def active?
+            pending_approval
+          end
+
+          def active_entities
+            [approver]
+          end
+
+          def current_entity
+            major
+          end
+
+          def description
+            'Approve or deny exchange request'
+          end
+
+          def choice_name
+            "Allow #{requester.name} to exchange minor #{minor.name} " \
+              'for a treasury share'
+          end
+
+          def choice_available?(entity)
+            entity == major
+          end
+
+          def choices
+            {
+              'approve' => 'Allow exchange',
+              'deny' => 'Do not allow exchange',
+            }
+          end
+
+          def process_choose(action)
+            approved = (action.choice == 'approve')
+            log_response(minor, major, approved)
+            if approved
+              exchange_minor(@round.minor, bundle, :choose)
+            else
+              @round.approvals[major] = :denied
+              if major.num_market_shares.positive?
+                @game.log << "#{minor.name} may now be exchanged for a " \
+                             "#{major.id} market share."
+              end
+            end
+            @round.pending_approval = nil
+          end
+
+          private
+
+          def major
+            pending_approval
+          end
+
+          def minor
+            @round.minor
+          end
+
+          def bundle
+            @round.bundle
+          end
+
+          def approver
+            major.owner
+          end
+
+          def requester
+            minor.owner
+          end
+
+          def pending_approval
+            @round.pending_approval
+          end
+
+          def log_response(minor, major, approved)
+            msg = "#{approver.name} #{approved ? 'approved' : 'denied'} " \
+                  "#{requester.name}’s request to exchange #{minor.name} " \
+                  "for a #{major.id} treasury share."
+            @round.process_action(Engine::Action::Log.new(approver, message: msg))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_ardennes/step/minor_exchange.rb
+++ b/lib/engine/game/g_18_ardennes/step/minor_exchange.rb
@@ -54,7 +54,7 @@ module Engine
 
             minor.trains.each do |train|
               @game.log << "Minor #{minor.name}’s #{train.name} train is " \
-                           "discarded to the open market."
+                           'discarded to the open market.'
               @game.depot.reclaim_train(train)
             end
 


### PR DESCRIPTION
## Implementation Notes

### Explanation of Change

18Ardennes allows minor companies to be exchanged for shares in public companies (majors). If there are shares of the public company both in the bank pool and the company's treasury, then there's a sequence that must be followed: first the minor company's owner may attempt to exchange the minor for a treasury share of the public company. If this is refused by the public company's president, then the minor may be exchanged for a pool share. This is very similar to the process for exchanging private railway companies for public company shares in 1858, so I have copied the approval/denial mechanism from that game.

This pull request also implements the rules for what happens when a minor is exchanged for a pool share – all its assets are discarded.


### Any Assumptions / Hacks

This touches the core code in one place: in `View::Game::BuySellShares` the `render_exchanges` method now looks for an `exchangeable_pool_shares` method in the active step. This is needed so that each pool share can be checked to see if it should be offered as an exchange option. With this mechanism, pool shares are not able to be exchanged until a request to exchange for a treasury share has been declined. This will not affect any other games as they do not have the `exchangeable_pool_shares` method implemented.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~~Add the `pins` or `archive_alpha_games` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`