### PR TITLE
[18Ardennes] Bug fixes

### DIFF
--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -26,6 +26,26 @@ module Engine
             actions
           end
 
+          def auto_actions(entity)
+            programmed_actions = super
+            return programmed_actions if programmed_actions
+
+            # The only situation that needs an auto action is when the only
+            # possible (non-pass) action is buy_shares, and this is for an
+            # exchange only (no shares can be bought), and there is no legal
+            # exchange possible as the minor companies owned by the player
+            # are not connected to any public companies.  The connection
+            # between the minor and public companies is not checked in
+            # `actions` to avoid calls to the graph when the game is loading.
+            return unless actions(entity) == %w[buy_shares pass]
+            return if @game.under_obligation?(entity)
+            return if can_buy_any_from_market?(entity)
+            return if can_buy_any_from_ipo?(entity)
+            return if can_exchange_any?(entity, check_connection: true)
+
+            [Engine::Action::Pass.new(entity)]
+          end
+
           def bankruptcy_description(player)
             concession = player.companies
                                .select { |c| c.type == :concession }
@@ -47,7 +67,7 @@ module Engine
           def can_buy_any?(entity)
             return false if bought?
 
-            super || can_exchange_any?(entity)
+            super || can_exchange_any?(entity, check_connection: false)
           end
 
           def can_gain?(entity, bundle, exchange: false)
@@ -57,11 +77,11 @@ module Engine
 
           # Checks whether a player can afford to exchange one of their minors
           # for a share in a major corporation.
-          # **Note** This does not check whether there is a track connection
-          # between the minor and the major, which is required to carry out the
-          # exchange. This is not checked to avoid having to recalculate the
-          # game graph whilst a game is being loaded.
-          def can_exchange_any?(player)
+          # If `check_connection` is false this method does not check whether
+          # there is a track connection between the minor and the major, which
+          # is required to carry out the exchange. This is not checked to avoid
+          # having to recalculate the game graph whilst a game is being loaded.
+          def can_exchange_any?(player, check_connection: false)
             majors = @game.major_corporations.select do |corp|
               corp.ipoed && (corp.num_treasury_shares.positive? || corp.num_market_shares.positive?)
             end
@@ -72,7 +92,10 @@ module Engine
               next false if minor.share_price.price.zero?
 
               max_price = (minor.share_price.price * 2) + @game.liquidity(player)
-              majors.any? { |corp| corp.share_price.price <= max_price }
+              majors.any? do |corp|
+                (corp.share_price.price <= max_price) &&
+                  (!check_connection || @game.major_minor_connected?(corp, minor))
+              end
             end
           end
 

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -59,8 +59,10 @@ module Engine
           end
 
           def sellable_companies(entity)
+            return [] unless entity.player?
+
             # Only the GL is sellable. Make sure concessions aren't visible.
-            super.select { |company| company.type == :minor }
+            entity.companies.select { |company| company.type == :minor }
           end
 
           # Exchanging a minor for a share in a floated major corporation is
@@ -98,10 +100,6 @@ module Engine
                   (!check_connection || @game.major_minor_connected?(corp, minor))
               end
             end
-          end
-
-          def can_sell_any_companies?(player)
-            @game.minor_companies.any? { |company| company.owner == player }
           end
 
           # Corporations whose cards are visible in the stock round.

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -17,7 +17,7 @@ module Engine
 
             actions = []
             actions << 'par' if under_limit?(entity)
-            actions << 'sell_shares' if can_sell_any?(entity)
+            actions.concat(%w[sell_shares sell_company]) if can_sell_any?(entity)
             # TODO: handle this properly.
             # Maybe stop the player from bidding for a major if they are at
             # certificate limit and do not have any sellable shares.

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -17,7 +17,8 @@ module Engine
 
             actions = []
             actions << 'par' if under_limit?(entity)
-            actions.concat(%w[sell_shares sell_company]) if can_sell_any?(entity)
+            actions << 'sell_shares' if can_sell_any?(entity)
+            actions << 'sell_company' if can_sell_any_companies?(entity)
             # TODO: handle this properly.
             # Maybe stop the player from bidding for a major if they are at
             # certificate limit and do not have any sellable shares.
@@ -97,6 +98,10 @@ module Engine
                   (!check_connection || @game.major_minor_connected?(corp, minor))
               end
             end
+          end
+
+          def can_sell_any_companies?(player)
+            @game.minor_companies.any? { |company| company.owner == player }
           end
 
           # Corporations whose cards are visible in the stock round.

--- a/lib/engine/game/g_18_ardennes/step/decline_forts.rb
+++ b/lib/engine/game/g_18_ardennes/step/decline_forts.rb
@@ -20,6 +20,14 @@ module Engine
             'Keep or decline fort tokens'
           end
 
+          def active?
+            !forts.empty?
+          end
+
+          def active_entities
+            [major]
+          end
+
           def choice_available?(_entity)
             true
           end

--- a/lib/engine/game/g_18_ardennes/step/decline_trains.rb
+++ b/lib/engine/game/g_18_ardennes/step/decline_trains.rb
@@ -11,7 +11,7 @@ module Engine
 
           def actions(entity)
             return [] unless entity == major
-            return [] if trains.empty?
+            return [] if trains(entity).empty?
 
             ACTIONS
           end
@@ -39,7 +39,7 @@ module Engine
           end
 
           def crowded_corps
-            return [] if trains.empty?
+            return [] if trains(major).empty?
 
             [major]
           end
@@ -50,13 +50,13 @@ module Engine
 
           def process_discard_train(action)
             train = action.train
-            trains.delete(train)
+            trains(major).delete(train)
             @game.depot.reclaim_train(train)
             @log << "#{action.entity.name} discards a #{train.name} train"
           end
 
           def process_pass(action)
-            trains.clear
+            trains(major).clear
             super
           end
 

--- a/lib/engine/game/g_18_ardennes/trains.rb
+++ b/lib/engine/game/g_18_ardennes/trains.rb
@@ -216,6 +216,7 @@ module Engine
         def rust?(train, purchased_train)
           return false unless super
           return true unless train.name == '2'
+          return true if train.owner == @depot
 
           operated_this_round?(train.owner)
         end

--- a/lib/engine/game/g_18_ardennes/trains.rb
+++ b/lib/engine/game/g_18_ardennes/trains.rb
@@ -117,6 +117,13 @@ module Engine
           'G1' => %w[G3],
         }.freeze
 
+        def check_other(route)
+          # A single city and a port off-board area is not a valid route.
+          return if visited_stops(route).count { |stop| !stop.offboard? } > 1
+
+          raise RouteTooShort, 'Route must have at least 2 stops'
+        end
+
         def visited_stops(route)
           return super unless route.train.name == '4D'
 


### PR DESCRIPTION
## Implementation Notes

### Explanation of Change

Fixes for a few issues identified in pre-alpha testing.

- Fix a syntax error (missing parameter) in `G18Ardennes::Step::DeclineTrains` that wasn't being picked up when run in hotseat mode, but was causing the game to break when run in server mode.
- The decline forts steps wasn't getting marked as active, and so wasn't running at the right time.
- The wrong player was getting asked to carry out the decline forts step.
- Allow the GL minor company to be sold at the start of a stock round, as well as public company shares, before a player is obliged to start a new public company.
- Set the priority deal correctly at the end of the initial minor company auction round. Priority goes to the player to the left of the person who bought the last minor.
- Use an auto-action to pass a player's stock round turn if their only possible action would have been to exchange a minor company for a public company share, but there is no track connection to any public companies. This can't be checked in `actions` as it requires the game graph to be calculated.

### Any Assumptions / Hacks

No shared code is affected by any of these changes.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~~Add the `pins` or `archive_alpha_games` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`