### PR TITLE
[18Ardennes] Display improvements

### DIFF
--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -439,7 +439,7 @@ module Engine
 
         def buyable_bank_owned_companies
           # Do not show the GL after a corporation grows up.
-          @round.is_a?(Engine::Round::Operating) ? [] : super
+          @round.operating? ? [] : super
         end
 
         # Has the player won any auctions for public companies in the

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -432,7 +432,7 @@ module Engine
 
         def buyable_bank_owned_companies
           # Do not show the GL after a corporation grows up.
-          @round.is_a?(Round::Operating) ? [] : super
+          @round.is_a?(Engine::Round::Operating) ? [] : super
         end
 
         # Has the player won any auctions for public companies in the

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -15,6 +15,13 @@ module Engine
             color: :yellow,
             text_color: :black,
             abilities: [{ type: 'no_buy' }],
+            desc: 'The player who owns the Guillaume-Luxembourg receives F25 ' \
+                  'income at the beginning of each operating round. The ' \
+                  'Guillaume-Luxembourg is treated as a single share worth ' \
+                  'F100. The player who owns it may sell it to the open ' \
+                  'market during a stock round. If the Guillaume-Luxembourg ' \
+                  'is in the open market then it may be bought by any ' \
+                  'player, unless they sold it earlier in the same stock round.',
           },
         ].freeze
 
@@ -451,11 +458,16 @@ module Engine
           major_corporations.map do |corporation|
             concession = Company.new(
               sym: corporation.id,
-              name: corporation.name,
+              name: corporation.full_name,
               type: :concession,
               value: 0,
               color: corporation.color,
               text_color: corporation.text_color,
+              desc: 'The player who wins the auction for this item has the ' \
+                    "right to form the #{corporation.full_name} " \
+                    "[#{corporation.id}] public company. Public companies " \
+                    'must be started as the player’s first actions in the ' \
+                    'stock round.',
             )
             corporation.par_via_exchange = concession
             concession

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -134,7 +134,7 @@ module Engine
 
         # Checks whether a player really is bankrupt.
         def can_go_bankrupt?(player, _corporation)
-          return super if @round.is_a?(Engine::Round::Operating)
+          return super if @round.operating?
 
           # Has the player won the auction for a major company concession
           # that they cannot afford to start?

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -57,11 +57,11 @@ module Engine
         def next_round!
           @round =
             case @round
+            when G18Ardennes::Round::Auction
+              new_stock_round
             when Engine::Round::Auction
-              if @turn == 1
-                init_round_finished
-                reorder_players
-              end
+              init_round_finished
+              reorder_players
               new_stock_round
             when Engine::Round::Stock
               @operating_rounds = @phase.operating_rounds
@@ -92,7 +92,7 @@ module Engine
         end
 
         def major_auction_round
-          Engine::Round::Auction.new(self, [
+          G18Ardennes::Round::Auction.new(self, [
             G18Ardennes::Step::MajorAuction,
           ])
         end

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -63,7 +63,7 @@ module Engine
               init_round_finished
               reorder_players
               new_stock_round
-            when Engine::Round::Stock
+            when G18Ardennes::Round::Stock
               @operating_rounds = @phase.operating_rounds
               reorder_players
               new_operating_round
@@ -98,7 +98,7 @@ module Engine
         end
 
         def stock_round
-          Engine::Round::Stock.new(self, [
+          G18Ardennes::Round::Stock.new(self, [
             G18Ardennes::Step::Exchange,
             G18Ardennes::Step::DeclineTokens,
             G18Ardennes::Step::DeclineTrains,

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -57,17 +57,17 @@ module Engine
         def next_round!
           @round =
             case @round
-            when Round::Auction
+            when Engine::Round::Auction
               if @turn == 1
                 init_round_finished
                 reorder_players
               end
               new_stock_round
-            when Round::Stock
+            when Engine::Round::Stock
               @operating_rounds = @phase.operating_rounds
               reorder_players
               new_operating_round
-            when Round::Operating
+            when Engine::Round::Operating
               if @round.round_num < @operating_rounds
                 or_round_finished
                 new_operating_round(@round.round_num + 1)
@@ -98,7 +98,7 @@ module Engine
         end
 
         def stock_round
-          Round::Stock.new(self, [
+          Engine::Round::Stock.new(self, [
             G18Ardennes::Step::Exchange,
             G18Ardennes::Step::DeclineTokens,
             G18Ardennes::Step::DeclineTrains,
@@ -109,7 +109,7 @@ module Engine
         end
 
         def operating_round(round_num)
-          Round::Operating.new(self, [
+          Engine::Round::Operating.new(self, [
             Engine::Step::Bankrupt,
             G18Ardennes::Step::Convert,
             G18Ardennes::Step::Exchange,
@@ -134,7 +134,7 @@ module Engine
 
         # Checks whether a player really is bankrupt.
         def can_go_bankrupt?(player, _corporation)
-          return super if @round.is_a?(Round::Operating)
+          return super if @round.is_a?(Engine::Round::Operating)
 
           # Has the player won the auction for a major company concession
           # that they cannot afford to start?

--- a/lib/engine/game/g_18_ardennes/round/auction.rb
+++ b/lib/engine/game/g_18_ardennes/round/auction.rb
@@ -10,11 +10,6 @@ module Engine
           def self.short_name
             'PCA'
           end
-
-          def description
-            puts "#{self.class}.description"
-            super
-          end
         end
       end
     end

--- a/lib/engine/game/g_18_ardennes/round/auction.rb
+++ b/lib/engine/game/g_18_ardennes/round/auction.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/auction'
+
+module Engine
+  module Game
+    module G18Ardennes
+      module Round
+        class Auction < Engine::Round::Auction
+          def self.short_name
+            'PCA'
+          end
+
+          def description
+            puts "#{self.class}.description"
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_ardennes/round/stock.rb
+++ b/lib/engine/game/g_18_ardennes/round/stock.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/stock'
+
+module Engine
+  module Game
+    module G18Ardennes
+      module Round
+        class Stock < Engine::Round::Stock
+          def show_auto?
+            active_step.is_a?(G18Ardennes::Step::BuySellParSharesCompanies)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -77,11 +77,16 @@ module Engine
           end
 
           # Corporations whose cards are visible in the stock round.
-          # Hide those whose concessions have not yet been auctioned.
+          # Hide public companies whose concessions have not yet been auctioned,
+          # and show the current player's minor companies.
           def visible_corporations
-            @game.major_corporations.select do |corporation|
+            minors = @game.minor_corporations.select do |corporation|
+              corporation.owner == current_entity
+            end
+            majors = @game.sorted_corporations.select do |corporation|
               corporation.floated || !corporation.par_via_exchange.owner.nil?
             end
+            majors.sort + minors.sort
           end
 
           # Valid par prices for public companies.

--- a/lib/engine/game/g_18_ardennes/step/decline_trains.rb
+++ b/lib/engine/game/g_18_ardennes/step/decline_trains.rb
@@ -29,7 +29,12 @@ module Engine
                   'trains. Click on a train to discard it or click ' \
                   '‘Done’ to keep the trains.'
             if over_limit?
-              time = ", at the end of #{major.id}’s operating turn," if @round.is_a?(Round::Operating)
+              time =
+                if @round.is_a?(Engine::Round::Operating)
+                  ", at the end of #{major.id}’s operating turn,"
+                else
+                  ''
+                end
               msg += " #{major.id} is currently over the train limit. If you " \
                      "pass then you will be given#{time} the option to discard " \
                      "any of its trains (not just those from minor #{minor.id}) " \

--- a/lib/engine/game/g_18_ardennes/step/decline_trains.rb
+++ b/lib/engine/game/g_18_ardennes/step/decline_trains.rb
@@ -29,12 +29,7 @@ module Engine
                   'trains. Click on a train to discard it or click ' \
                   '‘Done’ to keep the trains.'
             if over_limit?
-              time =
-                if @round.is_a?(Engine::Round::Operating)
-                  ", at the end of #{major.id}’s operating turn,"
-                else
-                  ''
-                end
+              time = @round.operating? ? ", at the end of #{major.id}’s operating turn," : ''
               msg += " #{major.id} is currently over the train limit. If you " \
                      "pass then you will be given#{time} the option to discard " \
                      "any of its trains (not just those from minor #{minor.id}) " \

--- a/lib/engine/game/g_18_ardennes/step/exchange.rb
+++ b/lib/engine/game/g_18_ardennes/step/exchange.rb
@@ -32,7 +32,7 @@ module Engine
             return false unless entity.corporation?
             return false unless entity.type == :minor
 
-            @round.is_a?(Round::Stock) ? !bought? : !@round.converted.nil?
+            @round.is_a?(Engine::Round::Stock) ? !bought? : !@round.converted.nil?
           end
 
           def process_buy_shares(action)

--- a/lib/engine/game/g_18_ardennes/step/exchange.rb
+++ b/lib/engine/game/g_18_ardennes/step/exchange.rb
@@ -32,7 +32,7 @@ module Engine
             return false unless entity.corporation?
             return false unless entity.type == :minor
 
-            @round.is_a?(Engine::Round::Stock) ? !bought? : !@round.converted.nil?
+            @round.stock? ? !bought? : !@round.converted.nil?
           end
 
           def process_buy_shares(action)


### PR DESCRIPTION
## Implementation Notes

### Explanation of Change

An assortment of minor changes to the information shown to players in 18Ardennes. No game logic is changed in this pull request.

- Show the company cards for a player's minor companies during their stock round turns. You can't buy or sell shares in the minor companies, but it useful to be able to see their stock prices and assets without having to switch to the 'entities' tab, in case you are considering exchanging one for a public company share.
- In a stock round, sort public company cards by stock market price.
- Add a description on the company card for the GL minor company.
- Add descriptions to the concession company cards shown when auctioning the rights to start public companies.
- Use the acronym 'PCA' for public company auction rounds on the operating history shown on the game spreadsheet.

### Any Assumptions / Hacks

All code changes are limited to the `g_18_ardennes` subdirectory, no core code is affected.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
