### PR TITLE
[Core] Log backtrace on caught exception

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -836,6 +836,7 @@ module Engine
       end
 
       def rescue_exception(e, action)
+        LOGGER.debug { "Caught exception #{e.inspect}, backtrace: [#{e.backtrace.join(', ')}]" }
         @raw_actions.pop
         @actions.pop
         @exception = e


### PR DESCRIPTION
## Implementation Notes

### Explanation of Change

This is a single line change: when an exception is caught processing an action in server mode, print the exception and the backtrace to the server log at debug priority.

This is should make it easier to identify where a error has occurred.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
