### PR TITLE
[1846] Correct Ohio & Indiana description in 1846

### DIFF
--- a/lib/engine/game/g_1846/entities.rb
+++ b/lib/engine/game/g_1846/entities.rb
@@ -194,7 +194,7 @@ module Engine
             value: 40,
             revenue: 15,
             desc: 'Owning corporation may lay up to two extra free yellow tiles '\
-                  'in reserved hexes F14 and F15. '\
+                  'in reserved hexes F14 and F16. '\
                   'If both tiles are laid, they must connect to each other. '\
                   'Owning corporation does not need to be connected to either hex to use this ability.',
             sym: 'O&I',


### PR DESCRIPTION
<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Very pedantic, but the description for the Ohio & Indiana private company in 1846 specified that F15 was a reserved tile, which is not on the 1846 board. It should be F16.

### Screenshots

### Any Assumptions / Hacks

I don't think it will break existing games since it's just a description change, but I'm not entirely clear on that...