### PR TITLE
[1844] allow P4 to be used at any time

### DIFF
--- a/lib/engine/game/g_1844/entities.rb
+++ b/lib/engine/game/g_1844/entities.rb
@@ -60,7 +60,7 @@ module Engine
               {
                 type: 'choose_ability',
                 after_phase: '2',
-                when: %w[track owning_player_track],
+                when: 'any',
                 choices: ['Place tile'],
               },
             ],
@@ -99,7 +99,7 @@ module Engine
               {
                 type: 'choose_ability',
                 after_phase: '4',
-                when: 'owning_player_or_turn',
+                when: 'any',
                 choices: [], # Defined in special_choose step
               },
             ],

--- a/lib/engine/game/g_1844/game.rb
+++ b/lib/engine/game/g_1844/game.rb
@@ -616,6 +616,7 @@ module Engine
         def stock_round
           Engine::Round::Stock.new(self, [
             G1844::Step::MountainRailwayTrack,
+            G1844::Step::SpecialChoose,
             G1844::Step::BuySellParShares,
           ])
         end


### PR DESCRIPTION
Fixes #10649

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Adds the existing step that has special handling for P4 to the SR . 

Changes P4 to be used at 'any' time

This doesn't affect P7 as it has a 'when' limiter for specific steps

I don't believe this requires pins as it enables an action that was previously not possible

### Screenshots
in an SR on a player's turn who doesn't own the P4:

![image](https://github.com/tobymao/18xx/assets/1711810/2bec128f-2850-4ea6-9f54-da5eed014051)

![image](https://github.com/tobymao/18xx/assets/1711810/3d0b8fdd-ffd9-47b7-9599-292c6f07fc9d)


### Any Assumptions / Hacks
