### PR TITLE
[18SJ] fix bot corp choice after fullcap hits

### DIFF
--- a/lib/engine/game/g_18_sj/game.rb
+++ b/lib/engine/game/g_18_sj/game.rb
@@ -844,10 +844,9 @@ module Engine
           upgrades
         end
 
-        def requisit_corporation(name)
-          requisited = corporation_by_id(name)
+        def requisit_corporation(requisited)
           @log << "#{operator_for_edelsward_requisition.name} selects #{requisited.name} to be requisited by #{@edelsward.name}"
-          shares = requisited.shares_of(requisited)
+          shares = requisited.ipo_shares
           @share_pool.transfer_shares(Engine::ShareBundle.new(shares), @edelsward, price: 0)
           @stock_market.set_par(requisited, @stock_market.par_prices.find { |p| p.price == 67 })
 

--- a/lib/engine/game/g_18_sj/step/requisition.rb
+++ b/lib/engine/game/g_18_sj/step/requisition.rb
@@ -47,7 +47,7 @@ module Engine
           end
 
           def process_choose(action)
-            @game.requisit_corporation(action.choice)
+            @game.requisit_corporation(@game.corporation_by_id(action.choice))
             @game.requisition_turn = @game.turn
             pass!
           end

--- a/public/fixtures/18SJ/bot_chooses_fullcap.json
+++ b/public/fixtures/18SJ/bot_chooses_fullcap.json
@@ -1,0 +1,6378 @@
+{
+    "status": "finished",
+    "actions": [
+      {
+        "type": "bid",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 1,
+        "created_at": 1713718495,
+        "company": "NOHAB",
+        "price": 95
+      },
+      {
+        "type": "bid",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 2,
+        "created_at": 1713719030,
+        "company": "SB",
+        "price": 50
+      },
+      {
+        "type": "bid",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 3,
+        "created_at": 1713742297,
+        "company": "KHJ",
+        "price": 145
+      },
+      {
+        "type": "bid",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 4,
+        "created_at": 1713780583,
+        "company": "NE",
+        "price": 225
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 5,
+        "created_at": 1713787141
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 6,
+        "created_at": 1713790497
+      },
+      {
+        "type": "bid",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 7,
+        "created_at": 1713798494,
+        "company": "NOJ",
+        "price": 15
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 8,
+        "created_at": 1713799490
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 9,
+        "created_at": 1713801941
+      },
+      {
+        "type": "bid",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 10,
+        "created_at": 1713806443,
+        "company": "KHJ",
+        "price": 150
+      },
+      {
+        "type": "bid",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 11,
+        "created_at": 1713809556,
+        "company": "KHJ",
+        "price": 155
+      },
+      {
+        "type": "bid",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 12,
+        "created_at": 1713813998,
+        "company": "NOHAB",
+        "price": 100
+      },
+      {
+        "type": "bid",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 13,
+        "created_at": 1713815602,
+        "company": "NOHAB",
+        "price": 105
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 14,
+        "created_at": 1713817124
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 15,
+        "created_at": 1713818462
+      },
+      {
+        "type": "bid",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 16,
+        "created_at": 1713827083,
+        "company": "KHJ",
+        "price": 160
+      },
+      {
+        "type": "bid",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 17,
+        "created_at": 1713874463,
+        "company": "KHJ",
+        "price": 165
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 18,
+        "created_at": 1713877604
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 19,
+        "user": 3429,
+        "created_at": 1713881692
+      },
+      {
+        "type": "undo",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 20,
+        "user": 3429,
+        "created_at": 1713881696
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 21,
+        "created_at": 1713881721
+      },
+      {
+        "type": "bid",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 22,
+        "created_at": 1713895216,
+        "company": "GC",
+        "price": 70
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 23,
+        "created_at": 1713895234
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 24,
+        "created_at": 1713895238
+      },
+      {
+        "type": "par",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 25,
+        "created_at": 1713895372,
+        "corporation": "ÖSJ",
+        "share_price": "82,2,2"
+      },
+      {
+        "type": "choose",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 26,
+        "created_at": 1713895384,
+        "choice": "wait"
+      },
+      {
+        "type": "par",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 27,
+        "created_at": 1713895851,
+        "corporation": "KFJ",
+        "share_price": "82,2,2"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 28,
+        "created_at": 1713900173,
+        "shares": [
+          "ÖSJ_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 29,
+        "created_at": 1713901470,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1713901470,
+            "shares": [
+              "KFJ_1"
+            ],
+            "percent": 10
+          }
+        ],
+        "corporation": "KFJ",
+        "until_condition": "float",
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 32,
+        "created_at": 1713910938,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1713910938,
+            "shares": [
+              "KFJ_2"
+            ],
+            "percent": 10
+          }
+        ],
+        "shares": [
+          "ÖSJ_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 33,
+        "created_at": 1713910944,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1713910944,
+            "shares": [
+              "KFJ_3"
+            ],
+            "percent": 10
+          }
+        ],
+        "shares": [
+          "ÖSJ_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 34,
+        "created_at": 1713910950,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1713910949,
+            "shares": [
+              "KFJ_4"
+            ],
+            "percent": 10
+          }
+        ],
+        "shares": [
+          "ÖSJ_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 35,
+        "created_at": 1713910974,
+        "shares": [
+          "KFJ_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 36,
+        "created_at": 1713910979,
+        "shares": [
+          "KFJ_6"
+        ],
+        "percent": 10
+      },
+      {
+        "hex": "C16",
+        "tile": "57-0",
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "rotation": 0,
+        "entity_type": "minor",
+        "id": 37,
+        "user": 3429,
+        "created_at": 1713911761
+      },
+      {
+        "type": "pass",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 38,
+        "user": 3429,
+        "created_at": 1713911772
+      },
+      {
+        "type": "run_routes",
+        "entity": "KHJ",
+        "routes": [
+          {
+            "hexes": [
+              "D15",
+              "C16"
+            ],
+            "nodes": [
+              "D15-0",
+              "C16-0"
+            ],
+            "train": "2-0",
+            "revenue": 40,
+            "connections": [
+              [
+                "D15",
+                "C16"
+              ]
+            ],
+            "revenue_str": "D15-C16"
+          }
+        ],
+        "entity_type": "minor",
+        "extra_revenue": 0,
+        "id": 39,
+        "user": 3429,
+        "created_at": 1713911780
+      },
+      {
+        "type": "undo",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 40,
+        "user": 3429,
+        "created_at": 1713912127
+      },
+      {
+        "type": "undo",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 41,
+        "user": 3429,
+        "created_at": 1713912129
+      },
+      {
+        "type": "undo",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 42,
+        "user": 3429,
+        "created_at": 1713912132
+      },
+      {
+        "hex": "E16",
+        "tile": "8-0",
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "rotation": 2,
+        "entity_type": "minor",
+        "id": 43,
+        "user": 3429,
+        "created_at": 1713912141
+      },
+      {
+        "type": "undo",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 44,
+        "user": 3429,
+        "created_at": 1713912165
+      },
+      {
+        "hex": "E16",
+        "tile": "8-0",
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "rotation": 2,
+        "entity_type": "minor",
+        "id": 45,
+        "user": 3429,
+        "created_at": 1713912183
+      },
+      {
+        "hex": "E18",
+        "tile": "9-0",
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "rotation": 1,
+        "entity_type": "minor",
+        "id": 46,
+        "user": 3429,
+        "created_at": 1713912192
+      },
+      {
+        "type": "undo",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 47,
+        "user": 3429,
+        "created_at": 1713912231
+      },
+      {
+        "type": "undo",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 48,
+        "user": 3429,
+        "created_at": 1713912233
+      },
+      {
+        "hex": "E16",
+        "tile": "8-0",
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "rotation": 2,
+        "entity_type": "minor",
+        "id": 49,
+        "user": 3429,
+        "created_at": 1713912266
+      },
+      {
+        "type": "undo",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 50,
+        "user": 3429,
+        "created_at": 1713912315
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 51,
+        "created_at": 1713912328,
+        "hex": "C16",
+        "tile": "6-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 52,
+        "created_at": 1713912334
+      },
+      {
+        "type": "run_routes",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 53,
+        "created_at": 1713912341,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "D15",
+                "C16"
+              ]
+            ],
+            "hexes": [
+              "D15",
+              "C16"
+            ],
+            "revenue": 40,
+            "revenue_str": "D15-C16",
+            "nodes": [
+              "D15-0",
+              "C16-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "hex": "C4",
+        "tile": "8-0",
+        "type": "lay_tile",
+        "entity": "ÖSJ",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 54,
+        "user": 12964,
+        "created_at": 1713916052
+      },
+      {
+        "type": "undo",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 55,
+        "user": 12964,
+        "created_at": 1713916155
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 56,
+        "created_at": 1713916182,
+        "hex": "C4",
+        "tile": "8-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 57,
+        "created_at": 1713916222
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 58,
+        "created_at": 1713916227
+      },
+      {
+        "type": "buy_train",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 59,
+        "created_at": 1713916232,
+        "train": "2-1",
+        "price": 80,
+        "variant": "2"
+      },
+      {
+        "type": "buy_train",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 60,
+        "created_at": 1713916234,
+        "train": "2-2",
+        "price": 80,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 61,
+        "created_at": 1713916264
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 62,
+        "created_at": 1713925136,
+        "hex": "B15",
+        "tile": "8-1",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 63,
+        "created_at": 1713925146
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 64,
+        "created_at": 1713925152
+      },
+      {
+        "type": "buy_train",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 65,
+        "created_at": 1713925182,
+        "train": "2-3",
+        "price": 80,
+        "variant": "2"
+      },
+      {
+        "type": "buy_train",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 66,
+        "created_at": 1713925184,
+        "train": "2-4",
+        "price": 80,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 67,
+        "created_at": 1713925188
+      },
+      {
+        "type": "choose",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 68,
+        "created_at": 1713951223,
+        "choice": "wait"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 69,
+        "created_at": 1713959370,
+        "shares": [
+          "ÖSJ_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 70,
+        "created_at": 1713959379
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 71,
+        "created_at": 1713961495,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 12964,
+            "entity_type": "player",
+            "created_at": 1713961494
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 72,
+        "created_at": 1713965092,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1713965091
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "choose",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 73,
+        "created_at": 1713971827,
+        "choice": "UGJ"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 74,
+        "created_at": 1713973792,
+        "hex": "E16",
+        "tile": "8-2",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 75,
+        "created_at": 1713973803
+      },
+      {
+        "type": "run_routes",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 76,
+        "created_at": 1713973812,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "D15",
+                "C16"
+              ]
+            ],
+            "hexes": [
+              "D15",
+              "C16"
+            ],
+            "revenue": 40,
+            "revenue_str": "D15-C16",
+            "nodes": [
+              "D15-0",
+              "C16-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 77,
+        "created_at": 1713980264,
+        "hex": "B3",
+        "tile": "7-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 78,
+        "created_at": 1713980285
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 79,
+        "created_at": 1713980331
+      },
+      {
+        "type": "run_routes",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 80,
+        "created_at": 1713980339,
+        "routes": [
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "C2",
+                "B1",
+                "B3",
+                "A2"
+              ]
+            ],
+            "hexes": [
+              "C2",
+              "A2"
+            ],
+            "revenue": 40,
+            "revenue_str": "C2-A2",
+            "nodes": [
+              "C2-0",
+              "A2-0"
+            ]
+          },
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "C2",
+                "C4",
+                "D5"
+              ]
+            ],
+            "hexes": [
+              "C2",
+              "D5"
+            ],
+            "revenue": 40,
+            "revenue_str": "C2-D5",
+            "nodes": [
+              "C2-0",
+              "D5-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 81,
+        "created_at": 1713980343,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 82,
+        "created_at": 1713980404,
+        "train": "2-5",
+        "price": 80,
+        "variant": "2"
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 83,
+        "created_at": 1713980444
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 84,
+        "created_at": 1713986433,
+        "hex": "A14",
+        "tile": "9-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 85,
+        "created_at": 1713986436
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 86,
+        "created_at": 1713986449
+      },
+      {
+        "type": "run_routes",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 87,
+        "created_at": 1713986458,
+        "routes": [
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "C16",
+                "D15"
+              ]
+            ],
+            "hexes": [
+              "C16",
+              "D15"
+            ],
+            "revenue": 40,
+            "revenue_str": "C16-D15",
+            "nodes": [
+              "C16-0",
+              "D15-0"
+            ]
+          },
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "C16",
+                "B15",
+                "A16"
+              ]
+            ],
+            "hexes": [
+              "C16",
+              "A16"
+            ],
+            "revenue": 70,
+            "revenue_str": "C16-A16",
+            "nodes": [
+              "C16-0",
+              "A16-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 88,
+        "created_at": 1713986462,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 89,
+        "created_at": 1713986465
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 90,
+        "user": 3429,
+        "created_at": 1713986549,
+        "hex": "F13",
+        "tile": "57-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 91,
+        "user": 3429,
+        "created_at": 1713986552
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 92,
+        "created_at": 1713987155,
+        "shares": [
+          "KFJ_7"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 93,
+        "created_at": 1713987193,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 12964,
+            "entity_type": "player",
+            "created_at": 1713987192
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 94,
+        "created_at": 1713989880,
+        "shares": [
+          "ÖSJ_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 95,
+        "created_at": 1713989885,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 12964,
+            "entity_type": "player",
+            "created_at": 1713989885
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 96,
+        "created_at": 1713989893
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 97,
+        "created_at": 1713989912,
+        "hex": "E18",
+        "tile": "9-1",
+        "rotation": 1
+      },
+      {
+        "hex": "E20",
+        "tile": "5-0",
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "rotation": 0,
+        "entity_type": "minor",
+        "id": 98,
+        "user": 3429,
+        "created_at": 1713989922
+      },
+      {
+        "type": "undo",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 99,
+        "user": 3429,
+        "created_at": 1713989934
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 100,
+        "created_at": 1713989938,
+        "hex": "E20",
+        "tile": "57-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 101,
+        "created_at": 1713989943
+      },
+      {
+        "type": "run_routes",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 102,
+        "created_at": 1713989949,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "D15",
+                "E16",
+                "E18",
+                "E20"
+              ]
+            ],
+            "hexes": [
+              "D15",
+              "E20"
+            ],
+            "revenue": 40,
+            "revenue_str": "D15-E20",
+            "nodes": [
+              "D15-0",
+              "E20-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 103,
+        "created_at": 1713995777,
+        "hex": "D7",
+        "tile": "8-3",
+        "rotation": 5
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 104,
+        "created_at": 1713995783,
+        "hex": "E8",
+        "tile": "57-2",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 105,
+        "created_at": 1713995824
+      },
+      {
+        "city": "D5-0-0",
+        "slot": 0,
+        "type": "place_token",
+        "entity": "ÖSJ",
+        "tokener": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 106,
+        "user": 12964,
+        "created_at": 1713995829
+      },
+      {
+        "type": "buy_company",
+        "price": 90,
+        "entity": "ÖSJ",
+        "company": "SB",
+        "entity_type": "corporation",
+        "id": 107,
+        "user": 12964,
+        "created_at": 1713995898
+      },
+      {
+        "type": "undo",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 108,
+        "user": 12964,
+        "created_at": 1713995936
+      },
+      {
+        "type": "undo",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 109,
+        "user": 12964,
+        "created_at": 1713995938
+      },
+      {
+        "type": "place_token",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 110,
+        "created_at": 1713995944,
+        "city": "D5-0-0",
+        "slot": 0,
+        "tokener": "ÖSJ"
+      },
+      {
+        "type": "buy_company",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 111,
+        "created_at": 1713995948,
+        "company": "SB",
+        "price": 90
+      },
+      {
+        "type": "assign",
+        "entity": "SB",
+        "entity_type": "company",
+        "id": 112,
+        "created_at": 1713995979,
+        "target": "A6",
+        "target_type": "hex"
+      },
+      {
+        "type": "assign",
+        "entity": "SB",
+        "entity_type": "company",
+        "id": 113,
+        "created_at": 1713996006,
+        "target": "D5",
+        "target_type": "hex"
+      },
+      {
+        "type": "run_routes",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 114,
+        "created_at": 1713996033,
+        "routes": [
+          {
+            "train": "2-5",
+            "connections": [
+              [
+                "C2",
+                "B1",
+                "B3",
+                "A2"
+              ]
+            ],
+            "hexes": [
+              "C2",
+              "A2"
+            ],
+            "revenue": 60,
+            "revenue_str": "C2-A2",
+            "nodes": [
+              "C2-0",
+              "A2-0"
+            ]
+          },
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "D5",
+                "D7",
+                "E8"
+              ]
+            ],
+            "hexes": [
+              "D5",
+              "E8"
+            ],
+            "revenue": 70,
+            "revenue_str": "D5-E8 + Port",
+            "nodes": [
+              "D5-0",
+              "E8-0"
+            ]
+          },
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "C2",
+                "C4",
+                "D5"
+              ]
+            ],
+            "hexes": [
+              "C2",
+              "D5"
+            ],
+            "revenue": 70,
+            "revenue_str": "C2-D5 + Port",
+            "nodes": [
+              "C2-0",
+              "D5-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 115,
+        "created_at": 1713996040,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 116,
+        "created_at": 1713996044,
+        "train": "3-1",
+        "price": 180,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 117,
+        "created_at": 1713996074
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 118,
+        "created_at": 1714000045,
+        "hex": "A12",
+        "tile": "9-2",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 119,
+        "created_at": 1714000052
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 120,
+        "created_at": 1714000065
+      },
+      {
+        "type": "run_routes",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 121,
+        "created_at": 1714000075,
+        "routes": [
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "C16",
+                "D15"
+              ]
+            ],
+            "hexes": [
+              "C16",
+              "D15"
+            ],
+            "revenue": 40,
+            "revenue_str": "C16-D15",
+            "nodes": [
+              "C16-0",
+              "D15-0"
+            ]
+          },
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "C16",
+                "B15",
+                "A16"
+              ]
+            ],
+            "hexes": [
+              "C16",
+              "A16"
+            ],
+            "revenue": 60,
+            "revenue_str": "C16-A16",
+            "nodes": [
+              "C16-0",
+              "A16-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 122,
+        "created_at": 1714000077,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 123,
+        "created_at": 1714000081,
+        "train": "3-2",
+        "price": 180,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 124,
+        "created_at": 1714000083
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 125,
+        "created_at": 1714000114
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 126,
+        "user": 12964,
+        "created_at": 1714038008,
+        "hex": "G12",
+        "tile": "8-4",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 127,
+        "user": 12964,
+        "created_at": 1714038015,
+        "hex": "E14",
+        "tile": "8-5",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 128,
+        "user": 12964,
+        "created_at": 1714038023
+      },
+      {
+        "type": "pass",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 129,
+        "user": 12964,
+        "created_at": 1714038031
+      },
+      {
+        "type": "run_routes",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 130,
+        "user": 12964,
+        "created_at": 1714038036,
+        "routes": [
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "F13",
+                "G12",
+                "G10"
+              ]
+            ],
+            "hexes": [
+              "F13",
+              "G10"
+            ],
+            "revenue": 40,
+            "revenue_str": "F13-G10",
+            "nodes": [
+              "F13-0",
+              "G10-3"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 131,
+        "user": 12964,
+        "created_at": 1714038042,
+        "kind": "payout"
+      },
+      {
+        "hex": "E20",
+        "tile": "14-0",
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "rotation": 0,
+        "entity_type": "minor",
+        "id": 132,
+        "user": 3429,
+        "created_at": 1714047690
+      },
+      {
+        "type": "undo",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 133,
+        "user": 3429,
+        "created_at": 1714047698
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 134,
+        "created_at": 1714047722,
+        "hex": "C16",
+        "tile": "619-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 135,
+        "created_at": 1714047727
+      },
+      {
+        "type": "run_routes",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 136,
+        "created_at": 1714047734,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "D15",
+                "C16"
+              ]
+            ],
+            "hexes": [
+              "D15",
+              "C16"
+            ],
+            "revenue": 50,
+            "revenue_str": "D15-C16",
+            "nodes": [
+              "D15-0",
+              "C16-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 137,
+        "created_at": 1714049858,
+        "hex": "C6",
+        "tile": "8-6",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 138,
+        "created_at": 1714049884
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 139,
+        "created_at": 1714049886
+      },
+      {
+        "type": "run_routes",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 140,
+        "created_at": 1714049924,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "C2",
+                "B1",
+                "B3",
+                "A2"
+              ]
+            ],
+            "hexes": [
+              "C2",
+              "A2"
+            ],
+            "revenue": 60,
+            "revenue_str": "C2-A2",
+            "nodes": [
+              "C2-0",
+              "A2-0"
+            ]
+          },
+          {
+            "train": "2-5",
+            "connections": [
+              [
+                "D5",
+                "C4",
+                "C2"
+              ]
+            ],
+            "hexes": [
+              "D5",
+              "C2"
+            ],
+            "revenue": 70,
+            "revenue_str": "D5-C2 + Port",
+            "nodes": [
+              "D5-0",
+              "C2-0"
+            ]
+          },
+          {
+            "train": "2-2",
+            "connections": [
+              [
+                "D5",
+                "C6",
+                "C8"
+              ]
+            ],
+            "hexes": [
+              "D5",
+              "C8"
+            ],
+            "revenue": 70,
+            "revenue_str": "D5-C8 + Port",
+            "nodes": [
+              "D5-0",
+              "C8-0"
+            ]
+          },
+          {
+            "train": "2-1",
+            "connections": [
+              [
+                "D5",
+                "D7",
+                "E8"
+              ]
+            ],
+            "hexes": [
+              "D5",
+              "E8"
+            ],
+            "revenue": 70,
+            "revenue_str": "D5-E8 + Port",
+            "nodes": [
+              "D5-0",
+              "E8-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 141,
+        "created_at": 1714049950,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 142,
+        "created_at": 1714049963
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 143,
+        "created_at": 1714062107,
+        "hex": "D15",
+        "tile": "619-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 144,
+        "created_at": 1714062119
+      },
+      {
+        "type": "place_token",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 145,
+        "created_at": 1714062121,
+        "city": "619-1-0",
+        "slot": 1,
+        "tokener": "KFJ"
+      },
+      {
+        "type": "run_routes",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 146,
+        "created_at": 1714062141,
+        "routes": [
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "C16",
+                "B15",
+                "A16"
+              ],
+              [
+                "A16",
+                "A14",
+                "A12",
+                "A10"
+              ]
+            ],
+            "hexes": [
+              "C16",
+              "A16",
+              "A10"
+            ],
+            "revenue": 110,
+            "revenue_str": "C16-A16-A10",
+            "nodes": [
+              "C16-0",
+              "A16-0",
+              "A10-0"
+            ]
+          },
+          {
+            "train": "2-4",
+            "connections": [
+              [
+                "D15",
+                "E16",
+                "E18",
+                "E20"
+              ]
+            ],
+            "hexes": [
+              "D15",
+              "E20"
+            ],
+            "revenue": 50,
+            "revenue_str": "D15-E20",
+            "nodes": [
+              "D15-0",
+              "E20-0"
+            ]
+          },
+          {
+            "train": "2-3",
+            "connections": [
+              [
+                "C16",
+                "D15"
+              ]
+            ],
+            "hexes": [
+              "C16",
+              "D15"
+            ],
+            "revenue": 60,
+            "revenue_str": "C16-D15",
+            "nodes": [
+              "C16-0",
+              "D15-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 147,
+        "created_at": 1714062143,
+        "kind": "payout"
+      },
+      {
+        "type": "buy_train",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 148,
+        "created_at": 1714062182,
+        "train": "3-3",
+        "price": 180,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 149,
+        "created_at": 1714062234
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 150,
+        "user": 12964,
+        "created_at": 1714065741,
+        "hex": "E16",
+        "tile": "23-0",
+        "rotation": 4
+      },
+      {
+        "hex": "F13",
+        "tile": "619-2",
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 151,
+        "user": 12964,
+        "created_at": 1714065782
+      },
+      {
+        "type": "pass",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 152,
+        "user": 12964,
+        "created_at": 1714065789
+      },
+      {
+        "type": "pass",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 153,
+        "user": 12964,
+        "created_at": 1714065794
+      },
+      {
+        "type": "undo",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 154,
+        "user": 12964,
+        "created_at": 1714065817
+      },
+      {
+        "type": "undo",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 155,
+        "user": 12964,
+        "created_at": 1714065820
+      },
+      {
+        "type": "undo",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 156,
+        "user": 12964,
+        "created_at": 1714065839
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 157,
+        "user": 12964,
+        "created_at": 1714065847,
+        "hex": "G10",
+        "tile": "X2-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 158,
+        "user": 12964,
+        "created_at": 1714065855
+      },
+      {
+        "type": "pass",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 159,
+        "user": 12964,
+        "created_at": 1714065857
+      },
+      {
+        "type": "run_routes",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 160,
+        "user": 12964,
+        "created_at": 1714065863,
+        "routes": [
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "F13",
+                "G12",
+                "G10"
+              ],
+              [
+                "G10",
+                "H9"
+              ]
+            ],
+            "hexes": [
+              "F13",
+              "G10",
+              "H9"
+            ],
+            "revenue": 90,
+            "revenue_str": "F13-G10-H9",
+            "nodes": [
+              "F13-0",
+              "G10-0",
+              "H9-0"
+            ]
+          },
+          {
+            "train": "2-6",
+            "connections": [
+              [
+                "F13",
+                "E14",
+                "E16",
+                "E18",
+                "E20"
+              ]
+            ],
+            "hexes": [
+              "F13",
+              "E20"
+            ],
+            "revenue": 40,
+            "revenue_str": "F13-E20",
+            "nodes": [
+              "F13-0",
+              "E20-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 161,
+        "user": 12964,
+        "created_at": 1714065866,
+        "kind": "payout"
+      },
+      {
+        "type": "sell_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 162,
+        "created_at": 1714065955,
+        "shares": [
+          "KFJ_5",
+          "KFJ_6",
+          "KFJ_7"
+        ],
+        "percent": 30
+      },
+      {
+        "type": "par",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 163,
+        "created_at": 1714066049,
+        "corporation": "SNJ",
+        "share_price": "100,0,2"
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 164,
+        "created_at": 1714066090
+      },
+      {
+        "type": "sell_shares",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 165,
+        "created_at": 1714086875,
+        "shares": [
+          "ÖSJ_5",
+          "ÖSJ_6"
+        ],
+        "percent": 20
+      },
+      {
+        "type": "par",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 166,
+        "created_at": 1714087078,
+        "corporation": "SWB",
+        "share_price": "100,0,2"
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 167,
+        "created_at": 1714087083
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 168,
+        "created_at": 1714101309,
+        "shares": [
+          "SNJ_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 169,
+        "created_at": 1714101429
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 170,
+        "created_at": 1714134150,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714134151,
+            "shares": [
+              "SWB_1"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714134151
+          }
+        ],
+        "corporation": "SWB",
+        "until_condition": "float",
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 171,
+        "created_at": 1714136883,
+        "shares": [
+          "SNJ_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 172,
+        "created_at": 1714136892,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714136893,
+            "shares": [
+              "SWB_2"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714136893
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 173,
+        "created_at": 1714136937,
+        "shares": [
+          "SNJ_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 174,
+        "created_at": 1714136938,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714136939,
+            "shares": [
+              "SWB_3"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714136939
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 175,
+        "created_at": 1714136941,
+        "shares": [
+          "SNJ_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 176,
+        "created_at": 1714136944,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714136944,
+            "shares": [
+              "SWB_4"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "program_disable",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714136944,
+            "reason": "SWB is floated"
+          }
+        ]
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 177,
+        "created_at": 1714137379,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714137379
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "par",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 178,
+        "created_at": 1714141824,
+        "corporation": "BJ",
+        "share_price": "76,3,2"
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 179,
+        "created_at": 1714141827,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714141828,
+            "reason": "Corporation BJ parred"
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 180,
+        "created_at": 1714144243
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 181,
+        "created_at": 1714145643,
+        "shares": [
+          "SWB_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 182,
+        "created_at": 1714145646
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 183,
+        "created_at": 1714151534,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714151534
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 184,
+        "created_at": 1714162349
+      },
+      {
+        "type": "choose",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 185,
+        "created_at": 1714163337,
+        "choice": "MÖJ"
+      },
+      {
+        "hex": "E20",
+        "tile": "619-2",
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "rotation": 1,
+        "entity_type": "minor",
+        "id": 186,
+        "user": 3429,
+        "created_at": 1714163381
+      },
+      {
+        "type": "undo",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 187,
+        "user": 3429,
+        "created_at": 1714163390
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 188,
+        "created_at": 1714163395,
+        "hex": "E20",
+        "tile": "14-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 189,
+        "created_at": 1714163398
+      },
+      {
+        "type": "run_routes",
+        "entity": "KHJ",
+        "entity_type": "minor",
+        "id": 190,
+        "created_at": 1714163408,
+        "routes": [
+          {
+            "train": "2-0",
+            "connections": [
+              [
+                "D15",
+                "E16",
+                "E18",
+                "E20"
+              ]
+            ],
+            "hexes": [
+              "D15",
+              "E20"
+            ],
+            "revenue": 60,
+            "revenue_str": "D15-E20",
+            "nodes": [
+              "D15-0",
+              "E20-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "buy_company",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 191,
+        "created_at": 1714165909,
+        "company": "GC",
+        "price": 140
+      },
+      {
+        "hex": "F27",
+        "tile": "9-3",
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 192,
+        "user": 12964,
+        "created_at": 1714165917
+      },
+      {
+        "type": "undo",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 193,
+        "user": 12964,
+        "created_at": 1714165936
+      },
+      {
+        "type": "lay_tile",
+        "entity": "GC",
+        "entity_type": "company",
+        "id": 194,
+        "created_at": 1714165996,
+        "hex": "F27",
+        "tile": "9-3",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 195,
+        "created_at": 1714166000,
+        "hex": "E28",
+        "tile": "9-4",
+        "rotation": 0
+      },
+      {
+        "hex": "F25",
+        "tile": "9-5",
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 196,
+        "user": 12964,
+        "created_at": 1714166042
+      },
+      {
+        "type": "undo",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 197,
+        "user": 12964,
+        "created_at": 1714166055
+      },
+      {
+        "hex": "F25",
+        "tile": "9-5",
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 198,
+        "user": 12964,
+        "created_at": 1714166104
+      },
+      {
+        "type": "undo",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 199,
+        "user": 12964,
+        "created_at": 1714166145
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 200,
+        "created_at": 1714166165,
+        "hex": "F25",
+        "tile": "9-5",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 201,
+        "created_at": 1714166171
+      },
+      {
+        "type": "buy_train",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 202,
+        "created_at": 1714166196,
+        "train": "3-4",
+        "price": 180,
+        "variant": "3"
+      },
+      {
+        "type": "pass",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 203,
+        "created_at": 1714166211
+      },
+      {
+        "type": "pass",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 204,
+        "created_at": 1714166220
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 205,
+        "created_at": 1714167330,
+        "hex": "F11",
+        "tile": "9-6",
+        "rotation": 0
+      },
+      {
+        "hex": "E12",
+        "tile": "6-1",
+        "type": "lay_tile",
+        "entity": "SWB",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 206,
+        "user": 3429,
+        "created_at": 1714167337
+      },
+      {
+        "city": "6-1-0",
+        "slot": 0,
+        "type": "place_token",
+        "entity": "SWB",
+        "tokener": "SWB",
+        "entity_type": "corporation",
+        "id": 207,
+        "user": 3429,
+        "created_at": 1714167338
+      },
+      {
+        "type": "undo",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 208,
+        "user": 3429,
+        "created_at": 1714167341
+      },
+      {
+        "type": "undo",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 209,
+        "user": 3429,
+        "created_at": 1714167344
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 210,
+        "created_at": 1714167347,
+        "hex": "E12",
+        "tile": "57-3",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 211,
+        "created_at": 1714167363
+      },
+      {
+        "type": "buy_train",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 212,
+        "created_at": 1714167378,
+        "train": "4-0",
+        "price": 300,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 213,
+        "created_at": 1714167380
+      },
+      {
+        "type": "pass",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 214,
+        "created_at": 1714167384
+      },
+      {
+        "type": "assign",
+        "entity": "SB",
+        "entity_type": "company",
+        "id": 215,
+        "created_at": 1714171143,
+        "target": "C2",
+        "target_type": "hex"
+      },
+      {
+        "type": "assign",
+        "entity": "SB",
+        "entity_type": "company",
+        "id": 216,
+        "created_at": 1714171151,
+        "target": "D5",
+        "target_type": "hex"
+      },
+      {
+        "type": "buy_shares",
+        "entity": "ÖSJ",
+        "shares": [
+          "ÖSJ_5"
+        ],
+        "percent": 10,
+        "entity_type": "corporation",
+        "share_price": 90,
+        "id": 217,
+        "user": 12964,
+        "created_at": 1714171181
+      },
+      {
+        "type": "undo",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 218,
+        "user": 12964,
+        "created_at": 1714171188
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 219,
+        "created_at": 1714171192
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 220,
+        "created_at": 1714171214,
+        "hex": "C2",
+        "tile": "X1-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 221,
+        "user": 12964,
+        "created_at": 1714171259
+      },
+      {
+        "type": "undo",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 222,
+        "user": 12964,
+        "created_at": 1714171294
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 223,
+        "created_at": 1714171312
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 224,
+        "created_at": 1714171332
+      },
+      {
+        "type": "run_routes",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 225,
+        "created_at": 1714171358,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "D5",
+                "C4",
+                "C2"
+              ],
+              [
+                "C2",
+                "B1",
+                "B3",
+                "A2"
+              ]
+            ],
+            "hexes": [
+              "D5",
+              "C2",
+              "A2"
+            ],
+            "revenue": 130,
+            "revenue_str": "D5-C2-A2 + Port",
+            "nodes": [
+              "D5-0",
+              "C2-0",
+              "A2-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 226,
+        "user": 12964,
+        "created_at": 1714171377
+      },
+      {
+        "type": "undo",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 227,
+        "user": 12964,
+        "created_at": 1714171387
+      },
+      {
+        "kind": "payout",
+        "type": "dividend",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 228,
+        "user": 12964,
+        "created_at": 1714171390
+      },
+      {
+        "type": "undo",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 229,
+        "user": 12964,
+        "created_at": 1714171398
+      },
+      {
+        "type": "dividend",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 230,
+        "created_at": 1714171399,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 231,
+        "created_at": 1714171407,
+        "train": "4-1",
+        "price": 300,
+        "variant": "4"
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 232,
+        "created_at": 1714171431
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 233,
+        "created_at": 1714171443
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 234,
+        "created_at": 1714227912
+      },
+      {
+        "hex": "E22",
+        "tile": "9-7",
+        "type": "lay_tile",
+        "entity": "KFJ",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 235,
+        "user": 3429,
+        "created_at": 1714227941
+      },
+      {
+        "type": "undo",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 236,
+        "user": 3429,
+        "created_at": 1714227954
+      },
+      {
+        "hex": "D21",
+        "tile": "5-0",
+        "type": "lay_tile",
+        "entity": "KFJ",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 237,
+        "user": 3429,
+        "created_at": 1714227987
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 238,
+        "user": 3429,
+        "created_at": 1714227991
+      },
+      {
+        "type": "undo",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 239,
+        "user": 3429,
+        "created_at": 1714228000
+      },
+      {
+        "type": "undo",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 240,
+        "user": 3429,
+        "created_at": 1714228009
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 241,
+        "created_at": 1714228023,
+        "hex": "E22",
+        "tile": "8-7",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 242,
+        "user": 3429,
+        "created_at": 1714228039
+      },
+      {
+        "type": "undo",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 243,
+        "user": 3429,
+        "created_at": 1714228042
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 244,
+        "created_at": 1714228047
+      },
+      {
+        "type": "run_routes",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 245,
+        "created_at": 1714228052,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "C16",
+                "D15"
+              ],
+              [
+                "D15",
+                "E16",
+                "E18",
+                "E20"
+              ]
+            ],
+            "hexes": [
+              "C16",
+              "D15",
+              "E20"
+            ],
+            "revenue": 90,
+            "revenue_str": "C16-D15-E20",
+            "nodes": [
+              "C16-0",
+              "D15-0",
+              "E20-0"
+            ]
+          },
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "C16",
+                "B15",
+                "A16"
+              ],
+              [
+                "A16",
+                "A14",
+                "A12",
+                "A10"
+              ]
+            ],
+            "hexes": [
+              "C16",
+              "A16",
+              "A10"
+            ],
+            "revenue": 110,
+            "revenue_str": "C16-A16-A10",
+            "nodes": [
+              "C16-0",
+              "A16-0",
+              "A10-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 246,
+        "created_at": 1714228058,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 247,
+        "created_at": 1714228064
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 248,
+        "created_at": 1714228066
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 249,
+        "user": 3429,
+        "created_at": 1714239942,
+        "hex": "F9",
+        "tile": "9-7",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 250,
+        "user": 3429,
+        "created_at": 1714239962
+      },
+      {
+        "type": "place_token",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 251,
+        "user": 3429,
+        "created_at": 1714239976,
+        "city": "X2-0-2",
+        "slot": 0,
+        "tokener": "MÖJ"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 252,
+        "user": 3429,
+        "created_at": 1714240029,
+        "hex": "F13",
+        "tile": "14-1",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 253,
+        "user": 3429,
+        "created_at": 1714240037
+      },
+      {
+        "type": "place_token",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 254,
+        "user": 3429,
+        "created_at": 1714240039,
+        "city": "14-0-0",
+        "slot": 0,
+        "tokener": "UGJ"
+      },
+      {
+        "type": "run_routes",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 255,
+        "user": 3429,
+        "created_at": 1714240048,
+        "routes": [
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "F13",
+                "G12",
+                "G10"
+              ],
+              [
+                "G10",
+                "H9"
+              ]
+            ],
+            "hexes": [
+              "F13",
+              "G10",
+              "H9"
+            ],
+            "revenue": 100,
+            "revenue_str": "F13-G10-H9",
+            "nodes": [
+              "F13-0",
+              "G10-0",
+              "H9-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 256,
+        "user": 3429,
+        "created_at": 1714240053,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 257,
+        "created_at": 1714240068
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 258,
+        "created_at": 1714240089,
+        "hex": "D21",
+        "tile": "5-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 259,
+        "created_at": 1714240092
+      },
+      {
+        "type": "place_token",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 260,
+        "created_at": 1714240120,
+        "city": "14-0-0",
+        "slot": 1,
+        "tokener": "KFJ"
+      },
+      {
+        "type": "run_routes",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 261,
+        "created_at": 1714240127,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "E20",
+                "E18",
+                "E16",
+                "E14",
+                "F13"
+              ],
+              [
+                "F13",
+                "G12",
+                "G10"
+              ]
+            ],
+            "hexes": [
+              "E20",
+              "F13",
+              "G10"
+            ],
+            "revenue": 100,
+            "revenue_str": "E20-F13-G10",
+            "nodes": [
+              "E20-0",
+              "F13-0",
+              "G10-0"
+            ]
+          },
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "C16",
+                "B15",
+                "A16"
+              ],
+              [
+                "A16",
+                "A14",
+                "A12",
+                "A10"
+              ]
+            ],
+            "hexes": [
+              "C16",
+              "A16",
+              "A10"
+            ],
+            "revenue": 120,
+            "revenue_str": "C16-A16-A10",
+            "nodes": [
+              "C16-0",
+              "A16-0",
+              "A10-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 262,
+        "created_at": 1714240131,
+        "kind": "payout"
+      },
+      {
+        "hex": "D29",
+        "tile": "57-4",
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 263,
+        "user": 12964,
+        "created_at": 1714266856
+      },
+      {
+        "type": "undo",
+        "entity": "SNJ",
+        "action_id": 262,
+        "entity_type": "corporation",
+        "id": 264,
+        "user": 12964,
+        "created_at": 1714266870
+      },
+      {
+        "hex": "E24",
+        "tile": "8-2",
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 265,
+        "user": 12964,
+        "created_at": 1714266884
+      },
+      {
+        "type": "undo",
+        "entity": "SNJ",
+        "action_id": 262,
+        "entity_type": "corporation",
+        "id": 266,
+        "user": 12964,
+        "created_at": 1714266908
+      },
+      {
+        "hex": "E24",
+        "tile": "7-1",
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 267,
+        "user": 12964,
+        "created_at": 1714266914
+      },
+      {
+        "type": "undo",
+        "entity": "SNJ",
+        "action_id": 262,
+        "entity_type": "corporation",
+        "id": 268,
+        "user": 12964,
+        "created_at": 1714266927
+      },
+      {
+        "hex": "E24",
+        "tile": "8-2",
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 269,
+        "user": 12964,
+        "created_at": 1714266931
+      },
+      {
+        "hex": "E22",
+        "tile": "23-1",
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 270,
+        "user": 12964,
+        "created_at": 1714266937
+      },
+      {
+        "type": "undo",
+        "entity": "SNJ",
+        "action_id": 262,
+        "entity_type": "corporation",
+        "id": 271,
+        "user": 12964,
+        "created_at": 1714266953
+      },
+      {
+        "hex": "E24",
+        "tile": "7-1",
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 272,
+        "user": 12964,
+        "created_at": 1714266958
+      },
+      {
+        "type": "undo",
+        "entity": "SNJ",
+        "action_id": 262,
+        "entity_type": "corporation",
+        "id": 273,
+        "user": 12964,
+        "created_at": 1714266974
+      },
+      {
+        "hex": "E24",
+        "tile": "7-1",
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 274,
+        "user": 12964,
+        "created_at": 1714266983
+      },
+      {
+        "type": "undo",
+        "entity": "SNJ",
+        "action_id": 262,
+        "entity_type": "corporation",
+        "id": 275,
+        "user": 12964,
+        "created_at": 1714267028
+      },
+      {
+        "hex": "D29",
+        "tile": "57-4",
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 276,
+        "user": 12964,
+        "created_at": 1714267032
+      },
+      {
+        "type": "undo",
+        "entity": "SNJ",
+        "action_id": 262,
+        "entity_type": "corporation",
+        "id": 277,
+        "user": 12964,
+        "created_at": 1714267056
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 278,
+        "created_at": 1714267061,
+        "hex": "E24",
+        "tile": "7-1",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 279,
+        "created_at": 1714267067
+      },
+      {
+        "type": "pass",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 280,
+        "created_at": 1714267072
+      },
+      {
+        "type": "run_routes",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 281,
+        "created_at": 1714267076,
+        "routes": [
+          {
+            "train": "3-4",
+            "connections": [
+              [
+                "G26",
+                "F25",
+                "E24",
+                "F23"
+              ],
+              [
+                "F23",
+                "E22",
+                "E20"
+              ]
+            ],
+            "hexes": [
+              "G26",
+              "F23",
+              "E20"
+            ],
+            "revenue": 70,
+            "revenue_str": "G26-F23-E20",
+            "nodes": [
+              "G26-0",
+              "F23-0",
+              "E20-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 282,
+        "created_at": 1714267079,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 283,
+        "created_at": 1714267090
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 284,
+        "created_at": 1714275607,
+        "hex": "D13",
+        "tile": "8-2",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 285,
+        "created_at": 1714275616
+      },
+      {
+        "type": "place_token",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 286,
+        "created_at": 1714275628,
+        "city": "619-0-0",
+        "slot": 1,
+        "tokener": "SWB"
+      },
+      {
+        "type": "run_routes",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 287,
+        "created_at": 1714275640,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "A10",
+                "A12",
+                "A14",
+                "A16"
+              ],
+              [
+                "A16",
+                "B15",
+                "C16"
+              ],
+              [
+                "C16",
+                "D15"
+              ]
+            ],
+            "hexes": [
+              "A10",
+              "A16",
+              "C16",
+              "D15"
+            ],
+            "revenue": 150,
+            "revenue_str": "A10-A16-C16-D15",
+            "nodes": [
+              "A10-0",
+              "A16-0",
+              "C16-0",
+              "D15-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 288,
+        "created_at": 1714275642,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 289,
+        "created_at": 1714275647
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 290,
+        "created_at": 1714276841,
+        "hex": "E8",
+        "tile": "15-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 291,
+        "created_at": 1714276892
+      },
+      {
+        "type": "run_routes",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 292,
+        "created_at": 1714276920,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "G10",
+                "F9",
+                "E8"
+              ],
+              [
+                "E8",
+                "D7",
+                "D5"
+              ],
+              [
+                "D5",
+                "C6",
+                "C8"
+              ]
+            ],
+            "hexes": [
+              "G10",
+              "E8",
+              "D5",
+              "C8"
+            ],
+            "revenue": 110,
+            "revenue_str": "G10-E8-D5-C8",
+            "nodes": [
+              "G10-2",
+              "E8-0",
+              "D5-0",
+              "C8-0"
+            ]
+          },
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "D5",
+                "C4",
+                "C2"
+              ],
+              [
+                "C2",
+                "B1",
+                "B3",
+                "A2"
+              ]
+            ],
+            "hexes": [
+              "D5",
+              "C2",
+              "A2"
+            ],
+            "revenue": 110,
+            "revenue_str": "D5-C2-A2",
+            "nodes": [
+              "D5-0",
+              "C2-0",
+              "A2-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 293,
+        "created_at": 1714276970,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 294,
+        "user": 12964,
+        "created_at": 1714277025,
+        "hex": "F9",
+        "tile": "23-1",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 295,
+        "user": 12964,
+        "created_at": 1714277070
+      },
+      {
+        "type": "run_routes",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 296,
+        "user": 12964,
+        "created_at": 1714277075,
+        "routes": [
+          {
+            "train": "4-3",
+            "connections": [
+              [
+                "G10",
+                "H9"
+              ]
+            ],
+            "hexes": [
+              "G10",
+              "H9"
+            ],
+            "revenue": 80,
+            "revenue_str": "G10-H9",
+            "nodes": [
+              "G10-2",
+              "H9-0"
+            ]
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "G10",
+                "G8",
+                "F9",
+                "E8"
+              ],
+              [
+                "E8",
+                "D7",
+                "D5"
+              ]
+            ],
+            "hexes": [
+              "G10",
+              "E8",
+              "D5"
+            ],
+            "revenue": 90,
+            "revenue_str": "G10-E8-D5",
+            "nodes": [
+              "G10-1",
+              "E8-0",
+              "D5-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 297,
+        "user": 12964,
+        "created_at": 1714277078,
+        "kind": "payout"
+      },
+      {
+        "hex": "G10",
+        "tile": "X4-0",
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "rotation": 4,
+        "entity_type": "corporation",
+        "id": 298,
+        "user": 12964,
+        "created_at": 1714277107
+      },
+      {
+        "type": "undo",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 299,
+        "user": 12964,
+        "created_at": 1714277117
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 300,
+        "user": 12964,
+        "created_at": 1714277150,
+        "hex": "E22",
+        "tile": "23-2",
+        "rotation": 1
+      },
+      {
+        "hex": "E24",
+        "tile": "29-0",
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "rotation": 5,
+        "entity_type": "corporation",
+        "id": 301,
+        "user": 12964,
+        "created_at": 1714277162
+      },
+      {
+        "type": "undo",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 302,
+        "user": 12964,
+        "created_at": 1714277189
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 303,
+        "user": 12964,
+        "created_at": 1714277193,
+        "hex": "D29",
+        "tile": "57-4",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 304,
+        "user": 12964,
+        "created_at": 1714277202
+      },
+      {
+        "type": "pass",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 305,
+        "user": 12964,
+        "created_at": 1714277216
+      },
+      {
+        "type": "run_routes",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 306,
+        "user": 12964,
+        "created_at": 1714277221,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "D15",
+                "E16",
+                "E18",
+                "E20"
+              ],
+              [
+                "E20",
+                "E22",
+                "F23"
+              ],
+              [
+                "F23",
+                "E24",
+                "F25",
+                "G26"
+              ],
+              [
+                "G26",
+                "F27",
+                "E28",
+                "D29"
+              ]
+            ],
+            "hexes": [
+              "D15",
+              "E20",
+              "F23",
+              "G26",
+              "D29"
+            ],
+            "revenue": 170,
+            "revenue_str": "D15-E20-F23-G26-D29 + m/M",
+            "nodes": [
+              "D15-0",
+              "E20-0",
+              "F23-0",
+              "G26-0",
+              "D29-0"
+            ]
+          },
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "F13",
+                "G12",
+                "G10"
+              ],
+              [
+                "G10",
+                "H9"
+              ]
+            ],
+            "hexes": [
+              "F13",
+              "G10",
+              "H9"
+            ],
+            "revenue": 110,
+            "revenue_str": "F13-G10-H9",
+            "nodes": [
+              "F13-0",
+              "G10-0",
+              "H9-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 307,
+        "user": 12964,
+        "created_at": 1714277223,
+        "kind": "payout"
+      },
+      {
+        "type": "choose",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 308,
+        "created_at": 1714277277,
+        "choice": "wait"
+      },
+      {
+        "type": "par",
+        "entity": 3429,
+        "corporation": "MYJ",
+        "entity_type": "player",
+        "share_price": "71,4,2",
+        "id": 311,
+        "user": 3429,
+        "created_at": 1714311257
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 312,
+        "user": 3429,
+        "created_at": 1714311261
+      },
+      {
+        "type": "undo",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 313,
+        "user": 3429,
+        "created_at": 1714312032
+      },
+      {
+        "type": "undo",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 314,
+        "user": 3429,
+        "created_at": 1714312035
+      },
+      {
+        "type": "undo",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 315,
+        "user": 3429,
+        "created_at": 1714312038
+      },
+      {
+        "type": "redo",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 316,
+        "user": 3429,
+        "created_at": 1714312041
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 317,
+        "created_at": 1714312069,
+        "shares": [
+          "ÖSJ_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 318,
+        "created_at": 1714320112
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 319,
+        "created_at": 1714322128,
+        "shares": [
+          "BJ_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 320,
+        "created_at": 1714322253
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 321,
+        "created_at": 1714342350,
+        "shares": [
+          "SNJ_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 322,
+        "created_at": 1714342364
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 324,
+        "created_at": 1714351981,
+        "shares": [
+          "BJ_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 325,
+        "created_at": 1714352010
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 326,
+        "created_at": 1714392767,
+        "shares": [
+          "BJ_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 327,
+        "created_at": 1714392824
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 328,
+        "created_at": 1714394223,
+        "shares": [
+          "BJ_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 329,
+        "created_at": 1714394228
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 330,
+        "created_at": 1714411894,
+        "shares": [
+          "ÖSJ_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 331,
+        "created_at": 1714411898
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 332,
+        "created_at": 1714421708,
+        "shares": [
+          "BJ_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 333,
+        "created_at": 1714421711
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 334,
+        "created_at": 1714429650
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 335,
+        "created_at": 1714431541,
+        "shares": [
+          "KFJ_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 336,
+        "created_at": 1714431543
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 337,
+        "created_at": 1714432952,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714432952
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 338,
+        "created_at": 1714434008,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 12964,
+            "entity_type": "player",
+            "created_at": 1714434007
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 339,
+        "created_at": 1714434992,
+        "hex": "B17",
+        "tile": "8-8",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 340,
+        "created_at": 1714434998
+      },
+      {
+        "type": "run_routes",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 341,
+        "created_at": 1714435008,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "E20",
+                "E18",
+                "E16",
+                "E14",
+                "F13"
+              ],
+              [
+                "F13",
+                "G12",
+                "G10"
+              ]
+            ],
+            "hexes": [
+              "E20",
+              "F13",
+              "G10"
+            ],
+            "revenue": 100,
+            "revenue_str": "E20-F13-G10",
+            "nodes": [
+              "E20-0",
+              "F13-0",
+              "G10-0"
+            ]
+          },
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "C16",
+                "B17",
+                "A16"
+              ],
+              [
+                "A16",
+                "A14",
+                "A12",
+                "A10"
+              ]
+            ],
+            "hexes": [
+              "C16",
+              "A16",
+              "A10"
+            ],
+            "revenue": 120,
+            "revenue_str": "C16-A16-A10",
+            "nodes": [
+              "C16-0",
+              "A16-0",
+              "A10-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 342,
+        "created_at": 1714435042,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 343,
+        "created_at": 1714435060,
+        "hex": "E12",
+        "tile": "15-1",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 344,
+        "created_at": 1714435066
+      },
+      {
+        "type": "run_routes",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 345,
+        "created_at": 1714435092,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "A10",
+                "A12",
+                "A14",
+                "A16"
+              ],
+              [
+                "A16",
+                "B15",
+                "C16"
+              ],
+              [
+                "C16",
+                "D15"
+              ]
+            ],
+            "hexes": [
+              "A10",
+              "A16",
+              "C16",
+              "D15"
+            ],
+            "revenue": 150,
+            "revenue_str": "A10-A16-C16-D15",
+            "nodes": [
+              "A10-0",
+              "A16-0",
+              "C16-0",
+              "D15-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 346,
+        "created_at": 1714435096,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 347,
+        "created_at": 1714435101
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 348,
+        "created_at": 1714435442,
+        "hex": "G10",
+        "tile": "X4-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 349,
+        "created_at": 1714435468
+      },
+      {
+        "type": "place_token",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 350,
+        "created_at": 1714435471,
+        "city": "X4-0-1",
+        "slot": 0,
+        "tokener": "ÖSJ"
+      },
+      {
+        "type": "run_routes",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 351,
+        "created_at": 1714435498,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "A2",
+                "B3",
+                "B1",
+                "C2"
+              ],
+              [
+                "C2",
+                "C4",
+                "D5"
+              ],
+              [
+                "D5",
+                "D7",
+                "E8"
+              ]
+            ],
+            "hexes": [
+              "A2",
+              "C2",
+              "D5",
+              "E8"
+            ],
+            "revenue": 140,
+            "revenue_str": "A2-C2-D5-E8",
+            "nodes": [
+              "A2-0",
+              "C2-0",
+              "D5-0",
+              "E8-0"
+            ]
+          },
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "H9",
+                "G10"
+              ],
+              [
+                "G10",
+                "G8",
+                "F9",
+                "E8"
+              ]
+            ],
+            "hexes": [
+              "H9",
+              "G10",
+              "E8"
+            ],
+            "revenue": 140,
+            "revenue_str": "H9-G10-E8",
+            "nodes": [
+              "H9-0",
+              "G10-1",
+              "E8-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 352,
+        "created_at": 1714435510,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 353,
+        "created_at": 1714435581,
+        "hex": "D29",
+        "tile": "15-2",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 354,
+        "created_at": 1714435597
+      },
+      {
+        "type": "pass",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 355,
+        "created_at": 1714435607
+      },
+      {
+        "type": "run_routes",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 356,
+        "created_at": 1714435627,
+        "routes": [
+          {
+            "train": "3-4",
+            "connections": [
+              [
+                "G26",
+                "F25",
+                "E24",
+                "F23"
+              ],
+              [
+                "F23",
+                "E22",
+                "E20"
+              ]
+            ],
+            "hexes": [
+              "G26",
+              "F23",
+              "E20"
+            ],
+            "revenue": 70,
+            "revenue_str": "G26-F23-E20",
+            "nodes": [
+              "G26-0",
+              "F23-0",
+              "E20-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 357,
+        "created_at": 1714435632,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 358,
+        "created_at": 1714435681
+      },
+      {
+        "type": "lay_tile",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 359,
+        "created_at": 1714435700,
+        "hex": "B11",
+        "tile": "57-1",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 360,
+        "created_at": 1714435703,
+        "hex": "C12",
+        "tile": "57-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 361,
+        "created_at": 1714435730
+      },
+      {
+        "type": "buy_train",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 362,
+        "created_at": 1714435807,
+        "train": "4-1",
+        "price": 410
+      },
+      {
+        "type": "pass",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 363,
+        "created_at": 1714435811
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 364,
+        "user": 3429,
+        "created_at": 1714492078,
+        "hex": "D9",
+        "tile": "8-9",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 365,
+        "user": 3429,
+        "created_at": 1714492094
+      },
+      {
+        "type": "run_routes",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 366,
+        "user": 3429,
+        "created_at": 1714492100,
+        "routes": [
+          {
+            "train": "4-3",
+            "connections": [
+              [
+                "G10",
+                "H9"
+              ]
+            ],
+            "hexes": [
+              "G10",
+              "H9"
+            ],
+            "revenue": 110,
+            "revenue_str": "G10-H9",
+            "nodes": [
+              "G10-2",
+              "H9-0"
+            ]
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "G10",
+                "G8",
+                "F9",
+                "E8"
+              ],
+              [
+                "E8",
+                "D7",
+                "D5"
+              ]
+            ],
+            "hexes": [
+              "G10",
+              "E8",
+              "D5"
+            ],
+            "revenue": 120,
+            "revenue_str": "G10-E8-D5",
+            "nodes": [
+              "G10-1",
+              "E8-0",
+              "D5-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 367,
+        "user": 3429,
+        "created_at": 1714492103,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 368,
+        "user": 3429,
+        "created_at": 1714492272,
+        "hex": "D21",
+        "tile": "15-3",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 369,
+        "user": 3429,
+        "created_at": 1714492277
+      },
+      {
+        "type": "place_token",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 370,
+        "user": 3429,
+        "created_at": 1714492279,
+        "city": "X4-0-0",
+        "slot": 0,
+        "tokener": "UGJ"
+      },
+      {
+        "type": "run_routes",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 371,
+        "user": 3429,
+        "created_at": 1714492288,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "G10",
+                "F11",
+                "E12"
+              ],
+              [
+                "E12",
+                "D13",
+                "D15"
+              ],
+              [
+                "D15",
+                "E16",
+                "E18",
+                "E20"
+              ],
+              [
+                "E20",
+                "D21"
+              ]
+            ],
+            "hexes": [
+              "G10",
+              "E12",
+              "D15",
+              "E20",
+              "D21"
+            ],
+            "revenue": 190,
+            "revenue_str": "G10-E12-D15-E20-D21",
+            "nodes": [
+              "G10-3",
+              "E12-0",
+              "D15-0",
+              "E20-0",
+              "D21-0"
+            ]
+          },
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "F13",
+                "G12",
+                "G10"
+              ],
+              [
+                "G10",
+                "H9"
+              ]
+            ],
+            "hexes": [
+              "F13",
+              "G10",
+              "H9"
+            ],
+            "revenue": 140,
+            "revenue_str": "F13-G10-H9",
+            "nodes": [
+              "F13-0",
+              "G10-0",
+              "H9-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 372,
+        "user": 3429,
+        "created_at": 1714492290,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 373,
+        "created_at": 1714492306,
+        "hex": "C22",
+        "tile": "8-7",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 374,
+        "created_at": 1714492313
+      },
+      {
+        "type": "run_routes",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 375,
+        "created_at": 1714492346,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "E20",
+                "E18",
+                "E16",
+                "E14",
+                "F13"
+              ],
+              [
+                "F13",
+                "G12",
+                "G10"
+              ]
+            ],
+            "hexes": [
+              "E20",
+              "F13",
+              "G10"
+            ],
+            "revenue": 130,
+            "revenue_str": "E20-F13-G10",
+            "nodes": [
+              "E20-0",
+              "F13-0",
+              "G10-0"
+            ]
+          },
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "C16",
+                "B17",
+                "A16"
+              ],
+              [
+                "A16",
+                "A14",
+                "A12",
+                "A10"
+              ]
+            ],
+            "hexes": [
+              "C16",
+              "A16",
+              "A10"
+            ],
+            "revenue": 120,
+            "revenue_str": "C16-A16-A10",
+            "nodes": [
+              "C16-0",
+              "A16-0",
+              "A10-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 376,
+        "created_at": 1714492354,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 377,
+        "created_at": 1714492884,
+        "hex": "C2",
+        "tile": "X3-0",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 378,
+        "created_at": 1714492917
+      },
+      {
+        "type": "run_routes",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 379,
+        "created_at": 1714492941,
+        "routes": [
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "H9",
+                "G10"
+              ]
+            ],
+            "hexes": [
+              "H9",
+              "G10"
+            ],
+            "revenue": 110,
+            "revenue_str": "H9-G10",
+            "nodes": [
+              "H9-0",
+              "G10-1"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 380,
+        "created_at": 1714492954,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 381,
+        "created_at": 1714492956,
+        "train": "5-1",
+        "price": 530,
+        "variant": "5"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 382,
+        "created_at": 1714493327,
+        "hex": "C16",
+        "tile": "611-0",
+        "rotation": 2
+      },
+      {
+        "type": "pass",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 383,
+        "created_at": 1714493330
+      },
+      {
+        "type": "run_routes",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 384,
+        "created_at": 1714493335,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "H9",
+                "G10"
+              ],
+              [
+                "G10",
+                "F11",
+                "E12"
+              ],
+              [
+                "E12",
+                "D13",
+                "D15"
+              ]
+            ],
+            "hexes": [
+              "H9",
+              "G10",
+              "E12",
+              "D15"
+            ],
+            "revenue": 170,
+            "revenue_str": "H9-G10-E12-D15",
+            "nodes": [
+              "H9-0",
+              "G10-3",
+              "E12-0",
+              "D15-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 385,
+        "created_at": 1714493338,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 386,
+        "user": 3429,
+        "created_at": 1714493346
+      },
+      {
+        "type": "undo",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 387,
+        "user": 3429,
+        "created_at": 1714493393
+      },
+      {
+        "type": "pass",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 388,
+        "created_at": 1714493399
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 389,
+        "created_at": 1714495997,
+        "hex": "E24",
+        "tile": "29-0",
+        "rotation": 5
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 390,
+        "created_at": 1714496007,
+        "hex": "C28",
+        "tile": "8-10",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 391,
+        "created_at": 1714496081
+      },
+      {
+        "type": "run_routes",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 392,
+        "created_at": 1714496094,
+        "routes": [
+          {
+            "train": "3-4",
+            "connections": [
+              [
+                "E20",
+                "E22",
+                "E24",
+                "F25",
+                "G26"
+              ],
+              [
+                "G26",
+                "F27",
+                "E28",
+                "D29"
+              ]
+            ],
+            "hexes": [
+              "E20",
+              "G26",
+              "D29"
+            ],
+            "revenue": 130,
+            "revenue_str": "E20-G26-D29 + m/M",
+            "nodes": [
+              "E20-0",
+              "G26-0",
+              "D29-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 393,
+        "created_at": 1714496106,
+        "kind": "withhold"
+      },
+      {
+        "type": "buy_train",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 394,
+        "created_at": 1714496108,
+        "train": "5-2",
+        "price": 530,
+        "variant": "5"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 395,
+        "created_at": 1714496149,
+        "hex": "B11",
+        "tile": "619-2",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 396,
+        "created_at": 1714496170
+      },
+      {
+        "type": "pass",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 397,
+        "created_at": 1714496187
+      },
+      {
+        "type": "run_routes",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 398,
+        "created_at": 1714496192,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "A10",
+                "A12",
+                "A14",
+                "A16"
+              ],
+              [
+                "A16",
+                "B15",
+                "C16"
+              ]
+            ],
+            "hexes": [
+              "A10",
+              "A16",
+              "C16"
+            ],
+            "revenue": 130,
+            "revenue_str": "A10-A16-C16",
+            "nodes": [
+              "A10-0",
+              "A16-0",
+              "C16-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 399,
+        "created_at": 1714496197,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 400,
+        "created_at": 1714496223
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 401,
+        "user": 3429,
+        "created_at": 1714579219,
+        "hex": "D11",
+        "tile": "6-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 402,
+        "user": 3429,
+        "created_at": 1714579226
+      },
+      {
+        "type": "run_routes",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 403,
+        "user": 3429,
+        "created_at": 1714579231,
+        "routes": [
+          {
+            "train": "4-3",
+            "connections": [
+              [
+                "G10",
+                "H9"
+              ]
+            ],
+            "hexes": [
+              "G10",
+              "H9"
+            ],
+            "revenue": 110,
+            "revenue_str": "G10-H9",
+            "nodes": [
+              "G10-2",
+              "H9-0"
+            ]
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "G10",
+                "G8",
+                "F9",
+                "E8"
+              ],
+              [
+                "E8",
+                "D9",
+                "D11"
+              ]
+            ],
+            "hexes": [
+              "G10",
+              "E8",
+              "D11"
+            ],
+            "revenue": 120,
+            "revenue_str": "G10-E8-D11",
+            "nodes": [
+              "G10-1",
+              "E8-0",
+              "D11-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 404,
+        "user": 3429,
+        "created_at": 1714579233,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 405,
+        "user": 3429,
+        "created_at": 1714579309,
+        "hex": "C24",
+        "tile": "57-2",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 406,
+        "user": 3429,
+        "created_at": 1714579320
+      },
+      {
+        "type": "run_routes",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 407,
+        "user": 3429,
+        "created_at": 1714579324,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "G10",
+                "F11",
+                "E12"
+              ],
+              [
+                "E12",
+                "D13",
+                "D15"
+              ],
+              [
+                "D15",
+                "E16",
+                "E18",
+                "E20"
+              ],
+              [
+                "E20",
+                "D21"
+              ]
+            ],
+            "hexes": [
+              "G10",
+              "E12",
+              "D15",
+              "E20",
+              "D21"
+            ],
+            "revenue": 190,
+            "revenue_str": "G10-E12-D15-E20-D21",
+            "nodes": [
+              "G10-3",
+              "E12-0",
+              "D15-0",
+              "E20-0",
+              "D21-0"
+            ]
+          },
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "F13",
+                "G12",
+                "G10"
+              ],
+              [
+                "G10",
+                "H9"
+              ]
+            ],
+            "hexes": [
+              "F13",
+              "G10",
+              "H9"
+            ],
+            "revenue": 140,
+            "revenue_str": "F13-G10-H9",
+            "nodes": [
+              "F13-0",
+              "G10-0",
+              "H9-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 408,
+        "user": 3429,
+        "created_at": 1714579327,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 409,
+        "created_at": 1714579346,
+        "hex": "E20",
+        "tile": "63-0",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 410,
+        "created_at": 1714579347
+      },
+      {
+        "type": "run_routes",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 411,
+        "created_at": 1714579355,
+        "routes": [
+          {
+            "train": "3-3",
+            "connections": [
+              [
+                "E20",
+                "E18",
+                "E16",
+                "E14",
+                "F13"
+              ],
+              [
+                "F13",
+                "G12",
+                "G10"
+              ]
+            ],
+            "hexes": [
+              "E20",
+              "F13",
+              "G10"
+            ],
+            "revenue": 140,
+            "revenue_str": "E20-F13-G10",
+            "nodes": [
+              "E20-0",
+              "F13-0",
+              "G10-0"
+            ]
+          },
+          {
+            "train": "3-2",
+            "connections": [
+              [
+                "E20",
+                "E22",
+                "E24",
+                "F25",
+                "G26"
+              ],
+              [
+                "G26",
+                "F27",
+                "E28",
+                "D29"
+              ]
+            ],
+            "hexes": [
+              "E20",
+              "G26",
+              "D29"
+            ],
+            "revenue": 140,
+            "revenue_str": "E20-G26-D29 + m/M",
+            "nodes": [
+              "E20-0",
+              "G26-0",
+              "D29-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 412,
+        "created_at": 1714579363,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 413,
+        "created_at": 1714579375,
+        "hex": "D11",
+        "tile": "619-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 414,
+        "created_at": 1714579377
+      },
+      {
+        "type": "run_routes",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 415,
+        "created_at": 1714579383,
+        "routes": [
+          {
+            "train": "4-0",
+            "connections": [
+              [
+                "H9",
+                "G10"
+              ],
+              [
+                "G10",
+                "F11",
+                "E12"
+              ],
+              [
+                "E12",
+                "D13",
+                "D15"
+              ]
+            ],
+            "hexes": [
+              "H9",
+              "G10",
+              "E12",
+              "D15"
+            ],
+            "revenue": 170,
+            "revenue_str": "H9-G10-E12-D15",
+            "nodes": [
+              "H9-0",
+              "G10-3",
+              "E12-0",
+              "D15-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 416,
+        "created_at": 1714579386,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "SWB",
+        "entity_type": "corporation",
+        "id": 417,
+        "created_at": 1714579404
+      },
+      {
+        "hex": "E12",
+        "tile": "611-1",
+        "type": "lay_tile",
+        "entity": "ÖSJ",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 418,
+        "user": 12964,
+        "created_at": 1714581542
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 419,
+        "user": 12964,
+        "created_at": 1714581577
+      },
+      {
+        "type": "undo",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 420,
+        "user": 12964,
+        "created_at": 1714581599
+      },
+      {
+        "type": "undo",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 421,
+        "user": 12964,
+        "created_at": 1714581602
+      },
+      {
+        "type": "lay_tile",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 422,
+        "created_at": 1714581606,
+        "hex": "D11",
+        "tile": "611-1",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 423,
+        "created_at": 1714581611
+      },
+      {
+        "type": "run_routes",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 424,
+        "created_at": 1714581624,
+        "routes": [
+          {
+            "train": "5-1",
+            "connections": [
+              [
+                "A2",
+                "B3",
+                "B1",
+                "C2"
+              ],
+              [
+                "C2",
+                "C4",
+                "D5"
+              ],
+              [
+                "D5",
+                "D7",
+                "E8"
+              ],
+              [
+                "E8",
+                "D9",
+                "D11"
+              ]
+            ],
+            "hexes": [
+              "A2",
+              "C2",
+              "D5",
+              "E8",
+              "D11"
+            ],
+            "revenue": 200,
+            "revenue_str": "A2-C2-D5-E8-D11",
+            "nodes": [
+              "A2-0",
+              "C2-0",
+              "D5-0",
+              "E8-0",
+              "D11-0"
+            ]
+          },
+          {
+            "train": "3-1",
+            "connections": [
+              [
+                "H9",
+                "G10"
+              ],
+              [
+                "G10",
+                "G8",
+                "F9",
+                "E8"
+              ]
+            ],
+            "hexes": [
+              "H9",
+              "G10",
+              "E8"
+            ],
+            "revenue": 140,
+            "revenue_str": "H9-G10-E8",
+            "nodes": [
+              "H9-0",
+              "G10-1",
+              "E8-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "ÖSJ",
+        "entity_type": "corporation",
+        "id": 425,
+        "created_at": 1714581651,
+        "kind": "payout"
+      },
+      {
+        "hex": "B9",
+        "tile": "9-8",
+        "type": "lay_tile",
+        "entity": "BJ",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 426,
+        "user": 12964,
+        "created_at": 1714581671
+      },
+      {
+        "type": "undo",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 427,
+        "user": 12964,
+        "created_at": 1714581704
+      },
+      {
+        "hex": "B9",
+        "tile": "8-11",
+        "type": "lay_tile",
+        "entity": "BJ",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 428,
+        "user": 12964,
+        "created_at": 1714581708
+      },
+      {
+        "type": "undo",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 429,
+        "user": 12964,
+        "created_at": 1714581741
+      },
+      {
+        "type": "lay_tile",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 430,
+        "created_at": 1714581754,
+        "hex": "D13",
+        "tile": "21-0",
+        "rotation": 4
+      },
+      {
+        "type": "pass",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 431,
+        "created_at": 1714581780
+      },
+      {
+        "type": "place_token",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 432,
+        "created_at": 1714581793,
+        "city": "611-1-0",
+        "slot": 1,
+        "tokener": "BJ"
+      },
+      {
+        "type": "run_routes",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 433,
+        "created_at": 1714581806,
+        "routes": [
+          {
+            "train": "4-1",
+            "connections": [
+              [
+                "G10",
+                "G8",
+                "F9",
+                "E8"
+              ],
+              [
+                "E8",
+                "D9",
+                "D11"
+              ],
+              [
+                "D11",
+                "E12"
+              ]
+            ],
+            "hexes": [
+              "G10",
+              "E8",
+              "D11",
+              "E12"
+            ],
+            "revenue": 170,
+            "revenue_str": "G10-E8-D11-E12",
+            "nodes": [
+              "G10-1",
+              "E8-0",
+              "D11-0",
+              "E12-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 434,
+        "created_at": 1714581827,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "BJ",
+        "entity_type": "corporation",
+        "id": 435,
+        "created_at": 1714581831
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 436,
+        "created_at": 1714581856,
+        "hex": "C26",
+        "tile": "9-8",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 437,
+        "created_at": 1714581933
+      },
+      {
+        "type": "pass",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 438,
+        "created_at": 1714581942
+      },
+      {
+        "type": "run_routes",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 439,
+        "created_at": 1714581950,
+        "routes": [
+          {
+            "train": "5-2",
+            "connections": [
+              [
+                "G26",
+                "F27",
+                "E28",
+                "D29"
+              ],
+              [
+                "D29",
+                "C28",
+                "C26",
+                "C24"
+              ],
+              [
+                "C24",
+                "C22",
+                "D21"
+              ],
+              [
+                "D21",
+                "E20"
+              ]
+            ],
+            "hexes": [
+              "G26",
+              "D29",
+              "C24",
+              "D21",
+              "E20"
+            ],
+            "revenue": 190,
+            "revenue_str": "G26-D29-C24-D21-E20 + m/M",
+            "nodes": [
+              "G26-0",
+              "D29-0",
+              "C24-0",
+              "D21-0",
+              "E20-0"
+            ]
+          },
+          {
+            "train": "3-4",
+            "connections": [
+              [
+                "G26",
+                "F25",
+                "E24",
+                "F23"
+              ],
+              [
+                "F23",
+                "E22",
+                "E20"
+              ]
+            ],
+            "hexes": [
+              "G26",
+              "F23",
+              "E20"
+            ],
+            "revenue": 80,
+            "revenue_str": "G26-F23-E20",
+            "nodes": [
+              "G26-0",
+              "F23-0",
+              "E20-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "SNJ",
+        "entity_type": "corporation",
+        "id": 440,
+        "created_at": 1714581960,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 441,
+        "user": 3429,
+        "created_at": 1714582580,
+        "hex": "B9",
+        "tile": "7-2",
+        "rotation": 3
+      },
+      {
+        "type": "pass",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 442,
+        "user": 3429,
+        "created_at": 1714582581
+      },
+      {
+        "type": "run_routes",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 443,
+        "user": 3429,
+        "created_at": 1714582585,
+        "routes": [
+          {
+            "train": "4-3",
+            "connections": [
+              [
+                "G10",
+                "H9"
+              ]
+            ],
+            "hexes": [
+              "G10",
+              "H9"
+            ],
+            "revenue": 110,
+            "revenue_str": "G10-H9",
+            "nodes": [
+              "G10-2",
+              "H9-0"
+            ]
+          },
+          {
+            "train": "4-2",
+            "connections": [
+              [
+                "G10",
+                "G8",
+                "F9",
+                "E8"
+              ],
+              [
+                "E8",
+                "D9",
+                "D11"
+              ]
+            ],
+            "hexes": [
+              "G10",
+              "E8",
+              "D11"
+            ],
+            "revenue": 140,
+            "revenue_str": "G10-E8-D11",
+            "nodes": [
+              "G10-1",
+              "E8-0",
+              "D11-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "MÖJ",
+        "entity_type": "corporation",
+        "id": 444,
+        "user": 3429,
+        "created_at": 1714582587,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 445,
+        "user": 3429,
+        "created_at": 1714582597,
+        "hex": "F13",
+        "tile": "63-1",
+        "rotation": 0
+      },
+      {
+        "type": "pass",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 446,
+        "user": 3429,
+        "created_at": 1714582599
+      },
+      {
+        "type": "run_routes",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 447,
+        "user": 3429,
+        "created_at": 1714582603,
+        "routes": [
+          {
+            "train": "5-0",
+            "connections": [
+              [
+                "G10",
+                "F11",
+                "E12"
+              ],
+              [
+                "E12",
+                "D13",
+                "D15"
+              ],
+              [
+                "D15",
+                "E16",
+                "E18",
+                "E20"
+              ],
+              [
+                "E20",
+                "D21"
+              ]
+            ],
+            "hexes": [
+              "G10",
+              "E12",
+              "D15",
+              "E20",
+              "D21"
+            ],
+            "revenue": 200,
+            "revenue_str": "G10-E12-D15-E20-D21",
+            "nodes": [
+              "G10-3",
+              "E12-0",
+              "D15-0",
+              "E20-0",
+              "D21-0"
+            ]
+          },
+          {
+            "train": "3-0",
+            "connections": [
+              [
+                "F13",
+                "G12",
+                "G10"
+              ],
+              [
+                "G10",
+                "H9"
+              ]
+            ],
+            "hexes": [
+              "F13",
+              "G10",
+              "H9"
+            ],
+            "revenue": 150,
+            "revenue_str": "F13-G10-H9",
+            "nodes": [
+              "F13-0",
+              "G10-0",
+              "H9-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "UGJ",
+        "entity_type": "corporation",
+        "id": 448,
+        "user": 3429,
+        "created_at": 1714582604,
+        "kind": "payout"
+      },
+      {
+        "type": "choose",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 449,
+        "created_at": 1714598762,
+        "choice": "activate"
+      },
+      {
+        "type": "par",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 450,
+        "created_at": 1714598768,
+        "corporation": "ÖKJ",
+        "share_price": "100,0,2"
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 451,
+        "created_at": 1714599721
+      },
+      {
+        "type": "par",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 452,
+        "created_at": 1714601013,
+        "corporation": "TGOJ",
+        "share_price": "100,0,2"
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 453,
+        "created_at": 1714601029
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 454,
+        "created_at": 1714643198,
+        "shares": [
+          "ÖKJ_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 455,
+        "created_at": 1714643258
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 456,
+        "created_at": 1714651818,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714651818,
+            "shares": [
+              "TGOJ_1"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714651818
+          }
+        ],
+        "corporation": "TGOJ",
+        "until_condition": "float",
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 457,
+        "created_at": 1714652084,
+        "shares": [
+          "ÖKJ_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 458,
+        "created_at": 1714652089,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714652089,
+            "shares": [
+              "TGOJ_2"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714652089
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 459,
+        "created_at": 1714652093,
+        "shares": [
+          "ÖKJ_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 460,
+        "created_at": 1714652095,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714652095,
+            "shares": [
+              "TGOJ_3"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "pass",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714652095
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 461,
+        "created_at": 1714652098,
+        "shares": [
+          "ÖKJ_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 462,
+        "created_at": 1714652100,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714652100,
+            "shares": [
+              "TGOJ_4"
+            ],
+            "percent": 10
+          },
+          {
+            "type": "program_disable",
+            "entity": 3429,
+            "entity_type": "player",
+            "created_at": 1714652100,
+            "reason": "TGOJ is floated"
+          }
+        ]
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 463,
+        "created_at": 1714652408
+      },
+      {
+        "type": "buy_shares",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 464,
+        "created_at": 1714667731,
+        "shares": [
+          "TGOJ_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 465,
+        "created_at": 1714667734
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 466,
+        "created_at": 1714667883,
+        "shares": [
+          "ÖKJ_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 467,
+        "created_at": 1714667885
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 468,
+        "created_at": 1714679933,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 12964,
+            "entity_type": "player",
+            "created_at": 1714679932
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "pass",
+        "entity": 3429,
+        "entity_type": "player",
+        "id": 469,
+        "created_at": 1714691753
+      },
+      {
+        "type": "choose",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 470,
+        "created_at": 1714809866,
+        "choice": "MYJ"
+      },
+      {
+        "type": "undo",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 471,
+        "created_at": 1714809957
+      },
+      {
+        "type": "choose",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 472,
+        "created_at": 1714810111,
+        "choice": "MYJ"
+      },
+      {
+        "type": "undo",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 473,
+        "created_at": 1714810231
+      },
+      {
+        "type": "choose",
+        "entity": 12964,
+        "entity_type": "player",
+        "id": 474,
+        "created_at": 1714810373,
+        "choice": "MYJ"
+      },
+      {
+        "type": "end_game",
+        "entity": "KFJ",
+        "entity_type": "corporation",
+        "id": 475,
+        "created_at": 1714844292
+      }
+    ],
+    "id": "hs_bwjtehic_160962",
+    "players": [
+      {
+        "id": 3429,
+        "name": "skippen"
+      },
+      {
+        "id": 12964,
+        "name": "pmanoff"
+      }
+    ],
+    "title": "18SJ",
+    "description": "Learning 18SJ",
+    "min_players": 2,
+    "max_players": 2,
+    "user": {
+      "id": 0,
+      "name": "You"
+    },
+    "settings": {
+      "seed": 891507424,
+      "is_async": true,
+      "unlisted": true,
+      "auto_routing": true,
+      "player_order": null,
+      "optional_rules": []
+    },
+    "user_settings": null,
+    "turn": 6,
+    "round": "Operating Round",
+    "acting": [
+      3429
+    ],
+    "result": {
+      "3429": 3285,
+      "12964": 2854
+    },
+    "loaded": true,
+    "created_at": "2024-05-04",
+    "updated_at": 1714844292,
+    "finished_at": null,
+    "mode": "hotseat",
+    "manually_ended": true
+  }


### PR DESCRIPTION
Fixes #10709

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

also adds test case

I don't believe this requires pins, as it enables previously broken actions

Obtain a `shares` object based on the corp's IPO shares, no matter who owns them

I believe the issue was that the [fullcap conversion logic](https://github.com/tobymao/18xx/blob/master/lib/engine/game/g_18_sj/game.rb#L758) moves IPO shares to the bank, so when we attempt to obtain those shares later from the corp's context, the corp doesn't actually own any shares so it returns nil which blows up the [share transfer logic](https://github.com/tobymao/18xx/blob/master/lib/engine/game/g_18_sj/game.rb#L851)

Also changed the requisite step to pass an ID instead of a bare name, since we immediately convert it to an ID anyway

### Screenshots

![image](https://github.com/tobymao/18xx/assets/1711810/0556d154-902c-4901-8acc-ba0234e444b3)

![image](https://github.com/tobymao/18xx/assets/1711810/66fc4849-feec-46bc-9607-f6530722c244)


### Any Assumptions / Hacks
