### PR TITLE
[18 India] [Core] Create Multiple Selection Action and Refactor Certificate Selection

### DIFF
--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -22,6 +22,7 @@ module View
 
       def selected?
         return @step.company_selected?(@company) if @step.respond_to?(:company_selected?)
+
         @company == @selected_company
       end
 

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -36,7 +36,7 @@ module View
           return process_action(Engine::Action::Assign.new(entity, target: selected_company))
         end
 
-        if @game.round.actions_for(entity).include?('select_multiple_companies') && @step.respond_to?(:select_company)
+        if @game.round.actions_for(entity).include?('select_multiple_companies')
           @step.select_company(entity, @company)
           return store(:selected_company, nil)
         end

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -21,6 +21,7 @@ module View
       needs :interactive, default: true
 
       def selected?
+        return @step.company_selected?(@company) if @step.respond_to?(:company_selected?)
         @company == @selected_company
       end
 
@@ -32,6 +33,11 @@ module View
         if selected_company && @game.round.actions_for(entity).include?('assign') &&
           (@game.class::ALL_COMPANIES_ASSIGNABLE || entity.respond_to?(:assign!))
           return process_action(Engine::Action::Assign.new(entity, target: selected_company))
+        end
+
+        if @game.round.actions_for(entity).include?('select_multiple_companies') && @step.respond_to?(:select_company)
+          @step.select_company(entity, @company)
+          return store(:selected_company, nil)
         end
 
         store(:tile_selector, nil, skip: true)
@@ -81,6 +87,7 @@ module View
       end
 
       def render
+        @step = @game.round.active_step
         # use alternate view of corporation if needed
         if @game.respond_to?(:company_view) && (view = @game.company_view(@company))
           return send("render_#{view}")

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -124,7 +124,7 @@ module View
           select_button = [h(:button, { on: { click: mutiple_companies } }, 'Confirm Selections')]
 
           children = []
-          children << h(:div, @step.selection_note.map { |text_block| h(:p, text_block) } )
+          children << h(:div, @step.selection_note.map { |text_block| h(:p, text_block) })
           children << h(:div, select_button) if @step.selections_completed?
           h(:div, children)
         end

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -124,10 +124,7 @@ module View
           select_button = [h(:button, { on: { click: mutiple_companies } }, 'Confirm Selections')]
 
           children = []
-          if @step.respond_to?(:selection_note)
-            note = @step.selection_note.map { |text_block| h(:p, text_block) }
-            children << h(:div, note)
-          end
+          children << h(:div, @step.selection_note.map { |text_block| h(:p, text_block) } )
           children << h(:div, select_button) if @step.selections_completed?
           h(:div, children)
         end

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -192,7 +192,6 @@ module View
           buy_str = @step.respond_to?(:buy_str) ? @step.buy_str(company) : 'Buy'
           return [h(:button, { on: { click: -> { buy(company) } } }, buy_str)] if @step.may_purchase?(company)
           return [h(:button, { on: { click: -> { choose } } }, 'Choose')] if @step.may_choose?(company)
-          return [] if @step.respond_to?(:select_company)
 
           input = h(:input, style: { marginRight: '1rem' }, props: {
                       value: @step.min_bid(company),

--- a/lib/engine/action/select_multiple_companies.rb
+++ b/lib/engine/action/select_multiple_companies.rb
@@ -7,14 +7,14 @@ module Engine
     class SelectMultipleCompanies < Base
       attr_reader :entity, :companies
 
-      def initialize(entity, companies)
+      def initialize(entity, companies:)
         super(entity)
         @companies = companies
       end
 
       def self.h_to_args(h, game)
         {
-          companies: h['companies'].map { |company| game.company_by_id(company) },
+          companies: h['companies'].map { |id| game.company_by_id(id) },
         }
       end
 

--- a/lib/engine/action/select_multiple_companies.rb
+++ b/lib/engine/action/select_multiple_companies.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Engine
+  module Action
+    class SelectMultipleCompanies < Base
+      attr_reader :entity, :companies
+
+      def initialize(entity, companies)
+        super(entity)
+        @companies = companies
+      end
+
+      def self.h_to_args(h, game)
+        {
+          companies: h['companies'].map { |company| game.company_by_id(company) },
+        }
+      end
+
+      def args_to_h
+        {
+          'companies' => @companies.map(&:id),
+        }
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_india/game.rb
+++ b/lib/engine/game/g_18_india/game.rb
@@ -70,7 +70,7 @@ module Engine
 
         STARTING_CASH = { 2 => 1100, 3 => 733, 4 => 550, 5 => 440 }.freeze
 
-        GAME_END_CHECK = { bank: :current_or, stock_market: :current_or }.freeze
+        GAME_END_CHECK = { bank: :full_or, stock_market: :current_or }.freeze
 
         MARKET = [
           %w[0c 56 58 61 64p 67p 71p 76p 82p 90p 100p 112p 126 142 160

--- a/lib/engine/game/g_18_india/step/certificate_selection.rb
+++ b/lib/engine/game/g_18_india/step/certificate_selection.rb
@@ -119,7 +119,7 @@ module Engine
             unselected_companies = player.hand - selected_companies
             unselected_companies.each { |company| company.owner = nil }
             @confirmed_selections += 1
-            LOGGER.debug " Test  Process Muti-Select => confirmed_selections: #{@confirmed_selections} finished?: #{finished?}  "\
+            LOGGER.debug "Process Muti-Select => confirmed_selections: #{@confirmed_selections} finished?: #{finished?}  "\
                          "selected: #{selected_companies.inspect} unselected: #{unselected_companies.inspect}"
             @round.next_entity_index!
             action_finalized

--- a/lib/engine/game/g_18_india/step/certificate_selection.rb
+++ b/lib/engine/game/g_18_india/step/certificate_selection.rb
@@ -40,10 +40,6 @@ module Engine
             false
           end
 
-          def may_choose?(_company)
-            false
-          end
-
           def auctioning; end
 
           def bids
@@ -113,14 +109,15 @@ module Engine
 
           def process_select_multiple_companies(action)
             player = action.entity
-            selected_companies = action.companies
-            @log << "#{player.name} selected #{selected_companies.size} certificates for hand"
-            selected_companies.each { |company| company.owner = player }
-            unselected_companies = player.hand - selected_companies
-            unselected_companies.each { |company| company.owner = nil }
+            selected = action.companies
+            raise GameError, "Selected companies are not in #{player.name}'s hand" unless (selected - player.hand).empty?
+            @log << "#{player.name} selected #{selected.size} certificates for hand"
+            selected.each { |company| company.owner = player }
+            unselected = player.hand - selected
+            unselected.each { |company| company.owner = nil }
             @confirmed_selections += 1
             LOGGER.debug "Process Muti-Select => confirmed_selections: #{@confirmed_selections} finished?: #{finished?}  "\
-                         "selected: #{selected_companies.inspect} unselected: #{unselected_companies.inspect}"
+                         "selected: #{selected.inspect} unselected: #{unselected.inspect}"
             @round.next_entity_index!
             action_finalized
           end

--- a/lib/engine/game/g_18_india/step/certificate_selection.rb
+++ b/lib/engine/game/g_18_india/step/certificate_selection.rb
@@ -72,14 +72,14 @@ module Engine
 
           def selection_note
             [
-              "Made #{number_of_selections} of #{@cards_to_keep} selections.",
               'Click on card to select or unselect it.',
+              "Made #{number_of_selections} of #{@cards_to_keep} selections.",
+              number_of_selections > @cards_to_keep ? 'Too many certs selected.' : '',
+              number_of_selections < @cards_to_keep ? 'Select more certs.' : '',
             ]
           end
 
           def select_company(player, company)
-            return if selections_completed? && company.owner.nil? # prevent selecting more than allowed
-
             # add or remove from choices
             if company_selected?(company)
               @choices[player].delete(company)
@@ -111,6 +111,7 @@ module Engine
             player = action.entity
             selected = action.companies
             raise GameError, "Selected companies are not in #{player.name}'s hand" unless (selected - player.hand).empty?
+
             @log << "#{player.name} selected #{selected.size} certificates for hand"
             selected.each { |company| company.owner = player }
             unselected = player.hand - selected

--- a/lib/engine/game/g_18_india/step/certificate_selection.rb
+++ b/lib/engine/game/g_18_india/step/certificate_selection.rb
@@ -40,7 +40,7 @@ module Engine
             false
           end
 
-          def may_choose?(company)
+          def may_choose?(_company)
             false
           end
 


### PR DESCRIPTION
- [x] Branch is derived from the latest `master`
- [n/a] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes
- Created a `SelectMultipleCompanies` action that stores an array of companies as part of a single action.
- Modified `View::Company` and `View::Round::Auction` behavior to support selection of multiple companies.
- Refactor Certificate Selection step to use multiple selection action. 

### Explanation of Change
The old version of the certificate selection step was very "clicky", often needing 20 - 30 clicks to complete and felt "clunky" as a user experience.  This refactor allows the completion of the step with 1/3 of the clicks, and without hiding the screen after individual certificate selection.
 
### Screenshots
![image](https://github.com/tobymao/18xx/assets/118568589/8e6d8435-33a1-4441-b3a8-70aaaad5719b)

### Any Assumptions / Hacks
- Uses the `click` -> `select_company` event on company card as the "button" to select and unselect the company. 