### PR TITLE
[18RG] fix ability keyword

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -390,7 +390,7 @@ module Engine
             choices: { 'pay_debt' => 'Pay Doc Holliday for one DEBT token' },
             count: 2,
             count_per_or: 1,
-            closed_when_used_up: true,
+            remove_when_used_up: true,
           )
           sf_debt.add_ability(ability)
           sf_debt.owner = santa_fe
@@ -413,7 +413,7 @@ module Engine
             choices: { 'pay_debt' => 'Pay Santa Fe for one DEBT token' },
             count: 4,
             count_per_or: 1,
-            closed_when_used_up: true,
+            remove_when_used_up: true,
           )
           rg_debt.add_ability(ability)
           rg_debt.owner = rio_grande

--- a/public/fixtures/18RoyalGorge/post_boston.json
+++ b/public/fixtures/18RoyalGorge/post_boston.json
@@ -1,0 +1,1649 @@
+{
+    "status": "finished",
+    "actions": [
+      {
+        "type": "pass",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 1,
+        "created_at": 1714367111
+      },
+      {
+        "type": "bid",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 2,
+        "created_at": 1714388070,
+        "company": "Y3",
+        "price": 40
+      },
+      {
+        "type": "bid",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 3,
+        "created_at": 1714421194,
+        "company": "Y3",
+        "price": 45
+      },
+      {
+        "type": "bid",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 4,
+        "created_at": 1714421323,
+        "company": "Y3",
+        "price": 50
+      },
+      {
+        "type": "pass",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 5,
+        "created_at": 1714421743
+      },
+      {
+        "type": "pass",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 6,
+        "created_at": 1714486883
+      },
+      {
+        "type": "pass",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 7,
+        "created_at": 1714488031
+      },
+      {
+        "type": "bid",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 8,
+        "created_at": 1714488336,
+        "company": "Y5",
+        "price": 70
+      },
+      {
+        "type": "bid",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 9,
+        "created_at": 1714490015,
+        "company": "Y5",
+        "price": 75
+      },
+      {
+        "type": "bid",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 10,
+        "created_at": 1714494097,
+        "company": "Y5",
+        "price": 80
+      },
+      {
+        "type": "bid",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 11,
+        "created_at": 1714497318,
+        "company": "Y5",
+        "price": 85
+      },
+      {
+        "type": "bid",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 12,
+        "created_at": 1714497739,
+        "company": "Y5",
+        "price": 90
+      },
+      {
+        "type": "bid",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 13,
+        "created_at": 1714498662,
+        "company": "Y5",
+        "price": 95
+      },
+      {
+        "type": "pass",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 14,
+        "created_at": 1714521763
+      },
+      {
+        "type": "pass",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 15,
+        "created_at": 1714540140
+      },
+      {
+        "type": "pass",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 16,
+        "created_at": 1714545143
+      },
+      {
+        "type": "bid",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 17,
+        "created_at": 1714550482,
+        "company": "G1",
+        "price": 70
+      },
+      {
+        "type": "bid",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 18,
+        "created_at": 1714584401,
+        "company": "G1",
+        "price": 75
+      },
+      {
+        "type": "bid",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 19,
+        "created_at": 1714590001,
+        "company": "G1",
+        "price": 80
+      },
+      {
+        "type": "pass",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 20,
+        "created_at": 1714595334
+      },
+      {
+        "type": "pass",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 21,
+        "created_at": 1714613810
+      },
+      {
+        "type": "pass",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 22,
+        "created_at": 1714620056
+      },
+      {
+        "type": "bid",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 23,
+        "created_at": 1714665263,
+        "company": "G6",
+        "price": 30
+      },
+      {
+        "type": "bid",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 24,
+        "created_at": 1714677623,
+        "company": "G6",
+        "price": 40
+      },
+      {
+        "type": "bid",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 25,
+        "created_at": 1714677683,
+        "company": "G6",
+        "price": 45
+      },
+      {
+        "type": "pass",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 26,
+        "created_at": 1714677717
+      },
+      {
+        "type": "pass",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 27,
+        "created_at": 1714683380
+      },
+      {
+        "type": "pass",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 28,
+        "created_at": 1714708341
+      },
+      {
+        "type": "bid",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 29,
+        "created_at": 1714710950,
+        "company": "B5",
+        "price": 60
+      },
+      {
+        "type": "bid",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 30,
+        "created_at": 1714724981,
+        "company": "B5",
+        "price": 90
+      },
+      {
+        "type": "bid",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 31,
+        "created_at": 1714727039,
+        "company": "B5",
+        "price": 95
+      },
+      {
+        "type": "bid",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 32,
+        "created_at": 1714728209,
+        "company": "B5",
+        "price": 100
+      },
+      {
+        "type": "pass",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 33,
+        "created_at": 1714728324
+      },
+      {
+        "type": "bid",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 34,
+        "created_at": 1714741788,
+        "company": "B5",
+        "price": 105
+      },
+      {
+        "type": "pass",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 35,
+        "created_at": 1714742378
+      },
+      {
+        "type": "pass",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 36,
+        "created_at": 1714742496
+      },
+      {
+        "type": "par",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 37,
+        "created_at": 1714743343,
+        "corporation": "RG",
+        "share_price": "70,0,8"
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 38,
+        "created_at": 1714743356,
+        "corporation": "RG",
+        "until_condition": 5,
+        "from_market": false,
+        "auto_pass_after": false
+      },
+      {
+        "type": "par",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 39,
+        "created_at": 1714743514,
+        "corporation": "KP",
+        "share_price": "70,0,8"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 40,
+        "created_at": 1714744198,
+        "shares": [
+          "CF&I_0"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 41,
+        "created_at": 1714764985,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 10874,
+            "entity_type": "player",
+            "created_at": 1714764984,
+            "shares": [
+              "RG_1"
+            ],
+            "percent": 10
+          }
+        ]
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 42,
+        "created_at": 1714765720,
+        "shares": [
+          "RG_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 43,
+        "created_at": 1714765796,
+        "shares": [
+          "RG_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 44,
+        "created_at": 1714831166,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 10874,
+            "entity_type": "player",
+            "created_at": 1714831166,
+            "shares": [
+              "RG_4"
+            ],
+            "percent": 10
+          }
+        ],
+        "shares": [
+          "VGC_0"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 45,
+        "created_at": 1714832900,
+        "shares": [
+          "KP_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 46,
+        "created_at": 1714832908,
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 47,
+        "created_at": 1714833388,
+        "shares": [
+          "KP_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 48,
+        "created_at": 1714833885,
+        "auto_actions": [
+          {
+            "type": "buy_shares",
+            "entity": 10874,
+            "entity_type": "player",
+            "created_at": 1714833884,
+            "shares": [
+              "RG_5"
+            ],
+            "percent": 10
+          }
+        ],
+        "shares": [
+          "CF&I_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 49,
+        "created_at": 1714833997,
+        "shares": [
+          "VGC_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 50,
+        "created_at": 1714834468,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 10874,
+            "entity_type": "player",
+            "created_at": 1714834467,
+            "reason": "5 share(s) bought in RG, end condition met"
+          }
+        ],
+        "shares": [
+          "RG_6"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 51,
+        "created_at": 1714867797,
+        "shares": [
+          "CF&I_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 52,
+        "created_at": 1714876320,
+        "shares": [
+          "CF&I_3"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 53,
+        "created_at": 1714876322
+      },
+      {
+        "hex": "K3",
+        "tile": "3-0",
+        "type": "lay_tile",
+        "entity": "RG",
+        "rotation": 3,
+        "entity_type": "corporation",
+        "id": 54,
+        "user": 10874,
+        "created_at": 1714894393
+      },
+      {
+        "hex": "L4",
+        "tile": "9-0",
+        "type": "lay_tile",
+        "entity": "RG",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 55,
+        "user": 10874,
+        "created_at": 1714894410
+      },
+      {
+        "hex": "L6",
+        "tile": "8-0",
+        "type": "lay_tile",
+        "entity": "RG",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 56,
+        "user": 10874,
+        "created_at": 1714894412
+      },
+      {
+        "hex": "K7",
+        "tile": "57-0",
+        "type": "lay_tile",
+        "entity": "RG",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 57,
+        "user": 10874,
+        "created_at": 1714894415
+      },
+      {
+        "hex": "J8",
+        "tile": "8-1",
+        "type": "lay_tile",
+        "entity": "RG",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 58,
+        "user": 10874,
+        "created_at": 1714894421
+      },
+      {
+        "type": "undo",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 59,
+        "user": 10874,
+        "created_at": 1714894449
+      },
+      {
+        "type": "undo",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 60,
+        "user": 10874,
+        "created_at": 1714894517
+      },
+      {
+        "type": "undo",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 61,
+        "user": 10874,
+        "created_at": 1714894517
+      },
+      {
+        "type": "undo",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 62,
+        "user": 10874,
+        "created_at": 1714894518
+      },
+      {
+        "type": "undo",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 63,
+        "user": 10874,
+        "created_at": 1714894518
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 64,
+        "created_at": 1714894582,
+        "hex": "K3",
+        "tile": "58-0",
+        "rotation": 4
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 65,
+        "created_at": 1714894588,
+        "hex": "K5",
+        "tile": "9-0",
+        "rotation": 0
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 66,
+        "created_at": 1714894611,
+        "hex": "K7",
+        "tile": "6-0",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 67,
+        "created_at": 1714894634
+      },
+      {
+        "type": "place_token",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 68,
+        "created_at": 1714894641,
+        "city": "6-0-0",
+        "slot": 0,
+        "tokener": "RG"
+      },
+      {
+        "type": "buy_train",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 69,
+        "created_at": 1714894644,
+        "train": "2+-0",
+        "price": 80,
+        "variant": "2+"
+      },
+      {
+        "type": "buy_train",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 70,
+        "created_at": 1714894648,
+        "train": "2+-1",
+        "price": 80,
+        "variant": "2+"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 71,
+        "created_at": 1714895043,
+        "hex": "N6",
+        "tile": "9-1",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 72,
+        "created_at": 1714895045,
+        "hex": "M7",
+        "tile": "9-2",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 73,
+        "created_at": 1714895052,
+        "hex": "L8",
+        "tile": "4-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 74,
+        "created_at": 1714895090,
+        "hex": "K9",
+        "tile": "8-0",
+        "rotation": 4
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 75,
+        "created_at": 1714895104,
+        "hex": "K11",
+        "tile": "8-1",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 76,
+        "created_at": 1714895105,
+        "hex": "J12",
+        "tile": "9-3",
+        "rotation": 1
+      },
+      {
+        "type": "buy_train",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 77,
+        "created_at": 1714895108,
+        "train": "2+-2",
+        "price": 80,
+        "variant": "2+"
+      },
+      {
+        "type": "pass",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 78,
+        "created_at": 1714895115
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 79,
+        "created_at": 1714897467,
+        "hex": "J8",
+        "tile": "8-2",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 80,
+        "created_at": 1714897487,
+        "hex": "I7",
+        "tile": "5-0",
+        "rotation": 5
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 81,
+        "created_at": 1714897494,
+        "hex": "I9",
+        "tile": "58-1",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 82,
+        "created_at": 1714897525,
+        "hex": "H10",
+        "tile": "8-3",
+        "rotation": 4
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 83,
+        "created_at": 1714897530,
+        "hex": "H12",
+        "tile": "5-1",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 84,
+        "created_at": 1714897539,
+        "hex": "G11",
+        "tile": "8-4",
+        "rotation": 5
+      },
+      {
+        "type": "place_token",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 85,
+        "created_at": 1714897588,
+        "city": "F12-0-0",
+        "slot": 0,
+        "tokener": "RG"
+      },
+      {
+        "type": "run_routes",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 86,
+        "created_at": 1714897622,
+        "routes": [
+          {
+            "train": "2+-0",
+            "connections": [
+              [
+                "H12",
+                "H10",
+                "I9"
+              ],
+              [
+                "F12",
+                "G11",
+                "H12"
+              ]
+            ],
+            "hexes": [
+              "I9",
+              "H12",
+              "F12"
+            ],
+            "revenue": 70,
+            "revenue_str": "I9-H12-F12",
+            "nodes": [
+              "H12-0",
+              "I9-0",
+              "F12-0"
+            ]
+          },
+          {
+            "train": "2+-1",
+            "connections": [
+              [
+                "K3",
+                "K5",
+                "K7"
+              ],
+              [
+                "L2",
+                "K3"
+              ]
+            ],
+            "hexes": [
+              "K7",
+              "K3",
+              "L2"
+            ],
+            "revenue": 60,
+            "revenue_str": "K7-K3-L2",
+            "nodes": [
+              "K3-0",
+              "K7-0",
+              "L2-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 87,
+        "created_at": 1714897627,
+        "kind": "payout"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 88,
+        "created_at": 1714897680,
+        "hex": "I13",
+        "tile": "57-0",
+        "rotation": 1
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 89,
+        "created_at": 1714897683,
+        "hex": "H14",
+        "tile": "4-1",
+        "rotation": 1
+      },
+      {
+        "type": "pass",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 90,
+        "created_at": 1714897692
+      },
+      {
+        "type": "run_routes",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 91,
+        "created_at": 1714897701,
+        "routes": [
+          {
+            "train": "2+-2",
+            "connections": [
+              [
+                "L8",
+                "M7",
+                "N6",
+                "O5"
+              ],
+              [
+                "I13",
+                "J12",
+                "K11",
+                "K9",
+                "L8"
+              ],
+              [
+                "H14",
+                "I13"
+              ]
+            ],
+            "hexes": [
+              "O5",
+              "L8",
+              "I13",
+              "H14"
+            ],
+            "revenue": 70,
+            "revenue_str": "O5-L8-I13-H14",
+            "nodes": [
+              "L8-0",
+              "O5-0",
+              "I13-0",
+              "H14-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 92,
+        "created_at": 1714897702,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 93,
+        "created_at": 1714897711
+      },
+      {
+        "type": "program_buy_shares",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 94,
+        "created_at": 1714897732,
+        "corporation": "CF&I",
+        "until_condition": 1,
+        "from_market": true,
+        "auto_pass_after": false
+      },
+      {
+        "type": "sell_shares",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 95,
+        "created_at": 1714914564,
+        "shares": [
+          "CF&I_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "par",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 96,
+        "created_at": 1714914625,
+        "corporation": "SPP",
+        "share_price": "90,0,10"
+      },
+      {
+        "type": "buy_shares",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 97,
+        "created_at": 1714914934,
+        "auto_actions": [
+          {
+            "type": "program_disable",
+            "entity": 3416,
+            "entity_type": "player",
+            "created_at": 1714914933,
+            "reason": "Shares were sold"
+          }
+        ],
+        "shares": [
+          "CF&I_4"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "buy_shares",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 98,
+        "created_at": 1714915003,
+        "shares": [
+          "CF&I_5"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 99,
+        "created_at": 1714915040,
+        "shares": [
+          "VGC_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "sell_shares",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 100,
+        "created_at": 1714915042,
+        "shares": [
+          "KP_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "par",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 101,
+        "created_at": 1714915052,
+        "corporation": "SF",
+        "share_price": "70,0,8"
+      },
+      {
+        "type": "pass",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 102,
+        "created_at": 1714932827
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 103,
+        "created_at": 1714935138,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 10874,
+            "entity_type": "player",
+            "created_at": 1714935137
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 3416,
+        "entity_type": "player",
+        "id": 104,
+        "created_at": 1714935299,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 3416,
+            "entity_type": "player",
+            "created_at": 1714935299
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 105,
+        "created_at": 1714935447,
+        "shares": [
+          "SF_1"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 106,
+        "created_at": 1714936739,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 306,
+            "entity_type": "player",
+            "created_at": 1714936739
+          },
+          {
+            "type": "pass",
+            "entity": 10874,
+            "entity_type": "player",
+            "created_at": 1714936739
+          },
+          {
+            "type": "pass",
+            "entity": 3416,
+            "entity_type": "player",
+            "created_at": 1714936739
+          }
+        ],
+        "unconditional": false,
+        "indefinite": false
+      },
+      {
+        "type": "program_share_pass",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 107,
+        "created_at": 1714936788,
+        "unconditional": true,
+        "indefinite": false
+      },
+      {
+        "type": "buy_shares",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 108,
+        "created_at": 1714936853,
+        "auto_actions": [
+          {
+            "type": "pass",
+            "entity": 306,
+            "entity_type": "player",
+            "created_at": 1714936854
+          },
+          {
+            "type": "pass",
+            "entity": 10874,
+            "entity_type": "player",
+            "created_at": 1714936854
+          },
+          {
+            "type": "pass",
+            "entity": 3416,
+            "entity_type": "player",
+            "created_at": 1714936854
+          }
+        ],
+        "shares": [
+          "SF_2"
+        ],
+        "percent": 10
+      },
+      {
+        "type": "pass",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 109,
+        "created_at": 1714936855
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SPP",
+        "entity_type": "corporation",
+        "id": 110,
+        "created_at": 1714967728,
+        "hex": "B6",
+        "tile": "6-1",
+        "rotation": 3
+      },
+      {
+        "hex": "B4",
+        "tile": "9-4",
+        "type": "lay_tile",
+        "entity": "SPP",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 111,
+        "user": 306,
+        "created_at": 1714967738
+      },
+      {
+        "type": "undo",
+        "entity": "SPP",
+        "entity_type": "corporation",
+        "id": 112,
+        "user": 306,
+        "created_at": 1714967759
+      },
+      {
+        "type": "pass",
+        "entity": "SPP",
+        "entity_type": "corporation",
+        "id": 113,
+        "created_at": 1714967785
+      },
+      {
+        "type": "buy_train",
+        "entity": "SPP",
+        "entity_type": "corporation",
+        "id": 114,
+        "created_at": 1714967787,
+        "train": "3+-0",
+        "price": 180,
+        "variant": "3+"
+      },
+      {
+        "type": "lay_tile",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 115,
+        "created_at": 1714969714,
+        "hex": "H12",
+        "tile": "14-0",
+        "rotation": 2
+      },
+      {
+        "hex": "K7",
+        "tile": "14-1",
+        "type": "lay_tile",
+        "entity": "RG",
+        "rotation": 0,
+        "entity_type": "corporation",
+        "id": 116,
+        "user": 10874,
+        "created_at": 1714969737
+      },
+      {
+        "type": "undo",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 117,
+        "user": 10874,
+        "created_at": 1714969787
+      },
+      {
+        "type": "pass",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 118,
+        "created_at": 1714969804
+      },
+      {
+        "type": "run_routes",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 119,
+        "created_at": 1714969823,
+        "routes": [
+          {
+            "train": "2+-0",
+            "connections": [
+              [
+                "H12",
+                "H10",
+                "I9"
+              ],
+              [
+                "F12",
+                "G11",
+                "H12"
+              ]
+            ],
+            "hexes": [
+              "I9",
+              "H12",
+              "F12"
+            ],
+            "revenue": 80,
+            "revenue_str": "I9-H12-F12",
+            "nodes": [
+              "H12-0",
+              "I9-0",
+              "F12-0"
+            ]
+          },
+          {
+            "train": "2+-1",
+            "connections": [
+              [
+                "K3",
+                "K5",
+                "K7"
+              ],
+              [
+                "L2",
+                "K3"
+              ]
+            ],
+            "hexes": [
+              "K7",
+              "K3",
+              "L2"
+            ],
+            "revenue": 70,
+            "revenue_str": "K7-K3-L2",
+            "nodes": [
+              "K3-0",
+              "K7-0",
+              "L2-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "type": "dividend",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 120,
+        "created_at": 1714969859,
+        "kind": "withhold"
+      },
+      {
+        "type": "pass",
+        "entity": "RG",
+        "entity_type": "corporation",
+        "id": 121,
+        "created_at": 1714969873
+      },
+      {
+        "type": "lay_tile",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 122,
+        "created_at": 1714970898,
+        "hex": "I13",
+        "tile": "15-0",
+        "rotation": 1
+      },
+      {
+        "hex": "L8",
+        "tile": "88-0",
+        "type": "lay_tile",
+        "entity": "KP",
+        "rotation": 1,
+        "entity_type": "corporation",
+        "id": 123,
+        "user": 3416,
+        "created_at": 1714970914
+      },
+      {
+        "type": "pass",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 124,
+        "user": 3416,
+        "created_at": 1714970929
+      },
+      {
+        "type": "undo",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 125,
+        "user": 3416,
+        "created_at": 1714970935
+      },
+      {
+        "type": "undo",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 126,
+        "user": 3416,
+        "created_at": 1714970937
+      },
+      {
+        "type": "pass",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 127,
+        "created_at": 1714970942
+      },
+      {
+        "type": "place_token",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 128,
+        "created_at": 1714970947,
+        "city": "14-0-0",
+        "slot": 0,
+        "tokener": "KP"
+      },
+      {
+        "type": "run_routes",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 129,
+        "created_at": 1714970983,
+        "routes": [
+          {
+            "train": "2+-2",
+            "connections": [
+              [
+                "I13",
+                "H14"
+              ],
+              [
+                "I13",
+                "H12"
+              ],
+              [
+                "H12",
+                "H10",
+                "I9"
+              ]
+            ],
+            "hexes": [
+              "H14",
+              "I13",
+              "H12",
+              "I9"
+            ],
+            "revenue": 80,
+            "revenue_str": "H14-I13-H12-I9",
+            "nodes": [
+              "I13-0",
+              "H14-0",
+              "H12-0",
+              "I9-0"
+            ]
+          }
+        ],
+        "extra_revenue": 0
+      },
+      {
+        "kind": "withhold",
+        "type": "dividend",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 130,
+        "user": 3416,
+        "created_at": 1714970985
+      },
+      {
+        "type": "undo",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 131,
+        "user": 3416,
+        "created_at": 1714970987
+      },
+      {
+        "type": "dividend",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 132,
+        "created_at": 1714970988,
+        "kind": "payout"
+      },
+      {
+        "type": "pass",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 133,
+        "created_at": 1714970995
+      },
+      {
+        "type": "buy_company",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 134,
+        "created_at": 1714971050,
+        "company": "G6",
+        "price": 20
+      },
+      {
+        "type": "pass",
+        "entity": "KP",
+        "entity_type": "corporation",
+        "id": 135,
+        "created_at": 1714971052
+      },
+      {
+        "hex": "N14",
+        "tile": "9-4",
+        "type": "lay_tile",
+        "entity": "SF",
+        "rotation": 2,
+        "entity_type": "corporation",
+        "id": 136,
+        "user": 11477,
+        "created_at": 1714971802
+      },
+      {
+        "type": "undo",
+        "entity": "SF",
+        "entity_type": "corporation",
+        "id": 137,
+        "user": 11477,
+        "created_at": 1714971806
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SF",
+        "entity_type": "corporation",
+        "id": 138,
+        "created_at": 1714971811,
+        "hex": "N14",
+        "tile": "8-5",
+        "rotation": 5
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SF",
+        "entity_type": "corporation",
+        "id": 139,
+        "created_at": 1714971815,
+        "hex": "M15",
+        "tile": "8-6",
+        "rotation": 2
+      },
+      {
+        "type": "lay_tile",
+        "entity": "SF",
+        "entity_type": "corporation",
+        "id": 140,
+        "created_at": 1714971825,
+        "hex": "L14",
+        "tile": "6-2",
+        "rotation": 5
+      },
+      {
+        "type": "pass",
+        "entity": "SF",
+        "entity_type": "corporation",
+        "id": 141,
+        "created_at": 1714971847
+      },
+      {
+        "type": "pass",
+        "entity": "SF",
+        "entity_type": "corporation",
+        "id": 142,
+        "created_at": 1714971853
+      },
+      {
+        "type": "buy_train",
+        "entity": "SF",
+        "entity_type": "corporation",
+        "id": 143,
+        "created_at": 1715011429,
+        "train": "3+-1",
+        "price": 180,
+        "variant": "3+"
+      },
+      {
+        "type": "end_game",
+        "entity": "SF",
+        "entity_type": "corporation",
+        "id": 144,
+        "created_at": 1715011543
+      }
+    ],
+    "id": "hs_gcwhhymo_161782",
+    "players": [
+      {
+        "id": 11477,
+        "name": "Shair"
+      },
+      {
+        "id": 306,
+        "name": "JK75"
+      },
+      {
+        "id": 10874,
+        "name": "gloinul"
+      },
+      {
+        "id": 3416,
+        "name": "fabian"
+      }
+    ],
+    "title": "18RoyalGorge",
+    "description": "Tunga krigar om klyftan",
+    "min_players": 2,
+    "max_players": 4,
+    "user": {
+      "id": 0,
+      "name": "You"
+    },
+    "settings": {
+      "seed": 156205547,
+      "is_async": true,
+      "unlisted": true,
+      "auto_routing": false,
+      "player_order": null,
+      "optional_rules": []
+    },
+    "user_settings": null,
+    "turn": 2,
+    "round": "Operating Round",
+    "acting": [
+      11477
+    ],
+    "result": {
+      "306": 385,
+      "3416": 443,
+      "10874": 317,
+      "11477": 419
+    },
+    "loaded": true,
+    "created_at": "2024-05-06",
+    "updated_at": 1715011543,
+    "finished_at": null,
+    "mode": "hotseat",
+    "manually_ended": true
+  }


### PR DESCRIPTION
Fixes #10695

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

`remove_when_used_up` is used instead of `closed_when_used_up` in the context of a `choose_ability`

`choose_ability` isn't documented in the Abilities readme, so I assume it's a newer feature that seems used for adding boutique abilities that aren't tied to a private
https://github.com/tobymao/18xx/blob/master/lib/engine/ability/README.md

I don't think this needs pins, as games were stuck on that step anyway (also it's alpha)

adds fixture

### Screenshots

![Screenshot 2024-05-06 9 04 01 AM](https://github.com/tobymao/18xx/assets/1711810/596240c3-29a0-4021-a0e4-e16d9b99aec4)

fwiw I also tested that the doc holiday debt ability worked as expected, and it seemed fine

https://gist.github.com/benjaminxscott/549b21902bf4da3da52707a4596ca0de

### Any Assumptions / Hacks
