### PR TITLE
[1822CA] adds the city name and hex coordinates to P18 description

### DIFF
--- a/lib/engine/game/g_1822_ca/entities.rb
+++ b/lib/engine/game/g_1822_ca/entities.rb
@@ -376,7 +376,7 @@ module Engine
             value: 0,
             revenue: 10,
             desc: 'MAJOR/MINOR, Phase 1. Winnipeg & Prince Albert Railway. Owner pays no upgrade '\
-                  'fee or terrain costs for the tile placement. This is in addition '\
+                  'fee or terrain costs for tile lays and upgrades to Winnipeg (N16). This is in addition '\
                   'to the company’s normal tile placement(s), but happens during the company’s '\
                   'tile laying step. Does not close. Minor may place yellow or green only. The '\
                   'company upgrading the city must be connected to it in order to exercise the '\


### PR DESCRIPTION
Fixes #10734

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

I changed the text to match the description of the other privates of this type. Added city name and hex coordinates to the description. 

### Screenshots

### Any Assumptions / Hacks
