### PR TITLE
[1817] fix check for exporting trains (relevant when other games inherit)

### DIFF
--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -978,6 +978,8 @@ module Engine
         end
 
         def or_round_finished
+          return if @depot.upcoming.empty?
+
           if @depot.upcoming.first.name == '2'
             depot.export_all!('2')
           else


### PR DESCRIPTION
Fixes #10746

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Fixes an issue where the 1817 export logic would bail if there were no upcoming trains 

Only relevant in cases where games inherit from 1817 code since 1817 has infinite trains, but I wanted to fix it at the source rather than expecting those games to handle this case

Specifically 18Hiawatha

### Screenshots

![Screenshot 2024-05-11 4 24 21 PM](https://github.com/tobymao/18xx/assets/1711810/73974809-d97b-4cf4-a713-c7ec3c152195)


### Any Assumptions / Hacks
