### PR TITLE
[18Uruguay] Updated the share bundle calculation in nationalization

### DIFF
--- a/lib/engine/game/g_18_uruguay/nationalization.rb
+++ b/lib/engine/game/g_18_uruguay/nationalization.rb
@@ -180,7 +180,11 @@ module Engine
           @log << '  Nationalization: RPTLA closes'
           corporation = @rptla
           corporation.share_holders.keys.each do |share_holder|
+            next if share_holder == share_pool
+
             shares = share_holder.shares_of(corporation)
+            next if shares.empty?
+
             bundle = ShareBundle.new(shares)
             sell_shares_and_change_price(bundle) unless corporation == share_holder
           end


### PR DESCRIPTION
Corrected bundle calculation in nationalization

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
