### PR TITLE
[18Uruguay] Updated reserved color of FCCU

### DIFF
--- a/lib/engine/game/g_18_uruguay/corporations.rb
+++ b/lib/engine/game/g_18_uruguay/corporations.rb
@@ -44,7 +44,7 @@ module Engine
             logo: '18_uruguay/FCCU',
             simple_logo: '18_uruguay/FCCU.alt',
             color: :'#1a1919',
-            reservation_color: '#1a1919',
+            reservation_color: '#FFFFFF',
             text_color: 'white',
             tokens: [0, 40, 60, 100],
             coordinates: 'J6',


### PR DESCRIPTION
Updated reserved color of FCCU since text color is not possible to update

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
