### PR TITLE
[18Uruguay] Corrected nationalization

### DIFF
--- a/lib/engine/game/g_18_uruguay/nationalization.rb
+++ b/lib/engine/game/g_18_uruguay/nationalization.rb
@@ -180,7 +180,11 @@ module Engine
           @log << '  Nationalization: RPTLA closes'
           corporation = @rptla
           corporation.share_holders.keys.each do |share_holder|
+            next if share_holder == share_pool
+
             shares = share_holder.shares_of(corporation)
+            next if shares.empty?
+
             bundle = ShareBundle.new(shares)
             sell_shares_and_change_price(bundle) unless corporation == share_holder
           end
@@ -219,6 +223,8 @@ module Engine
           @nationalized = true
           train = train_by_id('7-0')
           buy_train(@fce, train, :free)
+          phase.buying_train!(@fce, train, train.owner)
+          minors.each(&:close!)
         end
 
         # Move stock price one step left for each loan more than limit

--- a/lib/engine/game/g_18_uruguay/phases.rb
+++ b/lib/engine/game/g_18_uruguay/phases.rb
@@ -48,7 +48,7 @@ module Engine
             name: '7',
             on: '7',
             train_limit: 2,
-            tiles: %i[yellow green brown],
+            tiles: %i[yellow green brown gray],
             operating_rounds: 3,
           },
           {

--- a/lib/engine/game/g_18_uruguay/step/route.rb
+++ b/lib/engine/game/g_18_uruguay/step/route.rb
@@ -26,6 +26,7 @@ module Engine
           end
 
           def choice_name
+            return '' if @game.nationalized?
             return 'Attach goods to ships' if current_entity == @game.rptla
 
             'Attach good to a train'


### PR DESCRIPTION
[18Uruguay] Corrected nationalization
- Updated the share bunlde calculation in nationalization
- Updated so that you transition into phase 7 on nationalization
- Minor closes on nationalization
- Removed "Attach good to train" text  after nationalization

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
