### PR TITLE
[18Uruguay] RTPLA starts with three goods from start

### DIFF
--- a/lib/engine/game/g_18_uruguay/game.rb
+++ b/lib/engine/game/g_18_uruguay/game.rb
@@ -198,7 +198,7 @@ module Engine
 
           @rptla.add_ability(Engine::Ability::Base.new(
             type: 'Goods',
-            description: GOODS_DESCRIPTION_STR + '0',
+            description: GOODS_DESCRIPTION_STR + '3',
             count: 0
           ))
 

--- a/lib/engine/game/g_18_uruguay/goods.rb
+++ b/lib/engine/game/g_18_uruguay/goods.rb
@@ -9,7 +9,7 @@ module Engine
         def goods_setup
           @pickup_hex_for_train = {}
           @goods_on_ship = {}
-          @number_of_goods_at_harbor = 0
+          @number_of_goods_at_harbor = 3
         end
 
         # Train delivery
@@ -69,7 +69,7 @@ module Engine
           return if ability.nil?
 
           @number_of_goods_at_harbor -= goods_count
-          ability.description = GOODS_DESCRIPTION_STR + goods_count.to_s
+          ability.description = GOODS_DESCRIPTION_STR + @number_of_goods_at_harbor.to_s
         end
 
         # Ship gooods


### PR DESCRIPTION
[18Uruguay] RTPLA starts with three goods from start

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
