### PR TITLE
[1852] fix train discount ability timing

### DIFF
--- a/lib/engine/game/g_18_mo/entities.rb
+++ b/lib/engine/game/g_18_mo/entities.rb
@@ -163,7 +163,7 @@ module Engine
             trains: %w[Y2 Y2 G3 G4 3E 5 6],
             count: 1,
             closed_when_used_up: true,
-            when: 'buying_train',
+            when: 'buy_train',
           },
           ],
            color: nil,


### PR DESCRIPTION
Fixes #10782

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Changes `when` for train_discount ability from `buying_train` to `buy_train`, as per fix in #10098

### Screenshots

### Any Assumptions / Hacks
