### PR TITLE
[18Uruguay] Only final OR in last round should be doubled

### DIFF
--- a/lib/engine/game/g_18_uruguay/game.rb
+++ b/lib/engine/game/g_18_uruguay/game.rb
@@ -403,7 +403,7 @@ module Engine
         def revenue_for(route, stops)
           revenue = super
           revenue *= 2 if route.train.name == '4D'
-          revenue *= 2 if final_operating_round?
+          revenue *= 2 if final_operating_round? && final_or_in_set?(@round)
           return revenue unless route&.corporation == @rptla
 
           train = route.train


### PR DESCRIPTION
Only final OR in last round should be doubled
No track and token in last or

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
