### PR TITLE
[base] removes version info from docker-compose files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 x-rack: &rack
   image: 18xx_rack:dev
   environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 x-rack: &rack
   command: bash -c "bundle exec rake prod_up && bundle exec unicorn -c config/unicorn.rb"
   image: 18xx_rack:prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   rack:
     build:


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Removed the `version: 3.5` entry from the docker-compose files in the root folder of the site. [Version info is deprecated in docker-compose](https://nickjanetakis.com/blog/docker-tip-51-which-docker-compose-api-version-should-you-use)

### Screenshots

![image](https://github.com/tobymao/18xx/assets/26125362/556fef68-dcef-4f5c-988e-40efab9c035f)

### Any Assumptions / Hacks
