### PR TITLE
[18RoyalGorge] bug fixes

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2857,7 +2857,7 @@ module Engine
         self.class::NEXT_SR_PLAYER_ORDER
       end
 
-      def reorder_players(order = nil, log_player_order: false)
+      def reorder_players(order = nil, log_player_order: false, silent: false)
         order ||= next_sr_player_order
         case order
         when :after_last_to_act
@@ -2872,6 +2872,8 @@ module Engine
           current_order = @players.dup
           @players.sort_by! { |p| [p.cash, current_order.index(p)] }
         end
+        return if silent
+
         @log << if log_player_order
                   "Priority order: #{@players.reject(&:bankrupt).map(&:name).join(', ')}"
                 else

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -1247,6 +1247,14 @@ module Engine
                          .max_by(&:price)
           max_bundle&.price || 0
         end
+
+        def rust(train)
+          if (amount = train.salvage || 0).positive?
+            @bank.spend(amount, train.owner)
+            @log << "#{train.owner.name} salvages a #{train.name} train for #{format_currency(amount)}"
+          end
+          super
+        end
       end
     end
   end

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -105,7 +105,7 @@ module Engine
         SULPHUR_SPRINGS_BROWN_REVENUE = 50
 
         ST_CLOUD_START_HEX = 'G17'
-        ST_CLOUD_BROWN_HEX = 'H14'
+        ST_CLOUD_BROWN_HEX = 'H12'
         ST_CLOUD_BONUS = 20
         ST_CLOUD_BONUS_STR = ' (St. Cloud Hotel)'
         ST_CLOUD_ICON_NAME = 'SCH'

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -489,11 +489,13 @@ module Engine
               # reorder as normal first so that if there is a tie for most cash,
               # the player who would be first with :after_last_to_act turn order
               # gets the tiebreaker
-              reorder_players
+              reorder_players(silent: true)
 
               # most cash goes first, but keep same relative order; don't
               # reorder by descending cash
               @players.rotate!(@players.index(@players.max_by(&:cash)))
+
+              @log << "#{@players.first.name} has priority deal"
 
               new_stock_round
             end

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -1077,8 +1077,8 @@ module Engine
 
         def move_jeweler_cash!
           return unless @local_jeweler_cash.positive?
+          return unless (player = local_jeweler&.player)
 
-          player = local_jeweler&.player
           @log << "#{player.name} receives #{format_currency(@local_jeweler_cash)} from #{local_jeweler.name}"
           player.cash += @local_jeweler_cash
           @local_jeweler_cash = 0

--- a/lib/engine/game/g_18_royal_gorge/step/single_item_auction.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/single_item_auction.rb
@@ -70,7 +70,7 @@ module Engine
             company.close!
             @companies.delete(company)
 
-            auction_entity(@companies.first)
+            auction_entity_log(@companies.first) unless @companies.empty?
           end
 
           def process_bid(action)

--- a/lib/engine/game/g_18_royal_gorge/step/special_choose.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/special_choose.rb
@@ -31,8 +31,8 @@ module Engine
             debt_company.close!
 
             return unless debt_company == @game.sf_debt
+            return unless (doc = @game.doc_holliday)
 
-            doc = @game.doc_holliday
             @log << "#{doc.name} closes"
             doc.close!
           end


### PR DESCRIPTION
* fix salvaging rusted trains for some cash - fixes https://github.com/tobymao/18xx/issues/10761
* fix St Cloud Hotel's brown phase hex - fixes https://github.com/tobymao/18xx/issues/10762
* fix SF paying off Doc Holliday's debt when Doc private is not in the game - fixes https://github.com/tobymao/18xx/issues/10763
* fix everyone passing on last private company in the auction - fixes https://github.com/tobymao/18xx/issues/10771
* fix logging of priority deal player at end of auction - fixes https://github.com/tobymao/18xx/issues/10772
* fix handling local jeweler after it has closed - fixes https://github.com/tobymao/18xx/issues/10789
<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

* one small change to core code - adds a `silent` argument to `reorder_players()` to completely prevent logging