### PR TITLE
[1868WY] fix available variants on trains owned by corporations

### DIFF
--- a/lib/engine/game/g_1868_wy/step/buy_train.rb
+++ b/lib/engine/game/g_1868_wy/step/buy_train.rb
@@ -24,6 +24,7 @@ module Engine
             variants = super
 
             return variants if variants.size < 2
+            return [train.variant] if train.owned_by_corporation?
 
             min, max = variants.sort_by { |v| v[:price] }
             return [min] if (min[:price] <= entity.cash) && (entity.cash < max[:price])


### PR DESCRIPTION
Fixes #10783

* the base code determined that both the 4 and 4+3 variants should be available for other corporations to buy (other code made sure the UI only presented the 4+3, which is how the train was bought initially by LNP)
* FE&MV has $325, more than the face value of a 4-train ($300) but less than the 4+3's face value ($360)
* the 1868 Wyoming code assumes that if two variants are available, we're buying from the depot
* when buying from the depot, we can only buy a train we can afford or the cheapest, so the 4+3 gets filtered out

The fix is to simply return the single active variant if the train is in fact owned by a corporation instead of the depot.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`