### PR TITLE
[TOP1871] fixes liquidity calculation

### DIFF
--- a/lib/engine/game/g_1871/game.rb
+++ b/lib/engine/game/g_1871/game.rb
@@ -554,6 +554,15 @@ module Engine
           max_bundle&.price || 0
         end
 
+        # Forces Union Bank's liquidity to only every display its cash holding unless emergency funding,
+        # since the Union Bank cannot sell shares outside of emergency money raising.
+
+        def liquidity(player, emergency: false)
+          return player.cash if player == @union_bank && !emergency
+
+          super
+        end
+
         # Need to redefine this in order to add in union bank to the mix after
         # each round. The base function removes the bank since it's not active
         # during the stock round.

--- a/lib/engine/game/g_1871/game.rb
+++ b/lib/engine/game/g_1871/game.rb
@@ -546,10 +546,9 @@ module Engine
         def value_for_dumpable(player, corporation)
           max_bundle = bundles_for_corporation(player, corporation)
             .select do |bundle|
-            @round.active_step&.can_sell?(player, bundle) &&
-                        bundle.num_shares <= 3 &&
-                        bundle.can_dump?(player, bundle) &&
-                        @share_pool&.fit_in_bank?(bundle)
+            @round.active_step&.can_sell?(player, bundle) if @round.is_a?(G1871::Round::Stock)
+            bundle.num_shares <= 3 &&
+            bundle.can_dump?(player, bundle)
           end
             .max_by(&:price)
           max_bundle&.price || 0


### PR DESCRIPTION
Fixes #8991 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

I was thinking about this, and I agree with the initial report that the liquidity is wrong, but I disagree with the calculation. Liquidity is how much money the player potentially has access to _now_. So actually, liquidity is player cash + the value of maximum 3 sellable shares per corporation.

Additionally, the calculation would need to ignore the value of any shares in corporations that the player has already sold that turn. 

To do this, I took the `def value_for_dumpable` method, which is referenced in `def liquidity`, from base.rb, which is:

```
      def value_for_dumpable(player, corporation)
        return value_for_sellable(player, corporation) if self.class::PRESIDENT_SALES_TO_MARKET

        max_bundle = bundles_for_corporation(player, corporation)
          .select { |bundle| bundle.can_dump?(player) && @share_pool&.fit_in_bank?(bundle) }
          .max_by(&:price)
        max_bundle&.price || 0
      end
```

I added this method to the game.rb file and added two .select conditions ahead of the conditions already in place: `@round.active_step&.can_sell?(player, bundle)` and `bundle.num_shares <= 3`.

### Screenshots

### Any Assumptions / Hacks

I don't see why this would impact any games in place, since it only affects the displayed liquidity value, but I still tested this with a few games from the site and they all loaded correctly. 