### PR TITLE
Dev mode: compile only game files for requested games

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -102,7 +102,7 @@ desc 'Precompile assets for production'
 task :precompile do
   require_relative 'lib/assets'
   assets = Assets.new(cache: false, compress: true, gzip: true)
-  assets.combine
+  assets.combine(:all)
 
   # Copy to the pin directory
   git_rev = `git rev-parse --short HEAD`.strip

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -435,6 +435,7 @@ module View
           settings: {
             optional_rules: game_params[:optional_rules] || [],
           },
+          title: game_params[:title],
         }
         game_data[:settings][:seed] = game_params[:seed] if game_params[:seed]
       end

--- a/lib/engine.rb
+++ b/lib/engine.rb
@@ -51,6 +51,8 @@ module Engine
   end
 
   def self.meta_by_title(title)
+    return unless title
+
     GAME_META_BY_TITLE[closest_title(title)]
   end
 

--- a/lib/engine/game/g_18_los_angeles1/meta.rb
+++ b/lib/engine/game/g_18_los_angeles1/meta.rb
@@ -28,6 +28,10 @@ module Engine
         GAME_IS_VARIANT_OF = G18LosAngeles::Meta
         GAME_ALIASES = ['18LA_1'].freeze
         GAME_VARIANTS = [].freeze
+
+        def self.fs_name
+          @fs_name ||= 'g_18_los_angeles1'
+        end
       end
     end
   end


### PR DESCRIPTION
Stop waiting for the files for all titles to build in local dev mode; only build for titles as needed.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`