### PR TITLE
 Dev mode: compile only game files for requested games

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -102,7 +102,7 @@ desc 'Precompile assets for production'
 task :precompile do
   require_relative 'lib/assets'
   assets = Assets.new(cache: false, compress: true, gzip: true)
-  assets.combine
+  assets.combine(:all)
 
   # Copy to the pin directory
   git_rev = `git rev-parse --short HEAD`.strip

--- a/api.rb
+++ b/api.rb
@@ -96,7 +96,25 @@ class Api < Roda
   end
 
   route do |r|
-    r.public unless PRODUCTION
+    unless PRODUCTION
+      r.public
+
+      # build missing files for specific games on-demand; game files that are
+      # already in public/assets/ will be served by `r.public` above
+      r.on 'assets' do
+        r.get(/(g_.*\.js$)/) do |g_fs_name|
+          ASSETS.combine([g_fs_name])
+          path = "public/assets/#{g_fs_name}"
+          if File.file?(path) && File.readable?(path)
+            # now that the file exists, redirect to the same route and
+            # `r.public` will serve it
+            r.redirect "/assets/#{g_fs_name}"
+          else
+            halt(404, "Game file #{g_fs_name} not found")
+          end
+        end
+      end
+    end
 
     r.hash_branches
 

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -435,6 +435,7 @@ module View
           settings: {
             optional_rules: game_params[:optional_rules] || [],
           },
+          title: game_params[:title],
         }
         game_data[:settings][:seed] = game_params[:seed] if game_params[:seed]
       end

--- a/lib/assets.rb
+++ b/lib/assets.rb
@@ -70,46 +70,52 @@ class Assets
     Dir["#{@out_path}/g_*.js"]
   end
 
-  def builds
-    @builds ||=
-      if @precompiled
-        {
-          'deps' => {
-            'path' => @deps_path,
-            'files' => [@deps_path],
-          },
-          'main' => {
-            'path' => @main_path,
-            'files' => [@main_path],
-          },
-          'server' => {
-            'path' => @server_path,
-            'files' => [@server_path],
-          },
-          **game_builds,
-        }
-      else
-        opal = compile_lib('opal')
-        deps = compile_lib('deps', 'assets')
-        engine = compile('engine', 'lib', 'engine')
-        app = compile('app', 'assets/app', '')
-        game_files = game_builds.values.flat_map { |g| g['files'] }
-        {
-          'deps' => {
-            'path' => @deps_path,
-            'files' => [opal, deps],
-          },
-          'main' => {
-            'path' => @main_path,
-            'files' => [engine, app],
-          },
-          'server' => {
-            'path' => @server_path,
-            'files' => [opal, deps, engine, app, *game_files],
-          },
-          **game_builds,
-        }
-      end
+  def builds(titles = [])
+    if @precompiled
+      @builds ||= {
+        'deps' => {
+          'path' => @deps_path,
+          'files' => [@deps_path],
+        },
+        'main' => {
+          'path' => @main_path,
+          'files' => [@main_path],
+        },
+        'server' => {
+          'path' => @server_path,
+          'files' => [@server_path],
+        },
+        **game_builds(:all),
+      }
+    else
+      @_opal ||= compile_lib('opal')
+      @_deps ||= compile_lib('deps', 'assets')
+      @_engine ||= compile('engine', 'lib', 'engine')
+      @_app ||= compile('app', 'assets/app', '')
+
+      @_builds ||= {
+        'deps' => {
+          'path' => @deps_path,
+          'files' => [@_opal, @_deps],
+        },
+        'main' => {
+          'path' => @main_path,
+          'files' => [@_engine, @_app],
+        },
+      }
+
+      g_builds = game_builds(titles)
+      game_files = g_builds.values.flat_map { |g| g['files'] }
+
+      @builds = {
+        **@_builds,
+        'server' => {
+          'path' => @server_path,
+          'files' => [@_opal, @_deps, @_engine, @_app, *game_files],
+        },
+        **g_builds,
+      }
+    end
   end
 
   def js_tags(titles)

--- a/lib/assets.rb
+++ b/lib/assets.rb
@@ -132,15 +132,16 @@ class Assets
   def game_js_tags(title)
     return [] unless title
 
-    game = Engine.meta_by_title(title)
-    tags = game_js_tags(game::DEPENDS_ON)
+    titles = title_with_ancestors(title)
+    builds_for_games = builds(titles)
 
-    key = game.fs_name
-    return [] unless builds.key?(key)
+    titles.each_with_object([]) do |game_title, _tags|
+      key = to_fs_name(game_title)
+      next unless builds_for_games.key?(key)
 
-    file = builds[key]['path'].gsub(@out_path, @root_path)
-    tags << %(<script type="text/javascript" src="#{file}"></script>)
-    tags.compact
+      file = builds_for_games[key]['path'].gsub(@out_path, @root_path)
+      %(<script type="text/javascript" src="#{file}"></script>)
+    end
   end
 
   def combine(titles = [])

--- a/lib/assets.rb
+++ b/lib/assets.rb
@@ -29,13 +29,13 @@ class Assets
     @game_builds = {}
   end
 
-  def context
-    combine
+  def context(titles)
+    combine(titles)
     @context ||= JsContext.new(@server_path)
   end
 
-  def html(script, **needs)
-    context.eval(Snabberb.html_script(script, **needs))
+  def html(script, titles: :all, **needs)
+    context(titles).eval(Snabberb.html_script(script, **needs))
   end
 
   def game_builds(titles = [])
@@ -118,12 +118,11 @@ class Assets
     end
   end
 
-  def js_tags(titles)
-    combine
-    titles.delete('all')
+  def js_tags(titles = [])
+    combine(titles)
 
     scripts = %w[deps main].map do |key|
-      file = builds[key]['path'].gsub(@out_path, @root_path)
+      file = builds(titles)[key]['path'].gsub(@out_path, @root_path)
       %(<script type="text/javascript" src="#{file}"></script>)
     end
     scripts.concat(titles.flat_map { |title| game_js_tags(title) }.uniq).compact.join

--- a/lib/assets.rb
+++ b/lib/assets.rb
@@ -263,4 +263,21 @@ class Assets
       .uniq
       .each { |file| File.delete(file) if File.exist?(file) }
   end
+
+  def to_fs_name(title)
+    Engine.meta_by_title(title).fs_name
+  end
+
+  # returns an array of game titles, starting with the earliest ancestor and
+  # ending with the given game, e.g.,
+  # `title_with_ancestors('1822CA WRS') -> ['1822', '1822CA', '1822CA WRS']`
+  def title_with_ancestors(title)
+    return [] unless (game = Engine.meta_by_title(title))
+
+    [*title_with_ancestors(game::DEPENDS_ON), title]
+  end
+
+  def titles_with_ancestors(titles)
+    titles.flat_map { |t| title_with_ancestors(t) }.uniq
+  end
 end

--- a/lib/engine.rb
+++ b/lib/engine.rb
@@ -51,6 +51,8 @@ module Engine
   end
 
   def self.meta_by_title(title)
+    return unless title
+
     GAME_META_BY_TITLE[closest_title(title)]
   end
 


### PR DESCRIPTION
I sorted the caching issues I was having in #10797 and organized the changes here into more descriptive commits for each piece.

This changes functions in `lib/assets.rb` to use a `titles` param so that only the given titles are built, and change cached functions to cache things per-title when possible instead of caching the whole function call. In non-production mode, the API will trigger builds for game files that aren't already built.

It's best to view this diff with the "Hide whitespace" setting enabled.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`