### PR TITLE
[1822 family] when laying to border, remove adjacent border if it has track

### DIFF
--- a/lib/engine/game/g_1822/step/tracker.rb
+++ b/lib/engine/game/g_1822/step/tracker.rb
@@ -78,6 +78,13 @@ module Engine
             next 0 unless hex.targeting?(neighbor)
 
             tile.borders.delete(border)
+
+            # delete border on adjacent hex side if it also has track, i.e., if
+            # it was preprinted on a gray hex
+            n_tile = neighbor.tile
+            n_edge = hex.invert(edge)
+            n_tile.borders.reject! { |nb| nb.edge == n_edge } if n_tile.exits.include?(n_edge)
+
             types << border.type
             cost - border_cost_discount(entity, spender, border, cost, hex)
           end


### PR DESCRIPTION
Fixes #10799

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`