### PR TITLE
[1850] Selling shares of the corp in EMR immediately affects price

### DIFF
--- a/lib/engine/game/g_1850/game.rb
+++ b/lib/engine/game/g_1850/game.rb
@@ -330,6 +330,8 @@ module Engine
         end
 
         def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)
+          return super if @round.current_entity == bundle.corporation
+
           @sell_queue << [bundle, bundle.corporation.owner, bundle.owner]
 
           @share_pool.sell_shares(bundle)


### PR DESCRIPTION
Fixes #9949


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Previously, the share price of the corp in EMR wouldn't drop because of potential price protection, which would prevent a player from deliberately closing the corp.

I added a line in `def sell_shares_and_change_price` to return super if the current round entity is the bundle corporation. Since the only time the current entity could be a corp is during ORs, I didn't bother with an OR guard clause. 

### Screenshots

### Any Assumptions / Hacks
