### PR TITLE
[1822, 1822CA] fix Tax Haven cert limit, text, and display in corporation shareholders

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -440,12 +440,12 @@ module View
         }
 
         if @game.corporations_can_ipo?
-          player_rows = entities_rows(@game.players + @game.operating_order.reject do |c|
-                                                        c == @corporation && !c.treasury_as_holding
-                                                      end.sort, true)
+          player_rows = entities_rows(@game.share_owning_players + @game.operating_order.reject do |c|
+                                                                     c == @corporation && !c.treasury_as_holding
+                                                                   end.sort, true)
           other_corp_rows = []
         else
-          player_rows = entities_rows(@game.players, true)
+          player_rows = entities_rows(@game.share_owning_players, true)
           other_corp_rows = entities_rows(@game.corporations.reject { |c| c == @corporation && !c.treasury_as_holding })
         end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2328,6 +2328,11 @@ module Engine
 
       def after_phase_change(_name); end
 
+      # players and dummy players to show up as shareholders on entity cards
+      def share_owning_players
+        @players
+      end
+
       private
 
       def init_graph

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -1140,7 +1140,7 @@ module Engine
           @minor_14_city_exit = nil
 
           # Initialize a dummy player for Tax haven to hold the share and the cash it generates
-          @tax_haven = Engine::Player.new(-1, 'Tax Haven')
+          @tax_haven = Engine::Player.new(-1, self.class::COMPANY_OSTH)
 
           # Initialize the stock round choice for P9-M&GNR
           @double_cash_choice = nil
@@ -1968,6 +1968,16 @@ module Engine
 
         def pending_home_tokeners
           self.class::PENDING_HOME_TOKENERS
+        end
+
+        def share_owning_players
+          @tax_haven_company ||= company_by_id(self.class::COMPANY_OSTH)
+
+          if @tax_haven_company&.owned_by_player?
+            [*@players, @tax_haven]
+          else
+            @players
+          end
         end
 
         private

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -488,6 +488,9 @@ module Engine
         PLUS_EXPANSION_BIDBOX_2 = %w[P2 P5 P8 P10 P11 P12 P21].freeze
         PLUS_EXPANSION_BIDBOX_3 = %w[P6 P7 P9 P15 P16 P17 P18 P20].freeze
 
+        # companies that don't count against the cert limit, even when bidding
+        COMPANIES_NONCERT = [].freeze
+
         PRIVATE_COMPANIES_ACQUISITION = {
           'P1' => { acquire: %i[major], phase: 5 },
           'P2' => { acquire: %i[major minor], phase: 2 },

--- a/lib/engine/game/g_1822/round/stock.rb
+++ b/lib/engine/game/g_1822/round/stock.rb
@@ -102,6 +102,9 @@ module Engine
             price = bid.price
 
             company.owner = player
+
+            @game.tax_haven.rename!("#{@game.tax_haven.name} (#{player.name})") if company.id == @game.class::COMPANY_OSTH
+
             player.companies << company
             player.spend(price, @game.bank) if price.positive?
             @log << "#{player.name} wins the bid #{company.name} for #{@game.format_currency(price)}"

--- a/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
@@ -239,10 +239,16 @@ module Engine
           end
 
           def can_bid_company?(entity, company)
-            return false unless num_certs_with_bids(entity) < @game.cert_limit
+            return false unless cert_room_for_bid?(entity, company)
             return false if max_bid(entity, company) < min_bid(company) || highest_player_bid?(entity, company)
 
             !(!find_bid(entity, company) && bidding_tokens(entity).zero?)
+          end
+
+          def cert_room_for_bid?(entity, company)
+            return true if @game.class::COMPANIES_NONCERT.include?(company.id)
+
+            num_certs_with_bids(entity) < @game.cert_limit
           end
 
           def store_bids!

--- a/lib/engine/game/g_1822_ca/entities.rb
+++ b/lib/engine/game/g_1822_ca/entities.rb
@@ -187,7 +187,7 @@ module Engine
             revenue: 0,
             desc: 'CANNOT BE ACQUIRED. Registered Retirement Savings Plan. As a stock round '\
                   'action, under the direction and funded by the owning player, the off-shore Tax '\
-                  'Haven may purchase an available share certificate and place it onto P7’s '\
+                  'Haven may purchase an available share certificate and place it onto P11’s '\
                   'charter. The certificate is not counted for determining directorship of a '\
                   'company. The share held in the tax haven does NOT count against the 60% share '\
                   'limit for purchasing shares. If at 60% (or more) in hand in a company, a player '\

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -265,7 +265,7 @@ module Engine
           @double_cash_choice = nil
 
           # Initialize a dummy player for Tax haven to hold the share and the cash it generates
-          @tax_haven = Engine::Player.new(-1, 'Tax Haven')
+          @tax_haven = Engine::Player.new(-1, self.class::COMPANY_OSTH)
 
           # Initialize the extra city which minor 14 (actually 13 in 22CA) might add
           @minor_14_city_exit = nil

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -182,6 +182,8 @@ module Engine
 
         TWO_HOME_CORPORATION = 'CPR'
 
+        COMPANIES_NONCERT = ['P11'].freeze
+
         PRIVATE_COMPANIES_ACQUISITION = {
           'P1' => { acquire: %i[major], phase: 5 },
           'P2' => { acquire: %i[major minor], phase: 1 },

--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -61,8 +61,9 @@ module Engine
 
         LOCAL_TRAIN_CAN_CARRY_MAIL = true
 
-        # Don't run 1822 specific code for the LCDR
+        # Don't run 1822 specific code for certain private companies
         COMPANY_LCDR = nil
+        COMPANY_OSTH = nil
 
         PRIVATE_COMPANIES_ACQUISITION = {
           'P1' => { acquire: %i[major], phase: 5 },

--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -97,9 +97,10 @@ module Engine
 
         DOUBLE_HEX = %w[H19 M4].freeze
 
-        # Don't run 1822 specific code for the LCDR
+        # Don't run 1822 specific code for certain private companies
         COMPANY_CHPR = nil
         COMPANY_LCDR = nil
+        COMPANY_OSTH = nil
 
         PRIVATE_COMPANIES_ACQUISITION = {
           'P1' => { acquire: %i[major], phase: 5 },

--- a/lib/engine/player.rb
+++ b/lib/engine/player.rb
@@ -48,6 +48,10 @@ module Engine
       true
     end
 
+    def rename!(new_name)
+      @name = new_name
+    end
+
     def to_s
       "#{self.class.name} - #{@name}"
     end


### PR DESCRIPTION
* 1822CA - fix reference to wrong private ID in tax haven's text
* 1822, 1822CA - show tax haven ID and player owner's name on entity card as a shareholder
* 1822CA - allow bidding on tax haven even when at cert limit (this rule does not apply to 1822's tax haven)

Fixes #10654
Fixes #10678

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Screenshots

![Screenshot 2024-05-27 165046](https://github.com/tobymao/18xx/assets/1045173/792d94d3-36d6-478d-b138-9babfaa34b6d)