### PR TITLE
[1846] during auction, show private companies under bank in Entities tab

### DIFF
--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -989,6 +989,10 @@ module Engine
 
           super
         end
+
+        def unowned_purchasable_companies
+          @round.is_a?(Engine::Round::Draft) ? @companies.reject { |c| c.name.start_with?('Pass') }.sort_by(&:name) : []
+        end
       end
     end
   end

--- a/lib/engine/game/g_18_los_angeles/game.rb
+++ b/lib/engine/game/g_18_los_angeles/game.rb
@@ -451,6 +451,10 @@ module Engine
           str += ' - $20 (Dump)' if dump_penalty(route, route.stops).positive?
           str
         end
+
+        def unowned_purchasable_companies
+          []
+        end
       end
     end
   end

--- a/lib/engine/game/g_18_mo/game.rb
+++ b/lib/engine/game/g_18_mo/game.rb
@@ -386,6 +386,10 @@ module Engine
         def setup_turn
           1
         end
+
+        def unowned_purchasable_companies
+          []
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #10535

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`