### PR TITLE
[1846] add game end check for all companies and corporations being closed

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -106,7 +106,7 @@ module Engine
       #   after: When game should end if check triggered
       # Leave out a reason if game does not support that.
       # Allowed reasons:
-      #  bankrupt, stock_market, bank, final_train, final_phase, custom
+      #  bankrupt, stock_market, bank, final_train, final_phase, all_closed, custom
       # Allowed after:
       #  immediate - ends in current turn
       #  current_round - ends at the end of the current round
@@ -2704,6 +2704,7 @@ module Engine
 
       def game_end_check
         triggers = {
+          all_closed: all_closed?,
           bankrupt: bankruptcy_limit_reached?,
           bank: @bank.broken?,
           stock_market: @stock_market.max_reached?,
@@ -2722,6 +2723,10 @@ module Engine
         end
 
         nil
+      end
+
+      def all_closed?
+        (@corporations + @companies).reject(&:closed?).empty?
       end
 
       def final_or_in_set?(round)

--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -146,6 +146,12 @@ module Engine
         CERT_LIMIT_COUNTS_BANKRUPTED = true
         BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
 
+        GAME_END_CHECK = {
+          bankrupt: :immediate,
+          bank: :full_or,
+          all_closed: :immediate,
+        }.freeze
+
         ORANGE_GROUP = [
           'Lake Shore Line',
           'Michigan Central',

--- a/public/fixtures/1846/README.md
+++ b/public/fixtures/1846/README.md
@@ -1,0 +1,1 @@
+* `hs_wbpewgex_1715274627` - all companies and corporations close

--- a/public/fixtures/1846/hs_wbpewgex_1715274627.json
+++ b/public/fixtures/1846/hs_wbpewgex_1715274627.json
@@ -1,0 +1,8011 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1715274654,
+      "company": "MS",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1715274659,
+      "company": "C&WI",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1715274665,
+      "company": "SC",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1715274696,
+      "company": "BIG4",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1715274709,
+      "company": "LSL",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1715274713,
+      "company": "Pass (3)",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1715274723,
+      "company": "LM",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1715274738,
+      "company": "O&I",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1715274742,
+      "company": "Pass (5)",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1715274750,
+      "company": "MPC",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1715274753,
+      "company": "Pass (2)",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1715274763,
+      "company": "Pass (4)",
+      "price": 0
+    },
+    {
+      "type": "undo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1715274768
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1715274814,
+      "company": "BT",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1715274819,
+      "company": "Pass (1)",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1715274823,
+      "company": "Pass (4)",
+      "price": 0
+    },
+    {
+      "type": "undo",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1715274824
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1715274827,
+      "company": "Pass (4)",
+      "price": 0
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1715274829
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1715274830
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1715274831
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1715274832
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 23,
+      "created_at": 1715274834
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 24,
+      "created_at": 1715274834
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1715274835
+    },
+    {
+      "type": "bid",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 26,
+      "created_at": 1715274840,
+      "company": "MAIL",
+      "price": 80
+    },
+    {
+      "type": "par",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1715274878,
+      "corporation": "NYC",
+      "share_price": "100,0,10"
+    },
+    {
+      "type": "par",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 28,
+      "created_at": 1715274902,
+      "corporation": "IC",
+      "share_price": "100,0,10"
+    },
+    {
+      "type": "par",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 29,
+      "created_at": 1715274919,
+      "corporation": "GT",
+      "share_price": "100,0,10"
+    },
+    {
+      "type": "par",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 30,
+      "created_at": 1715274942,
+      "corporation": "B&O",
+      "share_price": "80,0,8"
+    },
+    {
+      "type": "par",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 31,
+      "created_at": 1715274976,
+      "corporation": "ERIE",
+      "share_price": "80,0,8"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 32,
+      "created_at": 1715274983,
+      "shares": [
+        "NYC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 33,
+      "created_at": 1715274986,
+      "shares": [
+        "IC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1715274989,
+      "shares": [
+        "GT_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1715274995,
+      "shares": [
+        "B&O_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1715274997,
+      "shares": [
+        "ERIE_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 37,
+      "created_at": 1715275007
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 38,
+      "created_at": 1715275007
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 39,
+      "created_at": 1715275008
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 40,
+      "created_at": 1715275009
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 41,
+      "created_at": 1715275010
+    },
+    {
+      "type": "assign",
+      "entity": "SC",
+      "entity_type": "company",
+      "id": 42,
+      "created_at": 1715275031,
+      "target": "D14",
+      "target_type": "hex"
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "company",
+      "id": 43,
+      "created_at": 1715275042
+    },
+    {
+      "type": "undo",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 44,
+      "created_at": 1715275045
+    },
+    {
+      "type": "assign",
+      "entity": "SC",
+      "entity_type": "company",
+      "id": 45,
+      "created_at": 1715275049,
+      "target": "GT",
+      "target_type": "corporation"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 46,
+      "created_at": 1715275060,
+      "hex": "C13",
+      "tile": "7-0",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 47,
+      "created_at": 1715275064,
+      "hex": "D14",
+      "tile": "5-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 48,
+      "created_at": 1715275070,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "C13",
+              "D14"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "C15"
+          ],
+          "revenue": 60,
+          "revenue_str": "D14-C15",
+          "nodes": [
+            "C15-0",
+            "D14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 49,
+      "created_at": 1715275084,
+      "hex": "G9",
+      "tile": "5-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 50,
+      "created_at": 1715275087,
+      "hex": "G7",
+      "tile": "6-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 51,
+      "created_at": 1715275094,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G7",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "G7"
+          ],
+          "revenue": 40,
+          "revenue_str": "G9-G7",
+          "nodes": [
+            "G7-0",
+            "G9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 52,
+      "created_at": 1715275124
+    },
+    {
+      "type": "buy_train",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 53,
+      "created_at": 1715275129,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 54,
+      "created_at": 1715275131
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 55,
+      "created_at": 1715275138
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 56,
+      "created_at": 1715275156,
+      "hex": "E19",
+      "tile": "9-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 57,
+      "created_at": 1715275161,
+      "hex": "E17",
+      "tile": "291-0",
+      "rotation": 3
+    },
+    {
+      "type": "place_token",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 58,
+      "created_at": 1715275170,
+      "city": "291-0-0",
+      "slot": 0,
+      "tokener": "ERIE"
+    },
+    {
+      "type": "undo",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 59,
+      "created_at": 1715275173
+    },
+    {
+      "type": "sell_shares",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 60,
+      "created_at": 1715275176,
+      "shares": [
+        "ERIE_2",
+        "ERIE_3"
+      ],
+      "percent": 20,
+      "share_price": 70
+    },
+    {
+      "type": "place_token",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 61,
+      "created_at": 1715275178,
+      "city": "291-0-0",
+      "slot": 0,
+      "tokener": "ERIE"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 62,
+      "created_at": 1715275182,
+      "train": "2-3",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 63,
+      "created_at": 1715275183,
+      "train": "2-4",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 64,
+      "created_at": 1715275184
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 65,
+      "created_at": 1715275186
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 66,
+      "created_at": 1715275193,
+      "hex": "D18",
+      "tile": "8-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 67,
+      "created_at": 1715275200
+    },
+    {
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 68,
+      "created_at": 1715275202
+    },
+    {
+      "type": "sell_shares",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 69,
+      "created_at": 1715275205,
+      "shares": [
+        "NYC_2"
+      ],
+      "percent": 10,
+      "share_price": 90
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 70,
+      "created_at": 1715275207
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 71,
+      "created_at": 1715275208,
+      "train": "2-5",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 72,
+      "created_at": 1715275209,
+      "train": "2-6",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 73,
+      "created_at": 1715275210
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 74,
+      "created_at": 1715275213
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 75,
+      "created_at": 1715275220,
+      "hex": "J4",
+      "tile": "8-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 76,
+      "created_at": 1715275224,
+      "hex": "I3",
+      "tile": "8-2",
+      "rotation": 3
+    },
+    {
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 77,
+      "created_at": 1715275228
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 78,
+      "created_at": 1715275234,
+      "hex": "I3",
+      "tile": "8-2",
+      "rotation": 5
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 79,
+      "created_at": 1715275238,
+      "train": "2-7",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 80,
+      "created_at": 1715275240,
+      "train": "2-8",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 81,
+      "created_at": 1715275241
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 82,
+      "created_at": 1715275243
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 83,
+      "created_at": 1715275252,
+      "hex": "B16",
+      "tile": "6-1",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 84,
+      "created_at": 1715275254,
+      "city": "5-0-0",
+      "slot": 0,
+      "tokener": "GT"
+    },
+    {
+      "type": "sell_shares",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 85,
+      "created_at": 1715275258,
+      "shares": [
+        "GT_2",
+        "GT_3"
+      ],
+      "percent": 20,
+      "share_price": 90
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 86,
+      "created_at": 1715275263,
+      "hex": "D12",
+      "tile": "9-1",
+      "rotation": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 87,
+      "created_at": 1715275270,
+      "train": "4-0",
+      "price": 160,
+      "variant": "3/5"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 88,
+      "created_at": 1715275278
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 89,
+      "created_at": 1715275280
+    },
+    {
+      "type": "pass",
+      "entity": "SC",
+      "entity_type": "company",
+      "id": 90,
+      "created_at": 1715275287
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 91,
+      "created_at": 1715275650,
+      "hex": "D14",
+      "tile": "15-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 92,
+      "created_at": 1715275653,
+      "hex": "D10",
+      "tile": "9-2",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "MS",
+      "entity_type": "minor",
+      "id": 93,
+      "created_at": 1715275656,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C15",
+              "C13",
+              "D14"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "D14"
+          ],
+          "revenue": 70,
+          "revenue_str": "C15-D14",
+          "nodes": [
+            "C15-0",
+            "D14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 94,
+      "created_at": 1715275673,
+      "hex": "G9",
+      "tile": "15-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "BIG4",
+      "entity_type": "minor",
+      "id": 95,
+      "created_at": 1715275676,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G7",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "G7",
+            "G9"
+          ],
+          "revenue": 50,
+          "revenue_str": "G7-G9",
+          "nodes": [
+            "G7-0",
+            "G9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 96,
+      "created_at": 1715275691,
+      "hex": "D20",
+      "tile": "14-0",
+      "rotation": 0
+    },
+    {
+      "type": "buy_company",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 97,
+      "created_at": 1715275699,
+      "company": "LSL",
+      "price": 40
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LSL",
+      "entity_type": "company",
+      "id": 98,
+      "created_at": 1715275710,
+      "hex": "E17",
+      "tile": "294-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 99,
+      "created_at": 1715275711,
+      "city": "294-0-0",
+      "slot": 1,
+      "tokener": "NYC"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 100,
+      "created_at": 1715275717
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 101,
+      "created_at": 1715275726,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "D20",
+            "E17"
+          ],
+          "revenue": 80,
+          "revenue_str": "D20-E17",
+          "nodes": [
+            "E17-0",
+            "D20-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "E17",
+              "E19",
+              "E21"
+            ]
+          ],
+          "hexes": [
+            "E21",
+            "E17"
+          ],
+          "revenue": 60,
+          "revenue_str": "E21-E17",
+          "nodes": [
+            "E17-0",
+            "E21-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 102,
+      "created_at": 1715275728,
+      "kind": "payout"
+    },
+    {
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 103,
+      "created_at": 1715275732
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 104,
+      "created_at": 1715275735,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 105,
+      "created_at": 1715275738,
+      "train": "4-1",
+      "price": 160,
+      "variant": "3/5"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 106,
+      "created_at": 1715275739
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 107,
+      "created_at": 1715275749
+    },
+    {
+      "type": "buy_company",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 108,
+      "created_at": 1715275759,
+      "company": "BIG4",
+      "price": 40
+    },
+    {
+      "type": "log",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 109,
+      "created_at": 1715275789,
+      "message": "• confirmed receiving consent from Backward"
+    },
+    {
+      "type": "buy_company",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 110,
+      "created_at": 1715275789,
+      "company": "MPC",
+      "price": 60
+    },
+    {
+      "type": "assign",
+      "entity": "MPC",
+      "entity_type": "company",
+      "id": 111,
+      "created_at": 1715275799,
+      "target": "I1",
+      "target_type": "hex"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 112,
+      "created_at": 1715275814,
+      "hex": "H8",
+      "tile": "8-3",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 113,
+      "created_at": 1715275818,
+      "hex": "I9",
+      "tile": "9-3",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 114,
+      "created_at": 1715275821
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 115,
+      "created_at": 1715275837,
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "G9",
+              "H8",
+              "I9",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "J10",
+            "G9"
+          ],
+          "revenue": 80,
+          "revenue_str": "J10-G9",
+          "nodes": [
+            "G9-0",
+            "J10-0"
+          ]
+        },
+        {
+          "train": "2-8",
+          "connections": [
+            [
+              "I1",
+              "I3",
+              "J4",
+              "K3"
+            ]
+          ],
+          "hexes": [
+            "K3",
+            "I1"
+          ],
+          "revenue": 100,
+          "revenue_str": "K3-I1 + Meat-Packing",
+          "nodes": [
+            "I1-0",
+            "K3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 116,
+      "created_at": 1715275842,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 117,
+      "created_at": 1715275845,
+      "train": "4-2",
+      "price": 160,
+      "variant": "3/5"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 118,
+      "created_at": 1715275852
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 119,
+      "created_at": 1715275861,
+      "hex": "D8",
+      "tile": "9-4",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 120,
+      "created_at": 1715275862,
+      "city": "D6-0-2",
+      "slot": 0,
+      "tokener": "GT"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 121,
+      "created_at": 1715275866,
+      "hex": "D6",
+      "tile": "298-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 122,
+      "created_at": 1715275886,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "D14",
+            "D6",
+            "C5"
+          ],
+          "revenue": 130,
+          "revenue_str": "C15-D14-D6-(C5) + Port",
+          "nodes": [
+            "D14-0",
+            "C15-0",
+            "D6-2",
+            "C5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "sell_shares",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 123,
+      "created_at": 1715275893,
+      "shares": [
+        "GT_4"
+      ],
+      "percent": 10,
+      "share_price": 80
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 124,
+      "created_at": 1715275903,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 125,
+      "created_at": 1715275905,
+      "train": "4-3",
+      "price": 160,
+      "variant": "3/5"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 126,
+      "created_at": 1715275906
+    },
+    {
+      "type": "buy_company",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 127,
+      "created_at": 1715275926,
+      "company": "SC",
+      "price": 40
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 128,
+      "created_at": 1715275928
+    },
+    {
+      "type": "buy_company",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 129,
+      "created_at": 1715275942,
+      "company": "C&WI",
+      "price": 60
+    },
+    {
+      "type": "place_token",
+      "entity": "C&WI",
+      "entity_type": "company",
+      "id": 130,
+      "created_at": 1715275949,
+      "city": "298-0-3",
+      "slot": 0,
+      "tokener": "B&O"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 131,
+      "created_at": 1715275969,
+      "hex": "E7",
+      "tile": "7-1",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 132,
+      "created_at": 1715275973,
+      "hex": "D8",
+      "tile": "24-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 133,
+      "created_at": 1715275977
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 134,
+      "created_at": 1715275999,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "D14",
+              "D12",
+              "D10",
+              "D8",
+              "E7",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "D14"
+          ],
+          "revenue": 70,
+          "revenue_str": "D6-D14",
+          "nodes": [
+            "D14-0",
+            "D6-3"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 135,
+      "created_at": 1715276001,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_company",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 136,
+      "created_at": 1715276014,
+      "company": "MAIL",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 137,
+      "created_at": 1715276017
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 138,
+      "created_at": 1715276019
+    },
+    {
+      "type": "buy_company",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 139,
+      "created_at": 1715276024,
+      "company": "MS",
+      "price": 60
+    },
+    {
+      "type": "sell_shares",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 140,
+      "created_at": 1715276055,
+      "shares": [
+        "ERIE_4"
+      ],
+      "percent": 10,
+      "share_price": 60
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 141,
+      "created_at": 1715276063,
+      "hex": "C15",
+      "tile": "294-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 142,
+      "created_at": 1715276069
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 143,
+      "created_at": 1715276107,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "C15",
+              "D14"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "C15"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-C15",
+          "nodes": [
+            "C15-0",
+            "D14-0"
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "C15",
+              "C13",
+              "D14"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "C15"
+          ],
+          "revenue": 80,
+          "revenue_str": "D14-C15",
+          "nodes": [
+            "C15-0",
+            "D14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 144,
+      "created_at": 1715276114,
+      "kind": "payout"
+    },
+    {
+      "type": "undo",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 145,
+      "created_at": 1715276123
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 146,
+      "created_at": 1715276128,
+      "kind": "half"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 147,
+      "created_at": 1715276131
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 148,
+      "created_at": 1715277710
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 149,
+      "created_at": 1715277721,
+      "shares": [
+        "NYC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 150,
+      "created_at": 1715277738,
+      "shares": [
+        "IC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 151,
+      "created_at": 1715277751,
+      "shares": [
+        "GT_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 152,
+      "created_at": 1715277764,
+      "shares": [
+        "B&O_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 153,
+      "created_at": 1715277771,
+      "shares": [
+        "ERIE_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 154,
+      "created_at": 1715277777,
+      "shares": [
+        "NYC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 155,
+      "created_at": 1715277797
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 156,
+      "created_at": 1715277831
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 157,
+      "created_at": 1715277843,
+      "shares": [
+        "B&O_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 158,
+      "created_at": 1715277862,
+      "shares": [
+        "ERIE_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 159,
+      "created_at": 1715277864
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 160,
+      "created_at": 1715277865
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 161,
+      "created_at": 1715277866
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 162,
+      "created_at": 1715277870,
+      "shares": [
+        "B&O_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 163,
+      "created_at": 1715277884
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 164,
+      "created_at": 1715277884
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 165,
+      "created_at": 1715277885
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 166,
+      "created_at": 1715277885
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 167,
+      "created_at": 1715277886
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 168,
+      "created_at": 1715277913,
+      "hex": "G7",
+      "tile": "619-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 169,
+      "created_at": 1715277916,
+      "hex": "H6",
+      "tile": "9-5",
+      "rotation": 0
+    },
+    {
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 170,
+      "created_at": 1715277933,
+      "action_id": 167
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 171,
+      "created_at": 1715277953,
+      "hex": "G11",
+      "tile": "8-4",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 172,
+      "created_at": 1715277971,
+      "hex": "H12",
+      "tile": "291-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 173,
+      "created_at": 1715277975
+    },
+    {
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 174,
+      "created_at": 1715277996,
+      "action_id": 167
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 175,
+      "created_at": 1715278002,
+      "hex": "H10",
+      "tile": "9-5",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 176,
+      "created_at": 1715278008,
+      "hex": "I11",
+      "tile": "8-4",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 177,
+      "created_at": 1715278012
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 178,
+      "created_at": 1715278024,
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "G9",
+              "H8",
+              "I9",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "J10"
+          ],
+          "revenue": 80,
+          "revenue_str": "G9-J10",
+          "nodes": [
+            "G9-0",
+            "J10-0"
+          ]
+        },
+        {
+          "train": "2-8",
+          "connections": [
+            [
+              "I1",
+              "I3",
+              "J4",
+              "K3"
+            ]
+          ],
+          "hexes": [
+            "I1",
+            "K3"
+          ],
+          "revenue": 100,
+          "revenue_str": "I1-K3 + Meat-Packing",
+          "nodes": [
+            "I1-0",
+            "K3-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "J10",
+            "G9"
+          ],
+          "revenue": 80,
+          "revenue_str": "J10-G9",
+          "nodes": [
+            "G9-0",
+            "J10-0"
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "G7",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "G7"
+          ],
+          "revenue": 50,
+          "revenue_str": "G9-G7",
+          "nodes": [
+            "G7-0",
+            "G9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 179,
+      "created_at": 1715278029,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 180,
+      "created_at": 1715278043
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 181,
+      "created_at": 1715278050,
+      "hex": "E19",
+      "tile": "24-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 182,
+      "created_at": 1715278063
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 183,
+      "created_at": 1715278092,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "E17",
+              "E19",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "D20",
+            "E17"
+          ],
+          "revenue": 80,
+          "revenue_str": "D20-E17",
+          "nodes": [
+            "E17-0",
+            "D20-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ]
+          ],
+          "hexes": [
+            "D22",
+            "D20"
+          ],
+          "revenue": 60,
+          "revenue_str": "D22-D20",
+          "nodes": [
+            "D20-0",
+            "D22-0"
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "C21",
+            "D20",
+            "E17"
+          ],
+          "revenue": 110,
+          "revenue_str": "C21-D20-E17",
+          "nodes": [
+            "D20-0",
+            "C21-0",
+            "E17-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 184,
+      "created_at": 1715278105,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 185,
+      "created_at": 1715278116
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 186,
+      "created_at": 1715278119
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 187,
+      "created_at": 1715278145,
+      "hex": "E13",
+      "tile": "9-4",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 188,
+      "created_at": 1715278147,
+      "hex": "F12",
+      "tile": "9-6",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 189,
+      "created_at": 1715278151
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 190,
+      "created_at": 1715278152,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "D14",
+              "D12",
+              "D10",
+              "D8",
+              "E7",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "D6"
+          ],
+          "revenue": 90,
+          "revenue_str": "D14-D6 + Mail Contract",
+          "nodes": [
+            "D14-0",
+            "D6-3"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 191,
+      "created_at": 1715278154,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 192,
+      "created_at": 1715278155,
+      "train": "4-4",
+      "price": 160,
+      "variant": "3/5"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 193,
+      "created_at": 1715278159
+    },
+    {
+      "type": "buy_company",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 194,
+      "created_at": 1715278164,
+      "company": "BT",
+      "price": 40
+    },
+    {
+      "type": "buy_company",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 195,
+      "created_at": 1715278167,
+      "company": "LM",
+      "price": 40
+    },
+    {
+      "type": "assign",
+      "entity": "BT",
+      "entity_type": "company",
+      "id": 196,
+      "created_at": 1715278171,
+      "target": "H12",
+      "target_type": "hex"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 197,
+      "created_at": 1715278174
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 198,
+      "created_at": 1715278197
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 199,
+      "created_at": 1715278212,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "D6",
+            "C5"
+          ],
+          "revenue": 190,
+          "revenue_str": "C17-(C15)-D14-(D6)-C5 + Port + E/W",
+          "nodes": [
+            "C15-0",
+            "C17-0",
+            "D14-0",
+            "D6-2",
+            "C5-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "C15",
+              "B16"
+            ],
+            [
+              "D14",
+              "C15"
+            ]
+          ],
+          "hexes": [
+            "B16",
+            "C15",
+            "D14"
+          ],
+          "revenue": 120,
+          "revenue_str": "B16-C15-D14 + Port",
+          "nodes": [
+            "C15-0",
+            "B16-0",
+            "D14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 200,
+      "created_at": 1715278219,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 201,
+      "created_at": 1715278244,
+      "train": "4-5",
+      "price": 160,
+      "variant": "3/5"
+    },
+    {
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 202,
+      "created_at": 1715278247
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 203,
+      "created_at": 1715278251
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 204,
+      "created_at": 1715278252
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 205,
+      "created_at": 1715278262,
+      "hex": "E7",
+      "tile": "28-0",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 206,
+      "created_at": 1715278265,
+      "hex": "E5",
+      "tile": "7-2",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 207,
+      "created_at": 1715278271
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 208,
+      "created_at": 1715278281,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "C15",
+              "D14"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "D14"
+          ],
+          "revenue": 80,
+          "revenue_str": "C15-D14",
+          "nodes": [
+            "C15-0",
+            "D14-0"
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "C15",
+              "C13",
+              "D14"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "D14"
+          ],
+          "revenue": 80,
+          "revenue_str": "C15-D14",
+          "nodes": [
+            "C15-0",
+            "D14-0"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "D20",
+            "E17"
+          ],
+          "revenue": 80,
+          "revenue_str": "D20-E17",
+          "nodes": [
+            "E17-0",
+            "D20-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 209,
+      "created_at": 1715278283,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 210,
+      "created_at": 1715278285,
+      "train": "4-5",
+      "price": 160,
+      "variant": "3/5"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 211,
+      "created_at": 1715278298
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 212,
+      "created_at": 1715282488,
+      "hex": "I11",
+      "tile": "30-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 213,
+      "created_at": 1715282496,
+      "hex": "G11",
+      "tile": "8-5",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 214,
+      "created_at": 1715282502
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 215,
+      "created_at": 1715282521,
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "G9",
+              "H8",
+              "I9",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "J10"
+          ],
+          "revenue": 80,
+          "revenue_str": "G9-J10",
+          "nodes": [
+            "G9-0",
+            "J10-0"
+          ]
+        },
+        {
+          "train": "2-8",
+          "connections": [
+            [
+              "I1",
+              "I3",
+              "J4",
+              "K3"
+            ]
+          ],
+          "hexes": [
+            "I1",
+            "K3"
+          ],
+          "revenue": 100,
+          "revenue_str": "I1-K3 + Meat-Packing",
+          "nodes": [
+            "I1-0",
+            "K3-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "J10"
+          ],
+          "revenue": 80,
+          "revenue_str": "G9-J10",
+          "nodes": [
+            "G9-0",
+            "J10-0"
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "G9",
+              "G11",
+              "F12",
+              "E13",
+              "D14"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "D14",
+            "C15"
+          ],
+          "revenue": 110,
+          "revenue_str": "G9-D14-C15",
+          "nodes": [
+            "G9-0",
+            "D14-0",
+            "C15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 216,
+      "created_at": 1715282524,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 217,
+      "created_at": 1715282536
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 218,
+      "created_at": 1715282578
+    },
+    {
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 219,
+      "created_at": 1715282579,
+      "action_id": 217
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 220,
+      "created_at": 1715282585,
+      "hex": "E15",
+      "tile": "9-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 221,
+      "created_at": 1715282589,
+      "hex": "E13",
+      "tile": "23-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 222,
+      "created_at": 1715282593
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 223,
+      "created_at": 1715282607,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "E17",
+              "E19",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "E17",
+            "D20"
+          ],
+          "revenue": 80,
+          "revenue_str": "E17-D20",
+          "nodes": [
+            "E17-0",
+            "D20-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ]
+          ],
+          "hexes": [
+            "D20",
+            "D22"
+          ],
+          "revenue": 60,
+          "revenue_str": "D20-D22",
+          "nodes": [
+            "D20-0",
+            "D22-0"
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "F12",
+              "G11",
+              "G9"
+            ],
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "C21",
+            "D20",
+            "E17",
+            "G9",
+            "J10"
+          ],
+          "revenue": 130,
+          "revenue_str": "C21-(D20)-E17-(G9)-J10",
+          "nodes": [
+            "D20-0",
+            "C21-0",
+            "E17-0",
+            "G9-0",
+            "J10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "sell_shares",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 224,
+      "created_at": 1715282635,
+      "shares": [
+        "NYC_4",
+        "NYC_5"
+      ],
+      "percent": 20,
+      "share_price": 100
+    },
+    {
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 225,
+      "created_at": 1715282641
+    },
+    {
+      "type": "sell_shares",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 226,
+      "created_at": 1715282644,
+      "shares": [
+        "NYC_4"
+      ],
+      "percent": 10,
+      "share_price": 100
+    },
+    {
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 227,
+      "created_at": 1715282647
+    },
+    {
+      "type": "sell_shares",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 228,
+      "created_at": 1715282653,
+      "shares": [
+        "NYC_4"
+      ],
+      "percent": 10,
+      "share_price": 100
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 229,
+      "created_at": 1715282655,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 230,
+      "created_at": 1715282657,
+      "train": "5-0",
+      "price": 450,
+      "variant": "4/6"
+    },
+    {
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 231,
+      "created_at": 1715282661
+    },
+    {
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 232,
+      "created_at": 1715282664
+    },
+    {
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 233,
+      "created_at": 1715282671
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 234,
+      "created_at": 1715282674,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 235,
+      "created_at": 1715282676
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 236,
+      "created_at": 1715282678
+    },
+    {
+      "type": "buy_company",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 237,
+      "created_at": 1715282682,
+      "company": "O&I",
+      "price": 40
+    },
+    {
+      "type": "lay_tile",
+      "entity": "O&I",
+      "entity_type": "company",
+      "id": 238,
+      "created_at": 1715282694,
+      "hex": "F16",
+      "tile": "8-4",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "O&I",
+      "entity_type": "company",
+      "id": 239,
+      "created_at": 1715282697,
+      "hex": "F14",
+      "tile": "9-7",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 240,
+      "created_at": 1715282712
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 241,
+      "created_at": 1715282726,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "D6",
+            "C5"
+          ],
+          "revenue": 190,
+          "revenue_str": "C17-(C15)-D14-(D6)-C5 + Port + E/W",
+          "nodes": [
+            "C15-0",
+            "C17-0",
+            "D14-0",
+            "D6-2",
+            "C5-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "D14",
+              "E13",
+              "F12",
+              "G11",
+              "G9"
+            ],
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "D14",
+            "G9",
+            "J10"
+          ],
+          "revenue": 150,
+          "revenue_str": "C15-D14-(G9)-J10 + Port",
+          "nodes": [
+            "D14-0",
+            "C15-0",
+            "G9-0",
+            "J10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 242,
+      "created_at": 1715282730,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 243,
+      "created_at": 1715282732
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LM",
+      "entity_type": "company",
+      "id": 244,
+      "created_at": 1715282749,
+      "hex": "H12",
+      "tile": "293-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LM",
+      "entity_type": "company",
+      "id": 245,
+      "created_at": 1715282777,
+      "hex": "G13",
+      "tile": "57-0",
+      "rotation": 0
+    },
+    {
+      "type": "sell_shares",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 246,
+      "created_at": 1715282783,
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10,
+      "share_price": 80
+    },
+    {
+      "type": "place_token",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 247,
+      "created_at": 1715282785,
+      "city": "293-0-0",
+      "slot": 0,
+      "tokener": "B&O"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 248,
+      "created_at": 1715282790
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 249,
+      "created_at": 1715282809,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "D14",
+              "D12",
+              "D10",
+              "D8",
+              "E7",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "D6"
+          ],
+          "revenue": 70,
+          "revenue_str": "D14-D6",
+          "nodes": [
+            "D14-0",
+            "D6-3"
+          ]
+        },
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "G9",
+              "H8",
+              "I9",
+              "J10"
+            ],
+            [
+              "H12",
+              "I11",
+              "H10",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "J10",
+            "G9",
+            "H12"
+          ],
+          "revenue": 170,
+          "revenue_str": "J10-G9-H12 + Boomtown + Mail Contract",
+          "nodes": [
+            "G9-0",
+            "J10-0",
+            "H12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 250,
+      "created_at": 1715282814,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 251,
+      "created_at": 1715282816
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 252,
+      "created_at": 1715282849,
+      "hex": "F12",
+      "tile": "20-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 253,
+      "created_at": 1715282864,
+      "hex": "F10",
+      "tile": "9-8",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 254,
+      "created_at": 1715282868
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 255,
+      "created_at": 1715282913,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E17",
+              "E19",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "D20",
+            "E17"
+          ],
+          "revenue": 80,
+          "revenue_str": "D20-E17",
+          "nodes": [
+            "E17-0",
+            "D20-0"
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "C15",
+              "C13",
+              "D14"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "D14"
+          ],
+          "revenue": 80,
+          "revenue_str": "C15-D14",
+          "nodes": [
+            "C15-0",
+            "D14-0"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "E17",
+            "D20"
+          ],
+          "revenue": 80,
+          "revenue_str": "E17-D20",
+          "nodes": [
+            "E17-0",
+            "D20-0"
+          ]
+        },
+        {
+          "train": "4-5",
+          "connections": [
+            [
+              "D6",
+              "C5"
+            ],
+            [
+              "D6",
+              "E5",
+              "E7",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "C15",
+              "C17"
+            ]
+          ],
+          "hexes": [
+            "C5",
+            "D6",
+            "D14",
+            "C15",
+            "C17"
+          ],
+          "revenue": 190,
+          "revenue_str": "C5-(D6)-(D14)-C15-C17 + E/W",
+          "nodes": [
+            "D6-0",
+            "C5-0",
+            "D14-0",
+            "C15-0",
+            "C17-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 256,
+      "created_at": 1715282917,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 257,
+      "created_at": 1715282927,
+      "shares": [
+        "ERIE_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 258,
+      "created_at": 1715282937,
+      "shares": [
+        "NYC_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 259,
+      "created_at": 1715282950,
+      "shares": [
+        "IC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 260,
+      "created_at": 1715282956,
+      "shares": [
+        "GT_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 261,
+      "created_at": 1715283011,
+      "corporation": "C&O",
+      "share_price": "100,0,10"
+    },
+    {
+      "type": "undo",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 262,
+      "created_at": 1715283014
+    },
+    {
+      "type": "par",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 263,
+      "created_at": 1715283020,
+      "corporation": "PRR",
+      "share_price": "100,0,10"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 264,
+      "created_at": 1715283030,
+      "shares": [
+        "GT_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 265,
+      "created_at": 1715283037,
+      "shares": [
+        "PRR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 266,
+      "created_at": 1715283090,
+      "shares": [
+        "GT_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 267,
+      "created_at": 1715283106,
+      "shares": [
+        "GT_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 268,
+      "created_at": 1715283117,
+      "shares": [
+        "PRR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 269,
+      "created_at": 1715283133,
+      "shares": [
+        "PRR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 270,
+      "created_at": 1715283135
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 271,
+      "created_at": 1715283136
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 272,
+      "created_at": 1715283136
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 273,
+      "created_at": 1715283137
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 274,
+      "created_at": 1715283138
+    },
+    {
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 275,
+      "created_at": 1715283151
+    },
+    {
+      "type": "undo",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 276,
+      "created_at": 1715283154
+    },
+    {
+      "type": "undo",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 277,
+      "created_at": 1715283156
+    },
+    {
+      "type": "undo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 278,
+      "created_at": 1715283159
+    },
+    {
+      "type": "undo",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 279,
+      "created_at": 1715283161
+    },
+    {
+      "type": "undo",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 280,
+      "created_at": 1715283163
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 281,
+      "created_at": 1715283182,
+      "shares": [
+        "PRR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 282,
+      "created_at": 1715283184
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 283,
+      "created_at": 1715283185
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 284,
+      "created_at": 1715283186
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 285,
+      "created_at": 1715283187
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 286,
+      "created_at": 1715283188
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 287,
+      "created_at": 1715283198,
+      "hex": "F6",
+      "tile": "9-9",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 288,
+      "created_at": 1715283201,
+      "hex": "E5",
+      "tile": "29-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 289,
+      "created_at": 1715283212
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 290,
+      "created_at": 1715283224,
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "G9",
+              "H8",
+              "I9",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "J10"
+          ],
+          "revenue": 80,
+          "revenue_str": "G9-J10",
+          "nodes": [
+            "G9-0",
+            "J10-0"
+          ]
+        },
+        {
+          "train": "2-8",
+          "connections": [
+            [
+              "I1",
+              "I3",
+              "J4",
+              "K3"
+            ]
+          ],
+          "hexes": [
+            "I1",
+            "K3"
+          ],
+          "revenue": 100,
+          "revenue_str": "I1-K3 + Meat-Packing",
+          "nodes": [
+            "I1-0",
+            "K3-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "J10"
+          ],
+          "revenue": 80,
+          "revenue_str": "G9-J10",
+          "nodes": [
+            "G9-0",
+            "J10-0"
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "G9",
+              "G11",
+              "F12",
+              "E13",
+              "D14"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "D14",
+            "C15"
+          ],
+          "revenue": 110,
+          "revenue_str": "G9-D14-C15",
+          "nodes": [
+            "G9-0",
+            "D14-0",
+            "C15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 291,
+      "created_at": 1715283230,
+      "kind": "payout"
+    },
+    {
+      "type": "undo",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 292,
+      "created_at": 1715283240
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 293,
+      "created_at": 1715283244,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 294,
+      "created_at": 1715283253,
+      "hex": "F8",
+      "tile": "9-4",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 295,
+      "created_at": 1715283261,
+      "hex": "F6",
+      "tile": "24-2",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 296,
+      "created_at": 1715283264
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 297,
+      "created_at": 1715283280,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "E17",
+              "E19",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "E17",
+            "D20"
+          ],
+          "revenue": 80,
+          "revenue_str": "E17-D20",
+          "nodes": [
+            "E17-0",
+            "D20-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "D20",
+              "D22"
+            ]
+          ],
+          "hexes": [
+            "D20",
+            "D22"
+          ],
+          "revenue": 60,
+          "revenue_str": "D20-D22",
+          "nodes": [
+            "D20-0",
+            "D22-0"
+          ]
+        },
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "E17",
+              "F16",
+              "F14",
+              "F12",
+              "F10",
+              "F8",
+              "F6",
+              "E5",
+              "D6"
+            ],
+            [
+              "D6",
+              "C5"
+            ]
+          ],
+          "hexes": [
+            "C21",
+            "D20",
+            "E17",
+            "D6",
+            "C5"
+          ],
+          "revenue": 180,
+          "revenue_str": "C21-(D20)-E17-(D6)-C5 + E/W",
+          "nodes": [
+            "D20-0",
+            "C21-0",
+            "E17-0",
+            "D6-0",
+            "C5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 298,
+      "created_at": 1715283282,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 299,
+      "created_at": 1715283289,
+      "train": "5-0",
+      "price": 450,
+      "variant": "4/6"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 300,
+      "created_at": 1715283291
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 301,
+      "created_at": 1715283298,
+      "hex": "C15",
+      "tile": "297-0",
+      "rotation": 0
+    },
+    {
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 302,
+      "created_at": 1715283311
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 303,
+      "created_at": 1715283319,
+      "hex": "D8",
+      "tile": "46-0",
+      "rotation": 4
+    },
+    {
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 304,
+      "created_at": 1715283330
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 305,
+      "created_at": 1715283338,
+      "hex": "C15",
+      "tile": "297-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 306,
+      "created_at": 1715283345
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 307,
+      "created_at": 1715283351,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "D6",
+            "C5"
+          ],
+          "revenue": 230,
+          "revenue_str": "C17-(C15)-D14-(D6)-C5 + Port + E/W",
+          "nodes": [
+            "C15-0",
+            "C17-0",
+            "D14-0",
+            "D6-2",
+            "C5-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "D14",
+              "E13",
+              "F12",
+              "G11",
+              "G9"
+            ],
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "D14",
+            "G9",
+            "J10"
+          ],
+          "revenue": 180,
+          "revenue_str": "C15-D14-(G9)-J10 + Port",
+          "nodes": [
+            "D14-0",
+            "C15-0",
+            "G9-0",
+            "J10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 308,
+      "created_at": 1715283353,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 309,
+      "created_at": 1715283357,
+      "train": "5-1",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 310,
+      "created_at": 1715283373,
+      "hex": "E17",
+      "tile": "297-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 311,
+      "created_at": 1715283376
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 312,
+      "created_at": 1715283395,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E17",
+              "E19",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "E17",
+            "D20"
+          ],
+          "revenue": 90,
+          "revenue_str": "E17-D20",
+          "nodes": [
+            "E17-0",
+            "D20-0"
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "C15",
+              "C13",
+              "D14"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "D14"
+          ],
+          "revenue": 90,
+          "revenue_str": "C15-D14",
+          "nodes": [
+            "C15-0",
+            "D14-0"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "E17",
+              "D18",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "E17",
+            "D20"
+          ],
+          "revenue": 90,
+          "revenue_str": "E17-D20",
+          "nodes": [
+            "E17-0",
+            "D20-0"
+          ]
+        },
+        {
+          "train": "4-5",
+          "connections": [
+            [
+              "D6",
+              "C5"
+            ],
+            [
+              "D6",
+              "E5",
+              "E7",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "D14",
+              "C15"
+            ],
+            [
+              "C15",
+              "C17"
+            ]
+          ],
+          "hexes": [
+            "C5",
+            "D6",
+            "D14",
+            "C15",
+            "C17"
+          ],
+          "revenue": 240,
+          "revenue_str": "C5-(D6)-(D14)-C15-C17 + E/W",
+          "nodes": [
+            "D6-0",
+            "C5-0",
+            "D14-0",
+            "C15-0",
+            "C17-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 313,
+      "created_at": 1715283396,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 314,
+      "created_at": 1715283397,
+      "train": "5-2",
+      "price": 450,
+      "variant": "4/6"
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 315,
+      "created_at": 1715283404
+    },
+    {
+      "type": "sell_shares",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 316,
+      "created_at": 1715283413,
+      "shares": [
+        "PRR_4",
+        "PRR_5",
+        "PRR_6",
+        "PRR_7",
+        "PRR_8"
+      ],
+      "percent": 50,
+      "share_price": 90
+    },
+    {
+      "type": "place_token",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 317,
+      "created_at": 1715283420,
+      "city": "E11-1-0",
+      "slot": 0,
+      "tokener": "PRR"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 318,
+      "created_at": 1715283429,
+      "hex": "E11",
+      "tile": "5-2",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 319,
+      "created_at": 1715283443,
+      "hex": "D12",
+      "tile": "24-3",
+      "rotation": 4
+    },
+    {
+      "type": "buy_train",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 320,
+      "created_at": 1715283445,
+      "train": "5-3",
+      "price": 450,
+      "variant": "4/6"
+    },
+    {
+      "type": "pass",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 321,
+      "created_at": 1715283446
+    },
+    {
+      "type": "sell_shares",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 322,
+      "created_at": 1715283469,
+      "shares": [
+        "B&O_6",
+        "B&O_7",
+        "B&O_8"
+      ],
+      "percent": 30,
+      "share_price": 90
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 323,
+      "created_at": 1715283485,
+      "hex": "I11",
+      "tile": "42-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 324,
+      "created_at": 1715283509
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 325,
+      "created_at": 1715283511,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "D14",
+              "D12",
+              "D10",
+              "D8",
+              "E7",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "D14",
+            "D6"
+          ],
+          "revenue": 70,
+          "revenue_str": "D14-D6",
+          "nodes": [
+            "D14-0",
+            "D6-3"
+          ]
+        },
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "G9",
+              "H8",
+              "I9",
+              "J10"
+            ],
+            [
+              "H12",
+              "I11",
+              "H10",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "J10",
+            "G9",
+            "H12"
+          ],
+          "revenue": 190,
+          "revenue_str": "J10-G9-H12 + Boomtown + Mail Contract",
+          "nodes": [
+            "G9-0",
+            "J10-0",
+            "H12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 326,
+      "created_at": 1715283513,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 327,
+      "created_at": 1715283522,
+      "train": "5-4",
+      "price": 450,
+      "variant": "4/6"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 328,
+      "created_at": 1715283523
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 329,
+      "created_at": 1715283587,
+      "hex": "F6",
+      "tile": "47-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 330,
+      "created_at": 1715283597
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 331,
+      "created_at": 1715283600,
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "G9",
+              "H8",
+              "I9",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "J10"
+          ],
+          "revenue": 100,
+          "revenue_str": "G9-J10",
+          "nodes": [
+            "G9-0",
+            "J10-0"
+          ]
+        },
+        {
+          "train": "2-8",
+          "connections": [
+            [
+              "I1",
+              "I3",
+              "J4",
+              "K3"
+            ]
+          ],
+          "hexes": [
+            "I1",
+            "K3"
+          ],
+          "revenue": 120,
+          "revenue_str": "I1-K3 + Meat-Packing",
+          "nodes": [
+            "I1-0",
+            "K3-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "J10"
+          ],
+          "revenue": 100,
+          "revenue_str": "G9-J10",
+          "nodes": [
+            "G9-0",
+            "J10-0"
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "G9",
+              "G11",
+              "F12",
+              "E13",
+              "D14"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "D14",
+            "C15"
+          ],
+          "revenue": 120,
+          "revenue_str": "G9-D14-C15",
+          "nodes": [
+            "G9-0",
+            "D14-0",
+            "C15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 332,
+      "created_at": 1715283601,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 333,
+      "created_at": 1715283605,
+      "train": "6-0",
+      "price": 900,
+      "variant": "7/8"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 334,
+      "created_at": 1715283606
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 335,
+      "created_at": 1715283630,
+      "hex": "F4",
+      "tile": "7-1",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 336,
+      "created_at": 1715283635,
+      "hex": "E13",
+      "tile": "41-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 337,
+      "created_at": 1715283639
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 338,
+      "created_at": 1715283661,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D20",
+              "C21"
+            ],
+            [
+              "E17",
+              "D18",
+              "D20"
+            ],
+            [
+              "E17",
+              "F16",
+              "F14",
+              "F12",
+              "F10",
+              "F8",
+              "F6",
+              "E5",
+              "D6"
+            ],
+            [
+              "D6",
+              "C5"
+            ]
+          ],
+          "hexes": [
+            "C21",
+            "D20",
+            "E17",
+            "D6",
+            "C5"
+          ],
+          "revenue": 240,
+          "revenue_str": "C21-(D20)-E17-(D6)-C5 + E/W",
+          "nodes": [
+            "D20-0",
+            "C21-0",
+            "E17-0",
+            "D6-0",
+            "C5-0"
+          ]
+        },
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "D14"
+            ],
+            [
+              "D20",
+              "E19",
+              "E17"
+            ],
+            [
+              "D22",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "D14",
+            "E17",
+            "D20",
+            "D22"
+          ],
+          "revenue": 210,
+          "revenue_str": "C15-D14-E17-(D20)-D22",
+          "nodes": [
+            "D14-0",
+            "C15-0",
+            "E17-0",
+            "D20-0",
+            "D22-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 339,
+      "created_at": 1715283662,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 340,
+      "created_at": 1715283664
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 341,
+      "created_at": 1715283671
+    },
+    {
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 342,
+      "created_at": 1715283726
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 343,
+      "created_at": 1715283737,
+      "hex": "F12",
+      "tile": "47-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 344,
+      "created_at": 1715283740
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 345,
+      "created_at": 1715283768,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "D6",
+            "C5"
+          ],
+          "revenue": 220,
+          "revenue_str": "C17-(C15)-(D14)-D6-C5 + E/W",
+          "nodes": [
+            "C15-0",
+            "C17-0",
+            "D14-0",
+            "D6-2",
+            "C5-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "C15",
+              "B16"
+            ],
+            [
+              "D14",
+              "C15"
+            ]
+          ],
+          "hexes": [
+            "B16",
+            "C15",
+            "D14"
+          ],
+          "revenue": 110,
+          "revenue_str": "B16-C15-D14",
+          "nodes": [
+            "C15-0",
+            "B16-0",
+            "D14-0"
+          ]
+        },
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ],
+            [
+              "E17",
+              "F16",
+              "F14",
+              "F12",
+              "G11",
+              "G9"
+            ],
+            [
+              "D14",
+              "E13",
+              "E15",
+              "E17"
+            ]
+          ],
+          "hexes": [
+            "J10",
+            "G9",
+            "E17",
+            "D14"
+          ],
+          "revenue": 190,
+          "revenue_str": "J10-G9-E17-D14",
+          "nodes": [
+            "G9-0",
+            "J10-0",
+            "E17-0",
+            "D14-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 346,
+      "created_at": 1715283770,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 347,
+      "created_at": 1715283773,
+      "train": "6-1",
+      "price": 900,
+      "variant": "7/8"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 348,
+      "created_at": 1715284147,
+      "hex": "G5",
+      "tile": "8-6",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 349,
+      "created_at": 1715284151,
+      "hex": "H4",
+      "tile": "8-7",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 350,
+      "created_at": 1715284154
+    },
+    {
+      "type": "run_routes",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 351,
+      "created_at": 1715284197,
+      "routes": [
+        {
+          "train": "4-5",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "J10"
+            ],
+            [
+              "E17",
+              "F16",
+              "F14",
+              "F12",
+              "G11",
+              "G9"
+            ],
+            [
+              "D20",
+              "E19",
+              "E17"
+            ],
+            [
+              "D22",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "J10",
+            "G9",
+            "E17",
+            "D20",
+            "D22"
+          ],
+          "revenue": 190,
+          "revenue_str": "J10-(G9)-E17-(D20)-D22",
+          "nodes": [
+            "G9-0",
+            "J10-0",
+            "E17-0",
+            "D20-0",
+            "D22-0"
+          ]
+        },
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "D6",
+              "E5",
+              "E7",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "D6",
+            "C5"
+          ],
+          "revenue": 280,
+          "revenue_str": "C17-C15-(D14)-D6-C5 + E/W",
+          "nodes": [
+            "C15-0",
+            "C17-0",
+            "D14-0",
+            "D6-0",
+            "C5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 352,
+      "created_at": 1715284199,
+      "kind": "withhold"
+    },
+    {
+      "type": "undo",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 353,
+      "created_at": 1715284203
+    },
+    {
+      "type": "sell_shares",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 354,
+      "created_at": 1715284207,
+      "shares": [
+        "ERIE_5",
+        "ERIE_6",
+        "ERIE_7",
+        "ERIE_8"
+      ],
+      "percent": 40,
+      "share_price": 90
+    },
+    {
+      "type": "dividend",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 355,
+      "created_at": 1715284208,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ERIE",
+      "entity_type": "corporation",
+      "id": 356,
+      "created_at": 1715284212,
+      "train": "6-2",
+      "price": 900,
+      "variant": "7/8"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 357,
+      "created_at": 1715284288,
+      "hex": "D10",
+      "tile": "23-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 358,
+      "created_at": 1715284292
+    },
+    {
+      "type": "run_routes",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 359,
+      "created_at": 1715284303,
+      "routes": [
+        {
+          "train": "5-3",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "E11",
+              "D12",
+              "D14"
+            ],
+            [
+              "D6",
+              "E5",
+              "E7",
+              "D8",
+              "D10",
+              "E11"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "E11",
+            "D6",
+            "C5"
+          ],
+          "revenue": 260,
+          "revenue_str": "C17-C15-(D14)-E11-(D6)-C5 + E/W",
+          "nodes": [
+            "C15-0",
+            "C17-0",
+            "D14-0",
+            "E11-0",
+            "D6-0",
+            "C5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 360,
+      "created_at": 1715284305,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 361,
+      "created_at": 1715284307
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 362,
+      "created_at": 1715284328,
+      "hex": "G19",
+      "tile": "14-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 363,
+      "created_at": 1715284331,
+      "hex": "F18",
+      "tile": "9-10",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 364,
+      "created_at": 1715284334
+    },
+    {
+      "type": "run_routes",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 365,
+      "created_at": 1715284351,
+      "routes": [
+        {
+          "train": "4-4",
+          "connections": [
+            [
+              "G9",
+              "H8",
+              "I9",
+              "J10"
+            ],
+            [
+              "H12",
+              "I11",
+              "H10",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "J10",
+            "G9",
+            "H12"
+          ],
+          "revenue": 140,
+          "revenue_str": "J10-G9-H12",
+          "nodes": [
+            "G9-0",
+            "J10-0",
+            "H12-0"
+          ]
+        },
+        {
+          "train": "5-4",
+          "connections": [
+            [
+              "D6",
+              "C5"
+            ],
+            [
+              "E17",
+              "F16",
+              "F14",
+              "F12",
+              "F10",
+              "F8",
+              "F6",
+              "E5",
+              "D6"
+            ],
+            [
+              "G19",
+              "F18",
+              "E17"
+            ],
+            [
+              "G21",
+              "G19"
+            ]
+          ],
+          "hexes": [
+            "C5",
+            "D6",
+            "E17",
+            "G19",
+            "G21"
+          ],
+          "revenue": 320,
+          "revenue_str": "C5-(D6)-E17-G19-G21 + E/W + Mail Contract",
+          "nodes": [
+            "D6-0",
+            "C5-0",
+            "E17-0",
+            "G19-0",
+            "G21-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 366,
+      "created_at": 1715284352,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "B&O",
+      "entity_type": "corporation",
+      "id": 367,
+      "created_at": 1715284355
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 368,
+      "created_at": 1715284359,
+      "shares": [
+        "NYC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 369,
+      "created_at": 1715284383,
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 370,
+      "created_at": 1715284394,
+      "shares": [
+        "IC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 371,
+      "created_at": 1715284403
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 372,
+      "created_at": 1715284412,
+      "shares": [
+        "GT_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 373,
+      "created_at": 1715284424
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 374,
+      "created_at": 1715284443,
+      "shares": [
+        "B&O_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 375,
+      "created_at": 1715284449,
+      "shares": [
+        "PRR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 376,
+      "created_at": 1715284458,
+      "shares": [
+        "ERIE_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 377,
+      "created_at": 1715284469,
+      "shares": [
+        "GT_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 378,
+      "created_at": 1715284477,
+      "shares": [
+        "NYC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 379,
+      "created_at": 1715284515
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 380,
+      "created_at": 1715284518,
+      "shares": [
+        "IC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 381,
+      "created_at": 1715284526
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 382,
+      "created_at": 1715284536,
+      "shares": [
+        "GT_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 383,
+      "created_at": 1715284543,
+      "shares": [
+        "ERIE_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 384,
+      "created_at": 1715284550,
+      "shares": [
+        "B&O_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 385,
+      "created_at": 1715284567
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 386,
+      "created_at": 1715284571,
+      "shares": [
+        "ERIE_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 387,
+      "created_at": 1715284578,
+      "shares": [
+        "B&O_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 388,
+      "created_at": 1715284585,
+      "shares": [
+        "NYC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 389,
+      "created_at": 1715284611,
+      "shares": [
+        "ERIE_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 390,
+      "created_at": 1715284626,
+      "shares": [
+        "IC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 391,
+      "created_at": 1715284636,
+      "shares": [
+        "GT_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 392,
+      "created_at": 1715284683,
+      "corporation": "C&O",
+      "share_price": "100,0,10"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 393,
+      "created_at": 1715284697,
+      "shares": [
+        "GT_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 394,
+      "created_at": 1715284705,
+      "shares": [
+        "C&O_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 395,
+      "created_at": 1715284715,
+      "shares": [
+        "B&O_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 396,
+      "created_at": 1715284719,
+      "shares": [
+        "ERIE_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 397,
+      "created_at": 1715284724,
+      "shares": [
+        "ERIE_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 398,
+      "created_at": 1715284728,
+      "shares": [
+        "B&O_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 399,
+      "created_at": 1715287002,
+      "shares": [
+        "NYC_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 400,
+      "created_at": 1715287006,
+      "shares": [
+        "C&O_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 401,
+      "created_at": 1715287013,
+      "shares": [
+        "C&O_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 402,
+      "created_at": 1715287019,
+      "shares": [
+        "GT_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 403,
+      "created_at": 1715287029,
+      "shares": [
+        "ERIE_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 404,
+      "created_at": 1715287036,
+      "shares": [
+        "B&O_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 405,
+      "created_at": 1715287041,
+      "shares": [
+        "C&O_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 406,
+      "created_at": 1715287050,
+      "shares": [
+        "ERIE_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 407,
+      "created_at": 1715287057,
+      "shares": [
+        "C&O_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 408,
+      "created_at": 1715287095,
+      "shares": [
+        "B&O_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 409,
+      "created_at": 1715287101,
+      "shares": [
+        "C&O_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 410,
+      "created_at": 1715287108,
+      "shares": [
+        "GT_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 411,
+      "created_at": 1715287117,
+      "shares": [
+        "C&O_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 412,
+      "created_at": 1715287125,
+      "shares": [
+        "B&O_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 413,
+      "created_at": 1715287137,
+      "shares": [
+        "GT_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 414,
+      "created_at": 1715287153
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 415,
+      "created_at": 1715287162,
+      "shares": [
+        "GT_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 416,
+      "created_at": 1715287183,
+      "shares": [
+        "C&O_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 417,
+      "created_at": 1715287191,
+      "shares": [
+        "NYC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 418,
+      "created_at": 1715287213,
+      "shares": [
+        "ERIE_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 419,
+      "created_at": 1715287233,
+      "shares": [
+        "PRR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 420,
+      "created_at": 1715287251,
+      "shares": [
+        "NYC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 421,
+      "created_at": 1715287277
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 422,
+      "created_at": 1715287289,
+      "shares": [
+        "GT_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 423,
+      "created_at": 1715287296,
+      "shares": [
+        "C&O_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 424,
+      "created_at": 1715287318,
+      "shares": [
+        "ERIE_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 425,
+      "created_at": 1715287326,
+      "shares": [
+        "ERIE_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 426,
+      "created_at": 1715287342,
+      "shares": [
+        "PRR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 427,
+      "created_at": 1715287362,
+      "shares": [
+        "PRR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 428,
+      "created_at": 1715287367,
+      "shares": [
+        "NYC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 429,
+      "created_at": 1715287392,
+      "shares": [
+        "GT_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 430,
+      "created_at": 1715287398,
+      "shares": [
+        "B&O_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 431,
+      "created_at": 1715287411,
+      "shares": [
+        "NYC_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 432,
+      "created_at": 1715287417,
+      "shares": [
+        "B&O_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "undo",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 433,
+      "created_at": 1715287422
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 434,
+      "created_at": 1715287430,
+      "shares": [
+        "B&O_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 435,
+      "created_at": 1715287451,
+      "shares": [
+        "C&O_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 436,
+      "created_at": 1715287457,
+      "shares": [
+        "B&O_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 437,
+      "created_at": 1715287471,
+      "shares": [
+        "ERIE_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 438,
+      "created_at": 1715287480,
+      "shares": [
+        "C&O_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 439,
+      "created_at": 1715287502
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 440,
+      "created_at": 1715287510,
+      "shares": [
+        "B&O_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 441,
+      "created_at": 1715287538
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 442,
+      "created_at": 1715287555,
+      "shares": [
+        "B&O_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 443,
+      "created_at": 1715287567,
+      "shares": [
+        "PRR_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 444,
+      "created_at": 1715287590,
+      "shares": [
+        "PRR_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 445,
+      "created_at": 1715287609,
+      "shares": [
+        "C&O_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 446,
+      "created_at": 1715287616,
+      "shares": [
+        "PRR_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 447,
+      "created_at": 1715287620
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 448,
+      "created_at": 1715287661
+    },
+    {
+      "type": "undo",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 449,
+      "created_at": 1715287665
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 450,
+      "created_at": 1715287673
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 451,
+      "created_at": 1715287680,
+      "shares": [
+        "B&O_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 452,
+      "created_at": 1715287691
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 453,
+      "created_at": 1715287709,
+      "shares": [
+        "NYC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 454,
+      "created_at": 1715287763
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 455,
+      "created_at": 1715287775,
+      "shares": [
+        "NYC_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 456,
+      "created_at": 1715287795,
+      "shares": [
+        "C&O_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 457,
+      "created_at": 1715287816
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 458,
+      "created_at": 1715287843
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 459,
+      "created_at": 1715287854,
+      "shares": [
+        "ERIE_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 460,
+      "created_at": 1715287896,
+      "shares": [
+        "C&O_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 461,
+      "created_at": 1715287921
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 462,
+      "created_at": 1715287951,
+      "shares": [
+        "PRR_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 463,
+      "created_at": 1715287963
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 464,
+      "created_at": 1715287985,
+      "shares": [
+        "ERIE_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 465,
+      "created_at": 1715287996
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 466,
+      "created_at": 1715288011,
+      "shares": [
+        "PRR_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 467,
+      "created_at": 1715288021
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 468,
+      "created_at": 1715288026
+    },
+    {
+      "type": "undo",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 469,
+      "created_at": 1715288060
+    },
+    {
+      "type": "undo",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 470,
+      "created_at": 1715288064
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 471,
+      "created_at": 1715288072,
+      "shares": [
+        "C&O_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 472,
+      "created_at": 1715288089
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 473,
+      "created_at": 1715288093,
+      "shares": [
+        "NYC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 474,
+      "created_at": 1715288104,
+      "shares": [
+        "C&O_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 475,
+      "created_at": 1715288120
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 476,
+      "created_at": 1715288125,
+      "shares": [
+        "C&O_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 477,
+      "created_at": 1715288132,
+      "shares": [
+        "C&O_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 478,
+      "created_at": 1715288137
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 479,
+      "created_at": 1715288175
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 480,
+      "created_at": 1715288216,
+      "shares": [
+        "GT_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 481,
+      "created_at": 1715288221,
+      "shares": [
+        "NYC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 482,
+      "created_at": 1715288240,
+      "shares": [
+        "IC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 483,
+      "created_at": 1715288283,
+      "shares": [
+        "PRR_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 484,
+      "created_at": 1715288302,
+      "shares": [
+        "ERIE_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 485,
+      "created_at": 1715288307,
+      "shares": [
+        "ERIE_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 486,
+      "created_at": 1715288339,
+      "shares": [
+        "NYC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 487,
+      "created_at": 1715288353,
+      "shares": [
+        "PRR_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 488,
+      "created_at": 1715288358
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 489,
+      "created_at": 1715288420,
+      "shares": [
+        "ERIE_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 490,
+      "created_at": 1715288454
+    },
+    {
+      "type": "undo",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 491,
+      "created_at": 1715288478
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 492,
+      "created_at": 1715288495
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 493,
+      "created_at": 1715288497
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 494,
+      "created_at": 1715288499
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 495,
+      "created_at": 1715288504,
+      "shares": [
+        "NYC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 496,
+      "created_at": 1715288511,
+      "shares": [
+        "PRR_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 497,
+      "created_at": 1715288533,
+      "shares": [
+        "NYC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 498,
+      "created_at": 1715288548,
+      "shares": [
+        "PRR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 499,
+      "created_at": 1715288563,
+      "shares": [
+        "GT_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 500,
+      "created_at": 1715288567,
+      "shares": [
+        "IC_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 501,
+      "created_at": 1715288577,
+      "shares": [
+        "PRR_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 502,
+      "created_at": 1715288591
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 503,
+      "created_at": 1715288610
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 504,
+      "created_at": 1715288613,
+      "shares": [
+        "IC_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 505,
+      "created_at": 1715288645
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 506,
+      "created_at": 1715288650,
+      "shares": [
+        "NYC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 507,
+      "created_at": 1715288679
+    },
+    {
+      "type": "buy_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 508,
+      "created_at": 1715288690,
+      "shares": [
+        "NYC_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 509,
+      "created_at": 1715288708
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 510,
+      "created_at": 1715288718
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 511,
+      "created_at": 1715288723,
+      "shares": [
+        "NYC_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 512,
+      "created_at": 1715288728
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 513,
+      "created_at": 1715288749
+    },
+    {
+      "type": "pass",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 514,
+      "created_at": 1715288766
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 515,
+      "created_at": 1715288778
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 516,
+      "created_at": 1715288779
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 517,
+      "created_at": 1715288779
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 518,
+      "created_at": 1715288805,
+      "hex": "G17",
+      "tile": "8-8",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 519,
+      "created_at": 1715288809,
+      "hex": "H16",
+      "tile": "9-6",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 520,
+      "created_at": 1715288816
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 521,
+      "created_at": 1715288853,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "G9",
+              "H10",
+              "I11",
+              "H12"
+            ],
+            [
+              "J10",
+              "I9",
+              "H8",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "H12",
+            "G9",
+            "J10"
+          ],
+          "revenue": 140,
+          "revenue_str": "H12-G9-J10",
+          "nodes": [
+            "G9-0",
+            "H12-0",
+            "J10-0"
+          ]
+        },
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "G9",
+              "G11",
+              "F12",
+              "E13",
+              "D14"
+            ],
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "D6",
+              "E5",
+              "F6",
+              "G7"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "G9",
+            "G7",
+            "D6",
+            "C5"
+          ],
+          "revenue": 360,
+          "revenue_str": "C17-C15-D14-G9-G7-D6-C5 + E/W",
+          "nodes": [
+            "C15-0",
+            "C17-0",
+            "D14-0",
+            "G9-0",
+            "G7-0",
+            "D6-0",
+            "C5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 522,
+      "created_at": 1715288854,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 523,
+      "created_at": 1715288856,
+      "train": "6-3",
+      "price": 900,
+      "variant": "7/8"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 524,
+      "created_at": 1715288867,
+      "hex": "B16",
+      "tile": "619-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 525,
+      "created_at": 1715288875
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 526,
+      "created_at": 1715288920,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "D6",
+            "C5"
+          ],
+          "revenue": 310,
+          "revenue_str": "C17-C15-D14-D6-C5 + E/W",
+          "nodes": [
+            "C15-0",
+            "C17-0",
+            "D14-0",
+            "D6-2",
+            "C5-0"
+          ]
+        },
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G7",
+              "F6",
+              "E5",
+              "D6"
+            ],
+            [
+              "G9",
+              "G7"
+            ],
+            [
+              "E17",
+              "F16",
+              "F14",
+              "F12",
+              "G11",
+              "G9"
+            ],
+            [
+              "D14",
+              "E13",
+              "E15",
+              "E17"
+            ],
+            [
+              "C15",
+              "D14"
+            ],
+            [
+              "C15",
+              "B16"
+            ],
+            [
+              "B16",
+              "B18"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "G7",
+            "G9",
+            "E17",
+            "D14",
+            "C15",
+            "B16",
+            "B18"
+          ],
+          "revenue": 300,
+          "revenue_str": "D6-(G7)-G9-E17-D14-C15-B16-B18",
+          "nodes": [
+            "G7-0",
+            "D6-0",
+            "G9-0",
+            "E17-0",
+            "D14-0",
+            "C15-0",
+            "B16-0",
+            "B18-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 527,
+      "created_at": 1715288921,
+      "kind": "withhold"
+    },
+    {
+      "type": "sell_shares",
+      "entity": "C&O",
+      "entity_type": "corporation",
+      "id": 528,
+      "created_at": 1715288925,
+      "shares": [
+        "C&O_8"
+      ],
+      "percent": 10,
+      "share_price": 10
+    },
+    {
+      "type": "lay_tile",
+      "entity": "C&O",
+      "entity_type": "corporation",
+      "id": 529,
+      "created_at": 1715288933,
+      "hex": "H14",
+      "tile": "8-9",
+      "rotation": 3
+    },
+    {
+      "type": "undo",
+      "entity": "C&O",
+      "entity_type": "corporation",
+      "id": 530,
+      "created_at": 1715288939
+    },
+    {
+      "type": "pass",
+      "entity": "C&O",
+      "entity_type": "corporation",
+      "id": 531,
+      "created_at": 1715288943
+    },
+    {
+      "type": "undo",
+      "entity": "C&O",
+      "entity_type": "corporation",
+      "id": 532,
+      "created_at": 1715288947
+    },
+    {
+      "type": "place_token",
+      "entity": "C&O",
+      "entity_type": "corporation",
+      "id": 533,
+      "created_at": 1715288956,
+      "city": "293-0-0",
+      "slot": 0,
+      "tokener": "C&O"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "C&O",
+      "entity_type": "corporation",
+      "id": 534,
+      "created_at": 1715288959,
+      "hex": "H12",
+      "tile": "294-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "C&O",
+      "entity_type": "corporation",
+      "id": 535,
+      "created_at": 1715288962
+    },
+    {
+      "type": "buy_train",
+      "entity": "C&O",
+      "entity_type": "corporation",
+      "id": 536,
+      "created_at": 1715288963,
+      "train": "6-4",
+      "price": 800,
+      "variant": "6"
+    },
+    {
+      "type": "pass",
+      "entity": "C&O",
+      "entity_type": "corporation",
+      "id": 537,
+      "created_at": 1715288965
+    },
+    {
+      "type": "pass",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 538,
+      "created_at": 1715288969
+    },
+    {
+      "type": "run_routes",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 539,
+      "created_at": 1715288971,
+      "routes": [
+        {
+          "train": "5-3",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "E11",
+              "D12",
+              "D14"
+            ],
+            [
+              "D6",
+              "E5",
+              "E7",
+              "D8",
+              "D10",
+              "E11"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "E11",
+            "D6",
+            "C5"
+          ],
+          "revenue": 260,
+          "revenue_str": "C17-C15-(D14)-E11-(D6)-C5 + E/W",
+          "nodes": [
+            "C15-0",
+            "C17-0",
+            "D14-0",
+            "E11-0",
+            "D6-0",
+            "C5-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PRR",
+      "entity_type": "corporation",
+      "id": 540,
+      "created_at": 1715288973,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 541,
+      "created_at": 1715288983
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 542,
+      "created_at": 1715288987,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "D14"
+            ],
+            [
+              "D20",
+              "E19",
+              "E17"
+            ],
+            [
+              "D22",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "C15",
+            "D14",
+            "E17",
+            "D20",
+            "D22"
+          ],
+          "revenue": 210,
+          "revenue_str": "C15-D14-E17-(D20)-D22",
+          "nodes": [
+            "D14-0",
+            "C15-0",
+            "E17-0",
+            "D20-0",
+            "D22-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYC",
+      "entity_type": "corporation",
+      "id": 543,
+      "created_at": 1715288990,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 544,
+      "created_at": 1715289002,
+      "hex": "H2",
+      "tile": "8-9",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 545,
+      "created_at": 1715289013
+    },
+    {
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 546,
+      "created_at": 1715289025,
+      "action_id": 543
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 547,
+      "created_at": 1715289034,
+      "hex": "F14",
+      "tile": "24-2",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 548,
+      "created_at": 1715289040,
+      "hex": "H2",
+      "tile": "8-9",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 549,
+      "created_at": 1715289044
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 550,
+      "created_at": 1715289068,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "G9",
+              "G11",
+              "F12",
+              "E13",
+              "D14"
+            ],
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "D6",
+              "E5",
+              "F6",
+              "G7"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "G9",
+            "G7",
+            "D6",
+            "C5"
+          ],
+          "revenue": 360,
+          "revenue_str": "C17-C15-D14-G9-G7-D6-C5 + E/W",
+          "nodes": [
+            "C15-0",
+            "C17-0",
+            "D14-0",
+            "G9-0",
+            "G7-0",
+            "D6-0",
+            "C5-0"
+          ]
+        },
+        {
+          "train": "6-3",
+          "connections": [
+            [
+              "G19",
+              "G21"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ],
+            [
+              "G13",
+              "F14",
+              "F16",
+              "E17"
+            ],
+            [
+              "H12",
+              "G13"
+            ],
+            [
+              "G9",
+              "H10",
+              "I11",
+              "H12"
+            ],
+            [
+              "J10",
+              "I9",
+              "H8",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "G21",
+            "G19",
+            "E17",
+            "G13",
+            "H12",
+            "G9",
+            "J10"
+          ],
+          "revenue": 330,
+          "revenue_str": "G21-G19-E17-G13-H12-G9-J10",
+          "nodes": [
+            "G19-0",
+            "G21-0",
+            "E17-0",
+            "G13-0",
+            "H12-0",
+            "G9-0",
+            "J10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 551,
+      "created_at": 1715289069,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 552,
+      "created_at": 1715289076,
+      "shares": [
+        "GT_1",
+        "GT_3",
+        "GT_6",
+        "GT_2",
+        "GT_5"
+      ],
+      "percent": 50,
+      "share_price": 30
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 553,
+      "created_at": 1715289090,
+      "hex": "G7",
+      "tile": "14-2",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 554,
+      "created_at": 1715289093
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 555,
+      "created_at": 1715289095,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "C15",
+              "C17"
+            ],
+            [
+              "D14",
+              "C13",
+              "C15"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10",
+              "D12",
+              "D14"
+            ],
+            [
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "C17",
+            "C15",
+            "D14",
+            "D6",
+            "C5"
+          ],
+          "revenue": 310,
+          "revenue_str": "C17-C15-D14-D6-C5 + E/W",
+          "nodes": [
+            "C15-0",
+            "C17-0",
+            "D14-0",
+            "D6-2",
+            "C5-0"
+          ]
+        },
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G7",
+              "F6",
+              "E5",
+              "D6"
+            ],
+            [
+              "G9",
+              "G7"
+            ],
+            [
+              "E17",
+              "F16",
+              "F14",
+              "F12",
+              "G11",
+              "G9"
+            ],
+            [
+              "D14",
+              "E13",
+              "E15",
+              "E17"
+            ],
+            [
+              "C15",
+              "D14"
+            ],
+            [
+              "C15",
+              "B16"
+            ],
+            [
+              "B16",
+              "B18"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "G7",
+            "G9",
+            "E17",
+            "D14",
+            "C15",
+            "B16",
+            "B18"
+          ],
+          "revenue": 300,
+          "revenue_str": "D6-G7-G9-E17-D14-C15-(B16)-B18",
+          "nodes": [
+            "G7-0",
+            "D6-0",
+            "G9-0",
+            "E17-0",
+            "D14-0",
+            "C15-0",
+            "B16-0",
+            "B18-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 556,
+      "created_at": 1715289096,
+      "kind": "withhold"
+    },
+    {
+      "type": "run_routes",
+      "entity": "C&O",
+      "entity_type": "corporation",
+      "id": 557,
+      "created_at": 1715289116,
+      "routes": [],
+      "extra_revenue": 0
+    },
+    {
+      "type": "sell_shares",
+      "entity": 4,
+      "entity_type": "player",
+      "id": 558,
+      "created_at": 1715289130,
+      "shares": [
+        "GT_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 559,
+      "created_at": 1715289146,
+      "shares": [
+        "GT_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 560,
+      "created_at": 1715289151,
+      "shares": [
+        "IC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 561,
+      "created_at": 1715289163
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 562,
+      "created_at": 1715289166,
+      "shares": [
+        "IC_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 563,
+      "created_at": 1715289173
+    },
+    {
+      "type": "sell_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 564,
+      "created_at": 1715289178,
+      "shares": [
+        "GT_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 565,
+      "created_at": 1715289187,
+      "shares": [
+        "IC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 566,
+      "created_at": 1715289191,
+      "shares": [
+        "IC_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 567,
+      "created_at": 1715289194
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 568,
+      "created_at": 1715289196,
+      "shares": [
+        "IC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 569,
+      "created_at": 1715289200,
+      "shares": [
+        "IC_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 570,
+      "created_at": 1715289203
+    },
+    {
+      "type": "buy_shares",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 571,
+      "created_at": 1715289206,
+      "shares": [
+        "IC_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 572,
+      "created_at": 1715289209,
+      "shares": [
+        "IC_0"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3,
+      "entity_type": "player",
+      "id": 573,
+      "created_at": 1715289213
+    },
+    {
+      "type": "pass",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 574,
+      "created_at": 1715289215
+    },
+    {
+      "type": "pass",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 575,
+      "created_at": 1715289217
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 576,
+      "created_at": 1715289224
+    },
+    {
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 577,
+      "created_at": 1715289236,
+      "action_id": 575
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 578,
+      "created_at": 1715289247,
+      "hex": "G5",
+      "tile": "25-0",
+      "rotation": 0
+    },
+    {
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 579,
+      "created_at": 1715289267
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 580,
+      "created_at": 1715289278
+    },
+    {
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 581,
+      "created_at": 1715289313,
+      "action_id": 575
+    },
+    {
+      "type": "place_token",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 582,
+      "created_at": 1715289319,
+      "city": "298-0-2",
+      "slot": 0,
+      "tokener": "IC"
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 583,
+      "created_at": 1715289324
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 584,
+      "created_at": 1715289357,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G19",
+              "G21"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ],
+            [
+              "G13",
+              "F14",
+              "F16",
+              "E17"
+            ],
+            [
+              "H12",
+              "G13"
+            ],
+            [
+              "G9",
+              "H10",
+              "I11",
+              "H12"
+            ],
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "I1",
+              "H2",
+              "H4",
+              "G5",
+              "F4",
+              "F6",
+              "G7"
+            ]
+          ],
+          "hexes": [
+            "G21",
+            "G19",
+            "E17",
+            "G13",
+            "H12",
+            "G9",
+            "G7",
+            "I1"
+          ],
+          "revenue": 380,
+          "revenue_str": "G21-G19-E17-(G13)-H12-G9-G7-I1 + E/W",
+          "nodes": [
+            "G19-0",
+            "G21-0",
+            "E17-0",
+            "G13-0",
+            "H12-0",
+            "G9-0",
+            "G7-0",
+            "I1-0"
+          ]
+        },
+        {
+          "train": "6-3",
+          "connections": [
+            [
+              "D6",
+              "C5"
+            ],
+            [
+              "E11",
+              "D10",
+              "D8",
+              "D6"
+            ],
+            [
+              "D14",
+              "D12",
+              "E11"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "D14"
+            ],
+            [
+              "D20",
+              "E19",
+              "E17"
+            ],
+            [
+              "D22",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "C5",
+            "D6",
+            "E11",
+            "D14",
+            "E17",
+            "D20",
+            "D22"
+          ],
+          "revenue": 360,
+          "revenue_str": "C5-D6-E11-D14-E17-D20-D22 + E/W",
+          "nodes": [
+            "D6-2",
+            "C5-0",
+            "E11-0",
+            "D14-0",
+            "E17-0",
+            "D20-0",
+            "D22-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 585,
+      "created_at": 1715289358,
+      "kind": "withhold"
+    },
+    {
+      "type": "place_token",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 586,
+      "created_at": 1715289373,
+      "city": "297-1-0",
+      "slot": 0,
+      "tokener": "IC"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 587,
+      "created_at": 1715289382,
+      "hex": "E17",
+      "tile": "290-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 588,
+      "created_at": 1715289386
+    },
+    {
+      "type": "run_routes",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 589,
+      "created_at": 1715289388,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G19",
+              "G21"
+            ],
+            [
+              "E17",
+              "F18",
+              "G19"
+            ],
+            [
+              "G13",
+              "F14",
+              "F16",
+              "E17"
+            ],
+            [
+              "H12",
+              "G13"
+            ],
+            [
+              "G9",
+              "H10",
+              "I11",
+              "H12"
+            ],
+            [
+              "G7",
+              "G9"
+            ],
+            [
+              "I1",
+              "H2",
+              "H4",
+              "G5",
+              "F4",
+              "F6",
+              "G7"
+            ]
+          ],
+          "hexes": [
+            "G21",
+            "G19",
+            "E17",
+            "G13",
+            "H12",
+            "G9",
+            "G7",
+            "I1"
+          ],
+          "revenue": 390,
+          "revenue_str": "G21-G19-E17-(G13)-H12-G9-G7-I1 + E/W",
+          "nodes": [
+            "G19-0",
+            "G21-0",
+            "E17-0",
+            "G13-0",
+            "H12-0",
+            "G9-0",
+            "G7-0",
+            "I1-0"
+          ]
+        },
+        {
+          "train": "6-3",
+          "connections": [
+            [
+              "D6",
+              "C5"
+            ],
+            [
+              "E11",
+              "D10",
+              "D8",
+              "D6"
+            ],
+            [
+              "D14",
+              "D12",
+              "E11"
+            ],
+            [
+              "E17",
+              "E15",
+              "E13",
+              "D14"
+            ],
+            [
+              "D20",
+              "E19",
+              "E17"
+            ],
+            [
+              "D22",
+              "D20"
+            ]
+          ],
+          "hexes": [
+            "C5",
+            "D6",
+            "E11",
+            "D14",
+            "E17",
+            "D20",
+            "D22"
+          ],
+          "revenue": 370,
+          "revenue_str": "C5-D6-E11-D14-E17-D20-D22 + E/W",
+          "nodes": [
+            "D6-2",
+            "C5-0",
+            "E11-0",
+            "D14-0",
+            "E17-0",
+            "D20-0",
+            "D22-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 590,
+      "created_at": 1716867963,
+      "kind": "withhold"
+    },
+    {
+      "type": "undo",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 591,
+      "created_at": 1716868214
+    },
+    {
+      "type": "dividend",
+      "entity": "IC",
+      "entity_type": "corporation",
+      "id": 592,
+      "created_at": 1716868261,
+      "kind": "withhold"
+    }
+  ],
+  "id": "hs_wbpewgex_1715274627",
+  "players": [
+    {
+      "name": "Backward",
+      "id": 0
+    },
+    {
+      "name": "Holder",
+      "id": 1
+    },
+    {
+      "name": "Withholder",
+      "id": 2
+    },
+    {
+      "name": "Fraidy Cat",
+      "id": 3
+    },
+    {
+      "name": "Grumbly",
+      "id": 4
+    }
+  ],
+  "title": "1846",
+  "description": "What if everything closes",
+  "min_players": "5",
+  "max_players": "5",
+  "settings": {
+    "optional_rules": [],
+    "seed": ""
+  },
+  "mode": "hotseat",
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "created_at": "2024-05-27",
+  "loaded": true,
+  "result": {
+    "0": 6,
+    "1": 103,
+    "2": 13,
+    "3": 64,
+    "4": 18
+  },
+  "manually_ended": false,
+  "turn": 5,
+  "round": "Operating Round",
+  "acting": [
+    2,
+    3,
+    4,
+    0,
+    1
+  ],
+  "updated_at": 1716868261
+}


### PR DESCRIPTION
Addresses #10743 where minors and private companies have all closed. There is still an outstanding issue when some private companies (but not minors) are still open and should eventually drain the bank, but the engine just hangs.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

The game end check is added to the base code, but not to the default conditions. While it is applicable to other games where corporations can be closed, I'm not confident enough that the implementation of `all_closed?` here would be universal, so it's only in 1846 for now.