### PR TITLE
[1860] implements simplified insolvency variant

### DIFF
--- a/lib/engine/game/g_1860/meta.rb
+++ b/lib/engine/game/g_1860/meta.rb
@@ -30,6 +30,11 @@ module Engine
             desc: 'Use the original (first edition) insolvency rules',
           },
           {
+            sym: :simplified_insolvency,
+            short_name: 'Simplified insolvency',
+            desc: 'Insolvent corporations run trains for fixed amounts',
+          },
+          {
             sym: :no_skip_towns,
             short_name: 'No skipping towns',
             desc: "Use the original (first edition) town rules - they can't be skipped on runs",
@@ -50,6 +55,16 @@ module Engine
             desc: 'Shares of unoperated corps sell for full value',
           },
         ].freeze
+
+        def self.check_options(options, _min_players, _max_players)
+          optional_rules = (options || []).map(&:to_sym)
+
+          if optional_rules.include?(:simplified_insolvency) &&
+             (optional_rules.include?(:original_insolvency) ||
+              optional_rules.include?(:original_game))
+            { error: "Can't combine Simplified Insolvency with Original Insolvency or First edition rules" }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #9484


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Implements the simplified insolvency rules from the game rules.

### Screenshots

### Any Assumptions / Hacks
