### PR TITLE
[18Mag] Prevent selecting both New Minors variants

### DIFF
--- a/lib/engine/game/g_18_mag/meta.rb
+++ b/lib/engine/game/g_18_mag/meta.rb
@@ -51,6 +51,15 @@ module Engine
                  'The chosen supporter may be used once per OR to benefit one of that player\'s minor companies (3-6 players)',
          },
         ].freeze
+
+        def self.check_options(options, _min_players, _max_players)
+          optional_rules = (options || []).map(&:to_sym)
+
+          if optional_rules.include?(:new_minors_challenge) &&
+             optional_rules.include?(:new_minors_simple)
+            { error: "Can't use both 'New minors' options together." }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #9668

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
The two New Minors variants are incompatible with each other. This tweak prevents players from creating a game with both variants selected.
### Screenshots

### Any Assumptions / Hacks
