### PR TITLE
[18Mag] restricts expansion content to 3+ players

### DIFF
--- a/lib/engine/game/g_18_mag/meta.rb
+++ b/lib/engine/game/g_18_mag/meta.rb
@@ -33,22 +33,26 @@ module Engine
            sym: :new_minors_challenge,
            short_name: 'New minors - challenging',
            desc: 'Minors 14, 15, 16 are added to the game (3-6 players)',
+           players: [3, 4, 5, 6],
          },
          {
            sym: :new_minors_simple,
            short_name: 'New minors - simple',
            desc: 'Minors 14, 15, 16 are added and three random minors are removed at setup (3-6 players)',
+           players: [3, 4, 5, 6],
          },
          {
            sym: :new_major,
            short_name: 'New major',
            desc: 'Major CIWL is added. The new major grants a bonus for running red to red routes (3-6 players)',
+           players: [3, 4, 5, 6],
          },
          {
            sym: :supporters,
            short_name: 'Add Supporter Cards',
            desc: 'Players may choose one of six "supporter cards" as an optional action in the first SR. '\
                  'The chosen supporter may be used once per OR to benefit one of that player\'s minor companies (3-6 players)',
+           players: [3, 4, 5, 6],
          },
         ].freeze
       end

--- a/lib/engine/game/g_18_mag/meta.rb
+++ b/lib/engine/game/g_18_mag/meta.rb
@@ -32,26 +32,26 @@ module Engine
          {
            sym: :new_minors_challenge,
            short_name: 'New minors - challenging',
-           desc: 'Minors 14, 15, 16 are added to the game (3-6 players)',
+           desc: 'Minors 14, 15, 16 are added to the game',
            players: [3, 4, 5, 6],
          },
          {
            sym: :new_minors_simple,
            short_name: 'New minors - simple',
-           desc: 'Minors 14, 15, 16 are added and three random minors are removed at setup (3-6 players)',
+           desc: 'Minors 14, 15, 16 are added and three random minors are removed at setup',
            players: [3, 4, 5, 6],
          },
          {
            sym: :new_major,
            short_name: 'New major',
-           desc: 'Major CIWL is added. The new major grants a bonus for running red to red routes (3-6 players)',
+           desc: 'Major CIWL is added. The new major grants a bonus for running red to red routes',
            players: [3, 4, 5, 6],
          },
          {
            sym: :supporters,
            short_name: 'Add Supporter Cards',
            desc: 'Players may choose one of six "supporter cards" as an optional action in the first SR. '\
-                 'The chosen supporter may be used once per OR to benefit one of that player\'s minor companies (3-6 players)',
+                 'The chosen supporter may be used once per OR to benefit one of that player\'s minor companies.',
            players: [3, 4, 5, 6],
          },
         ].freeze


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

The expansion content is restricted to 3-6 players, but currently the site allows you to create 2-player games using expansion content. Some of these do not work and throw out errors. 

This update will prevent 2 player games from being started with those options enabled.

### Screenshots

### Any Assumptions / Hacks
