### PR TITLE
[1866] Palace Car shouldn't work with E-trains

### DIFF
--- a/lib/engine/game/g_1866/game.rb
+++ b/lib/engine/game/g_1866/game.rb
@@ -72,13 +72,14 @@ module Engine
           'formation' => ['Formation', 'Forced formation of Major Nationals. Order of forming is: '\
                                        'Switzerland, Spain, Benelux, Austro-Hungarian Empire, Italy, France, '\
                                        'Germany, Great Britain.'],
-          'infrastructure_h' => ['Transit Hub', 'The H, transit hub infrastructure, will be available for purchase. '\
-                                                'The transit hub, gives one tokened city value to the treasury '\
-                                                '(when included on a route).'],
-          'infrastructure_p' => ['Palace Car', 'The P, palace car infrastructure, will be available for purchase. '\
-                                               'The palace car counts 10 for each town for one train, paid to the treasury.'],
-          'infrastructure_m' => ['Mail', 'The M, mail infrastructure, will be available for purchase. The mail, counts '\
-                                         'the sum value of the start and end locations of a route to the treasury.'],
+          'infrastructure_h' => ['Transit Hub', 'Transit Hub Infrastructure available for purchase. '\
+                                                'The Transit Hub (H) gives the value of one tokened city on the '\
+                                                'route to the treasury.'],
+          'infrastructure_p' => ['Palace Car', 'Palace Car Infrastructure available for purchase. '\
+                                               'The palace car gives £10 to the corporate treasury for each town '\
+                                               'visited by one train. Does not work with E-trains.'],
+          'infrastructure_m' => ['Mail', 'Mail infrastructure available for purchase. The Mail counts the sum value of the '\
+                                         'start and end tokened cities of a route and gives this value to the treasury.'],
         }.freeze
 
         MARKET_TEXT = Base::MARKET_TEXT.merge(par_overlap: 'Minor nationals',
@@ -1484,14 +1485,15 @@ module Engine
           end
 
           if entity.trains.any? { |t| t.name == self.class::INFRASTRUCTURE_HUB }
-            help << 'The H, transit hub, gives one tokened city value to the treasury (when included on a route)'
+            help << 'The Transit Hub (H) gives the value of one tokened city on the route to the treasury.'
           end
           if entity.trains.any? { |t| t.name == self.class::INFRASTRUCTURE_PALACE }
-            help << 'The P, palace car, counts 10 for each city for one train, paid to the treasury'
+            help << 'The Palace Car (P) gives £10 to the treasury for each town visited by one train. '\
+                    'Does not work with E-trains.'
           end
           if entity.trains.any? { |t| t.name == self.class::INFRASTRUCTURE_MAIL }
-            help << 'The M, mail, counts the sum value of the start and end tokened city value of a route '\
-                    'to the treasury'
+            help << 'The Mail (M) counts the sum value of the start and end tokened cities of a route and gives '\
+                    'this value to the treasury.'
           end
 
           help << 'Obsolete trains only runs for ½ revenue.' if runnable_trains.any?(&:obsolete)
@@ -1667,19 +1669,19 @@ module Engine
         end
 
         def event_infrastructure_h!
-          @log << '-- Event: The H, transit hub infrastructure, will be available for purchase --'
+          @log << '-- Event: Transit Hub Infrastructure available for purchase --'
 
           @depot_infrastructures.concat(@infrastructure_trains_h)
         end
 
         def event_infrastructure_m!
-          @log << '-- Event: The M, mail infrastructure, will be available for purchase --'
+          @log << '-- Event: Mail Infrastructure available for purchase --'
 
           @depot_infrastructures.concat(@infrastructure_trains_m)
         end
 
         def event_infrastructure_p!
-          @log << '-- Event: The P, palace car infrastructure, will be available for purchase --'
+          @log << '-- Event: Palace Car Infrastructure available for purchase --'
 
           @depot_infrastructures.concat(@infrastructure_trains_p)
         end
@@ -1805,7 +1807,7 @@ module Engine
             stops.each do |stop|
               next unless stop
 
-              palace_car_revenue += 10 if stop.town?
+              palace_car_revenue += 10 if stop.town? && !e_train?(train)
               next if !stop.city? || !stop.tokened_by?(entity)
 
               stop_base_revenue = stop.route_base_revenue(phase, train)
@@ -1844,6 +1846,10 @@ module Engine
 
         def infrastructure_train?(train)
           self.class::INFRASTRUCTURE_TRAINS.include?(train.name)
+        end
+
+        def e_train?(train)
+          self.class::E_TRAINS.include?(train.name)
         end
 
         def init_scenario(optional_rules)


### PR DESCRIPTION
Fixes #10481

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

**This will absolutely require pins, as it will drastically change the treasury of any corps that were running Palace Cars on E-trains.**

### Explanation of Change

As per section 2.6 of the rules, the Palace Car doesn't apply its bonus to E-Trains

![image](https://github.com/tobymao/18xx/assets/26125362/39e1b056-7020-4496-86d0-6f68d9801485)

I fixed this by adding the `e_train?(train)` method on lines 1851-1853, and then calling it on line 1810.

I also made some grammatical improvements to the description and events related to infrastructure.

### Screenshots

### Any Assumptions / Hacks
