### PR TITLE
[18RoyalGorge] bug fixes for DEBT and US Mint Worker (B6)

### DIFF
--- a/assets/app/view/game/button/buy_share.rb
+++ b/assets/app/view/game/button/buy_share.rb
@@ -28,7 +28,7 @@ module View
           reduced_price = @game.format_currency(bundle.price - @swap_share.price) if @swap_share
           if step.respond_to?(:modify_purchase_price)
             modified_price = step.modify_purchase_price(bundle)
-            modified_price = nil if bundle.price == modified_price
+            modified_price = nil if bundle.price == modified_price * bundle.num_shares
           end
 
           text = @prefix.to_s
@@ -38,7 +38,7 @@ module View
           text += ' Preferred' if @share.preferred
           text += ' Share'
           text += " (#{reduced_price} + #{@swap_share.percent}% Share)" if @swap_share
-          text += " (#{@game.format_currency(modified_price)})" if modified_price
+          text += " (#{@game.format_currency(modified_price * bundle.num_shares)})" if modified_price
           text += " for #{@purchase_for.name}" if @purchase_for
 
           process_buy = lambda do

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -546,6 +546,8 @@ module Engine
         end
 
         def or_round_finished
+          return unless @treaty_of_boston
+
           # debt increases
           old_price = @debt_corp.share_price
           @stock_market.move_right(@debt_corp)

--- a/lib/engine/game/g_18_royal_gorge/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/buy_sell_par_shares.rb
@@ -61,7 +61,7 @@ module Engine
             (1..2).map do |num_shares|
               shares = corp_shares.take(num_shares)
               bundle = ShareBundle.new(shares)
-              @_modify_purchase_price[bundle] = (bundle.price / 2.0).ceil
+              @_modify_purchase_price[bundle] = (bundle.price_per_share / 2.0).ceil
               [@game.mint_worker, bundle]
             end
           end


### PR DESCRIPTION
* only increase DEBT after Treaty of Boston

* fix US Mint Worker (B6)'s discount when buying 2 shares

    * the `modify_purchase_price` method actually affects the per-share price
      of the bundle, not the overall bundle price, so it didn't work with B6's
      two-share bundle

    * change the `buy_share` button to display the `modified_price` times the
      number of shares to given the total modified bundle price

Fixes #10838 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`