### PR TITLE
[1822] Implement 1822+ variants for no removals and single stack

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -651,7 +651,7 @@ module Engine
             return "Bid box #{index + 1}" if c == company
           end
 
-          if optional_plus_expansion?
+          if optional_plus_expansion? && !optional_plus_expansion_single_stack?
             bidbox_privates.each do |c|
               next unless c == company
 
@@ -1176,7 +1176,7 @@ module Engine
           concessions = timeline_companies(self.class::COMPANY_CONCESSION_PREFIX, bidbox_concessions)
           timeline << "Concessions: #{concessions.join(', ')}" unless concessions.empty?
 
-          if optional_plus_expansion?
+          if optional_plus_expansion? && !optional_plus_expansion_single_stack?
             b1_privates = timeline_companies_plus(self.class::COMPANY_PRIVATE_PREFIX,
                                                   self.class::PLUS_EXPANSION_BIDBOX_1)
             timeline << "Privates bidbox 1 : #{b1_privates.join(', ')}" unless b1_privates.empty?
@@ -1331,7 +1331,7 @@ module Engine
         end
 
         def bidbox_privates
-          if optional_plus_expansion?
+          if optional_plus_expansion? && !optional_plus_expansion_single_stack?
             companies = bank_companies(self.class::COMPANY_PRIVATE_PREFIX)
             privates = []
             privates << companies.find { |c| self.class::PLUS_EXPANSION_BIDBOX_1.include?(c.id) }
@@ -1751,6 +1751,14 @@ module Engine
           @optional_rules&.include?(:plus_expansion)
         end
 
+        def optional_plus_expansion_no_removals?
+          @optional_rules&.include?(:plus_expansion_no_removals)
+        end
+
+        def optional_plus_expansion_single_stack?
+          @optional_rules&.include?(:plus_expansion_single_stack)
+        end
+
         def payoff_player_loan(player)
           # Pay full or partial of the player loan. The money from loans is outside money, doesnt count towards
           # the normal bank money.
@@ -2016,7 +2024,7 @@ module Engine
           privates.unshift(p1)
 
           # If have have activated 1822+, 3 companies will be removed from the game
-          if optional_plus_expansion?
+          if optional_plus_expansion? && !optional_plus_expansion_no_removals?
             # Make sure we have correct order of the bidboxes
             bid_box_1 = privates.map { |c| c if self.class::PLUS_EXPANSION_BIDBOX_1.include?(c.id) }.compact
             bid_box_2 = privates.map { |c| c if self.class::PLUS_EXPANSION_BIDBOX_2.include?(c.id) }.compact

--- a/lib/engine/game/g_1822/meta.rb
+++ b/lib/engine/game/g_1822/meta.rb
@@ -41,10 +41,21 @@ module Engine
                   '(bidbox 2) and other (bidbox 3) stacks.',
           },
           {
+            sym: :plus_expansion_no_removals,
+            short_name: 'No Removals',
+            desc: '(1822+) Use all 21 private companies instead of removing 3. ',
+          },
+          {
+            sym: :plus_expansion_single_stack,
+            short_name: 'Single Stack',
+            desc: '(1822+) The privates are not categorized, and fill the 3 bidboxes as in base 1822.',
+          },
+          {
             sym: :tax_haven_multiple,
             short_name: 'Tax Haven Variant',
             desc: 'P16 (Tax Haven) can use the cash it accumulates to buy 1 share per SR. Cannot '\
-                  'own multiple shares of one corporation.',
+                  'own multiple shares of one corporation. To ensure P16 is present in 1822+, use '\
+                  'the "No Removals" variant.',
           },
         ].freeze
       end


### PR DESCRIPTION
These are official variants found on page 29, section 12.6 in the 2020 1822 rulebook

Fixes #9808 by way of providing an officially endorsed variant combo that gets the desired outcome


<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`