### PR TITLE
[1822PNW] prevent brown town tiles from upgrading to the Boom Town tile

### DIFF
--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -950,7 +950,9 @@ module Engine
         def upgrades_to?(from, to, special = false, selected_company: nil)
           return true if legal_city_and_town_tile(from.hex, to) && from.color == :white
           return true if from.color == :blue && to.color == :blue
-          return to.name == 'PNW3' if boomtown_company?(selected_company)
+          if to.name == 'PNW3' || boomtown_company?(selected_company)
+            return to.name == 'PNW3' && boomtown_company?(selected_company)
+          end
           return from.color == :brown if to.name == 'PNW4'
           return to.name == 'PNW5' if from.name == 'PNW4'
           return tokencity_upgrades_to?(from, to) if tokencity?(from.hex)


### PR DESCRIPTION
Fixes #10758

Pins needed if anyone got away with upgrading to the boom town tile without the private.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`