### PR TITLE
[18Uruguay] Corrected the forced train purchase after nationalization

### DIFF
--- a/lib/engine/game/g_18_uruguay/step/buy_train.rb
+++ b/lib/engine/game/g_18_uruguay/step/buy_train.rb
@@ -60,7 +60,7 @@ module Engine
           end
 
           def must_take_loan?(corporation)
-            return false if corporation == @game.rptla
+            return false if corporation == @game.rptla || @game.nationalized?
 
             price = cheapest_train_price(corporation)
             @game.buying_power(corporation) < price
@@ -91,7 +91,7 @@ module Engine
             price = action.price
             remaining = price - buying_power(entity)
             ebuy = must_buy_train?(entity) && remaining.positive? && entity != @game.rptla
-            @game.perform_ebuy_loans(entity, remaining) if ebuy
+            @game.perform_ebuy_loans(entity, remaining) if ebuy && !@game.nationalized?
             @round.loan_taken = true if ebuy
             @game.close_rptla_private! if entity == @game.rptla && action.train.name != '2'
 
@@ -124,6 +124,8 @@ module Engine
           end
 
           def buyable_trains_others(trains)
+            return trains.select { |train| train.owner == @game.depot } if current_entity.cash.zero?
+
             trains.reject { |train| train.name == '7' }
           end
 

--- a/lib/engine/game/g_18_uruguay/trains.rb
+++ b/lib/engine/game/g_18_uruguay/trains.rb
@@ -118,11 +118,6 @@ module Engine
                 ],
                 price: 850,
               },
-              {
-                name: 'Ship 8',
-                distance: 2,
-                price: 850,
-              },
             ],
           },
         ].freeze


### PR DESCRIPTION
[18Uruguay] Corrected the forced train purchase after nationalization

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
