### PR TITLE
[1822PNW] create placeholder company to occupy empty bid boxes

### DIFF
--- a/lib/engine/game/g_1822_pnw/round/stock.rb
+++ b/lib/engine/game/g_1822_pnw/round/stock.rb
@@ -25,6 +25,12 @@ module Engine
           def sold_out_stock_movement(corp)
             @game.stock_market.move_right(corp)
           end
+
+          def remove_minor_and_first_train(company)
+            return if @game.empty_bidbox_minor?(company)
+
+            super
+          end
         end
       end
     end


### PR DESCRIPTION
When an associated Minor is removed from a bid box because its associated Major is started directly, a placeholder company is used to fill the bidbox, and is cleaned up at the end of the stock round.

Fixes #10525 and #10609, where an associated Minor was removed from bid box 1, and the Minor in bid box 2 received no bids and caused a train to export as if it had been in bid box 1.

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`