### PR TITLE
[18RoyalGorge] mark gold icons as not preprinted

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -863,10 +863,16 @@ module Engine
               hex = action.hex
 
               hex.original_tile.icons.each do |icon|
-                if icon.name == 'mine'
-                  action.hex.tile.icons << Part::Icon.new('../icons/18_royal_gorge/gold_cube', 'gold')
-                  @gold_cubes[hex.id] += 1
-                end
+                next unless icon.name == 'mine'
+
+                action.hex.tile.icons << Part::Icon.new(
+                  '../icons/18_royal_gorge/gold_cube',
+                  'gold', # name
+                  true, # sticky
+                  nil, # blocks_lay
+                  false, # preprinted
+                )
+                @gold_cubes[hex.id] += 1
               end
             end
             if !@updated_sulphur_springs_company_revenue && sulphur_springs&.owner&.player?


### PR DESCRIPTION
Fixes #10846

Pins probably aren't needed, this should be deployed with other open RG PRs that do require pins anyway, adding the label for safety.

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`