### PR TITLE
[1822PNW] stock market endgame takes precedence over bank breaking

### DIFF
--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -1103,6 +1103,14 @@ module Engine
         def buyable_bank_owned_companies
           @round.active_step.respond_to?(:hide_bank_companies?) && @round.active_step.hide_bank_companies? ? [] : super
         end
+
+        def game_end_check
+          if @stock_market.max_reached?
+            %i[stock_market current_or]
+          elsif @bank.broken?
+            [:bank, @round.is_a?(Engine::Round::Operating) ? :full_or : :current_or]
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #10858

Note: in the prototype, this was not the rule, see #8393 and #8472, which reference Rule 7.1.7:

> Once the game end has been triggered, the game will end at the indicated time,
even if another end condition is triggered after the first.

In the final rulebook, Rule 7.1.8 says this:

> Once the game end has been triggered, the game will end at the indicated
> time. If another end condition is triggered after the first that would make
> the game end sooner, then that end game condition takes precedence in deciding
> when the game ends.

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`