### PR TITLE
[1822PNW] P20 - update home/dest on major's card, fix dest changing cases

### DIFF
--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -635,12 +635,22 @@ module Engine
         def add_home_icon(corporation, coordinates)
           hex = hex_by_id(coordinates)
           # Logo and Icon each add '.svg' to the end - so chop one of them off
-          hex.tile.icons << Part::Icon.new("../#{corporation.logo.chop.chop.chop.chop}", "#{corporation.id}_home")
+          hex.tile.icons << Part::Icon.new("../#{corporation.logo[0..-5]}", "#{corporation.id}_home")
         end
 
         def remove_home_icon(corporation, coordinates)
           hex = hex_by_id(coordinates)
           hex.tile.icons.reject! { |icon| icon.name == "#{corporation.id}_home" }
+        end
+
+        def add_destination_icon(corporation, coordinates)
+          hex = hex_by_id(coordinates)
+          hex.tile.icons << Part::Icon.new("../#{corporation.destination_icon}", "#{corporation.id}_destination")
+        end
+
+        def remove_destination_icon(corporation, coordinates)
+          hex = hex_by_id(coordinates)
+          hex.tile.icons.reject! { |icon| icon.name == "#{corporation.id}_destination" }
         end
 
         def corp_id_from_company_id(id)

--- a/lib/engine/operator.rb
+++ b/lib/engine/operator.rb
@@ -6,10 +6,10 @@ module Engine
   module Operator
     include Entity
 
-    attr_accessor :coordinates, :color, :text_color
+    attr_accessor :coordinates, :color, :text_color, :destination_coordinates
     attr_reader :city, :loans, :logo, :logo_filename, :simple_logo,
                 :operating_history, :tokens, :trains, :destination_icon,
-                :destination_coordinates, :destination_exits, :destination_loc,
+                :destination_exits, :destination_loc,
                 :share_price, :destination_icon_in_city_slot
 
     def init_operator(opts)


### PR DESCRIPTION
* fix showing the Major's new home on the card after P20 Backroom Negotiations changes it, fixes #9751


* P20 Backroom Negotiations changes the Major's destination when its destination is the same as the newly associated Minor's home; the Major's original home becomes the destination; fix this case and show the new destination on the card, fixes #9993



<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`