### PR TITLE
[1868WY] don't show corp stacks in phase 5, when all corps can be started

### DIFF
--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -1010,8 +1010,10 @@ module Engine
         # extends the given array with the string representation of the
         # corporation stacks
         def corp_stacks_str_arr(arr = [])
-          @corp_stacks.each.with_index do |stack, index|
-            arr << "- Railroad Company stack #{index + 1}: #{stack.map(&:name).reverse.join(', ')}" unless stack.empty?
+          if @phase && @phase.name.to_i < 5
+            @corp_stacks.each.with_index do |stack, index|
+              arr << "- Railroad Company stack #{index + 1}: #{stack.map(&:name).reverse.join(', ')}" unless stack.empty?
+            end
           end
           arr
         end


### PR DESCRIPTION
Fixes #10865


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`