### PR TITLE
[18FL] restricts 2p variant to 2 players

### DIFF
--- a/lib/engine/game/g_18_fl/meta.rb
+++ b/lib/engine/game/g_18_fl/meta.rb
@@ -23,6 +23,7 @@ module Engine
             sym: :two_player_share_limit,
             short_name: '(2p only) 70% Corporation Holding Limit',
             desc: 'When enabled, in a 2p game a player can hold up to 70% of a corporation\'s shares',
+            players: [2],
           },
         ].freeze
       end


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Adds a `players` attribute to the 2 player share limit variant so this can only be used in 2p games.

### Screenshots

### Any Assumptions / Hacks
