### PR TITLE
[Core] Minor's abilities can be used in stock round

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -3208,7 +3208,7 @@ module Engine
       end
 
       def player_owned_ability?(ability)
-        ability.owner&.player? || (ability.owner&.company? && ability.owner&.owner&.player?)
+        ability.owner&.player? || (!ability.owner&.corporation? && ability.owner&.owner&.player?)
       end
 
       def corporation_owned_ability?(ability)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -3208,7 +3208,7 @@ module Engine
       end
 
       def player_owned_ability?(ability)
-        ability.owner&.player? || (!ability.owner&.corporation? && ability.owner&.owner&.player?)
+        ability.owner&.player? || ((ability.owner&.company? || ability.owner&.minor?) && ability.owner&.owner&.player?)
       end
 
       def corporation_owned_ability?(ability)


### PR DESCRIPTION
Commit 67572e8 had broken 1858. This commit introduced changes to ability timing, introducing a check that an ability with timing `owning_player_sr_turn` was either owned by a player or a player's company.

1858 includes abilities that are owned by minor entities which were failing this check. This meant that it was not possible to exchange a private railway company (minor+company pair) for a share in a public comany (corporation).

Fix this by changing the check to work for minors too.

Fixes tobymao#10813.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~~Add the `pins` or `archive_alpha_games` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`