### PR TITLE
[1841] color-coding the concessions

### DIFF
--- a/lib/engine/game/g_1841/entities.rb
+++ b/lib/engine/game/g_1841/entities.rb
@@ -16,6 +16,8 @@ module Engine
               revenue: 20,
               desc: 'Pays L.20 at the end of each Stock Round',
               corporation: nil,
+              color: 'black',
+              text_color: 'white',
             },
           ]
           unless lite?
@@ -26,6 +28,7 @@ module Engine
               revenue: 0,
               desc: 'Can start the SFLP Minor Corporation',
               corporation: 'SFLP',
+              color: 'lightGreen',
             }
           end
           companies << {
@@ -35,6 +38,7 @@ module Engine
             revenue: 0,
             desc: "Can start the SFTC #{version == 1 ? 'Minor' : 'Major'} Corporation",
             corporation: 'SFTC',
+            color: 'yellow',
           }
           unless lite?
             companies << {
@@ -44,6 +48,8 @@ module Engine
               revenue: 0,
               desc: 'Can start the SFMA Minor Corporation',
               corporation: 'SFMA',
+              color: 'red',
+              text_color: 'white',
             }
           end
           companies << {
@@ -53,6 +59,7 @@ module Engine
             revenue: 0,
             desc: 'Can start the SFTN Major Corporation',
             corporation: 'SFTN',
+            color: 'sandyBrown',
           }
           unless lite?
             companies << {
@@ -62,6 +69,8 @@ module Engine
               revenue: 0,
               desc: 'Can start the SSFL Major Corporation',
               corporation: 'SSFL',
+              color: 'purple',
+              text_color: 'white',
             }
           end
           companies << {
@@ -71,6 +80,8 @@ module Engine
             revenue: 0,
             desc: 'Can start the SFTG Major Corporation',
             corporation: 'SFTG',
+            color: 'blue',
+            text_color: 'white',
           }
           companies << {
             name: '8 Imperial Regia Strada Ferrata Ferdinandea',
@@ -79,6 +90,8 @@ module Engine
             revenue: 0,
             desc: 'Can start the IRSFF Major Corporation',
             corporation: 'IRSFF',
+            color: 'orange',
+            text_color: 'white',
           }
           companies
         end


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Pretty much everyone I know who plays 1841 refers to the different private companies by their color, not the random jumble of 4-5 letters in its abbreviation or even its name. We have the ability to color code the privates, I think we should do it. 

### Screenshots

Here's how it would look: 

![image](https://github.com/tobymao/18xx/assets/26125362/2acfa250-4c38-4ab5-a03e-404051669830)


### Any Assumptions / Hacks
