### PR TITLE
[18CZ] must buy usable train in last train slot

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -218,6 +218,8 @@ module View
             children << if @step.must_issue_before_ebuy?(@corporation)
                           h(:div, "#{@corporation.name} must buy a train from another corporation, "\
                                   'or issue shares and then buy an available train ')
+                        elsif @step.respond_to?(:needs_usable_train?) && @step.needs_usable_train?(@corporation)
+                          h(:div, "#{@corporation.name} must buy a train that it can run")
                         else
                           h(:div, "#{@corporation.name} must buy an available train")
                         end

--- a/lib/engine/game/g_18_cz/step/buy_train.rb
+++ b/lib/engine/game/g_18_cz/step/buy_train.rb
@@ -73,6 +73,7 @@ module Engine
           end
 
           def train_available?(entity, train)
+            return false if needs_usable_train?(entity) && !@game.train_of_size?(train, entity.type)
             return true if @game.train_of_size?(train, entity.type) || @game.train_of_size?(train, :small)
             return false if entity.type == :small
 
@@ -99,6 +100,10 @@ module Engine
           def must_take_player_loan?(corporation)
             price = cheapest_train_price(corporation)
             (@game.buying_power(corporation) + corporation.owner.cash) < price
+          end
+
+          def needs_usable_train?(entity)
+            @game.train_limit(entity) - @game.num_corp_trains(entity) == 1 && must_buy_train?(entity)
           end
         end
       end

--- a/lib/engine/game/g_18_cz/step/buy_train.rb
+++ b/lib/engine/game/g_18_cz/step/buy_train.rb
@@ -103,7 +103,7 @@ module Engine
           end
 
           def needs_usable_train?(entity)
-            @game.train_limit(entity) - @game.num_corp_trains(entity) == 1 && must_buy_train?(entity)
+            must_buy_train?(entity) && @game.train_limit(entity) - @game.num_corp_trains(entity) == 1
           end
         end
       end


### PR DESCRIPTION
Fixes #9570 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

_Note: this will likely require pins, for any games where players have maxed out on trains the corp couldn't run. Seems like an unlikely edge case of rules lawyering though._ 

Currently, corporations can buy trains they can't run up to the train limit, and this ends the `must_buy_train` check.

### Explanation of Change

I've added in a `needs_usable_train?` method that checks if the corp is currently in 'must_buy_train' status and if it only has one space for trains left. If this returns true, the only trains available for purchase will be trains of the size this corp can run. 

I also modified the render code so that if this is the case, the player sees a message that they need to buy a train the corp can run (top of screenshot below)

### Screenshots

![image](https://github.com/tobymao/18xx/assets/26125362/fff39a8d-75c7-4469-a45d-bb801e251fef)


### Any Assumptions / Hacks
