### PR TITLE
fix buy share button logic with modified share price

### DIFF
--- a/assets/app/view/game/button/buy_share.rb
+++ b/assets/app/view/game/button/buy_share.rb
@@ -27,8 +27,11 @@ module View
                             (bundle.percent != bundle.corporation.share_percent && !bundle.presidents_share)
           reduced_price = @game.format_currency(bundle.price - @swap_share.price) if @swap_share
           if step.respond_to?(:modify_purchase_price)
-            modified_price = step.modify_purchase_price(bundle)
-            modified_price = nil if bundle.price == modified_price * bundle.num_shares
+            if (modified_bundle_price = step.modify_purchase_price(bundle)) == bundle.price
+              modified_bundle_price = nil
+            else
+              modified_share_price = modified_bundle_price / bundle.num_shares
+            end
           end
 
           text = @prefix.to_s
@@ -38,12 +41,12 @@ module View
           text += ' Preferred' if @share.preferred
           text += ' Share'
           text += " (#{reduced_price} + #{@swap_share.percent}% Share)" if @swap_share
-          text += " (#{@game.format_currency(modified_price * bundle.num_shares)})" if modified_price
+          text += " (#{@game.format_currency(modified_bundle_price)})" if modified_bundle_price
           text += " for #{@purchase_for.name}" if @purchase_for
 
           process_buy = lambda do
             do_buy = lambda do
-              buy_shares(@entity, bundle, share_price: modified_price, swap: @swap_share,
+              buy_shares(@entity, bundle, share_price: modified_share_price, swap: @swap_share,
                                           purchase_for: @purchase_for, borrow_from: @borrow_from,
                                           discounter: @discounter)
             end

--- a/lib/engine/game/g_18_royal_gorge/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/buy_sell_par_shares.rb
@@ -61,7 +61,7 @@ module Engine
             (1..2).map do |num_shares|
               shares = corp_shares.take(num_shares)
               bundle = ShareBundle.new(shares)
-              @_modify_purchase_price[bundle] = (bundle.price_per_share / 2.0).ceil
+              @_modify_purchase_price[bundle] = (bundle.price / 2.0).ceil
               [@game.mint_worker, bundle]
             end
           end


### PR DESCRIPTION
`modify_purchase_price` modifies the price of the bundle, but it was being passed as an arg that modifies the price of each share in the bundle; some variables have been renamed, the per-share price is computed, and the correct value is now passed into `buy_shares`

Caused by [#10840](https://github.com/tobymao/18xx/pull/10840/files#diff-9b2159472e7490019b81ebc059e863df6e9875c016bad07ae7627ed9322cd024)

Fixes #10870



<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`