### PR TITLE
[18Mag] fixes ciwl_add calculation

### DIFF
--- a/lib/engine/game/g_18_mag/game.rb
+++ b/lib/engine/game/g_18_mag/game.rb
@@ -683,7 +683,7 @@ module Engine
                        0
                      end
 
-          ciwl_add = ciwl_delta if new_major? && red_to_red_route?(route)
+          ciwl_add =  new_major? && red_to_red_route?(route) ? ciwl_delta : 0
 
           corp_tokens = stops.select(&:city?).sum { |c| c.tokens.count { |t| t&.corporation&.corporation? } }
 


### PR DESCRIPTION
fixes the calculation for ciwl_add with a ternary.

Fixes #10876 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

My initial change didn't take into account that sometimes there wouldn't be any ciwl_add value. This corrects the calculation by turning it into a ternary.

### Screenshots

### Any Assumptions / Hacks
