### PR TITLE
[1870] implements Station Wars rulebook variant

### DIFF
--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -518,6 +518,10 @@ module Engine
           @reissued[corporation]
         end
 
+        def station_wars?
+          @station_wars ||= @optional_rules&.include?(:station_wars)
+        end
+
         # allows implementation of diesels variant
         def game_trains
           @optional_rules&.include?(:diesels) ? self.class::DIESEL_VARIANT_TRAINS : self.class::STANDARD_TRAINS

--- a/lib/engine/game/g_1870/meta.rb
+++ b/lib/engine/game/g_1870/meta.rb
@@ -28,6 +28,13 @@ module Engine
             short_name: '$400 Finish',
             desc: 'Game ends as soon as a corporation hits 400 on the stock market. No further operations.',
           },
+          {
+            sym: :station_wars,
+            short_name: 'Station Wars',
+            desc: 'Destination tokens on non-offboard hexes now use up a token space. A new space is created if '\
+                  'no space is available, but if the tile is later upgraded and a new token space would be opened, the '\
+                  'destination token will fill that space.',
+          },
         ].freeze
       end
     end

--- a/lib/engine/game/g_1870/meta.rb
+++ b/lib/engine/game/g_1870/meta.rb
@@ -30,7 +30,7 @@ module Engine
           },
           {
             sym: :station_wars,
-            short_name: 'Station Wars',
+            short_name: 'Station Marker Wars',
             desc: 'Destination tokens on non-offboard hexes now use up a token space. A new space is created if '\
                   'no space is available, but if the tile is later upgraded and a new token space would be opened, the '\
                   'destination token will fill that space.',

--- a/lib/engine/game/g_1870/step/connection_token.rb
+++ b/lib/engine/game/g_1870/step/connection_token.rb
@@ -10,6 +10,8 @@ module Engine
         class ConnectionToken < Engine::Step::Token
           include Connection
 
+          STATION_WARS_CORPS = %w[GMO MP SP SSW TP].freeze
+
           def actions(_entity)
             %w[choose]
           end
@@ -39,7 +41,11 @@ module Engine
             destination.remove_assignment!(entity)
 
             if action.choice == 'Map'
-              destination.tile.cities.first.place_token(entity, token, free: true, extra_slot: true)
+              if @game.station_wars? && STATION_WARS_CORPS.include?(entity.id)
+                destination.tile.cities.first.place_token(entity, token, free: true, cheater: true)
+              else
+                destination.tile.cities.first.place_token(entity, token, free: true, extra_slot: true)
+              end
               @game.graph.clear
               ability.description = 'Reached ' + ability.description
 

--- a/lib/engine/game/g_1870/step/connection_token.rb
+++ b/lib/engine/game/g_1870/step/connection_token.rb
@@ -41,11 +41,13 @@ module Engine
             destination.remove_assignment!(entity)
 
             if action.choice == 'Map'
-              if @game.station_wars? && STATION_WARS_CORPS.include?(entity.id)
-                destination.tile.cities.first.place_token(entity, token, free: true, cheater: true)
-              else
-                destination.tile.cities.first.place_token(entity, token, free: true, extra_slot: true)
-              end
+              token_placement_arg =
+                if @game.station_wars? && STATION_WARS_CORPS.include?(entity.id)
+                  { cheater: true }
+                else
+                  { extra_slot: true }
+                end
+              destination.tile.cities.first.place_token(entity, token, free: true, **token_placement_arg)
               @game.graph.clear
               ability.description = 'Reached ' + ability.description
 


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

This variant makes the destination tokens on non-offboard spaces `cheater` tokens instead of `extra_slot` tokens. 

### Explanation of Change

### Screenshots

from the rulebook:

![image](https://github.com/tobymao/18xx/assets/26125362/1d93929f-b1bd-4cff-80d1-04f4ae6d915f)

### Any Assumptions / Hacks
