### PR TITLE
[1868WY] fix double-heading trains selection for light mode

### DIFF
--- a/assets/app/view/game/double_head_trains.rb
+++ b/assets/app/view/game/double_head_trains.rb
@@ -22,7 +22,7 @@ module View
           end
 
           style = {
-            border: 'solid 1px',
+            border: "solid 1px #{color_for(:font)}",
             display: 'inline-block',
             cursor: 'pointer',
             margin: '0.1rem 0rem',
@@ -33,8 +33,12 @@ module View
           }
 
           bg_color = route_prop(0, :color)
-          style[:backgroundColor] = @selected_trains[train] ? bg_color : color_for(:bg)
-          style[:color] = contrast_on(bg_color)
+          if @selected_trains[train]
+            style[:backgroundColor] = bg_color
+            style[:color] = contrast_on(bg_color)
+          else
+            style[:backgroundColor] = color_for(:bg)
+          end
 
           [
             h(:tr,


### PR DESCRIPTION
Fixes #9737

Dark mode is unchanged.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Screenshots

### Before

![before](https://github.com/tobymao/18xx/assets/1045173/fb885dc6-5837-4135-abe8-44b1863362ae)

### After

![Screenshot 2024-06-07 232004](https://github.com/tobymao/18xx/assets/1045173/c49e0647-050e-41aa-9a9c-4650b1e45498)


