### PR TITLE
[1822 family] show winning bids in the player card's cert count; fix 1822CA tax haven

### DIFF
--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -84,7 +84,13 @@ module View
       end
 
       def render_info
-        num_certs = @game.num_certs(@player)
+        num_certs =
+          if @game.active_step.respond_to?(:num_certs_with_bids)
+            @game.active_step.num_certs_with_bids(@player)
+          else
+            @game.num_certs(@player)
+          end
+
         cert_limit = @game.cert_limit(@player)
 
         td_cert_props = {

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -488,9 +488,6 @@ module Engine
         PLUS_EXPANSION_BIDBOX_2 = %w[P2 P5 P8 P10 P11 P12 P21].freeze
         PLUS_EXPANSION_BIDBOX_3 = %w[P6 P7 P9 P15 P16 P17 P18 P20].freeze
 
-        # companies that don't count against the cert limit, even when bidding
-        COMPANIES_NONCERT = [].freeze
-
         PRIVATE_COMPANIES_ACQUISITION = {
           'P1' => { acquire: %i[major], phase: 5 },
           'P2' => { acquire: %i[major minor], phase: 2 },

--- a/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1822/step/buy_sell_par_shares.rb
@@ -239,16 +239,10 @@ module Engine
           end
 
           def can_bid_company?(entity, company)
-            return false unless cert_room_for_bid?(entity, company)
+            return false unless num_certs_with_bids(entity) < @game.cert_limit
             return false if max_bid(entity, company) < min_bid(company) || highest_player_bid?(entity, company)
 
             !(!find_bid(entity, company) && bidding_tokens(entity).zero?)
-          end
-
-          def cert_room_for_bid?(entity, company)
-            return true if @game.class::COMPANIES_NONCERT.include?(company.id)
-
-            num_certs_with_bids(entity) < @game.cert_limit
           end
 
           def store_bids!

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -182,8 +182,6 @@ module Engine
 
         TWO_HOME_CORPORATION = 'CPR'
 
-        COMPANIES_NONCERT = ['P11'].freeze
-
         PRIVATE_COMPANIES_ACQUISITION = {
           'P1' => { acquire: %i[major], phase: 5 },
           'P2' => { acquire: %i[major minor], phase: 1 },


### PR DESCRIPTION
Fixes #10159

See also #10678

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

* 1822 family: change view to count winning bids as certificates
* 1822CA: revert commit which allowed bidding on P11 Tax Haven when at cert limit; although the private itself does not count, the bidding cube does.

> 4.10.8 A player may not place or move a bid on an item if they are at the certificate limit. Each item on which a player currently has the highest bid counts as a certificate against the certificate limit. (!is applies to P11 Registered Retirement Savings Plan as well.)