### PR TITLE
[1822MX] ensure builder cubes are the only potential tiles for builder cube companies

### DIFF
--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -143,7 +143,7 @@ module Engine
         end
 
         def cube_company?(entity)
-          entity.id == 'P10' || entity.id == 'P11'
+          entity && (entity.id == 'P10' || entity.id == 'P11')
         end
 
         BIDDING_BOX_START_PRIVATE = 'P1'
@@ -647,6 +647,7 @@ module Engine
 
         def upgrades_to?(from, to, special = false, selected_company: nil)
           return true if from.color == :blue && to.color == :blue
+          return false if cube_company?(selected_company) && to.name != 'BC'
 
           super
         end


### PR DESCRIPTION
Fixes #9276

Probably doesn't need a pin, the only tile showing was one that had no copies left available to lay.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`