### PR TITLE
[1822PNW] add colored logos for associated minors

### DIFF
--- a/lib/engine/game/g_1822_pnw/entities.rb
+++ b/lib/engine/game/g_1822_pnw/entities.rb
@@ -708,7 +708,7 @@ module Engine
           {
             sym: '1',
             name: 'Pacific Great Eastern Railway',
-            logo: '1822/1',
+            logo: '1822_pnw/1',
             tokens: [0],
             type: 'minor',
             always_market_price: true,
@@ -778,7 +778,7 @@ module Engine
           {
             sym: '5',
             name: 'Idaho & Washington Northern Railway',
-            logo: '1822/5',
+            logo: '1822_pnw/5',
             tokens: [0],
             type: 'minor',
             always_market_price: true,
@@ -816,7 +816,7 @@ module Engine
           {
             sym: '7',
             name: 'Spokane Falls and Northern Railway',
-            logo: '1822/7',
+            logo: '1822_pnw/7',
             tokens: [0],
             type: 'minor',
             always_market_price: true,
@@ -838,7 +838,7 @@ module Engine
           {
             sym: '8',
             name: 'Puget Sound Shore Railroad',
-            logo: '1822/8',
+            logo: '1822_pnw/8',
             tokens: [0],
             type: 'minor',
             always_market_price: true,
@@ -988,7 +988,7 @@ module Engine
           {
             sym: '17',
             name: 'Oregon Central Railroad',
-            logo: '1822/17',
+            logo: '1822_pnw/17',
             tokens: [0],
             type: 'minor',
             always_market_price: true,
@@ -1010,7 +1010,7 @@ module Engine
           {
             sym: '18',
             name: 'Portland and Willamette Valley Railway',
-            logo: '1822/18',
+            logo: '1822_pnw/18',
             tokens: [0],
             type: 'minor',
             always_market_price: true,
@@ -1048,7 +1048,7 @@ module Engine
           {
             sym: '20',
             name: 'Walla Walla Valley Railway',
-            logo: '1822/20',
+            logo: '1822_pnw/20',
             tokens: [0],
             type: 'minor',
             always_market_price: true,

--- a/lib/engine/game/g_1822_pnw/step/acquire_company.rb
+++ b/lib/engine/game/g_1822_pnw/step/acquire_company.rb
@@ -53,6 +53,8 @@ module Engine
             old_company = @game.company_by_id(@game.company_id_from_corp_id(action.choice))
             @new_associated_minor.color = old_company.color
             @new_associated_minor.text_color = old_company.text_color
+            @new_associated_minor.logo = "1822_pnw/#{major.id.downcase}/#{@new_associated_minor.name}"
+            @new_associated_minor.tokens.first.logo = @new_associated_minor.logo
 
             original_home_coordinates = major.coordinates
             @game.remove_home_icon(major, original_home_coordinates)

--- a/lib/engine/operator.rb
+++ b/lib/engine/operator.rb
@@ -64,5 +64,10 @@ module Engine
     def placed_tokens
       @tokens.select(&:city)
     end
+
+    def logo=(logo)
+      @logo_filename = "#{logo}.svg"
+      @logo = "/logos/#{@logo_filename}"
+    end
   end
 end

--- a/public/logos/1822_pnw/1.svg
+++ b/public/logos/1822_pnw/1.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="17.900623" y="24.676655" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">1</tspan></text></svg>

--- a/public/logos/1822_pnw/17.svg
+++ b/public/logos/1822_pnw/17.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="16.640215" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">17</tspan></text></svg>

--- a/public/logos/1822_pnw/18.svg
+++ b/public/logos/1822_pnw/18.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="16.645422" y="24.541132" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">18</tspan></text></svg>

--- a/public/logos/1822_pnw/20.svg
+++ b/public/logos/1822_pnw/20.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">20</tspan></text></svg>

--- a/public/logos/1822_pnw/5.svg
+++ b/public/logos/1822_pnw/5.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="17.900623" y="24.676655" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">5</tspan></text></svg>

--- a/public/logos/1822_pnw/7.svg
+++ b/public/logos/1822_pnw/7.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="17.900623" y="24.676655" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">7</tspan></text></svg>

--- a/public/logos/1822_pnw/8.svg
+++ b/public/logos/1822_pnw/8.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="17.056875" y="24.541132" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">8</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/10.svg
+++ b/public/logos/1822_pnw/cmps/10.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="16.692297" y="24.546341" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">10</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/11.svg
+++ b/public/logos/1822_pnw/cmps/11.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="17.900612" y="24.676548" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">11</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/12.svg
+++ b/public/logos/1822_pnw/cmps/12.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="16.702713" y="24.676548" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">12</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/13.svg
+++ b/public/logos/1822_pnw/cmps/13.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="16.62459" y="24.546341" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">13</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/14.svg
+++ b/public/logos/1822_pnw/cmps/14.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="16.411051" y="24.676548" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">14</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/15.svg
+++ b/public/logos/1822_pnw/cmps/15.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="16.489176" y="24.546341" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">15</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/16.svg
+++ b/public/logos/1822_pnw/cmps/16.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="16.546465" y="24.546341" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">16</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/19.svg
+++ b/public/logos/1822_pnw/cmps/19.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="16.661047" y="24.541132" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">19</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/2.svg
+++ b/public/logos/1822_pnw/cmps/2.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="17.280828" y="24.676548" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">2</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/21.svg
+++ b/public/logos/1822_pnw/cmps/21.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="18.478727" y="24.676548" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">21</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/3.svg
+++ b/public/logos/1822_pnw/cmps/3.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="17.067291" y="24.546341" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">3</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/4.svg
+++ b/public/logos/1822_pnw/cmps/4.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="17.056875" y="24.676548" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">4</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/6.svg
+++ b/public/logos/1822_pnw/cmps/6.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="16.937084" y="24.546341" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">6</tspan></text></svg>

--- a/public/logos/1822_pnw/cmps/9.svg
+++ b/public/logos/1822_pnw/cmps/9.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#F69B1D"/><text x="17.166248" y="24.541132" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">9</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/10.svg
+++ b/public/logos/1822_pnw/cpr/10.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="16.692297" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">10</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/11.svg
+++ b/public/logos/1822_pnw/cpr/11.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="17.900612" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">11</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/12.svg
+++ b/public/logos/1822_pnw/cpr/12.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="16.702713" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">12</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/13.svg
+++ b/public/logos/1822_pnw/cpr/13.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="16.62459" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">13</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/14.svg
+++ b/public/logos/1822_pnw/cpr/14.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="16.411051" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">14</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/15.svg
+++ b/public/logos/1822_pnw/cpr/15.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="16.489176" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">15</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/16.svg
+++ b/public/logos/1822_pnw/cpr/16.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="16.546465" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">16</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/19.svg
+++ b/public/logos/1822_pnw/cpr/19.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="16.661047" y="24.541132" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">19</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/2.svg
+++ b/public/logos/1822_pnw/cpr/2.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="17.280828" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">2</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/21.svg
+++ b/public/logos/1822_pnw/cpr/21.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="18.478727" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">21</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/3.svg
+++ b/public/logos/1822_pnw/cpr/3.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="17.067291" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">3</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/4.svg
+++ b/public/logos/1822_pnw/cpr/4.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="17.056875" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">4</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/6.svg
+++ b/public/logos/1822_pnw/cpr/6.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="16.937084" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">6</tspan></text></svg>

--- a/public/logos/1822_pnw/cpr/9.svg
+++ b/public/logos/1822_pnw/cpr/9.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#EF1D24"/><text x="17.166248" y="24.541132" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">9</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/10.svg
+++ b/public/logos/1822_pnw/gnr/10.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="16.692297" y="24.546341" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">10</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/11.svg
+++ b/public/logos/1822_pnw/gnr/11.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="17.900612" y="24.676548" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">11</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/12.svg
+++ b/public/logos/1822_pnw/gnr/12.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="16.702713" y="24.676548" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">12</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/13.svg
+++ b/public/logos/1822_pnw/gnr/13.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="16.62459" y="24.546341" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">13</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/14.svg
+++ b/public/logos/1822_pnw/gnr/14.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="16.411051" y="24.676548" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">14</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/15.svg
+++ b/public/logos/1822_pnw/gnr/15.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="16.489176" y="24.546341" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">15</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/16.svg
+++ b/public/logos/1822_pnw/gnr/16.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="16.546465" y="24.546341" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">16</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/19.svg
+++ b/public/logos/1822_pnw/gnr/19.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="16.661047" y="24.541132" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">19</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/2.svg
+++ b/public/logos/1822_pnw/gnr/2.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="17.280828" y="24.676548" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">2</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/21.svg
+++ b/public/logos/1822_pnw/gnr/21.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="18.478727" y="24.676548" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">21</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/3.svg
+++ b/public/logos/1822_pnw/gnr/3.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="17.067291" y="24.546341" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">3</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/4.svg
+++ b/public/logos/1822_pnw/gnr/4.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="17.056875" y="24.676548" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">4</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/6.svg
+++ b/public/logos/1822_pnw/gnr/6.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="16.937084" y="24.546341" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">6</tspan></text></svg>

--- a/public/logos/1822_pnw/gnr/9.svg
+++ b/public/logos/1822_pnw/gnr/9.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#6BCFF7"/><text x="17.166248" y="24.541132" fill="#000000" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#000000" font-size="21.333px">9</tspan></text></svg>

--- a/public/logos/1822_pnw/np/10.svg
+++ b/public/logos/1822_pnw/np/10.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">10</tspan></text></svg>

--- a/public/logos/1822_pnw/np/11.svg
+++ b/public/logos/1822_pnw/np/11.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">11</tspan></text></svg>

--- a/public/logos/1822_pnw/np/12.svg
+++ b/public/logos/1822_pnw/np/12.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">12</tspan></text></svg>

--- a/public/logos/1822_pnw/np/13.svg
+++ b/public/logos/1822_pnw/np/13.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">13</tspan></text></svg>

--- a/public/logos/1822_pnw/np/14.svg
+++ b/public/logos/1822_pnw/np/14.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">14</tspan></text></svg>

--- a/public/logos/1822_pnw/np/15.svg
+++ b/public/logos/1822_pnw/np/15.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">15</tspan></text></svg>

--- a/public/logos/1822_pnw/np/16.svg
+++ b/public/logos/1822_pnw/np/16.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">16</tspan></text></svg>

--- a/public/logos/1822_pnw/np/19.svg
+++ b/public/logos/1822_pnw/np/19.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">19</tspan></text></svg>

--- a/public/logos/1822_pnw/np/2.svg
+++ b/public/logos/1822_pnw/np/2.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">2</tspan></text></svg>

--- a/public/logos/1822_pnw/np/21.svg
+++ b/public/logos/1822_pnw/np/21.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">21</tspan></text></svg>

--- a/public/logos/1822_pnw/np/3.svg
+++ b/public/logos/1822_pnw/np/3.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">3</tspan></text></svg>

--- a/public/logos/1822_pnw/np/4.svg
+++ b/public/logos/1822_pnw/np/4.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">4</tspan></text></svg>

--- a/public/logos/1822_pnw/np/6.svg
+++ b/public/logos/1822_pnw/np/6.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">6</tspan></text></svg>

--- a/public/logos/1822_pnw/np/9.svg
+++ b/public/logos/1822_pnw/np/9.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="45.001%" ry="45%" fill="#ffffff" stroke="#221E20" stroke-width="2.5px"/><text x="17.270412" y="24.546341" fill="#221E20" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#221E20" font-size="21.333px">9</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/10.svg
+++ b/public/logos/1822_pnw/ornc/10.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="16.692297" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">10</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/11.svg
+++ b/public/logos/1822_pnw/ornc/11.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="17.900612" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">11</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/12.svg
+++ b/public/logos/1822_pnw/ornc/12.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="16.702713" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">12</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/13.svg
+++ b/public/logos/1822_pnw/ornc/13.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="16.62459" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">13</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/14.svg
+++ b/public/logos/1822_pnw/ornc/14.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="16.411051" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">14</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/15.svg
+++ b/public/logos/1822_pnw/ornc/15.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="16.489176" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">15</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/16.svg
+++ b/public/logos/1822_pnw/ornc/16.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="16.546465" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">16</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/19.svg
+++ b/public/logos/1822_pnw/ornc/19.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="16.661047" y="24.541132" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">19</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/2.svg
+++ b/public/logos/1822_pnw/ornc/2.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="17.280828" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">2</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/21.svg
+++ b/public/logos/1822_pnw/ornc/21.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="18.478727" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">21</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/3.svg
+++ b/public/logos/1822_pnw/ornc/3.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="17.067291" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">3</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/4.svg
+++ b/public/logos/1822_pnw/ornc/4.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="17.056875" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">4</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/6.svg
+++ b/public/logos/1822_pnw/ornc/6.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="16.937084" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">6</tspan></text></svg>

--- a/public/logos/1822_pnw/ornc/9.svg
+++ b/public/logos/1822_pnw/ornc/9.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#3078C1"/><text x="17.166248" y="24.541132" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">9</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/10.svg
+++ b/public/logos/1822_pnw/sps/10.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="16.692297" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">10</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/11.svg
+++ b/public/logos/1822_pnw/sps/11.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="17.900612" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">11</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/12.svg
+++ b/public/logos/1822_pnw/sps/12.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="16.702713" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">12</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/13.svg
+++ b/public/logos/1822_pnw/sps/13.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="16.62459" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">13</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/14.svg
+++ b/public/logos/1822_pnw/sps/14.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="16.411051" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">14</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/15.svg
+++ b/public/logos/1822_pnw/sps/15.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="16.489176" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">15</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/16.svg
+++ b/public/logos/1822_pnw/sps/16.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="16.546465" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">16</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/19.svg
+++ b/public/logos/1822_pnw/sps/19.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="16.661047" y="24.541132" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">19</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/2.svg
+++ b/public/logos/1822_pnw/sps/2.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="17.280828" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">2</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/21.svg
+++ b/public/logos/1822_pnw/sps/21.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="18.478727" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">21</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/3.svg
+++ b/public/logos/1822_pnw/sps/3.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="17.067291" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">3</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/4.svg
+++ b/public/logos/1822_pnw/sps/4.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="17.056875" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">4</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/6.svg
+++ b/public/logos/1822_pnw/sps/6.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="16.937084" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">6</tspan></text></svg>

--- a/public/logos/1822_pnw/sps/9.svg
+++ b/public/logos/1822_pnw/sps/9.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#8D061B"/><text x="17.166248" y="24.541132" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">9</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/10.svg
+++ b/public/logos/1822_pnw/sww/10.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="16.692297" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">10</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/11.svg
+++ b/public/logos/1822_pnw/sww/11.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="17.900612" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">11</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/12.svg
+++ b/public/logos/1822_pnw/sww/12.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="16.702713" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">12</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/13.svg
+++ b/public/logos/1822_pnw/sww/13.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="16.62459" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">13</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/14.svg
+++ b/public/logos/1822_pnw/sww/14.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="16.411051" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">14</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/15.svg
+++ b/public/logos/1822_pnw/sww/15.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="16.489176" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">15</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/16.svg
+++ b/public/logos/1822_pnw/sww/16.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="16.546465" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">16</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/19.svg
+++ b/public/logos/1822_pnw/sww/19.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="16.661047" y="24.541132" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">19</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/2.svg
+++ b/public/logos/1822_pnw/sww/2.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="17.280828" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">2</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/21.svg
+++ b/public/logos/1822_pnw/sww/21.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="18.478727" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">21</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/3.svg
+++ b/public/logos/1822_pnw/sww/3.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="17.067291" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">3</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/4.svg
+++ b/public/logos/1822_pnw/sww/4.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="17.056875" y="24.676548" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">4</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/6.svg
+++ b/public/logos/1822_pnw/sww/6.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="16.937084" y="24.546341" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">6</tspan></text></svg>

--- a/public/logos/1822_pnw/sww/9.svg
+++ b/public/logos/1822_pnw/sww/9.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 34.02 34.02" xmlns="http://www.w3.org/2000/svg"><ellipse cx="17.01" cy="17.01" rx="49.001%" ry="49%" fill="#238541"/><text x="17.166248" y="24.541132" fill="#ffffff" font-family="Arial" font-size="21.333px" font-weight="700" text-anchor="middle"><tspan fill="#ffffff" font-size="21.333px">9</tspan></text></svg>


### PR DESCRIPTION
* also add colored versions of logos for unassociated minors using backroom negotiations

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Screenshots

#### Before

![market before](https://github.com/tobymao/18xx/assets/1045173/875c3cab-0966-450d-91e3-2b764a028e9a)


##### After

![market after](https://github.com/tobymao/18xx/assets/1045173/41b4a3fe-07b5-4308-b8f4-1efd8e01271f)
