### PR TITLE
[1822 family] add private company colors

### DIFF
--- a/lib/engine/game/g_1822/entities.rb
+++ b/lib/engine/game/g_1822/entities.rb
@@ -4,6 +4,10 @@ module Engine
   module Game
     module G1822
       module Entities
+        PRIVATE_RED = '#FF7276'
+        PRIVATE_GREEN = '#90EE90'
+        PRIVATE_BLUE = '#89CFF0'
+
         COMPANIES = [
           {
             name: 'P1-BEC (5-Train)',
@@ -16,7 +20,7 @@ module Engine
                   'However, once acquired the acquiring company needs to check whether it is at train limit and '\
                   'discard any trains held in excess of limit.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P2-MtonR (Remove Town)',
@@ -42,7 +46,7 @@ module Engine
                 combo_entities: %w[P8 P10 P11 P12],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P3-S&HR (Permanent 2T)',
@@ -60,7 +64,7 @@ module Engine
                   'from the 2P, this also still counts as a normal dividend for stock price movement purposes. Does '\
                   'not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P4-SDR (Permanent 2T)',
@@ -78,7 +82,7 @@ module Engine
                   'from the 2P, this also still counts as a normal dividend for stock price movement purposes. '\
                   'Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P5-LC&DR (English Channel)',
@@ -115,7 +119,7 @@ module Engine
                 when: 'token',
               },
             ],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P6-L&SR (Mail Contract)',
@@ -129,7 +133,7 @@ module Engine
                   'the mail contract by stopping at a large city and not running beyond it to include small '\
                   'stations. Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P7-S&BR (Mail Contract)',
@@ -143,7 +147,7 @@ module Engine
                   'the mail contract by stopping at a large city and not running beyond it to include small '\
                   'stations. Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P8-E&GR (Hill Discount)',
@@ -187,7 +191,7 @@ module Engine
                 terrain: 'mountain',
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P9-M&GNR (Double Cash)',
@@ -199,7 +203,7 @@ module Engine
                   'order in the next stock round. If held by a company it pays revenue of '\
                   '£20 (green)/£40 (brown)/£60 (grey). Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P10-G&SWR (River Discount)',
@@ -230,7 +234,7 @@ module Engine
                 terrain: 'swamp',
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P11-B&ER (Adv. Tile Lay)',
@@ -257,7 +261,7 @@ module Engine
                 combo_entities: %w[P2 P10 P12],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P12-L&SR (Extra Tile Lay)',
@@ -284,7 +288,7 @@ module Engine
                 combo_entities: %w[P2 P8 P10 P11],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P13-YN&BR (Pullman)',
@@ -296,7 +300,7 @@ module Engine
                   'and does not count as a train for the purposes of train ownership. Can’t be sold to another '\
                   'company. Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P14-K&TR (Pullman)',
@@ -308,7 +312,7 @@ module Engine
                   'and does not count as a train for the purposes of train ownership. Can’t be sold to another '\
                   'company. Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P15-HR (£10x Phase)',
@@ -321,14 +325,14 @@ module Engine
                   'this private company closes. If not acquired beforehand, this company closes at the start of '\
                   'Phase 7 and all treasury credits are returned to the bank.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P16-TH (Tax Haven)',
             sym: 'P16',
             value: 0,
             revenue: 0,
-            desc: 'CAN NOT BE ACQUIRED. Tax Haven. As a stock round action, under the direction and funded by the '\
+            desc: 'CANNOT BE ACQUIRED. Tax Haven. As a stock round action, under the direction and funded by the '\
                   'owning player, the off-shore Tax Haven may purchase an available share certificate and place it '\
                   'onto P16’s charter. The certificate is not counted for determining directorship of a company. '\
                   'The share held in the tax haven does NOT count against the 60% share limit for purchasing '\
@@ -342,7 +346,7 @@ module Engine
                   'cash from dividend income accumulated on the charter. Can’t be acquired. Does not count against '\
                   'the certificate limit.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_BLUE,
           },
           {
             name: 'P17-LUR (Move Card)',
@@ -354,7 +358,7 @@ module Engine
                   'currently in the bidding boxes, and move it to the top or the bottom of the stack. Closes when '\
                   'the power is exercised.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P18-C&HPR (Station Swap)',
@@ -365,7 +369,7 @@ module Engine
                   'token area of its charter to the available token area, or vice versa. This company closes when '\
                   'its power is exercised.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P19-AEC (Perm. L Train)',
@@ -382,7 +386,7 @@ module Engine
                   'retains the dividend from the permanent L, this also still counts as a normal dividend for stock '\
                   'price movement purposes. Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P20-C&WR (£5x Phase)',
@@ -395,7 +399,7 @@ module Engine
                   'this private company closes. If not acquired beforehand, this company closes at the start of '\
                   'Phase 7 and all treasury credits are returned to the bank.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P21-HSBC (Grimsby/Hull Bridge)',
@@ -424,7 +428,7 @@ module Engine
                 consume_tile_lay: true,
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'CONCESSION: LNWR',

--- a/lib/engine/game/g_1822_africa/entities.rb
+++ b/lib/engine/game/g_1822_africa/entities.rb
@@ -4,6 +4,9 @@ module Engine
   module Game
     module G1822Africa
       module Entities
+        PRIVATE_RED = '#FF7276'
+        PRIVATE_GREEN = '#90EE90'
+
         COMPANIES = [
           {
             name: 'P1 (Permanent L-train)',
@@ -12,7 +15,7 @@ module Engine
             value: 0,
             revenue: 0,
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P2 (Permanent 2-train)',
@@ -21,7 +24,7 @@ module Engine
             value: 0,
             revenue: 0,
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P3 (Permanent 2-train)',
@@ -30,7 +33,7 @@ module Engine
             value: 0,
             revenue: 0,
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P4 (Pullman)',
@@ -41,7 +44,7 @@ module Engine
             value: 0,
             revenue: 10,
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P5 (Add Town)',
@@ -67,7 +70,7 @@ module Engine
                 combo_entities: %w[P7 P11],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P6 (Recycled train)',
@@ -77,7 +80,7 @@ module Engine
             value: 0,
             revenue: 10,
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P7 (Extra tile)',
@@ -105,7 +108,7 @@ module Engine
                 combo_entities: %w[P9 P11],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P8 (Reserve Three Tiles)',
@@ -118,7 +121,7 @@ module Engine
             value: 0,
             revenue: 10,
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P9 (Remove Town)',
@@ -144,7 +147,7 @@ module Engine
                 combo_entities: %w[P7 P11],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P10 (Game Reserve)',
@@ -171,7 +174,7 @@ module Engine
                 closed_when_used_up: true,
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P11 (Mountain Rebate)',
@@ -200,7 +203,7 @@ module Engine
                 owner_only: true,
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P12 (Fast Sahara Building)',
@@ -228,7 +231,7 @@ module Engine
                 combo_entities: %w[P7 P9 P11],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P13 (Station Swap)',
@@ -239,7 +242,7 @@ module Engine
             value: 0,
             revenue: 10,
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P14 (Gold Mine)',
@@ -265,7 +268,7 @@ module Engine
                 check_tokenable: false,
               },
             ],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P15 (Coffee Plantation)',
@@ -287,7 +290,7 @@ module Engine
                 owner_type: 'corporation',
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P16 (A10x Phase)',
@@ -301,7 +304,7 @@ module Engine
             value: 0,
             revenue: 0,
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P17 (Bank Share Buy)',
@@ -312,7 +315,7 @@ module Engine
             value: 0,
             revenue: 10,
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P18 (Safari Bonus)',
@@ -324,7 +327,7 @@ module Engine
             value: 0,
             revenue: 10,
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'CONCESSION: NAR',

--- a/lib/engine/game/g_1822_mx/entities.rb
+++ b/lib/engine/game/g_1822_mx/entities.rb
@@ -4,6 +4,9 @@ module Engine
   module Game
     module G1822MX
       module Entities
+        PRIVATE_RED = '#FF7276'
+        PRIVATE_GREEN = '#90EE90'
+
         COMPANIES = [
           {
             name: 'P1-BLWC (5-Train)',
@@ -17,7 +20,7 @@ module Engine
                   'buying action.  However, once acquired the acquiring company must check whether it as at the '\
                   'train limit and must discard any trains held in excess of limit.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P2-MCSL (Permanent 2T)',
@@ -36,7 +39,7 @@ module Engine
                   'this also still counts as a normal dividend for share price movement purposes. '\
                   'Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P3-IGT (Permanent 3/2T)',
@@ -57,7 +60,7 @@ module Engine
                   'this also still counts as a normal dividend for share price movement purposes. '\
                   'Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P4-MCST (Permanent LT)',
@@ -76,7 +79,7 @@ module Engine
                   'this also still counts as a normal dividend for share price movement purposes. '\
                   'Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P5-Pullman (Pullman)',
@@ -89,7 +92,7 @@ module Engine
                   'not count toward the train limit. Cannot be sold to another company. Does '\
                   'not close. No company may own more than one Pullman.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P6-Pullman (Pullman)',
@@ -102,7 +105,7 @@ module Engine
                   'not count toward the train limit. Cannot be sold to another company. Does '\
                   'not close. No company may own more than one Pullman.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P7-EI (Double Cash)',
@@ -114,7 +117,7 @@ module Engine
                   'player turn order in the next stock round. If held by a company it pays '\
                   'revenue of $20 (green)/$40 (brown)/$60 (gray). Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P8-CMB (Adv. Tile Lay)',
@@ -143,7 +146,7 @@ module Engine
                 combo_entities: %w[P9 P12 P13],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P9-M&GNR (Extra Tile Lay)',
@@ -172,7 +175,7 @@ module Engine
                 combo_entities: %w[P8 P12 P13],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P10-CCNM (Three Builder Cubes)',
@@ -197,7 +200,7 @@ module Engine
                 tiles: [],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P11-SMB (Three Builder Cubes)',
@@ -222,7 +225,7 @@ module Engine
                 tiles: [],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P12-AIAS (Remove Town)',
@@ -249,7 +252,7 @@ module Engine
                 combo_entities: %w[P8 P9],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P13-AIDS (Remove Town)',
@@ -276,7 +279,7 @@ module Engine
                 combo_entities: %w[P8 P9],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P14-NMS (Mail Contract)',
@@ -293,7 +296,7 @@ module Engine
                   'towns. A company that owns more than one Mail Contract may not use '\
                   'more than one on any train.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P15-NMS (Mail Contract)',
@@ -310,7 +313,7 @@ module Engine
                   'towns. A company that owns more than one Mail Contract may not use '\
                   'more than one on any train.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P16-VTPN (Stock Drop)',
@@ -329,7 +332,7 @@ module Engine
                 choices: { 'close_p16' => 'Close P16' },
               },
             ],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P17-UD (Small Port)',
@@ -356,7 +359,7 @@ module Engine
                 consume_tile_lay: false,
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P18-HI (Large Port)',
@@ -383,7 +386,7 @@ module Engine
                 consume_tile_lay: false,
               },
             ],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'CONCESSION: FCM',

--- a/lib/engine/game/g_1822_pnw/entities.rb
+++ b/lib/engine/game/g_1822_pnw/entities.rb
@@ -4,6 +4,9 @@ module Engine
   module Game
     module G1822PNW
       module Entities
+        PRIVATE_RED = '#FF7276'
+        PRIVATE_GREEN = '#90EE90'
+
         COMPANIES = [
           {
             name: 'P1-The Olympian Hiawatha (5-Train)',
@@ -17,7 +20,7 @@ module Engine
                   'buying action.  However, once acquired the acquiring company must check whether it as at the '\
                   'train limit and must discard any trains held in excess of limit.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P2-J.S. Ruckle OSNC 4-4-0 (Permanent 2T)',
@@ -36,7 +39,7 @@ module Engine
                   'this also still counts as a normal dividend for share price movement purposes. '\
                   'Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P3-Portland Streetcar (Permanent LT)',
@@ -55,7 +58,7 @@ module Engine
                   'this also still counts as a normal dividend for share price movement purposes. '\
                   'Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P4-South Lake Union Trolley (Permanent LT)',
@@ -74,7 +77,7 @@ module Engine
                   'this also still counts as a normal dividend for share price movement purposes. '\
                   'Does not close.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P5-Pullman (Pullman)',
@@ -87,7 +90,7 @@ module Engine
                   'not count toward the train limit. Cannot be sold to another company. Does '\
                   'not close. No company may own more than one Pullman.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P6-Pullman (Pullman)',
@@ -100,7 +103,7 @@ module Engine
                   'not count toward the train limit. Cannot be sold to another company. Does '\
                   'not close. No company may own more than one Pullman.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P7-Dit Crusher (Remove Town)',
@@ -127,7 +130,7 @@ module Engine
               combo_entities: %w[P11],
             },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P8-Dit Crusher (Remove Town)',
@@ -154,7 +157,7 @@ module Engine
                 combo_entities: %w[P11],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P9-USPS Mail Service (Mail Contract)',
@@ -171,7 +174,7 @@ module Engine
                   'towns. A company that owns more than one Mail Contract may not use '\
                   'more than one on any train.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P10-American Bridge Company (Three Builder Cubes)',
@@ -196,7 +199,7 @@ module Engine
                 tiles: [],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P11-Surveyors (Extra Tile Lay)',
@@ -224,7 +227,7 @@ module Engine
                 combo_entities: %w[P7 P8],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P12-Dock Upgrades (Small Port)',
@@ -251,7 +254,7 @@ module Engine
                 consume_tile_lay: false,
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P13-Harbor Improvements (Large Port)',
@@ -278,7 +281,7 @@ module Engine
                 consume_tile_lay: false,
               },
             ],
-            color: nil,
+            color: PRIVATE_RED,
           },
           {
             name: 'P14-Lumber Baron (2x Timber Value)',
@@ -291,7 +294,7 @@ module Engine
                   'connection requirements. Once acquired by a company '\
                   'this private no longer pays its revenue.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P15-Paper Mill (City Revenue)',
@@ -314,7 +317,7 @@ module Engine
                 closed_when_used_up: true,
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P16-Pacific Portage Company (Special Tile Placement)',
@@ -343,7 +346,7 @@ module Engine
                 tiles: %w[PNW1 PNW2],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P17-Ski Haus (Route Enhancement)',
@@ -367,7 +370,7 @@ module Engine
                 closed_when_used_up: true,
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P18-Boom Town (Special Tile Upgrade)',
@@ -389,7 +392,7 @@ module Engine
                 tiles: %w[PNW3],
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P19-Rockport Coal Mine (Special Tile Placement)',
@@ -419,7 +422,7 @@ module Engine
                 free: true,
               },
             ],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P20-Backroom Negotiations (Minor Status Upgrade)',
@@ -437,7 +440,7 @@ module Engine
                   'company and its location becomes the major’s new home '\
                   'token location.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'P21-Credit Mobilier (Move Card/Exchange Token)',
@@ -452,7 +455,7 @@ module Engine
                   'a major company to move a station token from exchange to '\
                   'available. Closes when the power is exercised.',
             abilities: [],
-            color: nil,
+            color: PRIVATE_GREEN,
           },
           {
             name: 'MINOR: 1. Pacific Great Eastern Railway',


### PR DESCRIPTION
match the physical games, where companies which can be acquired by minors are green, and companies which cannot are red; this is already done for 1822CA

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`