### PR TITLE
1841: add version 1 optional rule for SFLi

### DIFF
--- a/lib/engine/game/g_1841/game.rb
+++ b/lib/engine/game/g_1841/game.rb
@@ -454,7 +454,7 @@ module Engine
           sfma_idx = @round.entities.find_index(sfma)
           ssfl_idx = @round.entities.find_index(ssfl)
 
-          will_run = (version == 2)
+          will_run = (version == 2) || sfli_run_variant?
           will_run = false if sflp_idx && sflp_idx <= @round.entity_index
           will_run = false if sfma_idx && sfma_idx <= @round.entity_index
           will_run = false if ssfl_idx && ssfl_idx <= @round.entity_index
@@ -1109,6 +1109,10 @@ module Engine
 
         def lite?
           @lite ||= @optional_rules&.include?(:lite)
+        end
+
+        def sfli_run_variant?
+          @sfli_run_variant ||= @optional_rules&.include?(:sfli_run_variant)
         end
 
         def event_close_companies!

--- a/lib/engine/game/g_1841/meta.rb
+++ b/lib/engine/game/g_1841/meta.rb
@@ -35,6 +35,11 @@ module Engine
             short_name: 'Version 1',
             desc: 'Original auction, map and corporations',
           },
+          {
+            sym: :sfli_run_variant,
+            short_name: 'Use Version 2 SFLi formation',
+            desc: 'For Version 1 rules, allow SFLi to run during the OR it is formed the same as Version 2',
+          },
         ].freeze
       end
     end


### PR DESCRIPTION
Fixes #10832 

Add optional rule for Version 1 games to allow SFLi formation to use Version 2 rules.