### PR TITLE
[1822MX] include NdeM shares in liquidity calculation

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1125,9 +1125,17 @@ module Engine
         return value_for_sellable(player, corporation) if self.class::PRESIDENT_SALES_TO_MARKET
 
         max_bundle = bundles_for_corporation(player, corporation)
-          .select { |bundle| bundle.can_dump?(player) && @share_pool&.fit_in_bank?(bundle) }
+          .select { |bundle| can_dump?(player, bundle) && @share_pool&.fit_in_bank?(bundle) }
           .max_by(&:price)
         max_bundle&.price || 0
+      end
+
+      def can_dump?(entity, bundle)
+        if active_step.respond_to?(:can_dump?)
+          active_step.can_dump?(entity, bundle)
+        else
+          bundle.can_dump?(entity)
+        end
       end
 
       def issuable_shares(_entity)

--- a/lib/engine/game/g_1822_mx/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1822_mx/step/buy_sell_par_shares.rb
@@ -32,6 +32,12 @@ module Engine
               @game.share_pool.fit_in_bank?(bundle)
             # For NDEM, removed the "bundle.can_dump?" check
           end
+
+          def can_dump?(entity, bundle)
+            return super unless bundle.corporation.id == 'NDEM'
+
+            true
+          end
         end
       end
     end

--- a/lib/engine/game/g_1841/game.rb
+++ b/lib/engine/game/g_1841/game.rb
@@ -2551,8 +2551,7 @@ module Engine
           @round.recalculate_order if @round.respond_to?(:recalculate_order)
         end
 
-        # can sell any amount?
-        def can_dump?(owner, corp, active)
+        def can_sell_any_amount?(owner, corp, active)
           # can dump IPO stock
           owner == corp ||
             # can dump stock if not president of corp
@@ -2569,7 +2568,7 @@ module Engine
         end
 
         def corp_minimum_to_retain(owner, corp, active)
-          return 0 if can_dump?(owner, corp, active)
+          return 0 if can_sell_any_amount?(owner, corp, active)
           return 0 if historical?(corp)
 
           corp.player_share_holders.reject { |s_h, _| s_h == owner }.values.max || 0
@@ -2580,7 +2579,7 @@ module Engine
           corp = bundle.corporation
 
           return false if bundle.partial? && !can_sell_partial?(owner, corp)
-          return true if can_dump?(owner, corp, active)
+          return true if can_sell_any_amount?(owner, corp, active)
 
           corp_minimum_to_retain(owner, corp, active) <= (owner.percent_of(corp) - bundle.percent) &&
             !bundle.presidents_share
@@ -2592,7 +2591,7 @@ module Engine
           bundles = all_bundles_for_corporation(owner, corp)
           bundles.each { |b| b.share_price = corp.share_price.price / 2.0 }
           max = owner.percent_of(corp) - corp_minimum_to_retain(owner, corp, active)
-          bundles.reject!(&:presidents_share) unless can_dump?(owner, corp, active)
+          bundles.reject!(&:presidents_share) unless can_sell_any_amount?(owner, corp, active)
           bundles.reject { |b| b.percent > max }
         end
 

--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -212,6 +212,11 @@ TEST_CASES = [
      'double headed trains',
      ['Operating Round 3.2 (of 2)',
       '3+2 [5+4]']]]],
+  ['1841',
+   132_002,
+   [[939,
+     'endgame',
+     ['1841: Phase 8 - Operating Round 7.1 (of 3) - Game Over - Company hit max stock value']]]],
 ].freeze
 
 AUTO_ACTIONS_TEST_CASES = [


### PR DESCRIPTION
Fixes #9821 without causing #10900, which #10896 did

* adds an 1841 test that would have caught #10900 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`