### PR TITLE
[1822PNW] fix updating the minor's simple logo when associated major changes

### DIFF
--- a/lib/engine/game/g_1822_pnw/step/acquire_company.rb
+++ b/lib/engine/game/g_1822_pnw/step/acquire_company.rb
@@ -55,6 +55,7 @@ module Engine
             @new_associated_minor.text_color = old_company.text_color
             @new_associated_minor.logo = "1822_pnw/#{major.id.downcase}/#{@new_associated_minor.name}"
             @new_associated_minor.tokens.first.logo = @new_associated_minor.logo
+            @new_associated_minor.tokens.first.simple_logo = @new_associated_minor.logo
 
             original_home_coordinates = major.coordinates
             @game.remove_home_icon(major, original_home_coordinates)

--- a/lib/engine/operator.rb
+++ b/lib/engine/operator.rb
@@ -68,6 +68,7 @@ module Engine
     def logo=(logo)
       @logo_filename = "#{logo}.svg"
       @logo = "/logos/#{@logo_filename}"
+      @simple_logo = @logo
     end
   end
 end


### PR DESCRIPTION
this was missed in #10903

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`