### PR TITLE
[1822MX] buying NdeM shares in first stock round prevents a game end

### DIFF
--- a/lib/engine/game/g_1822_mx/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1822_mx/step/buy_sell_par_shares.rb
@@ -10,6 +10,7 @@ module Engine
           def process_buy_shares(action)
             return super unless action.bundle.corporation.id == 'NDEM'
 
+            @game.something_sold_in_sr!
             @round.bought_from_ipo = true if action.bundle.owner.corporation?
             buy_shares(action.entity, action.bundle, swap: action.swap, allow_president_change: false)
             track_action(action, action.bundle.corporation)


### PR DESCRIPTION
Rule 1.3.1 says the game ends "Immediately, if the first stock round ends with nothing sold", NdeM shares are something

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`