### PR TITLE
[1822 family] Allow auto-routing to run L-trains in different cities

### DIFF
--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -103,9 +103,16 @@ module Engine
             next unless left
 
             chains << { nodes: [left, nil], paths: [] }
+
+            # use the Local train's 1 city instead of any paths as their key;
+            # only 1 train can visit each city, but we want Locals to be able to
+            # visit multiple different cities if a corporation has more than one
+            # of them
+            id = [left]
+          else
+            id = chains.flat_map { |c| c[:paths] }.sort!
           end
 
-          id = chains.flat_map { |c| c[:paths] }.sort!
           next if connections[id]
 
           connections[id] = chains.map do |c|

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -584,15 +584,10 @@ module Engine
           # Tracks by e-train and normal trains
           tracks_by_type = Hash.new { |h, k| h[k] = [] }
 
-          # Check local train not use the same token more then one time
-          local_cities = []
-
           # Merthyr Tydfil and Pontypool
           merthyr_tydfil_pontypool = {}
 
           routes.each do |route|
-            local_cities.concat(route.visited_stops.select(&:city?)) if route.train.local? && !route.chains.empty?
-
             route.paths.each do |path|
               a = path.a
               b = path.b
@@ -621,14 +616,30 @@ module Engine
             end
           end
 
-          local_cities.group_by(&:itself).each do |k, v|
-            raise GameError, "Local train can only use each token on #{k.hex.id} once" if v.size > 1
-          end
+          check_local_cities(routes)
 
           # Check Merthyr Tydfil and Pontypool, only one of the 2 tracks may be used
           return if !merthyr_tydfil_pontypool[1] || !merthyr_tydfil_pontypool[2]
 
           raise GameError, 'May only use one of the tracks connecting Merthyr Tydfil and Pontypool'
+        end
+
+        # Check local train not use the same token more then one time
+        def check_local_cities(routes)
+          local_cities = []
+          routes.each do |route|
+            local_cities.concat(route.visited_stops.select(&:city?)) if route.train.local? && !route.chains.empty?
+          end
+
+          local_cities.group_by(&:itself).each do |k, v|
+            puts "Local train can only use each token on #{k.hex.id} once"
+            raise GameError, "Local train can only use each token on #{k.hex.id} once" if v.size > 1
+          end
+        end
+
+        # called by AutoRouter
+        def check_other(route)
+          check_local_cities(route.routes)
         end
 
         def company_bought(company, entity)


### PR DESCRIPTION
Move 1822's check for L-trains into a new method so that it can be called during auto routing

Technically applicable to all 1822 games, most applicable to 1822MX as the NdeM is the most likely entity across these titles to be running multiple L-trains

Fixes #7902

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`