### PR TITLE
[18RoyalGorge] fix endgame, add some small enhancements

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/entities.rb
+++ b/lib/engine/game/g_18_royal_gorge/entities.rb
@@ -4,6 +4,9 @@ module Engine
   module Game
     module G18RoyalGorge
       module Entities
+        PRIVATE_GREEN = '#90EE90'
+        PRIVATE_BROWN = '#CB7745'
+
         YELLOW_COMPANIES = [
           {
             sym: 'Y1',
@@ -129,6 +132,7 @@ module Engine
               # treaty of boston: 2 debt tokens; closes after SF buys both of them
               { type: 'no_buy' },
             ],
+            color: PRIVATE_GREEN,
           },
           {
             sym: 'G2',
@@ -146,6 +150,7 @@ module Engine
                 count: 1,
               },
             ],
+            color: PRIVATE_GREEN,
           },
           {
             sym: 'G3',
@@ -156,6 +161,7 @@ module Engine
                                                 '  Closes when the first 5+ train is purchased.",
             value: 50,
             revenue: 10,
+            color: PRIVATE_GREEN,
           },
           {
             sym: 'G4',
@@ -168,6 +174,7 @@ module Engine
               { type: 'revenue_change', revenue: 25, on_phase: 'Green' },
               { type: 'no_buy' },
             ],
+            color: PRIVATE_GREEN,
           },
           {
             sym: 'G5',
@@ -186,6 +193,7 @@ module Engine
                 when: %w[owning_player_sr_turn],
               },
             ],
+            color: PRIVATE_GREEN,
           },
           {
             sym: 'G6',
@@ -196,6 +204,7 @@ module Engine
                   'Closes when the first 5+ train is purchased.',
             value: 10,
             revenue: 5,
+            color: PRIVATE_GREEN,
           },
         ].freeze
 
@@ -208,6 +217,7 @@ module Engine
             value: 70,
             revenue: 0,
             abilities: [{ type: 'revenue_change', revenue: 25, on_phase: 'Brown' }],
+            color: PRIVATE_BROWN,
           },
           {
             sym: 'B2',
@@ -229,6 +239,7 @@ module Engine
                 special: true,
               },
             ],
+            color: PRIVATE_BROWN,
           },
           {
             sym: 'B3',
@@ -251,6 +262,7 @@ module Engine
                 reachable: true,
               },
             ],
+            color: PRIVATE_BROWN,
           },
           {
             sym: 'B4',
@@ -263,6 +275,7 @@ module Engine
             abilities: [
               { type: 'no_buy' },
             ],
+            color: PRIVATE_BROWN,
           },
           {
             sym: 'B5',
@@ -272,6 +285,7 @@ module Engine
                   'Closes when the first 5+ train is purchased.',
             value: 60,
             revenue: 10,
+            color: PRIVATE_BROWN,
           },
           {
             sym: 'B6',
@@ -288,6 +302,7 @@ module Engine
                 when: %w[owning_player_sr_turn],
               },
             ],
+            color: PRIVATE_BROWN,
           },
         ].freeze
 

--- a/lib/engine/game/g_18_royal_gorge/entities.rb
+++ b/lib/engine/game/g_18_royal_gorge/entities.rb
@@ -244,10 +244,10 @@ module Engine
           {
             sym: 'B3',
             name: 'Steel Depot (B3)',
-            desc: 'Comes with the Steel Depot card. Once per operating round, owning corporation '\
-                  'may use 0-2 steel from the Steel Depot card to lay yellow track for free. (Max '\
-                  'of 6 track applies). '\
-                  'Closes when the first 5+ train is purchased.',
+            desc: 'Comes with the Steel Depot card, which holds 5 steel cubes. '\
+                  'Once per operating round, owning corporation may use 0-2 steel '\
+                  'from the Steel Depot card to lay yellow track for free. (Max '\
+                  'of 6 track applies). Closes when the first 5+ train is purchased.',
             value: 55,
             revenue: 10,
             abilities: [

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -552,6 +552,8 @@ module Engine
           # debt increases
           old_price = @debt_corp.share_price
           @stock_market.move_right(@debt_corp)
+          @debt_corp.cash = @debt_corp.share_price.price
+
           log_share_price(@debt_corp, old_price, 1)
         end
 
@@ -907,6 +909,7 @@ module Engine
           corporation.ipoed = true
           corporation.floated = true
           price = @stock_market.share_price([0, 6])
+          corporation.cash = price.price
           @stock_market.set_par(corporation, price)
           bundle = ShareBundle.new(corporation.shares_of(corporation))
           @share_pool.transfer_shares(bundle, @share_pool)

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -122,12 +122,12 @@ module Engine
         }.freeze
         GAME_END_REASONS_TEXT = {
           bankrupt: 'Player is bankrupt',
-          custom: '6-train is bought/exported',
+          custom: '6x2-train is bought/exported',
           stock_market: 'Corporation enters end game trigger on stock market',
         }.freeze
         GAME_END_DESCRIPTION_REASON_MAP_TEXT = {
           bankrupt: 'Bankruptcy',
-          custom: '6-train was bought/exported',
+          custom: '6x2-train was bought/exported',
           stock_market: 'Company hit max stock value',
         }.freeze
 

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -1053,6 +1053,11 @@ module Engine
         def end_game!(player_initiated: false)
           return if @finished
 
+          if !@manually_ended && @round.finished?
+            handle_metal_payout(@steel_corp)
+            handle_metal_payout(@gold_corp)
+          end
+
           logged_drop = false
           @indebted.each do |corporation, (_, amount)|
             next unless corporation.floated?

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -136,8 +136,8 @@ module Engine
         end
 
         def game_companies
-          YELLOW_COMPANIES.sort_by { rand }.take(2).sort_by { |c| c[:sym] } +
-            GREEN_COMPANIES.sort_by { rand }.take(2).sort_by { |c| c[:sym] } +
+          YELLOW_COMPANIES.sort_by { rand }.take(2).sort_by { |c| c[:value] } +
+            GREEN_COMPANIES.sort_by { rand }.take(2).sort_by { |c| c[:value] } +
             BROWN_COMPANIES.sort_by { rand }.take(1)
         end
 

--- a/lib/engine/game/g_18_royal_gorge/trains.rb
+++ b/lib/engine/game/g_18_royal_gorge/trains.rb
@@ -20,7 +20,7 @@ module Engine
             distance: [{ 'nodes' => %w[city offboard], 'pay' => 3, 'visit' => 3 },
                        { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
             price: 180,
-            rusts_on: '6',
+            rusts_on: '6x2',
             salvage: 45,
             num: 4,
             events: [{ 'type' => 'treaty_of_boston', 'when' => 2 }],
@@ -42,7 +42,7 @@ module Engine
             events: [{ 'type' => 'close_companies' }, { 'type' => 'gray_phase', 'when' => 2 }],
           },
           {
-            name: '6',
+            name: '6x2',
             distance: [{ 'nodes' => %w[city offboard town], 'pay' => 6, 'visit' => 6, 'multiplier' => 2 }],
             price: 650,
             num: 5,

--- a/public/fixtures/18RoyalGorge/post_boston.json
+++ b/public/fixtures/18RoyalGorge/post_boston.json
@@ -132,22 +132,42 @@
         "created_at": 1714545143
       },
       {
-        "type": "bid",
+        "type": "pass",
         "entity": 10874,
         "entity_type": "player",
-        "id": 17,
-        "created_at": 1714550482,
-        "company": "G1",
-        "price": 70
+        "id": 20,
+        "created_at": 1714595334
       },
       {
         "type": "bid",
         "entity": 3416,
         "entity_type": "player",
-        "id": 18,
-        "created_at": 1714584401,
-        "company": "G1",
-        "price": 75
+        "id": 25,
+        "created_at": 1714677683,
+        "company": "G6",
+        "price": 45
+      },
+
+      {
+        "type": "pass",
+        "entity": 11477,
+        "entity_type": "player",
+        "id": 20,
+        "created_at": 1714595334
+      },
+      {
+        "type": "pass",
+        "entity": 306,
+        "entity_type": "player",
+        "id": 26,
+        "created_at": 1714677717
+      },
+      {
+        "type": "pass",
+        "entity": 10874,
+        "entity_type": "player",
+        "id": 20,
+        "created_at": 1714595334
       },
       {
         "type": "bid",
@@ -169,63 +189,36 @@
         "type": "pass",
         "entity": 10874,
         "entity_type": "player",
-        "id": 21,
-        "created_at": 1714613810
+        "id": 20,
+        "created_at": 1714595334
       },
       {
         "type": "pass",
         "entity": 3416,
         "entity_type": "player",
-        "id": 22,
-        "created_at": 1714620056
+        "id": 20,
+        "created_at": 1714595334
       },
       {
-        "type": "bid",
+        "type": "pass",
         "entity": 306,
         "entity_type": "player",
-        "id": 23,
-        "created_at": 1714665263,
-        "company": "G6",
-        "price": 30
+        "id": 20,
+        "created_at": 1714595334
       },
       {
-        "type": "bid",
+        "type": "pass",
         "entity": 10874,
         "entity_type": "player",
-        "id": 24,
-        "created_at": 1714677623,
-        "company": "G6",
-        "price": 40
+        "id": 20,
+        "created_at": 1714595334
       },
       {
-        "type": "bid",
+        "type": "pass",
         "entity": 3416,
         "entity_type": "player",
-        "id": 25,
-        "created_at": 1714677683,
-        "company": "G6",
-        "price": 45
-      },
-      {
-        "type": "pass",
-        "entity": 11477,
-        "entity_type": "player",
-        "id": 26,
-        "created_at": 1714677717
-      },
-      {
-        "type": "pass",
-        "entity": 306,
-        "entity_type": "player",
-        "id": 27,
-        "created_at": 1714683380
-      },
-      {
-        "type": "pass",
-        "entity": 10874,
-        "entity_type": "player",
-        "id": 28,
-        "created_at": 1714708341
+        "id": 20,
+        "created_at": 1714595334
       },
       {
         "type": "bid",


### PR DESCRIPTION
* metal companies should pay at end of final OR set, fixes https://github.com/tobymao/18xx/issues/10922
*  put debt "share price" on corp card as cash so it is visible on the entities tab 
* set colors for the private companies for more clear auction grouping
* sort companies in auction by price, not number (migrated the `post_boston` fixture by hand)
* better description for Steel Depot 
* rename 6-trains to "6x2"

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
