### PR TITLE
 [1822 family] render bid info based on step, not just available actions

### DIFF
--- a/assets/app/view/game/bid.rb
+++ b/assets/app/view/game/bid.rb
@@ -11,7 +11,7 @@ module View
         needs :biddable
 
         def render
-          step = @game.round.step_for(@entity, 'bid')
+          return '' unless (step = @game.round.step_for(@entity, 'bid'))
 
           children = []
           children << h(:div, [step.bid_description]) if step.respond_to?(:bid_description) && step.bid_description

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -169,7 +169,7 @@ module View
           unless @company.discount.zero?
             children << h(:div, { style: { float: 'center' } }, "Price: #{@game.format_currency(@company.min_bid)}")
           end
-          children << render_bidders if @bids&.any?
+          children << render_bidders if @bids && !@bids.empty?
 
           if @company.owner && @game.show_company_owners?
             children << h('div.nowrap', { style: bidders_style },

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -81,7 +81,7 @@ module View
         end
         abilities_to_display = @corporation.all_abilities.select(&:description)
         children << render_abilities(abilities_to_display) if abilities_to_display.any?
-        children << render_bidders if @bids&.any?
+        children << render_bidders if @bids && !@bids.empty?
 
         extras = []
         if @game.corporation_show_loans?(@corporation)

--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -106,7 +106,7 @@ module View
           ]),
         ]
 
-        if @game.active_step&.current_actions&.include?('bid')
+        if @game.active_step&.current_actions&.include?('bid') || @game.active_step&.auctioneer?
           committed = @game.active_step.committed_cash(@player, @show_hidden)
           if committed.positive?
             trs.concat([

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -84,7 +84,7 @@ module View
           end
 
           children.concat(render_buttons)
-          children << render_bid if @current_actions.include?('bid')
+          children << render_bid if should_render_bid?
           children << h(SpecialBuy) if @current_actions.include?('special_buy')
           children.concat(render_failed_merge) if @current_actions.include?('failed_merge')
           children.concat(render_bank_companies) if @bank_first
@@ -287,7 +287,7 @@ module View
           when :par
             children << h(Par, corporation: corporation) if @current_actions.include?('par')
           when :bid
-            children << h(Bid, entity: @current_entity, biddable: corporation) if @current_actions.include?('bid')
+            children << h(Bid, entity: @current_entity, biddable: corporation) if should_render_bid?
           when :form
             children << h(FormCorporation, corporation: corporation) if @current_actions.include?('par')
           when String
@@ -410,11 +410,11 @@ module View
           @game.buyable_bank_owned_companies.map do |company|
             inputs = []
             inputs.concat(render_buy_input(company)) if @current_actions.include?('buy_company')
-            inputs.concat(render_company_bid_input(company)) if @current_actions.include?('bid')
+            inputs.concat(render_company_bid_input(company)) if should_render_bid?
 
             children = []
             children << h(Company, company: company,
-                                   bids: (@current_actions.include?('bid') ? @step.bids[company] : nil),
+                                   bids: (should_render_bid? ? @step.bids[company] : nil),
                                    interactive: !inputs.empty?)
             if !inputs.empty? && @selected_company == company
               children << h('div.margined_bottom', { style: { width: '20rem' } }, inputs)
@@ -581,6 +581,10 @@ module View
             children << h(Bid, entity: @current_entity, biddable: @step.bid_entity)
           end
           h(:div, children)
+        end
+
+        def should_render_bid?
+          @current_actions.include?('bid') || @step.auctioneer?
         end
       end
     end

--- a/spec/assets_spec.rb
+++ b/spec/assets_spec.rb
@@ -123,7 +123,12 @@ TEST_CASES = [
      ['Convert',
       'Merge',
       'Pittsburgh, Shawmut and Northern Railroad',
-      'Corporations that can merge with J']]]],
+      'Corporations that can merge with J']],
+    [1502,
+     'stock',
+     ['Stock Round 7',
+      'Final phase was reached',
+      'buys a 10% share of Bess from the market for $165']]]],
   ['1817',
    16_852,
    [[889, 'cash_crisis', ['Random Guy owes the bank $294 and must raise cash if possible.']]]],
@@ -217,6 +222,12 @@ TEST_CASES = [
    [[939,
      'endgame',
      ['1841: Phase 8 - Operating Round 7.1 (of 3) - Game Over - Company hit max stock value']]]],
+  ['18NY',
+   108_746,
+   [[130,
+     'stock',
+     ['Stock Round 3',
+      '10 receives $110 in its Treasury']]]],
 ].freeze
 
 AUTO_ACTIONS_TEST_CASES = [


### PR DESCRIPTION
Fixes #10543

1822's auctions are during a Stock round instead of a special Auction round, so it can be a player's turn without `bid` being an available action.

#10913 was the first attempt at this, but it broke 18NY and 1817 so it  was reverted. Tests have been added for those titles at actions where they failed to render with the original change.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`