### PR TITLE
[1822PNW] prevent other tile lays from being made after portage

### DIFF
--- a/lib/engine/game/g_1822_pnw/step/special_track.rb
+++ b/lib/engine/game/g_1822_pnw/step/special_track.rb
@@ -174,6 +174,14 @@ module Engine
             action.entity.revenue = 0
           end
 
+          def get_tile_lay(entity)
+            # portage company uses up normal tile lay, and needs weird handling
+            # since it lays blue tiles on water hexes
+            return if @round.num_laid_portage.positive? && !@game.portage_company?(entity)
+
+            super
+          end
+
           def process_lay_tile_boomtown_company(action)
             lay_tile(action)
             ability = abilities(action.entity)


### PR DESCRIPTION
other logic is already in place to prevent the portage from going after other tile lays, this fixes when portage is used first

Fixes #10920

some pins will be needed `[126288, 126312, 142944, 143929, 150567, 157534, 160785]`

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
