### PR TITLE
[Autorouting] create groups of different trains for autorouting

### DIFF
--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -14,13 +14,27 @@ module Engine
     end
 
     def compute(corporation, **opts)
+      trains = @game.route_trains(corporation).sort_by(&:price).reverse
+
+      train_groups =
+        if (groups = @game.class::TRAIN_AUTOROUTE_GROUPS)
+          trains.group_by { |t| groups.index { |g| g.include?(t.name) } }.values
+        else
+          [trains]
+        end
+
+      train_groups.flat_map do |train_group|
+        compute_for_train_group(train_group, corporation, **opts)
+      end
+    end
+
+    def compute_for_train_group(trains, corporation, **opts)
       static = opts[:routes] || []
       path_timeout = opts[:path_timeout] || 30
       route_timeout = opts[:route_timeout] || 10
       route_limit = opts[:route_limit] || 10_000
 
       connections = {}
-      trains = @game.route_trains(corporation).sort_by(&:price).reverse
 
       graph = @game.graph_for_entity(corporation)
       nodes = graph.connected_nodes(corporation).keys.sort_by do |node|

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -137,6 +137,12 @@ module Engine
 
       TRAINS = [].freeze
 
+      # Array of groups (arrays) of train names; trains within a group cannot
+      # have overlapping routes, but a train in one group can overlap with
+      # routes of trains in another group. Any trains not listed here fall into
+      # a default group.
+      TRAIN_AUTOROUTE_GROUPS = nil
+
       CERT_LIMIT_TYPES = %i[multiple_buy unlimited no_cert_limit].freeze
       # Does the cert limit decrease when a player becomes bankrupt?
       CERT_LIMIT_CHANGE_ON_BANKRUPTCY = false

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -288,6 +288,10 @@ module Engine
           },
         ].freeze
 
+        TRAIN_AUTOROUTE_GROUPS = [
+          %w[E],
+        ].freeze
+
         LAYOUT = :flat
 
         SELL_MOVEMENT = :down_share

--- a/lib/engine/game/g_18_los_angeles/game.rb
+++ b/lib/engine/game/g_18_los_angeles/game.rb
@@ -106,6 +106,11 @@ module Engine
         DUMP_PENALTY_WESTMINSTER = 10
         WESTMINSTER_HEX = 'F9'
 
+        TRAIN_AUTOROUTE_GROUPS = [
+          %w[2 4 5 6],
+          %w[3/5 4/6 7/8],
+        ].freeze
+
         def setup
           super
 


### PR DESCRIPTION
Trains within a group cannot have overlapping routes, but they can overlap with routes of trains in different groups. Trains not listed in `TRAIN_AUTOROUTE_GROUPS` end up in a default group.

* in 1822, E-trains can overlap with other trains; all others are automatically placed in another group
* in 18 Los Angeles, freight  (e.g., 3/5) trains can have routes overlapping with passenger trains

Fixes #7982 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`