### PR TITLE
[Core/1822MX] Simplify base implementation of Game.can_dump?

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1131,11 +1131,7 @@ module Engine
       end
 
       def can_dump?(entity, bundle)
-        if active_step.respond_to?(:can_dump?)
-          active_step.can_dump?(entity, bundle)
-        else
-          bundle.can_dump?(entity)
-        end
+        bundle.can_dump?(entity)
       end
 
       def issuable_shares(_entity)

--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -518,6 +518,14 @@ module Engine
           @share_pool.sell_shares(bundle, allow_president_change: false, swap: swap)
         end
 
+        def can_dump?(entity, bundle)
+          if active_step.respond_to?(:can_dump?)
+            active_step.can_dump?(entity, bundle)
+          else
+            bundle.can_dump?(entity)
+          end
+        end
+
         def operating_order
           ndem, others = @corporations.select(&:floated?).sort.partition { |c| c.id == 'NDEM' }
           minors, majors = others.sort.partition { |c| c.type == :minor }


### PR DESCRIPTION
The implementation of `Game.can_dump?` introduced by tobymao#10907 broke the (pre-alpha) implementation of 18Ardennes. It caused a 'maximum stack size exceeded' error. This is because there is a step in 18Ardenees where `actions` calls `@game.liquidity`, and so the call to `active_step` in this new `can_dump?` function is causing an infinite loop.

To fix this, and avoid the same error being caused in future, this commit makes the base class implementation of `can_dump?` as simple as possible, just calling `Bundle.can_dump?`. The version of the method which checks `active_step` is moved into the 1822MX game code.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`