### PR TITLE
[1822Africa] fix step and tiles for P12

### DIFF
--- a/lib/engine/game/g_1822_africa/entities.rb
+++ b/lib/engine/game/g_1822_africa/entities.rb
@@ -194,7 +194,8 @@ module Engine
           {
             name: 'P12 (Fast Sahara Building)',
             sym: 'P12',
-            desc: 'MAJOR/MINOR, Phase 1. The owning company may place any amount of yellow tiles in the hexes marked '\
+            desc: 'MAJOR/MINOR, Phase 1. The owning company may place any amount of yellow tiles '\
+                  'following the other tile laying rules in the hexes marked '\
                   'with desert terrain as their normal tile laying step at normal cost. '\
                   'Using this ability closes the private company.',
             value: 0,
@@ -203,9 +204,9 @@ module Engine
               {
                 type: 'tile_lay',
                 hexes: %w[B6 C3 C5 C7 D4 D6 D8 E5 E7 F6 G7],
-                tiles: [],
+                tiles: %w[7 8 9],
                 owner_type: 'corporation',
-                when: 'special_track',
+                when: %w[track special_track],
                 must_lay_together: true,
                 lay_count: 11,
                 upgrade_count: 0,


### PR DESCRIPTION
also update to use Scott's suggested working

Fixes #10886

Pins needed for games where P12 was used and then more tiles were laid on the same turn, at least these games: `[137381, 138358, 139168, 139558, 143179, 143324, 144765, 144839, 145246, 145270, 150797, 158656, 161673]`

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
