### PR TITLE
Dev mode: compile only game files for requested games 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development do
   gem 'rubocop-performance', require: 'false'
   gem 'sequel-annotate'
   gem 'stackprof'
+  gem 'tilt'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
       opal (>= 1.1)
     stackprof (0.2.19)
     strscan (3.1.0)
+    tilt (2.3.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
@@ -145,6 +146,7 @@ DEPENDENCIES
   sequel_pg
   snabberb
   stackprof
+  tilt
   unicorn
   unicorn-worker-killer
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,4 +151,4 @@ DEPENDENCIES
   unicorn-worker-killer
 
 BUNDLED WITH
-   2.4.10
+   2.5.13

--- a/Rakefile
+++ b/Rakefile
@@ -102,7 +102,7 @@ desc 'Precompile assets for production'
 task :precompile do
   require_relative 'lib/assets'
   assets = Assets.new(cache: false, compress: true, gzip: true)
-  assets.combine
+  assets.combine(:all)
 
   # Copy to the pin directory
   git_rev = `git rev-parse --short HEAD`.strip

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -433,6 +433,7 @@ module View
           settings: {
             optional_rules: game_params[:optional_rules] || [],
           },
+          title: game_params[:title],
         }
         game_data[:settings][:seed] = game_params[:seed] if game_params[:seed]
       end

--- a/lib/assets.rb
+++ b/lib/assets.rb
@@ -27,13 +27,13 @@ class Assets
     @precompiled = precompiled
   end
 
-  def context
-    combine
+  def context(titles)
+    combine(titles)
     @context ||= JsContext.new(@server_path)
   end
 
-  def html(script, **needs)
-    context.eval(Snabberb.html_script(script, **needs))
+  def html(script, titles: :all, **needs)
+    context(titles).eval(Snabberb.html_script(script, **needs))
   end
 
   def game_builds(titles = [])
@@ -123,12 +123,11 @@ class Assets
     end
   end
 
-  def js_tags(titles)
-    combine
-    titles.delete('all')
+  def js_tags(titles = [])
+    combine(titles)
 
     scripts = %w[deps main].map do |key|
-      file = builds[key]['path'].gsub(@out_path, @root_path)
+      file = builds(titles)[key]['path'].gsub(@out_path, @root_path)
       %(<script type="text/javascript" src="#{file}"></script>)
     end
     scripts.concat(titles.flat_map { |title| game_js_tags(title) }.uniq).compact.join

--- a/lib/assets.rb
+++ b/lib/assets.rb
@@ -148,30 +148,38 @@ class Assets
     tags.compact
   end
 
-  def combine
-    @combine ||=
-      begin
-        builds.each do |key, build|
-          next if @precompiled
+  def combine(titles = [])
+    @_combined ||= Set.new
 
-          source = build['files'].map { |file| File.read(file).to_s }.join("\n")
-          source = compress(key, source) if @compress
-          File.write(build['path'], source)
-
-          next if !@gzip || build['path'] == @server_path
-
-          Zlib::GzipWriter.open("#{build['path']}.gz") do |gz|
-            # two gzipped files with identical contents look different to
-            # tools like rsync if their mtimes are different; we don't want
-            # rsync to deploy "new" versions of deps.js.gz, etc if they
-            # haven't changed
-            gz.mtime = 0
-            gz.write(source)
-          end
-        end
-
-        [@deps_path, @main_path, *game_paths]
+    combine_titles =
+      if titles == :all
+        :all
+      else
+        titles_with_ancestors(titles)
       end
+
+    builds(combine_titles).each do |key, build|
+      next if @precompiled
+
+      @_combined.include?(key) ? next : @_combined.add(key)
+
+      source = build['files'].map { |file| File.read(file).to_s }.join("\n")
+      source = compress(key, source) if @compress
+      File.write(build['path'], source)
+
+      next if !@gzip || build['path'] == @server_path
+
+      Zlib::GzipWriter.open("#{build['path']}.gz") do |gz|
+        # two gzipped files with identical contents look different to
+        # tools like rsync if their mtimes are different; we don't want
+        # rsync to deploy "new" versions of deps.js.gz, etc if they
+        # haven't changed
+        gz.mtime = 0
+        gz.write(source)
+      end
+    end
+
+    [@deps_path, @main_path, *game_paths]
   end
 
   def compile_lib(name, *append_paths)

--- a/lib/assets.rb
+++ b/lib/assets.rb
@@ -263,4 +263,21 @@ class Assets
       .uniq
       .each { |file| File.delete(file) if File.exist?(file) }
   end
+
+  def to_fs_name(title)
+    Engine.meta_by_title(title).fs_name
+  end
+
+  # returns an array of game titles, starting with the earliest ancestor and
+  # ending with the given game, e.g.,
+  # `title_with_ancestors('1822CA WRS') -> ['1822', '1822CA', '1822CA WRS']`
+  def title_with_ancestors(title)
+    return [] unless (game = Engine.meta_by_title(title))
+
+    [*title_with_ancestors(game::DEPENDS_ON), title]
+  end
+
+  def titles_with_ancestors(titles)
+    titles.flat_map { |t| title_with_ancestors(t) }.uniq
+  end
 end

--- a/lib/assets.rb
+++ b/lib/assets.rb
@@ -137,15 +137,16 @@ class Assets
   def game_js_tags(title)
     return [] unless title
 
-    game = Engine.meta_by_title(title)
-    tags = game_js_tags(game::DEPENDS_ON)
+    titles = title_with_ancestors(title)
+    builds_for_games = builds(titles)
 
-    key = game.fs_name
-    return [] unless builds.key?(key)
+    titles.each_with_object([]) do |game_title, _tags|
+      key = to_fs_name(game_title)
+      next unless builds_for_games.key?(key)
 
-    file = builds[key]['path'].gsub(@out_path, @root_path)
-    tags << %(<script type="text/javascript" src="#{file}"></script>)
-    tags.compact
+      file = builds_for_games[key]['path'].gsub(@out_path, @root_path)
+      %(<script type="text/javascript" src="#{file}"></script>)
+    end
   end
 
   def combine(titles = [])

--- a/lib/engine.rb
+++ b/lib/engine.rb
@@ -51,6 +51,8 @@ module Engine
   end
 
   def self.meta_by_title(title)
+    return unless title
+
     GAME_META_BY_TITLE[closest_title(title)]
   end
 


### PR DESCRIPTION
After the issues with #10797 and #10810, I've used this branch for a few weeks to make sure it was stable before opening another PR for this.

Stop waiting for the files for all titles to build in local dev mode; only build for titles as needed. This reduces time for initial development setup, and reduces the pain for every `make clean`.

This changes functions in `lib/assets.rb` to use a `titles` param so that only the given titles are built, and change cached functions to cache things per-title when possible instead of caching the whole function call. In non-production mode, the API will trigger builds for game files that aren't already built.

It's best to view this diff with the "Hide whitespace" setting enabled. If the changes as a whole are confusing / difficult to review, looking at the individual commits one at a time might be easier.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`