### PR TITLE
System18: fix inc-cap dividends; add legend to Poland map

### DIFF
--- a/lib/engine/game/g_system18/map_poland_customization.rb
+++ b/lib/engine/game/g_system18/map_poland_customization.rb
@@ -101,6 +101,7 @@ module Engine
             'E9' => '(Austria)',
             'E11' => 'Kiev',
             'F4' => 'Wien',
+            'F10' => 'N-S and E-W bonuses',
           }
         end
 
@@ -109,6 +110,7 @@ module Engine
           {
             gray: {
               %w[F6 F8] => 'path=a:2,b:3',
+              %w[F10] => 'offboard=revenue:yellow_0|green_0|brown_50|gray_60',
             },
 
             red: {

--- a/lib/engine/game/g_system18/step/dividend.rb
+++ b/lib/engine/game/g_system18/step/dividend.rb
@@ -15,15 +15,16 @@ module Engine
             return super unless @game.game_capitalization == :incremental
 
             price = entity.share_price.price
+            puts "price: #{price}, revenue: #{revenue}"
 
             if revenue.zero?
               { share_direction: :left, share_times: 1 }
-            elsif revenue < price
-              {}
-            elsif revenue >= price
-              { share_direction: :right, share_times: 1 }
             elsif revenue >= 2 * price
               { share_direction: :right, share_times: 2 }
+            elsif revenue >= price
+              { share_direction: :right, share_times: 1 }
+            else
+              {}
             end
           end
 


### PR DESCRIPTION
Fixes #10947 

Adds bonus legend to Poland map.