### PR TITLE
[graph] track and log the number of calls made to `node.walk` and `path.walk`

### DIFF
--- a/lib/engine/game/g_1822_ca/step/destination_token.rb
+++ b/lib/engine/game/g_1822_ca/step/destination_token.rb
@@ -93,9 +93,24 @@ module Engine
           end
 
           def nodes_connected?(node_a, node_b, entity)
-            node_a&.walk(corporation: entity) do |path, _, _|
-              return true if path.nodes.include?(node_b)
+            LOGGER.debug { "    nodes_connected?(#{node_a}, #{node_b}, #{entity.name})" }
+            walk_calls = Hash.new(0)
+
+            node_a&.walk(corporation: entity, walk_calls: walk_calls) do |path, _, _|
+              if path.nodes.include?(node_b)
+                LOGGER.debug do
+                  "    nodes_connected? returning true after #{walk_calls[:not_skipped]} "\
+                    "walk calls (#{walk_calls[:skipped]} skipped)"
+                end
+                return true
+              end
             end
+
+            LOGGER.debug do
+              "    nodes_connected? returning false after #{walk_calls[:not_skipped]} "\
+                "walk calls (#{walk_calls[:skipped]} skipped)"
+            end
+
             false
           end
 

--- a/lib/engine/part/node.rb
+++ b/lib/engine/part/node.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'base'
+
 module Engine
   module Part
     class Node < Base
@@ -44,9 +46,14 @@ module Engine
         counter: Hash.new(0),
         skip_track: nil,
         converging_path: true,
+        walk_calls: Hash.new(0),
         &block
       )
+        walk_calls[:all] += 1
+
         return if visited[self]
+
+        walk_calls[:not_skipped] += 1
 
         visited[self] = true
 
@@ -60,6 +67,7 @@ module Engine
             skip_track: skip_track,
             counter: counter,
             converging: converging_path,
+            walk_calls: walk_calls,
           ) do |path, vp, ct, converging|
             ret = yield path, vp, visited
             next if ret == :abort
@@ -77,6 +85,7 @@ module Engine
                 skip_track: skip_track,
                 skip_paths: skip_paths,
                 converging_path: converging_path || converging,
+                walk_calls: walk_calls,
                 &block
               )
             end


### PR DESCRIPTION
Working on #10331. This helps compare performance with the new graph system, and helps better identify where the graph computation is turning out to be very costly.

There are a number of other places where `node.walk` or `path.walk` are called directly, so far I've only adding logging for that to the 1822CA step destination step for #10956, it's probably worth adding logging in more places.

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

A hash is created in `Graph#compute` and passed into `Node#walk` and `Path#walk` where it is mutated. If the `walk` methods are called outside of `Graph`, the total walk calls will still be computed but are not currently logged.