### PR TITLE
fix: mitigate wrong numer of arguments in max.

### DIFF
--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -410,7 +410,7 @@ module Engine
             # in the brown and made decisions appropriately.
             bigger_share = @game.shares_for_corporation(corporation).select do |s|
               s.percent > share_to_buy.percent && (s.owner != entity || s.owner != corporation.owner)
-            end.max(&:percent)
+            end.max_by(&:percent)
 
             if bigger_share
               other_percent = action.entity.percent_of(corporation) + bigger_share.percent


### PR DESCRIPTION
In certain cases/games more than one share may exists which is eligible. max_by function evaluates without an error in this case.

Fixes #10814 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~~[] Add the `pins` or `archive_alpha_games` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
In 1847 a constellation may occur, where this particular loop collects more than one share with equal percent value. 
The Array.max function seems to not work as expected with the shorthand notation, because it is accepting an integer argument.
Enumeration.max_by does not have this issue.

### Screenshots

### Any Assumptions / Hacks
