### PR TITLE
[18GA] Adds coordinates to private description

### DIFF
--- a/lib/engine/game/g_18_ga/entities.rb
+++ b/lib/engine/game/g_18_ga/entities.rb
@@ -40,7 +40,7 @@ module Engine
             value: 70,
             revenue: 15,
             desc: 'A corporation that owns the Waycross & Southern may place a station token in '\
-                  'Waycross at no cost, if there is room. The corporation need not connect to Waycross '\
+                  'Waycross (I9) at no cost, if there is room. The corporation need not connect to Waycross '\
                   'to use this special ability. However, it can only be done during the token-placement '\
                   'step of the corporation\'s turn, and only if the corporation has a token left, and it '\
                   'counts as the corporation\'s one station placement allowed per turn (excluding the home '\


### PR DESCRIPTION
Fixes #10965 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Adds hex coordinate I9 to the description of the Waycross & Southern private company description.

### Screenshots

### Any Assumptions / Hacks
