### PR TITLE
[Core] Rotate stripes on tiles for games with a :flat layout

### DIFF
--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -79,13 +79,15 @@ module View
         children << hex_highlight if @highlight
 
         if (color = @tile&.stripes&.color)
-          Lib::Hex.stripe_points.each do |stripe|
+          stripes = Lib::Hex.stripe_points.map do |stripe|
             attrs = {
               fill: Lib::Hex::COLOR[color],
               points: stripe,
             }
-            children << h(:polygon, attrs: attrs)
+            h(:polygon, attrs: attrs)
           end
+          attrs = @hex.layout == :flat ? { attrs: { transform: "rotate(60)" } } : {}
+          children << h(:g, attrs, stripes)
         end
 
         if @tile

--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -86,7 +86,7 @@ module View
             }
             h(:polygon, attrs: attrs)
           end
-          attrs = @hex.layout == :flat ? { attrs: { transform: "rotate(60)" } } : {}
+          attrs = @hex.layout == :flat ? { attrs: { transform: 'rotate(60)' } } : {}
           children << h(:g, attrs, stripes)
         end
 


### PR DESCRIPTION
### Explanation of Change

Almost all of the games with striped tiles that have been implemented so far have a `:pointy` layout (1822Africa is the only exception I could find). With a pointy layout the stripes on a tile are rotated 30° degrees from vertical.

If a game with a `:flat` layout has a striped tile then these will currently be rendered with vertical stripes. This, IMHO, doesn’t look great. This pull request rotates these stripes by 60°.


### Implementation notes

This change has been done by grouping the stripes in a `g` element and applying a `rotate` transformation to it. It would also be possible to have done this by changing the points returned from the `stripe_points` method in `assets/app/lib/hex.rb` but my trigonometry was too rusty to be able to calculate all of the coordinates.

[CC: @vandamm and @scottredracecar for the changes to the 1822Africa tile rendering]

### Screenshots

#### Current rendering for flat layout:
![image](https://github.com/tobymao/18xx/assets/11144854/6832c496-8c62-4050-816a-30569251f8eb)

#### Proposed rendering for flat layout:
![image](https://github.com/tobymao/18xx/assets/11144854/d259935f-fd2b-491c-8800-4480fab1ea0f)

#### Rendering for pointy layout, unaffected by this change:
![image](https://github.com/tobymao/18xx/assets/11144854/f524d6c5-d6e5-4d96-88b1-e3eb1b5761ba)

#### 1822Africa with current rendering
![image](https://github.com/tobymao/18xx/assets/11144854/4f20f50a-3657-4bfc-9a64-b52d97edb97a)

#### 1822Africa with proposed rendering
![image](https://github.com/tobymao/18xx/assets/11144854/2f41313e-21f3-46c4-b43b-2b821ccf5af7)


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`