### PR TITLE
[1822PNW SRS] add bidding tokens, fix 2p

### DIFF
--- a/lib/engine/game/g_1822_pnw_srs/game.rb
+++ b/lib/engine/game/g_1822_pnw_srs/game.rb
@@ -29,6 +29,7 @@ module Engine
 
         CERT_LIMIT = { 2 => 18, 3 => 14 }.freeze
         STARTING_CASH = { 2 => 750, 3 => 500 }.freeze
+        BIDDING_TOKENS = { '2' => 6, '3' => 5 }.freeze
 
         STATUS_TEXT = G1822PNW::Game::STATUS_TEXT.merge(
           'l_upgrade' => ['$70 L-train upgrades',


### PR DESCRIPTION
this was missed in the rulebook as well, the correct count of 6 was provided at https://boardgamegeek.com/thread/3233220/article/43669844#43669844
