### PR TITLE
[1850] must buy from depot if pres contributes

### DIFF
--- a/lib/engine/game/g_1850/game.rb
+++ b/lib/engine/game/g_1850/game.rb
@@ -20,6 +20,7 @@ module Engine
         COMPANY_CLASS = G1850::Company
         CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT = true
         MULTIPLE_BUY_ONLY_FROM_MARKET = true
+        EBUY_OTHER_VALUE = false
 
         CERT_LIMIT = {
           2 => { 9 => 24, 8 => 21 },


### PR DESCRIPTION
Fixes #10976

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA since alpha] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Once a president contributes to a train purchase, it may only be from the depot

no pins since the game is alpha

### Screenshots

![image](https://github.com/tobymao/18xx/assets/1711810/8314a1e1-dee3-4cd8-abb4-667e9d4b4f51)


### Any Assumptions / Hacks
