### PR TITLE
[Core/18Ardennes] Allow notes to be shown on corporation cards

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -96,6 +96,7 @@ module View
         end
         extras << render_capitalization_type if @corporation.corporation? && @corporation.respond_to?(:capitalization_type_desc)
         extras << render_escrow_account if @corporation.corporation? && @corporation.respond_to?(:escrow) && @corporation.escrow
+        extras << render_corporation_notes if @game.respond_to?(:corporation_notes) && @game.corporation_notes(@corporation)
         if extras.any?
           props = { style: { borderCollapse: 'collapse' } }
           children << h('table.center', props, [h(:tbody, extras)])
@@ -675,6 +676,11 @@ module View
           h('td.right', 'Escrow'),
           h('td.padded_number', @game.format_currency(@corporation.escrow)),
         ])
+      end
+
+      def render_corporation_notes
+        notes = @game.corporation_notes(@corporation).map { |note| h(:div, note) }
+        h('tr.left', notes)
       end
 
       def render_buying_power

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -482,6 +482,18 @@ module Engine
           end
         end
 
+        def corporation_notes(corporation)
+          return if corporation.floated?
+          return unless (minor = @pledged_minors[corporation])
+
+          player = minor.presidents_share.owner
+          verb = @round.auction? ? 'bid' : 'won the right'
+          [
+            "#{player.name} has #{verb} to start this company using " \
+            "minor #{minor.id}."
+          ]
+        end
+
         # The minimum amount of cash needed to start one of the corporations
         # that the player is under obligation for.
         def cash_needed(player)

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -490,7 +490,7 @@ module Engine
           verb = @round.auction? ? 'bid' : 'won the right'
           [
             "#{player.name} has #{verb} to start this company using " \
-            "minor #{minor.id}."
+            "minor #{minor.id}.",
           ]
         end
 


### PR DESCRIPTION
## Implementation notes / explanation of change

This allows arbitrary text to be added to a corporation card.

This is useful in 18Ardennes, where there are auction rounds for the rights to start public companies (corporations). When placing a bid the player must specify which minor company they will be using to start the public company. In the stock round after the auction round these notes are used to show which minor has been pledged to start each new public company. Without this you had to scroll through the game log to see which bids had been placed.


### Screenshots
#### The BY and N public companies with added notes:
![image](https://github.com/tobymao/18xx/assets/11144854/ce1fce5c-5467-46b2-a2b0-b74e3fe0da04)


### Any Assumptions / Hacks

This uses a `@game.respond_to?(:corporation_notes)` test. It would also be possible to add a `corporation_notes` method to the base Corporation class that returns nil.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

