### PR TITLE
18Rhl: fix typo in name of company No. 3

### DIFF
--- a/lib/engine/game/g_18_rhl/entities.rb
+++ b/lib/engine/game/g_18_rhl/entities.rb
@@ -199,7 +199,7 @@ module Engine
           },
           {
             sym: 'Szl',
-            name: 'No. 3 Seilzyganlage',
+            name: 'No. 3 Seilzuganlage',
             value: 50,
             revenue: 15,
             desc: 'As director of a corporation the owner may place a tile on a mountain hex for free during the '\


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~~[ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games~~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
just a typo.

### Screenshots

### Any Assumptions / Hacks
