### PR TITLE
[1826] remove 'can_buy_trains' status, keep only as event

### DIFF
--- a/lib/engine/game/g_1826/game.rb
+++ b/lib/engine/game/g_1826/game.rb
@@ -64,7 +64,6 @@ module Engine
                     train_limit: { five_share: 1, ten_share: 3 },
                     tiles: %i[yellow green],
                     operating_rounds: 2,
-                    status: ['can_buy_trains'],
                   },
                   {
                     name: '10H',
@@ -72,7 +71,6 @@ module Engine
                     train_limit: 2,
                     tiles: %i[yellow green brown],
                     operating_rounds: 3,
-                    status: ['can_buy_trains'],
                   },
                   {
                     name: 'E',
@@ -80,7 +78,6 @@ module Engine
                     train_limit: 2,
                     tiles: %i[yellow green brown blue],
                     operating_rounds: 3,
-                    status: ['can_buy_trains'],
                   },
                   {
                     name: 'TVG',
@@ -88,7 +85,6 @@ module Engine
                     train_limit: 2,
                     tiles: %i[yellow green brown blue gray],
                     operating_rounds: 3,
-                    status: ['can_buy_trains'],
                   }].freeze
 
         TRAINS = [
@@ -161,6 +157,10 @@ module Engine
           ], round_num: round_num)
         end
 
+        def setup
+          @can_buy_trains = false
+        end
+
         def regie
           @regie ||= company_by_id('P2')
         end
@@ -202,6 +202,11 @@ module Engine
             corp = removal[:corporation]
             @log << "-- Event: #{corp}'s #{company_by_id(company).name} ability is removed --"
           end
+        end
+
+        def event_can_buy_trains!
+          @can_buy_trains = true
+          @log << 'Corporations can buy trains from other corporations'
         end
       end
     end

--- a/lib/engine/game/g_1826/step/buy_train.rb
+++ b/lib/engine/game/g_1826/step/buy_train.rb
@@ -10,7 +10,7 @@ module Engine
         class BuyTrain < Engine::Step::BuyTrain
           def buyable_trains(entity)
             # Can't buy trains from other corporations until phase 6H
-            return super if @game.phase.status.include?('can_buy_trains')
+            return super if @game.can_buy_trains
 
             super.select(&:from_depot?)
           end


### PR DESCRIPTION


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Initially I had implemented 'can_buy_trains' as both a status and an event. I removed the status since this was redundant.

### Screenshots

### Any Assumptions / Hacks
