### PR TITLE
[1870] implements original intended price protection rules as a variant.

### DIFF
--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -522,6 +522,10 @@ module Engine
           @station_wars ||= @optional_rules&.include?(:station_wars)
         end
 
+        def can_protect_if_sold?
+          @can_protect_if_sold ||= @optional_rules&.include?(:can_protect_if_sold)
+        end
+
         # allows implementation of diesels variant
         def game_trains
           @optional_rules&.include?(:diesels) ? self.class::DIESEL_VARIANT_TRAINS : self.class::STANDARD_TRAINS

--- a/lib/engine/game/g_1870/meta.rb
+++ b/lib/engine/game/g_1870/meta.rb
@@ -35,6 +35,12 @@ module Engine
                   'no space is available, but if the tile is later upgraded and a new token space would be opened, the '\
                   'destination token will fill that space.',
           },
+          {
+            sym: :can_protect_if_sold,
+            short_name: 'Price protection allowed even if president has sold shares',
+            desc: 'Allows the president of a corporation to price protect shares of their company, even if the president has '\
+                  'sold shares of the corporation this SR.',
+          },
         ].freeze
       end
     end

--- a/lib/engine/game/g_1870/step/price_protection.rb
+++ b/lib/engine/game/g_1870/step/price_protection.rb
@@ -52,9 +52,13 @@ module Engine
                              else
                                true # can price protect yellow/green/brown even if over cert limit
                              end
-            entity.cash >= bundle.price &&
-              !@round.players_sold[entity][bundle.corporation] &&
-              have_cert_room
+            if entity.cash >= bundle.price &&
+              have_cert_room &&
+              @game.can_protect_if_sold?
+              price_protection_seller != entity
+            else
+              !@round.players_sold[entity][bundle.corporation]
+            end
           end
 
           def process_buy_shares(action)


### PR DESCRIPTION
Fixes #[PUT_ISSUE_NUMBER_HERE]

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
As per Bill Dixon's reply in [this thread on 18xx@groups.io](https://groups.io/g/18xx/topic/106908720#msg51514), his original rules for 1870 intended for the president of a corp to be able to price protect their shares even if they had previously sold them. 

I've implemented this as a variant rule, since it's not in the official rules. 

### Screenshots

### Any Assumptions / Hacks
