### PR TITLE
disallow zero as playercount on user input

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -405,9 +405,14 @@ module View
     end
 
     def submit
-      return if !selected_game_or_variant && @mode != :json
+      title = selected_game_or_variant.title
+      return if !title && @mode != :json
 
       game_params = params
+      if game_params[:min_players].to_i < @min_p[title] || game_params[:max_players].to_i > @max_p[title]
+        return store(:flash_opts,
+                     'Invalid playercount')
+      end
 
       if @mode == :multi
         game_params[:seed] = game_params[:seed].to_i
@@ -514,9 +519,9 @@ module View
         max_players = max_p
         min_players = min_p
       else
-        # Letters resolve to 0 when converted to integers
-        max_players = (val = max_players_elm&.value.to_i).zero? ? nil : val
-        min_players = (val = min_players_elm&.value.to_i).zero? ? nil : val
+        # NOTE: Letters resolve to 0 when converted to integers
+        max_players = max_players_elm&.value.to_i
+        min_players = min_players_elm&.value.to_i
       end
       if max_players
         max_players = [max_players, min_p].max


### PR DESCRIPTION
Fixes #11010

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [na] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

This is just to file off the sharp edge of typing zero accidentially

It only covers the case where the frontend generates a bad playercount, not a tamperdata/direct POST

I believe the issue was that we were checking explicitly for .zero? on those fields, and then setting them to nil. That doesn't seem to be necessary and actually creates an issue where the "autocorrect" logic doesn't fire 

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
