### PR TITLE
22Mars: Add map and tiles

### DIFF
--- a/lib/engine/game/g_22_mars.rb
+++ b/lib/engine/game/g_22_mars.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G22Mars
+    end
+  end
+end

--- a/lib/engine/game/g_22_mars/entities.rb
+++ b/lib/engine/game/g_22_mars/entities.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G22Mars
+      module Entities
+        COMPANIES = [].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_22_mars/game.rb
+++ b/lib/engine/game/g_22_mars/game.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require_relative '../base'
+require_relative 'meta'
+require_relative 'entities'
+require_relative 'map'
+
+module Engine
+  module Game
+    module G22Mars
+      class Game < Game::Base
+        include_meta(G22Mars::Meta)
+        include Entities
+        include Map
+
+        CURRENCY_FORMAT_STR = '%sc'
+        BANK_CASH = 9999
+
+        STARTING_CASH = { 3 => 300, 4 => 225, 5 => 180 }.freeze
+
+        MARKET = [
+          %w[90 100 110 120 130 145 160 175 195 215 235 255 275 300e],
+          %w[80 90p 100 110 120 130 145 160 175 195 215 235 255],
+          %w[70 80p 90 100 110 120 130 145 160 175 195 215],
+          %w[60 70p 80 90 100 110 120 130 145 160 175],
+          %w[50 60p 70 80 90 100 110 120 130 145],
+          %w[45 50p 55 65 75 85 95 105],
+          %w[40 45 50 55 65 75],
+          %w[35r 40r 45r 50r],
+          %w[0c],
+        ].freeze
+
+        CERT_LIMIT = { 2 => 12, 3 => 12, 4 => 9, 5 => 7 }.freeze
+
+        PHASES = [
+          {
+            name: '2',
+            train_limit: 3,
+            tiles: [:yellow],
+            operating_rounds: 2,
+            status: [],
+          },
+          {
+            name: '3',
+            on: '3',
+            train_limit: 3,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+            status: [],
+          },
+          {
+            name: '4',
+            on: '4',
+            train_limit: 3,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+            status: [],
+          },
+          {
+            name: '5',
+            on: '5',
+            train_limit: 3,
+            tiles: %i[yellow green brown],
+            operating_rounds: 2,
+            status: [],
+          },
+          {
+            name: '7',
+            on: '6+S',
+            train_limit: 3,
+            tiles: %i[yellow green brown gray],
+            operating_rounds: 2,
+            status: [],
+          },
+          {
+            name: '8',
+            on: '6+SS',
+            train_limit: 3,
+            tiles: %i[yellow green brown gray black],
+            operating_rounds: 2,
+            status: [],
+          },
+        ].freeze
+
+        TRAINS = [
+          {
+            name: '2',
+            distance: 2,
+            price: 100,
+            rusts_on: '4',
+            num: 6,
+          },
+          {
+            name: '3',
+            distance: 3,
+            price: 17,
+            rusts_on: '5',
+            num: 4,
+          },
+          {
+            name: '4',
+            distance: 4,
+            price: 250,
+            rusts_on: '6+S',
+            num: 3,
+          },
+          {
+            name: '5',
+            distance: 5,
+            price: 340,
+            rusts_on: '6+SS',
+            num: 3,
+          },
+          {
+            name: '6+S',
+            distance: 6,
+            price: 440,
+            rusts_on: '4',
+            num: 4,
+          },
+          {
+            name: '6+SS',
+            distance: 6,
+            price: 560,
+            rusts_on: '4',
+            num: 6,
+            discount: { '5' => 400 },
+          },
+        ].freeze
+
+        CAPITALIZATION = :incremental
+
+        SELL_BUY_ORDER = :sell_buy
+        SELL_MOVEMENT = :down_share
+        HOME_TOKEN_TIMING = :float
+
+        CLOSED_CORP_RESERVATIONS_REMOVED = false
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_22_mars/game.rb
+++ b/lib/engine/game/g_22_mars/game.rb
@@ -30,7 +30,7 @@ module Engine
           %w[0c],
         ].freeze
 
-        CERT_LIMIT = { 2 => 12, 3 => 12, 4 => 9, 5 => 7 }.freeze
+        CERT_LIMIT = { 3 => 12, 4 => 9, 5 => 7 }.freeze
 
         PHASES = [
           {
@@ -93,7 +93,7 @@ module Engine
           {
             name: '3',
             distance: 3,
-            price: 17,
+            price: 170,
             rusts_on: '5',
             num: 4,
           },
@@ -115,16 +115,14 @@ module Engine
             name: '6+S',
             distance: 6,
             price: 440,
-            rusts_on: '4',
             num: 4,
           },
           {
             name: '6+SS',
             distance: 6,
             price: 560,
-            rusts_on: '4',
             num: 6,
-            discount: { '5' => 400 },
+            discount: { '5' => 160 },
           },
         ].freeze
 

--- a/lib/engine/game/g_22_mars/map.rb
+++ b/lib/engine/game/g_22_mars/map.rb
@@ -1,0 +1,385 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G22Mars
+      module Map
+        TILES = {
+          '3' => 2,
+          '4' => 2,
+          '7' => 2,
+          '8' => 2,
+          '9' => 2,
+          '58' => 2,
+          '19' => 1,
+          '20' => 1,
+          '23' => 1,
+          '24' => 1,
+          '25' => 1,
+          '26' => 1,
+          '27' => 1,
+          '28' => 1,
+          '29' => 1,
+          '624' => 1,
+          '39' => 1,
+          '40' => 1,
+          '41' => 1,
+          '42' => 1,
+          '44' => 1,
+          '47' => 1,
+          'M1' => {
+            'count' => 2,
+            'color' => 'yellow',
+            'code' => 'city=revenue:10;path=a:0,b:_0;path=a:1,b:_0',
+          },
+          'M2' => {
+            'count' => 3,
+            'color' => 'yellow',
+            'code' => 'city=revenue:10;path=a:0,b:_0;path=a:2,b:_0',
+          },
+          'M3' => {
+            'count' => 3,
+            'color' => 'yellow',
+            'code' => 'city=revenue:10;path=a:0,b:_0;path=a:3,b:_0',
+          },
+          'M4' => {
+            'count' => 3,
+            'color' => 'green',
+            'code' => 'city=revenue:20,slots:2;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0',
+          },
+          'M5' => {
+            'count' => 2,
+            'color' => 'green',
+            'code' => 'city=revenue:20,slots:2;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
+          },
+          'M6' => {
+            'count' => 3,
+            'color' => 'green',
+            'code' => 'city=revenue:20,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0',
+          },
+          'M7' => {
+            'count' => 2,
+            'color' => 'green',
+            'code' => 'city=revenue:20,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0',
+          },
+          'M8' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:30,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
+          },
+          'M9' => {
+            'count' => 2,
+            'color' => 'brown',
+            'code' => 'city=revenue:30,slots:3;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
+          },
+          'M10' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:30,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0',
+          },
+          'M11' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:30,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0',
+          },
+          'M12' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:30,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0',
+          },
+          'M13' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:30,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0',
+          },
+          'M14' => {
+            'count' => 2,
+            'color' => 'gray',
+            'code' => 'city=revenue:40,slots:3;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
+          },
+          'M15' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:40,slots:3;'\
+                      'path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
+          },
+          'M16' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:40,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
+          },
+          'CC1' => {
+            'count' => 2,
+            'color' => 'yellow',
+            'code' => 'label=CC;city=revenue:20;city=revenue:20;path=a:0,b:_0;path=a:4,b:_1',
+          },
+          'CC2' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'label=CC;city=revenue:20,loc:0;city=revenue:20,loc:3;path=a:5,b:_0;path=a:4,b:_1',
+          },
+          'CC3' => {
+            'count' => 2,
+            'color' => 'yellow',
+            'code' => 'label=CC;city=revenue:20;city=revenue:20;path=a:0,b:_0;path=a:3,b:_1',
+          },
+          'CC4' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'label=CC;city=revenue:30,loc:0;city=revenue:30,slots:2,loc:2;'\
+                      'path=a:0,b:_0;path=a:4,b:_0;path=a:1,b:_1;path=a:3,b:_1',
+          },
+          'CC5' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'label=CC;city=revenue:30,loc:3.5;city=revenue:30,slots:2,loc:0;'\
+                      'path=a:3,b:_0;path=a:4,b:_0;path=a:0,b:_1;path=a:5,b:_1',
+          },
+          'CC6' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'label=CC;city=revenue:30;city=revenue:30,slots:2;'\
+                      'path=a:1,b:_0;path=a:4,b:_0;path=a:0,b:_1;path=a:5,b:_1',
+          },
+          'CC7' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'label=CC;city=revenue:30;city=revenue:30,slots:2;'\
+                      'path=a:3,b:_0;path=a:5,b:_0;path=a:0,b:_1;path=a:4,b:_1',
+          },
+          'CC8' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'label=CC;city=revenue:30,slots:2;city=revenue:30;'\
+                      'path=a:3,b:_0;path=a:5,b:_0;path=a:0,b:_1;path=a:4,b:_1',
+          },
+          'CC9' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'label=CC;city=revenue:30,slots:2;city=revenue:30;'\
+                      'path=a:1,b:_0;path=a:4,b:_0;path=a:0,b:_1;path=a:5,b:_1',
+          },
+          'CC10' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'label=CC;city=revenue:30,slots:2;city=revenue:30;path=a:0,b:_0;path=a:4,b:_0;path=a:1,b:_1;path=a:3,b:_1',
+          },
+          'CC11' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'label=CC;city=revenue:30,slots:2;city=revenue:30;path=a:3,b:_0;path=a:4,b:_0;path=a:0,b:_1;path=a:5,b:_1',
+          },
+          'CC12' => {
+            'count' => 2,
+            'color' => 'brown',
+            'code' => 'label=CC;city=revenue:40,slots:2,loc:0;city=revenue:40,slots:2,loc:3;'\
+                      'path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_1;path=a:3,b:_1;path=a:4,b:_1;path=a:5,b:_0',
+          },
+          'CC13' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'label=CC;city=revenue:40,slots:2;city=revenue:40,slots:2;'\
+                      'path=a:0,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:3,b:_1;path=a:4,b:_1;path=a:5,b:_1',
+          },
+          'CC14' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'label=CC;city=revenue:40,slots:2,loc:0;city=revenue:40,slots:2,loc:3;'\
+                      'path=a:0,b:_0;path=a:5,b:_0;path=a:1,b:_1;path=a:2,b:_1;path=a:4,b:_1',
+          },
+          'CC15' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'label=CC;city=revenue:40,slots:2,loc:0;city=revenue:40,slots:2,loc:3;'\
+                      'path=a:0,b:_0;path=a:5,b:_0;path=a:1,b:_1;path=a:3,b:_1;path=a:4,b:_1',
+          },
+          'CC16' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'label=CC;city=revenue:50,slots:2,loc:0;city=revenue:50,slots:2,loc:3;'\
+                      'path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_1;path=a:3,b:_1;path=a:4,b:_1;path=a:5,b:_0;path=a:_0,b:_1',
+          },
+          'CC17' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'label=CC;city=revenue:50,slots:2,loc:0;city=revenue:50,slots:2,loc:3;'\
+                      'path=a:0,b:_0;path=a:5,b:_0;path=a:1,b:_1;path=a:2,b:_1;path=a:3,b:_1;path=a:4,b:_1',
+          },
+          'CC18' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'label=CC;city=revenue:50,slots:2,loc:0.5;city=revenue:50,slots:2;'\
+                      'path=a:0,b:_0;path=a:1,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:3,b:_1;path=a:4,b:_1;path=a:5,b:_1',
+          },
+          'AA' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'label=CC;town=revenue:30;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
+          },
+        }.freeze
+
+        LOCATION_NAMES = {
+          'D13' => 'Mining Area Gamma',
+          'H15' => 'Mining Area Alpha',
+        }.freeze
+
+        HEXES = {
+          white: {
+            # Board 1
+            ['C6'] => 'city=revenue:20;city=revenue:20;label=CC',
+            ['C8'] => 'city=revenue:10',
+            ['D5'] => '',
+            ['D7'] => 'town=revenue:10',
+            ['D9'] => 'city=revenue:10',
+            ['E6'] => '',
+            ['E8'] => 'city=revenue:20;city=revenue:20;label=CC',
+            # Board 2
+            ['C12'] => 'city=revenue:10',
+            ['C14'] => 'city=revenue:10',
+            ['D11'] => 'city=revenue:10',
+            ['D13'] => 'frame=color:#00aa00',
+            ['D15'] => 'town=revenue:10',
+            ['E12'] => '',
+            ['E14'] => 'city=revenue:10',
+            # Board 3
+            ['G6'] => '',
+            ['G8'] => 'city=revenue:10',
+            ['H5'] => 'city=revenue:20;city=revenue:20;label=CC',
+            ['H7'] => 'city=revenue:20;city=revenue:20;label=CC',
+            ['H9'] => 'town=revenue:10',
+            ['I6'] => '',
+            ['I8'] => 'city=revenue:10',
+            # Board 4
+            ['G12'] => '',
+            ['G14'] => 'city=revenue:10',
+            ['H11'] => 'city=revenue:20;city=revenue:20;label=CC',
+            ['H13'] => 'city=revenue:10',
+            ['H15'] => 'frame=color:#aa0000',
+            ['I12'] => 'town=revenue:10',
+            ['I14'] => 'city=revenue:10',
+          },
+          gray: {
+            ['A4'] => 'path=a:4,b:0,lanes:5',
+            %w[A6 A8 A10 A12 A14 K6 K8 K10 K12 K14] => 'path=a:3,b:0,lanes:5',
+            ['A16'] => 'path=a:3,b:5,lanes:5',
+            ['B3'] => 'path=a:5,b:1,a_lane:4.0,b_lane:5.4;'\
+                       'path=a:5,b:1,a_lane:4.1,b_lane:5.3
+                       path=a:4,b:1,a_lane:3.0,b_lane:5.2;'\
+                       'path=a:4,b:1,a_lane:3.1,b_lane:5.1;'\
+                       'path=a:4,b:1,a_lane:3.2,b_lane:5.0',
+            ['B5'] => 'path=a:5,b:4,b_lane:4.0;'\
+                      'path=a:0,b:4,a_lane:4.3,b_lane:4.1;'\
+                      'path=a:0,b:4,a_lane:4.2,b_lane:4.2;'\
+                      'path=a:0,b:4,a_lane:4.1,b_lane:4.3',
+            ['B7'] => 'path=a:4,b:3,b_lane:4.0;'\
+                      'path=a:5,b:3,b_lane:4.1;'\
+                      'path=a:0,b:3,b_lane:4.2',
+            ['B9'] => 'path=a:4,b:3',
+            ['B11'] => 'path=a:0,b:5',
+            ['B13'] => 'path=a:5,b:0,b_lane:4.3;'\
+                       'path=a:4,b:0,b_lane:4.2;'\
+                       'path=a:3,b:0,b_lane:4.1',
+            ['B15'] => 'path=a:4,b:5,b_lane:4.3;'\
+                       'path=a:3,b:5,a_lane:4.0,b_lane:4.2;'\
+                       'path=a:3,b:5,a_lane:4.1,b_lane:4.1;'\
+                       'path=a:3,b:5,a_lane:4.2,b_lane:4.0',
+            ['B17'] => 'path=a:4,b:2,a_lane:4.3,b_lane:5.0;'\
+                       'path=a:4,b:2,a_lane:4.2,b_lane:5.1;'\
+                       'path=a:5,b:2,a_lane:3.2,b_lane:5.2;'\
+                       'path=a:5,b:2,a_lane:3.1,b_lane:5.3;'\
+                       'path=a:5,b:2,a_lane:3.0,b_lane:5.4',
+            ['C2'] => 'path=a:5,b:1,lanes:3',
+            ['C4'] => 'path=a:1,b:4,lanes:4;'\
+                      'path=a:0,b:2,b_lane:4.3;'\
+                      'path=a:5,b:2,b_lane:4.2',
+            %w[C10 G10] => 'path=a:0,b:3;'\
+                           'path=a:4,b:5',
+            ['C16'] => 'path=a:2,b:5,lanes:4;'\
+                       'path=a:3,b:1,b_lane:4.0;'\
+                       'path=a:4,b:1,b_lane:4.1;',
+            ['C18'] => 'path=a:4,b:2,lanes:3',
+            %w[D1 H1] => '',
+            ['D3'] => 'path=a:1,b:4,lanes:4;'\
+                      'path=a:0,b:2,b_lane:3.2;'\
+                      'path=a:5,a_lane:2.0,b:2,b_lane:3.1;'\
+                      'path=a:5,a_lane:2.1,b:2,b_lane:3.0',
+            ['D17'] => 'path=a:2,b:5,lanes:4;'\
+                       'path=a:3,b:1,b_lane:3.0;'\
+                       'path=a:4,b:1,a_lane:2.1,b_lane:3.1;'\
+                       'path=a:4,b:1,a_lane:2.0,b_lane:3.2',
+            ['D19'] => '',
+            ['E2'] => 'path=a:1,b:4,lanes:4',
+            ['E4'] => 'path=a:1,b:2,b_lane:2.1;'\
+                      'path=a:0,b:2,b_lane:2.0',
+            %w[E10 I10] => 'path=a:0,b:3;'\
+                           'path=a:1,b:2',
+            ['E16'] => 'path=a:2,b:1,b_lane:2.0;'\
+                       'path=a:3,b:1,b_lane:2.1',
+            ['E18'] => 'path=a:2,b:5,lanes:4',
+            ['F1'] => 'path=a:1,b:5,lanes:4',
+            ['F3'] => '',
+            %w[F5 F11] => 'path=a:1,b:5',
+            %w[F7 F13] => 'path=a:2,b:4;'\
+                          'path=a:1,b:5',
+            %w[F9 F15] => 'path=a:2,b:4',
+            ['F17'] => '',
+            ['F19'] => 'path=a:2,b:4,lanes:4',
+            ['G2'] => 'path=a:2,b:5,lanes:4',
+            ['G4'] => 'path=a:0,b:4,b_lane:2.1;'\
+                      'path=a:5,b:4,b_lane:2.0',
+            ['G16'] => 'path=a:3,b:5,b_lane:2.0;'\
+                       'path=a:4,b:5,b_lane:2.1',
+            ['G18'] => 'path=a:1,b:4,lanes:4',
+            ['H3'] => 'path=a:2,b:5,lanes:4;'\
+                      'path=a:0,b:4,b_lane:3.0;'\
+                      'path=a:1,b:4,a_lane:2.1,b_lane:3.1;'\
+                      'path=a:1,b:4,a_lane:2.0,b_lane:3.2',
+            ['H17'] => 'path=a:1,b:4,lanes:4;'\
+                       'path=a:2,b:5,a_lane:2.1,b_lane:3.0;'\
+                       'path=a:2,b:5,a_lane:2.0,b_lane:3.1;'\
+                       'path=a:3,b:5,b_lane:3.2;',
+            ['H19'] => '',
+            ['I2'] => 'path=a:5,b:1,lanes:3',
+            ['I4'] => 'path=a:2,b:5,lanes:4;'\
+                      'path=a:1,b:4,b_lane:4.1;'\
+                      'path=a:0,b:4,b_lane:4.0',
+            ['I16'] => 'path=a:1,b:4,lanes:4;'\
+                       'path=a:2,b:5,b_lane:4.2;'\
+                       'path=a:3,b:5,b_lane:4.3',
+            ['I18'] => 'path=a:4,b:2,lanes:3',
+            ['J3'] => 'path=a:1,b:5,a_lane:4.3,b_lane:5.0;'\
+                      'path=a:1,b:5,a_lane:4.2,b_lane:5.1;'\
+                      'path=a:2,b:5,a_lane:3.2,b_lane:5.2;'\
+                      'path=a:2,b:5,a_lane:3.1,b_lane:5.3;'\
+                      'path=a:2,b:5,a_lane:3.0,b_lane:5.4',
+            ['J5'] => 'path=a:1,b:2,b_lane:4.3;'\
+                      'path=a:0,b:2,a_lane:3.0,b_lane:4.2;'\
+                      'path=a:0,b:2,a_lane:3.1,b_lane:4.1;'\
+                      'path=a:0,b:2,a_lane:3.2,b_lane:4.0',
+            ['J7'] => 'path=a:2,b:3,b_lane:3.2;'\
+                      'path=a:1,b:3,b_lane:3.1;'\
+                      'path=a:0,b:3,b_lane:3.0',
+            ['J9'] => 'path=a:2,b:3',
+            ['J11'] => 'path=a:1,b:0',
+            ['J13'] => 'path=a:1,b:0,b_lane:3.0;'\
+                       'path=a:2,b:0,b_lane:3.1;'\
+                       'path=a:3,b:0,b_lane:3.2',
+            ['J15'] => 'path=a:2,b:1,b_lane:4.0;'\
+                       'path=a:3,b:1,a_lane:3.2,b_lane:4.1;'\
+                       'path=a:3,b:1,a_lane:3.1,b_lane:4.2;'\
+                       'path=a:3,b:1,a_lane:3.0,b_lane:4.3',
+            ['J17'] => 'path=a:1,b:4,a_lane:3.2,b_lane:5.0;'\
+                       'path=a:1,b:4,a_lane:3.1,b_lane:5.1;'\
+                       'path=a:1,b:4,a_lane:3.0,b_lane:5.2;'\
+                       'path=a:2,b:4,a_lane:4.1,b_lane:5.3;'\
+                       'path=a:2,b:4,a_lane:4.0,b_lane:5.4',
+            ['K4'] => 'path=a:2,b:0,lanes:5',
+            ['K16'] => 'path=a:3,b:1,lanes:5',
+          },
+        }.freeze
+
+        LAYOUT = :flat
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_22_mars/meta.rb
+++ b/lib/engine/game/g_22_mars/meta.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../meta'
+
+module Engine
+  module Game
+    module G22Mars
+      module Meta
+        include Game::Meta
+
+        DEV_STAGE = :alpha
+        PROTOTYPE = true
+
+        GAME_DESIGNER = 'Jonas Jones'
+        GAME_LOCATION = 'Mars'
+        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/270966/22mars-rules'
+        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/22Mars'
+
+        PLAYER_RANGE = [3, 5].freeze
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Explanation of Change
First part of 22Mars implementation: only the map.
Does not include random map generation now.

### Screenshots

<img width="800" src="https://github.com/tobymao/18xx/assets/576786/2d43ad83-73da-4c8a-9361-99756b8581db">
