### PR TITLE
[18Ardennes] Various fixes

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -96,7 +96,6 @@ module View
         end
         extras << render_capitalization_type if @corporation.corporation? && @corporation.respond_to?(:capitalization_type_desc)
         extras << render_escrow_account if @corporation.corporation? && @corporation.respond_to?(:escrow) && @corporation.escrow
-        extras << render_corporation_notes if @game.respond_to?(:corporation_notes) && @game.corporation_notes(@corporation)
         if extras.any?
           props = { style: { borderCollapse: 'collapse' } }
           children << h('table.center', props, [h(:tbody, extras)])
@@ -676,11 +675,6 @@ module View
           h('td.right', 'Escrow'),
           h('td.padded_number', @game.format_currency(@corporation.escrow)),
         ])
-      end
-
-      def render_corporation_notes
-        notes = @game.corporation_notes(@corporation).map { |note| h(:div, note) }
-        h('tr.left', notes)
       end
 
       def render_buying_power

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -96,6 +96,7 @@ module View
         end
         extras << render_capitalization_type if @corporation.corporation? && @corporation.respond_to?(:capitalization_type_desc)
         extras << render_escrow_account if @corporation.corporation? && @corporation.respond_to?(:escrow) && @corporation.escrow
+        extras << render_corporation_notes if @game.respond_to?(:corporation_notes) && @game.corporation_notes(@corporation)
         if extras.any?
           props = { style: { borderCollapse: 'collapse' } }
           children << h('table.center', props, [h(:tbody, extras)])
@@ -675,6 +676,11 @@ module View
           h('td.right', 'Escrow'),
           h('td.padded_number', @game.format_currency(@corporation.escrow)),
         ])
+      end
+
+      def render_corporation_notes
+        notes = @game.corporation_notes(@corporation).map { |note| h(:div, note) }
+        h('tr.left', notes)
       end
 
       def render_buying_power

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -482,6 +482,18 @@ module Engine
           end
         end
 
+        def status_array(corporation)
+          return if corporation.floated?
+          return unless (minor = @pledged_minors[corporation])
+
+          player = minor.presidents_share.owner
+          verb = @round.auction? ? 'bid' : 'won the right'
+          [
+            "#{player.name} has #{verb} to start this company using " \
+            "minor #{minor.id}.",
+          ]
+        end
+
         # The minimum amount of cash needed to start one of the corporations
         # that the player is under obligation for.
         def cash_needed(player)

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -450,6 +450,10 @@ module Engine
           @round.operating? ? [] : super
         end
 
+        def company_sale_price(company)
+          company.value
+        end
+
         # Has the player won any auctions for public companies in the
         # preceding auction round? If they have then they must start these
         # majors before they can buy any other shares or pass.

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -482,18 +482,6 @@ module Engine
           end
         end
 
-        def corporation_notes(corporation)
-          return if corporation.floated?
-          return unless (minor = @pledged_minors[corporation])
-
-          player = minor.presidents_share.owner
-          verb = @round.auction? ? 'bid' : 'won the right'
-          [
-            "#{player.name} has #{verb} to start this company using " \
-            "minor #{minor.id}."
-          ]
-        end
-
         # The minimum amount of cash needed to start one of the corporations
         # that the player is under obligation for.
         def cash_needed(player)

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -482,6 +482,18 @@ module Engine
           end
         end
 
+        def corporation_notes(corporation)
+          return if corporation.floated?
+          return unless (minor = @pledged_minors[corporation])
+
+          player = minor.presidents_share.owner
+          verb = @round.auction? ? 'bid' : 'won the right'
+          [
+            "#{player.name} has #{verb} to start this company using " \
+            "minor #{minor.id}."
+          ]
+        end
+
         # The minimum amount of cash needed to start one of the corporations
         # that the player is under obligation for.
         def cash_needed(player)

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -490,7 +490,7 @@ module Engine
           verb = @round.auction? ? 'bid' : 'won the right'
           [
             "#{player.name} has #{verb} to start this company using " \
-            "minor #{minor.id}.",
+            "minor #{minor.id}."
           ]
         end
 

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -490,7 +490,7 @@ module Engine
           verb = @round.auction? ? 'bid' : 'won the right'
           [
             "#{player.name} has #{verb} to start this company using " \
-            "minor #{minor.id}."
+            "minor #{minor.id}.",
           ]
         end
 

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -62,7 +62,7 @@ module Engine
             when Engine::Round::Auction
               init_round_finished
               reorder_players
-              new_stock_round
+              new_operating_round
             when G18Ardennes::Round::Stock
               @operating_rounds = @phase.operating_rounds
               reorder_players

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -36,6 +36,7 @@ module Engine
 
         SELL_BUY_ORDER = :sell_buy
         SELL_AFTER = :operate
+        SELL_MOVEMENT = :left_block_pres
 
         CAPITALIZATION = :incremental
         HOME_TOKEN_TIMING = :par

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -41,6 +41,7 @@ module Engine
         HOME_TOKEN_TIMING = :par
 
         MUST_BUY_TRAIN = :always # Just for majors, minors are handled in #must_buy_train?
+        EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false
         BANKRUPTCY_ALLOWED = true
         BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
 

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -45,6 +45,10 @@ module Engine
         BANKRUPTCY_ALLOWED = true
         BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
 
+        # 4D trains can share track with other trains. Put them in their own
+        # autoroute group so that the autorouter works correctly.
+        TRAIN_AUTOROUTE_GROUPS = [['4D']].freeze
+
         # The maximum number of tokens a major can have on the map.
         LIMIT_TOKENS_AFTER_MERGER = 6
 

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -147,6 +147,12 @@ module Engine
           major_corporations.select(&:ipoed).sort
         end
 
+        def liquidity(player, emergency: false)
+          return player.cash unless sellable_turn?
+
+          super + player.companies.sum(&:value)
+        end
+
         # Checks whether a player really is bankrupt.
         def can_go_bankrupt?(player, _corporation)
           return super if @round.operating?

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -96,8 +96,13 @@ module Engine
           end
 
           def can_gain?(entity, bundle, exchange: false)
-            # Can go above 60% ownership if exchanging a minor for a share.
-            exchange || super
+            # Can go above 60% ownership if exchanging a minor for a share or
+            # if buying a share from the open market.
+            return true if exchange
+            return true if (bundle.owner == @game.share_pool) &&
+                           (@game.num_certs(entity) < @game.cert_limit)
+
+            super
           end
 
           # Can this ShareBundle be sold to the open market?

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -100,6 +100,15 @@ module Engine
             exchange || super
           end
 
+          # Can this ShareBundle be sold to the open market?
+          def can_dump?(entity, bundle)
+            # The implementation of this method in Step::BuySellParSharesCompanies
+            # is for games where the president's certificate can be sold to the
+            # market. This isn't true in 18Ardennes, the method implemented in
+            # Step::BuySellParShares is correct.
+            bundle.can_dump?(entity)
+          end
+
           # Checks whether a player can afford to exchange one of their minors
           # for a share in a major corporation.
           # If `check_connection` is false this method does not check whether

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -192,6 +192,12 @@ module Engine
             @game.declare_bankrupt(player)
           end
 
+          def log_skip(entity)
+            # Don't print a '[player] has no valid actions and passes' message
+            # after exchanging a minor for a share.
+            super if @round.current_actions.empty?
+          end
+
           private
 
           def sell_bankrupt_shares(player)

--- a/lib/engine/game/g_18_ardennes/step/buy_train.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_train.rb
@@ -7,10 +7,36 @@ module Engine
     module G18Ardennes
       module Step
         class BuyTrain < Engine::Step::BuyTrain
+          def actions(entity)
+            actions = super
+            actions << 'sell_company' if actions.include?('sell_shares') &&
+                                         can_sell_any_companies?(entity)
+            actions
+          end
+
           def train_variant_helper(train, entity)
             return super if @game.can_buy_4d?(entity)
 
             super.reject { |v| v[:name] == '4D' }
+          end
+
+          def process_sell_company(action)
+            player = action.entity
+            company = action.company
+            price = company.value
+            company.owner = @game.bank
+            player.companies.delete(company)
+            @game.bank.spend(price, player)
+            @log << "#{player.name} sells #{company.name} to bank for #{@game.format_currency(price)}"
+          end
+
+          private
+
+          def can_sell_any_companies?(entity)
+            player = entity.owner
+            return false unless player&.player?
+
+            !player.companies.select { |c| c.type == :minor }.empty?
           end
         end
       end

--- a/lib/engine/game/g_18_ardennes/step/minor_exchange.rb
+++ b/lib/engine/game/g_18_ardennes/step/minor_exchange.rb
@@ -41,6 +41,10 @@ module Engine
             # If there are tokens that may optionally be rejected the minor
             # needs to be left open for the DeclineTokens step.
             @game.close_corporation(minor) unless @round.corporations_removing_tokens
+
+            # The game graph might be invalid after station tokens have been
+            # exchanged or removed.
+            @game.clear_graph_for_entity(major)
           end
 
           # Discards a minor company's assets.

--- a/lib/engine/game/g_18_ardennes/step/post_conversion_shares.rb
+++ b/lib/engine/game/g_18_ardennes/step/post_conversion_shares.rb
@@ -22,6 +22,10 @@ module Engine
             'Buy shares'
           end
 
+          def pass_description
+            'Done (buy shares)'
+          end
+
           def log_skip(_entity); end
 
           def active_entities

--- a/lib/engine/game/g_18_ardennes/step/track.rb
+++ b/lib/engine/game/g_18_ardennes/step/track.rb
@@ -33,6 +33,25 @@ module Engine
             super
             @game.after_lay_tile(action.hex, action.tile, action.entity)
           end
+
+          def update_token!(action, entity, tile, old_tile)
+            super
+
+            # Might need to remove a token if two cities have joined together.
+            return if !tile.cities.one? || old_tile.cities.size != 2
+
+            corp_tokens = tile.cities.first.tokens.compact.group_by(&:corporation)
+            corp_tokens.each do |corporation, tokens|
+              next if tokens.one?
+
+              # This can only happen in Amsterdam, Basel, Frankfurt-am-Main and
+              # Rotterdam. These all have two slots in brown, so there's never
+              # more than one token to remove.
+              tokens.last.remove!
+              @game.log << "#{corporation.id} token removed from " \
+                           "#{tile.hex.name} (#{tile.hex.location_name})."
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
## Implementation Notes

Various fixes for 18Ardennes identified during private alpha testing:

- Allow the GL minor company (which is implemented as a Company object) can be sold during emergency money raising.
- The GL minor company can be sold when over the certificate limit.
- Include the value of the GL minor company in liquidity calculations.
- Share price does not change on sales, apart from president sales.
- Invalidate the game graph after a minor is exchanged for a public company share. There are changes to tokens when this happens, and hexes available for track lays were not being correctly calculated.
- You don't have to buy the cheapest available train when in emergency money raising.
- You can go above 60% ownership of a public company when buying shares from the bank pool.
- After the initial auction of minor companies go straight to an operating round.
- Don't allow the president's certificate of a public company to be sold to the open market.
- Remove duplicate tokens when two cities on a hex join together.


Plus a few enhancements:

- Add a separated train autoroute group for 4D trains, so that the autorouter knows these can share track with other types of train.
- After a public company auction round, show on the corporation cards which minor companies have been pledged to start each public company.
- Change the pass button in the post-conversion shares step to read 'done'  instead of 'pass'.
- Don't log a skip message after exchanging a minor company for a public company share.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
