### PR TITLE
[1862/autorouter] Fix freight trains not being able to auto route

### DIFF
--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -83,7 +83,7 @@ module Engine
           last_right = nil
 
           complete = lambda do
-            chains << { nodes: [left, right], paths: chain }
+            chains << { nodes: [left, right], paths: chain, hexes: chain.map(&:hex) }
             last_left = left
             last_right = right
             left, right = nil


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

A minimal repro is here: https://gist.github.com/PistonPercy/dbbad162540451e8941dfae3e57ccbc9

The error I'm attempting to fix is:
```
Uncaught []: undefined method `[]' for nil
Caused by: Object { … }
klass runtime.js:589
$Exception_new$1 error.rb:12
$$method_missing basic_object.rb:146
method_missing_stub runtime.js:1563
$$adjust_end game.rb:1618
$$hex_crow_distance game.rb:1631
$$freight_revenue game.rb:1671
$$revenue_for game.rb:1676
```

which is originating from this line: https://github.com/tobymao/18xx/blob/master/lib/engine/game/g_1862/game.rb#L1618

The issue is the chains from the auto router don't have :hexes, but this code expects there to be. I'm not sure if :hexes is suppose to be there or the other side should be tweaked.

### Explanation of Change

This isn't enough to fix 1862 auto routing, but it is the most obvious issue and I figured I'd start small.
