### PR TITLE
[1826] implements logic for e-trains

### DIFF
--- a/lib/engine/game/g_1826/step/buy_train.rb
+++ b/lib/engine/game/g_1826/step/buy_train.rb
@@ -14,6 +14,25 @@ module Engine
 
             super.select(&:from_depot?)
           end
+
+          def buy_train_action(action)
+            super
+
+            return unless action.train.name == 'E'
+            return unless action.train.from_depot?
+
+            @game.e_trains_purchased += 1
+            case @game.e_trains_purchased
+            when 1
+              @game.e_train_range = 2
+            when 2, 3
+              @game.e_train_range = 3
+            when 4
+              @game.e_train_range = 4
+            end
+            @log << "#{e_trains_purchased} E-trains have been sold. E-trains now run #{@game.e_train_range} "\
+                    'stops, skipping towns, and count each stop twice.'
+          end
         end
       end
     end


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Game has E-trains which run a variable distance based on the number of that train currently sold. I'm tracking this in an attr that is incremented through the 'buy_train_action(action)' method in the buy_trains.rb file of the game.

### Screenshots

### Any Assumptions / Hacks
