### PR TITLE
[1849 K2S] fix Societa Marittima description

### DIFF
--- a/lib/engine/game/g_1849_boot/entities.rb
+++ b/lib/engine/game/g_1849_boot/entities.rb
@@ -66,7 +66,7 @@ module Engine
                   'this private company in lieu of performing both its tile '\
                   'and token placement steps. Performing this action allows '\
                   'the corporation to select any coastal city hex (all cities '\
-                  'except Foggia, Campobasso, and Potenza), optionally lay or '\
+                  "except Foggia, Campobasso, L'Aquila, and Potenza), optionally lay or "\
                   'upgrade a tile there, and optionally place a station token '\
                   'there. This power may be used even if the corporation is '\
                   'unable to trace a route to that city, but all other normal '\


### PR DESCRIPTION
Fixes #10775 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Adds "L'Aquila" to the description of this private, since even though this city is not a coastal city, it is on the edge of the map and it's the only city that is neither a valid target for the private ability nor mentioned in the exceptions. 

This makes it clearer. 

### Screenshots

### Any Assumptions / Hacks
