### PR TITLE
[1830] implements private company cross-buys

### DIFF
--- a/lib/engine/game/g_1830/game.rb
+++ b/lib/engine/game/g_1830/game.rb
@@ -109,14 +109,20 @@ module Engine
           ['', '', '', '10b', '20b', '30b', '40o'],
         ].freeze
 
-        PHASES = [{ name: '2', train_limit: 4, tiles: [:yellow], operating_rounds: 1 },
+        PHASES = [{
+          name: '2',
+          train_limit: 4,
+          tiles: [:yellow],
+          operating_rounds: 1,
+          status: ['can_buy_companies_from_other_players'],
+        },
                   {
                     name: '3',
                     on: '3',
                     train_limit: 4,
                     tiles: %i[yellow green],
                     operating_rounds: 2,
-                    status: ['can_buy_companies'],
+                    status: %w[can_buy_companies can_buy_companies_from_other_players],
                   },
                   {
                     name: '4',
@@ -124,7 +130,7 @@ module Engine
                     train_limit: 3,
                     tiles: %i[yellow green],
                     operating_rounds: 2,
-                    status: ['can_buy_companies'],
+                    status: %w[can_buy_companies can_buy_companies_from_other_players],
                   },
                   {
                     name: '5',
@@ -185,6 +191,20 @@ module Engine
             [Engine::Step::BuyCompany, { blocks: true }],
           ], round_num: round_num)
         end
+
+        def stock_round
+          Round::Stock.new(self, [
+            Engine::Step::DiscardTrain,
+            Engine::Step::Exchange,
+            Engine::Step::SpecialTrack,
+            G1830::Step::BuySellParShares,
+          ])
+        end
+
+        STATUS_TEXT = Base::STATUS_TEXT.merge(
+         'can_buy_companies_from_other_players' => ['Interplayer Company Buy',
+                                                    'Companies can be bought between players after first stock round'],
+       ).freeze
 
         def multiple_buy_only_from_market?
           !optional_rules&.include?(:multiple_brown_from_ipo)

--- a/lib/engine/game/g_1830/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1830/step/buy_sell_par_shares.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares'
+
+module Engine
+  module Game
+    module G1830
+      module Step
+        class BuySellParShares < Engine::Step::BuySellParShares
+          def purchasable_companies(entity)
+            return [] if bought? ||
+              !available_cash(entity).positive? ||
+              !@game.phase ||
+              !@game.phase.status.include?('can_buy_companies_from_other_players') ||
+              @game.turn == 1
+
+            @game.purchasable_companies(entity)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #9735 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Both the Avalon Hill and Mayfair rules for 1830 say that players can buy private companies from each other in any stock round after SR1. This implements the ability. 

I tested with several live games, but it would be a good idea to check for pins, in the case where players who had no possible actions in subsequent SRs were automatically skipped, which wouldn't happen with this code.

### Screenshots

### Any Assumptions / Hacks
