### PR TITLE
assets: Emit source maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CONTAINER_COMPOSE ?= $(CONTAINER_ENGINE)-compose
 CONTAINER_ENGINE ?= docker
 
 clean:
-	sudo rm -rfv build/ public/assets/*.js public/assets/*.js.gz public/assets/version.json
+	sudo rm -rfv build/ public/assets/*.js public/assets/*.js.map public/assets/*.js.gz public/assets/version.json
 
 cleandeps:
 	sudo rm -rfv public/assets/deps.js

--- a/api.rb
+++ b/api.rb
@@ -77,7 +77,7 @@ class Api < Roda
     }
   end
 
-  ASSETS = Assets.new(precompiled: PRODUCTION)
+  ASSETS = Assets.new(precompiled: PRODUCTION, source_maps: !PRODUCTION)
 
   Bus.configure
 

--- a/queue.rb
+++ b/queue.rb
@@ -20,7 +20,7 @@ QUEUE_LOGGER = Logger.new($stdout)
 
 Bus.configure
 
-ASSETS = Assets.new(precompiled: PRODUCTION)
+ASSETS = Assets.new(precompiled: PRODUCTION, source_maps: !PRODUCTION)
 
 scheduler = Rufus::Scheduler.new
 


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

I had to rename deps because there was a name collision where the file was written to twice once in compile_lib and another time in combine and thus the corresponding source maps would get mangled. 


### Explanation of Change

This made it much easier to debug some issues. I was able to get ruby source code in the web inspector and see where exceptions where being thrown from.

### Any Assumptions / Hacks