### PR TITLE
[18 Hiawatha] adds fixture files

### DIFF
--- a/public/fixtures/18 Hiawatha/164543.json
+++ b/public/fixtures/18 Hiawatha/164543.json
@@ -1,0 +1,10890 @@
+{
+  "id": 164543,
+  "description": "Learning Game - Casual Workday Async US TZ's",
+  "user": {
+    "id": 11123,
+    "name": "jackietreehorn"
+  },
+  "players": [
+    {
+      "id": 11123,
+      "name": "jackietreehorn"
+    },
+    {
+      "id": 17510,
+      "name": "EricGu"
+    },
+    {
+      "id": 16104,
+      "name": "Czl_Dzl"
+    },
+    {
+      "id": 1152,
+      "name": "JaxHammerHex"
+    },
+    {
+      "id": 2091,
+      "name": "Ragnar"
+    }
+  ],
+  "min_players": 4,
+  "max_players": 6,
+  "title": "18 Hiawatha",
+  "settings": {
+    "seed": 106334840,
+    "is_async": true,
+    "unlisted": false,
+    "auto_routing": true,
+    "player_order": null,
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "status": "finished",
+  "turn": 3,
+  "round": "Acquisition Round",
+  "acting": [
+    16104
+  ],
+  "result": {
+    "1152": 0,
+    "2091": 460,
+    "11123": 0,
+    "16104": 2245,
+    "17510": 3046
+  },
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1716386592,
+      "company": "US",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1716400173,
+      "company": "US",
+      "price": 15
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1716400583,
+      "company": "US",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1716422730,
+      "company": "US",
+      "price": 40
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1716424032
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1716424214,
+      "company": "US",
+      "price": 60
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1716435668
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1716435715,
+      "company": "US",
+      "price": 65
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1716469139
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1716471769
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1716471949,
+      "company": "GLS",
+      "price": 10
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1716476705,
+      "company": "GLS",
+      "price": 15
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1716507947,
+      "company": "GLS",
+      "price": 35
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1716508178
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1716511246,
+      "company": "GLS",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1716518364,
+      "company": "GLS",
+      "price": 45
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1716518915
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1716556352
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1716558822
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1716561758,
+      "company": "PC",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1716594425,
+      "company": "PC",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 23,
+      "created_at": 1716594521,
+      "company": "PC",
+      "price": 65
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 24,
+      "created_at": 1716595198,
+      "company": "PC",
+      "price": 70
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1716605097,
+      "company": "PC",
+      "price": 75
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 26,
+      "created_at": 1716607594,
+      "company": "PC",
+      "price": 80
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1716632610,
+      "company": "PC",
+      "price": 85
+    },
+    {
+      "type": "bid",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 28,
+      "created_at": 1716663184,
+      "company": "PC",
+      "price": 90
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 29,
+      "created_at": 1716663244
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 30,
+      "created_at": 1716663886
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 31,
+      "created_at": 1716672151,
+      "company": "PC",
+      "price": 95
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 32,
+      "created_at": 1716679387
+    },
+    {
+      "type": "bid",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 33,
+      "created_at": 1716680565,
+      "company": "PC",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1716682197
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1716686935,
+      "company": "MB",
+      "price": 50
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1716686992
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 37,
+      "created_at": 1716689792
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 38,
+      "created_at": 1716690331,
+      "company": "MB",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 39,
+      "created_at": 1716691987,
+      "company": "MB",
+      "price": 65
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 40,
+      "created_at": 1716726395
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 41,
+      "created_at": 1716727254,
+      "company": "MB",
+      "price": 70
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 42,
+      "created_at": 1716742241
+    },
+    {
+      "type": "bid",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 43,
+      "created_at": 1716743604,
+      "company": "JLBC",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 44,
+      "created_at": 1716745941,
+      "company": "JLBC",
+      "price": 10
+    },
+    {
+      "type": "bid",
+      "price": 15,
+      "entity": 17510,
+      "company": "JLBC",
+      "entity_type": "player",
+      "id": 45,
+      "user": 17510,
+      "created_at": 1716746087
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 46,
+      "user": 17510,
+      "created_at": 1716746089
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 47,
+      "created_at": 1716746091,
+      "company": "JLBC",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 48,
+      "created_at": 1716746361,
+      "company": "JLBC",
+      "price": 25
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 49,
+      "created_at": 1716747761,
+      "company": "JLBC",
+      "price": 60
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 50,
+      "created_at": 1716752702
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 51,
+      "created_at": 1716754331
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 52,
+      "created_at": 1716780611
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 53,
+      "created_at": 1716780644
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 54,
+      "created_at": 1716817320,
+      "company": "FU",
+      "price": 10
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 55,
+      "created_at": 1716817713,
+      "company": "FU",
+      "price": 15
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 56,
+      "created_at": 1716818031,
+      "company": "FU",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 57,
+      "created_at": 1716820054,
+      "company": "FU",
+      "price": 50
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 58,
+      "created_at": 1716830096
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 59,
+      "created_at": 1716832398,
+      "company": "FU",
+      "price": 55
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 60,
+      "created_at": 1716832525
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 61,
+      "created_at": 1716832803
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 62,
+      "created_at": 1716859799,
+      "company": "FU",
+      "price": 60
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 63,
+      "created_at": 1716864168
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 64,
+      "created_at": 1716864218,
+      "company": "FC",
+      "price": 10
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 65,
+      "created_at": 1716864307,
+      "company": "FC",
+      "price": 15
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 66,
+      "created_at": 1716865069,
+      "company": "FC",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 67,
+      "created_at": 1716865096,
+      "company": "FC",
+      "price": 45
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 68,
+      "created_at": 1716899657
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 69,
+      "user": 17510,
+      "created_at": 1716899816
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 70,
+      "user": 17510,
+      "created_at": 1716899821
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 71,
+      "created_at": 1716899860,
+      "company": "FC",
+      "price": 50
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 72,
+      "created_at": 1716899869
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 73,
+      "created_at": 1716901075
+    },
+    {
+      "type": "bid",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 74,
+      "created_at": 1716910312,
+      "company": "FC",
+      "price": 55
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 75,
+      "created_at": 1716913293
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 76,
+      "created_at": 1716915267,
+      "company": "RR",
+      "price": 30
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 77,
+      "created_at": 1716928812,
+      "company": "RR",
+      "price": 100
+    },
+    {
+      "type": "bid",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 78,
+      "created_at": 1716937809,
+      "company": "RR",
+      "price": 105
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 79,
+      "created_at": 1716937864,
+      "company": "RR",
+      "price": 110
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 80,
+      "created_at": 1716945904,
+      "company": "RR",
+      "price": 115
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 81,
+      "created_at": 1716946553,
+      "company": "RR",
+      "price": 120
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 82,
+      "created_at": 1716949578
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 83,
+      "created_at": 1716950470
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 84,
+      "created_at": 1716950808
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 85,
+      "created_at": 1716953084,
+      "corporation": "DL&W",
+      "price": 140
+    },
+    {
+      "type": "place_token",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 86,
+      "created_at": 1716953095,
+      "city": "C3-1-0",
+      "slot": 0,
+      "tokener": "DL&W"
+    },
+    {
+      "type": "bid",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 87,
+      "created_at": 1716953282,
+      "corporation": "DL&W",
+      "price": 145
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 88,
+      "created_at": 1716984106,
+      "corporation": "DL&W",
+      "price": 160
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 89,
+      "created_at": 1716985492
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 90,
+      "created_at": 1716985502,
+      "corporation": "DL&W",
+      "price": 165
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 91,
+      "created_at": 1716986084
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 92,
+      "created_at": 1717002991
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 93,
+      "created_at": 1717008077
+    },
+    {
+      "type": "assign",
+      "entity": 16104,
+      "target": "RR",
+      "entity_type": "player",
+      "target_type": "company",
+      "id": 94,
+      "user": 16104,
+      "created_at": 1717008536
+    },
+    {
+      "type": "undo",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 95,
+      "user": 16104,
+      "created_at": 1717008664
+    },
+    {
+      "type": "assign",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 96,
+      "created_at": 1717008713,
+      "target": "RR",
+      "target_type": "company"
+    },
+    {
+      "type": "bid",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 97,
+      "created_at": 1717023528,
+      "corporation": "GT",
+      "price": 100
+    },
+    {
+      "type": "place_token",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 98,
+      "created_at": 1717023545,
+      "city": "I11-13-0",
+      "slot": 0,
+      "tokener": "GT"
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 99,
+      "created_at": 1717029210,
+      "corporation": "GT",
+      "price": 130
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 100,
+      "created_at": 1717043473
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 101,
+      "created_at": 1717072634,
+      "corporation": "GT",
+      "price": 140
+    },
+    {
+      "type": "bid",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 102,
+      "created_at": 1717089805,
+      "corporation": "GT",
+      "price": 145
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 103,
+      "created_at": 1717090685
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 104,
+      "created_at": 1717114517
+    },
+    {
+      "type": "assign",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 105,
+      "created_at": 1717137000,
+      "target": "PC",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 106,
+      "created_at": 1717137003,
+      "target": "FC",
+      "target_type": "company"
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 107,
+      "created_at": 1717155131,
+      "corporation": "H",
+      "price": 130
+    },
+    {
+      "type": "place_token",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 108,
+      "created_at": 1717155134,
+      "city": "F8-8-0",
+      "slot": 0,
+      "tokener": "H"
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 109,
+      "created_at": 1717156187
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 110,
+      "created_at": 1717158361,
+      "corporation": "H",
+      "price": 140
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 111,
+      "created_at": 1717159345,
+      "corporation": "H",
+      "price": 160
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 112,
+      "created_at": 1717161247
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 113,
+      "created_at": 1717162751,
+      "corporation": "PLE",
+      "price": 120
+    },
+    {
+      "type": "place_token",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 114,
+      "created_at": 1717162752,
+      "city": "D6-4-0",
+      "slot": 0,
+      "tokener": "PLE"
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 115,
+      "created_at": 1717199803
+    },
+    {
+      "type": "assign",
+      "entity": 17510,
+      "target": "GLS",
+      "entity_type": "player",
+      "target_type": "company",
+      "id": 116,
+      "user": 17510,
+      "created_at": 1717213634
+    },
+    {
+      "type": "assign",
+      "entity": 17510,
+      "target": "MB",
+      "entity_type": "player",
+      "target_type": "company",
+      "id": 117,
+      "user": 17510,
+      "created_at": 1717213640
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 118,
+      "user": 17510,
+      "created_at": 1717213669
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 119,
+      "user": 17510,
+      "created_at": 1717213676
+    },
+    {
+      "type": "assign",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 120,
+      "created_at": 1717213755,
+      "target": "MB",
+      "target_type": "company"
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 121,
+      "created_at": 1717213790
+    },
+    {
+      "type": "short",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 122,
+      "created_at": 1717213827,
+      "corporation": "PLE"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 123,
+      "created_at": 1717213832,
+      "shares": [
+        "DL&W_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 124,
+      "created_at": 1717237220,
+      "corporation": "R",
+      "price": 140
+    },
+    {
+      "type": "place_token",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 125,
+      "created_at": 1717237226,
+      "city": "F4-6-0",
+      "slot": 0,
+      "tokener": "R"
+    },
+    {
+      "type": "assign",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 126,
+      "created_at": 1717237240,
+      "target": "FU",
+      "target_type": "company"
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 127,
+      "created_at": 1717237247
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 128,
+      "created_at": 1717391981,
+      "shares": [
+        "GT_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 129,
+      "created_at": 1717415589,
+      "shares": [
+        "H_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 130,
+      "created_at": 1717416421,
+      "corporation": "UR",
+      "price": 125
+    },
+    {
+      "type": "place_token",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 131,
+      "created_at": 1717416423,
+      "city": "A7-0-0",
+      "slot": 1,
+      "tokener": "UR"
+    },
+    {
+      "type": "assign",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 132,
+      "created_at": 1717416426,
+      "target": "GLS",
+      "target_type": "company"
+    },
+    {
+      "type": "short",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 133,
+      "created_at": 1717416939,
+      "corporation": "H"
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 134,
+      "created_at": 1717416945
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 135,
+      "created_at": 1717417816,
+      "corporation": "NYSW",
+      "price": 120
+    },
+    {
+      "type": "place_token",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 136,
+      "created_at": 1717417822,
+      "city": "D2-3-0",
+      "slot": 0,
+      "tokener": "NYSW"
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 137,
+      "created_at": 1717417864
+    },
+    {
+      "type": "assign",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 138,
+      "created_at": 1717417875,
+      "target": "JLBC",
+      "target_type": "company"
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 139,
+      "created_at": 1717427664
+    },
+    {
+      "type": "take_loan",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 140,
+      "created_at": 1717432246,
+      "loan": 0
+    },
+    {
+      "type": "buy_shares",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 141,
+      "created_at": 1717432260,
+      "shares": [
+        "H_10"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "corporation": "H",
+      "entity_type": "player",
+      "id": 142,
+      "user": 17510,
+      "created_at": 1717435004
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "shares": [
+        "PLE_1"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 143,
+      "user": 17510,
+      "created_at": 1717435043
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 144,
+      "user": 17510,
+      "created_at": 1717435087
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "shares": [
+        "PLE_10"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 145,
+      "user": 17510,
+      "created_at": 1717435094
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 146,
+      "user": 17510,
+      "created_at": 1717435919
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 147,
+      "user": 17510,
+      "created_at": 1717436241
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 148,
+      "created_at": 1717436314,
+      "corporation": "R"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 149,
+      "created_at": 1717436327,
+      "shares": [
+        "PLE_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "short",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 150,
+      "created_at": 1717438517,
+      "corporation": "H"
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 151,
+      "created_at": 1717439590
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 152,
+      "created_at": 1717462688,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1152,
+          "entity_type": "player",
+          "created_at": 1717462689
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "short",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 153,
+      "created_at": 1717486032,
+      "corporation": "DL&W"
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 154,
+      "created_at": 1717486036
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 155,
+      "created_at": 1717502230
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 156,
+      "created_at": 1717502608,
+      "corporation": "H"
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 157,
+      "created_at": 1717502648
+    },
+    {
+      "type": "short",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 158,
+      "created_at": 1717502956,
+      "corporation": "GT"
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 159,
+      "created_at": 1717502999,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 1152,
+          "entity_type": "player",
+          "created_at": 1717502999,
+          "reason": "Short bought"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 160,
+      "created_at": 1717504135,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1152,
+          "entity_type": "player",
+          "created_at": 1717504137
+        }
+      ],
+      "unconditional": true,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 161,
+      "created_at": 1717600589,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1717600588
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 162,
+      "created_at": 1717604582
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 163,
+      "created_at": 1717604644,
+      "corporation": "H"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 164,
+      "created_at": 1717604732,
+      "shares": [
+        "UR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 165,
+      "created_at": 1717607597,
+      "corporation": "NYOW",
+      "price": 140
+    },
+    {
+      "type": "place_token",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 166,
+      "created_at": 1717607613,
+      "city": "H8-1-0",
+      "slot": 0,
+      "tokener": "NYOW"
+    },
+    {
+      "type": "assign",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 167,
+      "created_at": 1717607621,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1152,
+          "entity_type": "player",
+          "created_at": 1717607621
+        },
+        {
+          "type": "program_disable",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1717607621,
+          "reason": "Corporation NYOW parred"
+        }
+      ],
+      "target": "US",
+      "target_type": "company"
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 168,
+      "created_at": 1717611851,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1717611850
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 169,
+      "created_at": 1717614848
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "corporation": "H",
+      "entity_type": "player",
+      "id": 170,
+      "user": 17510,
+      "created_at": 1717643091
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "shares": [
+        "GT_2"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 171,
+      "user": 17510,
+      "created_at": 1717643104
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 172,
+      "user": 17510,
+      "created_at": 1717643108
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "shares": [
+        "GT_10"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 173,
+      "user": 17510,
+      "created_at": 1717643111
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 174,
+      "user": 17510,
+      "created_at": 1717643161
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 175,
+      "user": 17510,
+      "created_at": 1717643162
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "corporation": "H",
+      "entity_type": "player",
+      "id": 176,
+      "user": 17510,
+      "created_at": 1717643280
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "shares": [
+        "GT_10"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 177,
+      "user": 17510,
+      "created_at": 1717643306
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 178,
+      "user": 17510,
+      "created_at": 1717643349
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 179,
+      "user": 17510,
+      "created_at": 1717643350
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 180,
+      "created_at": 1717643383,
+      "corporation": "R"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 181,
+      "created_at": 1717643398,
+      "shares": [
+        "GT_10"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 182,
+      "created_at": 1717643573,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1152,
+          "entity_type": "player",
+          "created_at": 1717643572
+        },
+        {
+          "type": "program_disable",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1717643572,
+          "reason": "Short bought"
+        }
+      ],
+      "shares": [
+        "NYOW_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 183,
+      "created_at": 1717658919,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1717658919
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "short",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 184,
+      "created_at": 1717675646,
+      "corporation": "GT"
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 185,
+      "created_at": 1717675676
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 186,
+      "created_at": 1717675942,
+      "corporation": "R"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 187,
+      "created_at": 1717675969,
+      "shares": [
+        "GT_12"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "short",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 188,
+      "created_at": 1717676280,
+      "corporation": "GT"
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 189,
+      "created_at": 1717676334,
+      "corporation": "PSNR",
+      "price": 150
+    },
+    {
+      "type": "place_token",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 190,
+      "created_at": 1717676373,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1152,
+          "entity_type": "player",
+          "created_at": 1717676373
+        },
+        {
+          "type": "program_disable",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1717676373,
+          "reason": "Short bought"
+        }
+      ],
+      "city": "E7-5-0",
+      "slot": 0,
+      "tokener": "PSNR"
+    },
+    {
+      "type": "short",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 191,
+      "created_at": 1717688208,
+      "corporation": "DL&W"
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 192,
+      "created_at": 1717688214
+    },
+    {
+      "type": "short",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 193,
+      "created_at": 1717689647,
+      "corporation": "PLE"
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 194,
+      "created_at": 1717689666,
+      "corporation": "J",
+      "price": 140
+    },
+    {
+      "type": "place_token",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 195,
+      "created_at": 1717689680,
+      "city": "G7-9-0",
+      "slot": 0,
+      "tokener": "J"
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 196,
+      "created_at": 1717693202,
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "bid",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 197,
+      "created_at": 1717721067,
+      "corporation": "J",
+      "price": 145
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 198,
+      "created_at": 1717721102,
+      "corporation": "J",
+      "price": 150
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 199,
+      "created_at": 1717721120
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 200,
+      "created_at": 1717730280,
+      "corporation": "R"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 201,
+      "created_at": 1717730284,
+      "shares": [
+        "GT_14"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "take_loan",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 202,
+      "created_at": 1717730360,
+      "loan": 0
+    },
+    {
+      "type": "buy_shares",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 203,
+      "created_at": 1717730402,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1152,
+          "entity_type": "player",
+          "created_at": 1717730401
+        },
+        {
+          "type": "program_disable",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1717730401,
+          "reason": "DL&W took a loan"
+        }
+      ],
+      "shares": [
+        "DL&W_10",
+        "DL&W_12"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 204,
+      "created_at": 1717739674,
+      "shares": [
+        "NYOW_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 205,
+      "created_at": 1717742379
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "corporation": "R",
+      "entity_type": "player",
+      "id": 206,
+      "user": 17510,
+      "created_at": 1717746138
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 207,
+      "user": 17510,
+      "created_at": 1717746243
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "corporation": "H",
+      "entity_type": "player",
+      "id": 208,
+      "user": 17510,
+      "created_at": 1717746249
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 209,
+      "user": 17510,
+      "created_at": 1717746253
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 210,
+      "created_at": 1717746254,
+      "corporation": "R"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 211,
+      "created_at": 1717746319,
+      "shares": [
+        "NYOW_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "short",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 212,
+      "created_at": 1717763084,
+      "corporation": "GT"
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 213,
+      "created_at": 1717763091,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1152,
+          "entity_type": "player",
+          "created_at": 1717763091
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 214,
+      "created_at": 1717799491,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1717799490
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 215,
+      "user": 11123,
+      "created_at": 1717800004
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 216,
+      "user": 11123,
+      "created_at": 1717800041
+    },
+    {
+      "type": "short",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 217,
+      "created_at": 1717800043,
+      "corporation": "DL&W"
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 218,
+      "created_at": 1717800047,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 11123,
+          "entity_type": "player",
+          "created_at": 1717800048
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 219,
+      "created_at": 1717821194,
+      "shares": [
+        "DL&W_14"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 220,
+      "created_at": 1717821363,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1152,
+          "entity_type": "player",
+          "created_at": 1717821360
+        },
+        {
+          "type": "program_disable",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1717821360,
+          "reason": "Short bought"
+        }
+      ],
+      "shares": [
+        "PSNR_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 221,
+      "created_at": 1717824363,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 11123,
+          "entity_type": "player",
+          "created_at": 1717824363
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 222,
+      "created_at": 1717824750
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 223,
+      "created_at": 1717824881
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 224,
+      "created_at": 1717825059,
+      "hex": "H8",
+      "tile": "5-0",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 225,
+      "created_at": 1717825080,
+      "hex": "F8",
+      "tile": "57-0",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 226,
+      "created_at": 1717825082,
+      "city": "G9-0-0",
+      "slot": 0,
+      "tokener": "NYOW"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 227,
+      "created_at": 1717825089,
+      "train": "2-1",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 228,
+      "created_at": 1717825090,
+      "train": "2-2",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 229,
+      "created_at": 1717825097
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 230,
+      "created_at": 1717825100
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 231,
+      "created_at": 1717825121,
+      "hex": "E7",
+      "tile": "6-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 232,
+      "created_at": 1717825137
+    },
+    {
+      "type": "buy_train",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 233,
+      "created_at": 1717825141,
+      "train": "2-3",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 234,
+      "created_at": 1717825148
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 235,
+      "created_at": 1717825154
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 237,
+      "created_at": 1717856576,
+      "hex": "G7",
+      "tile": "5-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 238,
+      "created_at": 1717856580,
+      "hex": "F6",
+      "tile": "6-1",
+      "rotation": 5
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 239,
+      "user": 11123,
+      "created_at": 1717856594
+    },
+    {
+      "type": "undo",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 240,
+      "user": 11123,
+      "created_at": 1717856603
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 241,
+      "created_at": 1717856605
+    },
+    {
+      "type": "buy_train",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 242,
+      "created_at": 1717856608,
+      "train": "2-4",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 243,
+      "created_at": 1717856616
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 244,
+      "created_at": 1717856620
+    },
+    {
+      "hex": "C3",
+      "tile": "6-2",
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 245,
+      "user": 16104,
+      "created_at": 1717858008
+    },
+    {
+      "hex": "D4",
+      "tile": "8-0",
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 246,
+      "user": 16104,
+      "created_at": 1717858013
+    },
+    {
+      "type": "undo",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 247,
+      "user": 16104,
+      "created_at": 1717858035
+    },
+    {
+      "hex": "D4",
+      "tile": "8-0",
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 248,
+      "user": 16104,
+      "created_at": 1717858043
+    },
+    {
+      "type": "undo",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 249,
+      "user": 16104,
+      "created_at": 1717858070
+    },
+    {
+      "type": "undo",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 250,
+      "user": 16104,
+      "created_at": 1717858071
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 251,
+      "created_at": 1717858082,
+      "hex": "C3",
+      "tile": "6-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 252,
+      "created_at": 1717858086,
+      "hex": "D2",
+      "tile": "57-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 253,
+      "created_at": 1717858090,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C3",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "D2",
+            "C3"
+          ],
+          "revenue": 40,
+          "revenue_str": "D2-C3",
+          "nodes": [
+            "C3-0",
+            "D2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 254,
+      "created_at": 1717858094,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 255,
+      "created_at": 1717858104
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 256,
+      "created_at": 1717858115
+    },
+    {
+      "hex": "I11",
+      "tile": "6-3",
+      "type": "lay_tile",
+      "entity": "GT",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 257,
+      "user": 2091,
+      "created_at": 1717860129
+    },
+    {
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 258,
+      "user": 2091,
+      "created_at": 1717860144
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 259,
+      "created_at": 1717860155,
+      "hex": "I11",
+      "tile": "6-3",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 260,
+      "created_at": 1717860164
+    },
+    {
+      "type": "place_token",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 261,
+      "created_at": 1717860177,
+      "city": "H10-0-0",
+      "slot": 0,
+      "tokener": "GT"
+    },
+    {
+      "type": "take_loan",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 262,
+      "created_at": 1717860192,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 263,
+      "created_at": 1717860197,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 264,
+      "created_at": 1717860198,
+      "train": "2-5",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 265,
+      "created_at": 1717860199,
+      "train": "2-6",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 266,
+      "created_at": 1717860205
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 267,
+      "created_at": 1717860223
+    },
+    {
+      "hex": "B6",
+      "tile": "6-4",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 268,
+      "user": 17510,
+      "created_at": 1717869283
+    },
+    {
+      "type": "assign",
+      "entity": "GLS",
+      "target": "A9",
+      "entity_type": "company",
+      "target_type": "hex",
+      "id": 269,
+      "user": 17510,
+      "created_at": 1717869287
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 270,
+      "user": 17510,
+      "created_at": 1717869344
+    },
+    {
+      "city": "6-4-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "UR",
+      "tokener": "UR",
+      "entity_type": "corporation",
+      "id": 271,
+      "user": 17510,
+      "created_at": 1717869389
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 272,
+      "user": 17510,
+      "created_at": 1717869416
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 273,
+      "user": 17510,
+      "created_at": 1717869416
+    },
+    {
+      "type": "buy_train",
+      "price": 100,
+      "train": "2-7",
+      "entity": "UR",
+      "variant": "2",
+      "entity_type": "corporation",
+      "id": 274,
+      "user": 17510,
+      "created_at": 1717869418
+    },
+    {
+      "type": "buy_train",
+      "price": 100,
+      "train": "2-8",
+      "entity": "UR",
+      "variant": "2",
+      "entity_type": "corporation",
+      "id": 275,
+      "user": 17510,
+      "created_at": 1717869418
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 276,
+      "user": 17510,
+      "created_at": 1717869560
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 277,
+      "user": 17510,
+      "created_at": 1717869561
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 278,
+      "user": 17510,
+      "created_at": 1717869562
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 279,
+      "user": 17510,
+      "created_at": 1717869562
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 280,
+      "user": 17510,
+      "created_at": 1717869565
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 281,
+      "user": 17510,
+      "created_at": 1717869567
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 282,
+      "user": 17510,
+      "created_at": 1717869569
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 283,
+      "user": 17510,
+      "created_at": 1717869571
+    },
+    {
+      "type": "take_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 284,
+      "created_at": 1717869575,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 285,
+      "created_at": 1717869575,
+      "loan": 0
+    },
+    {
+      "type": "assign",
+      "entity": "GLS",
+      "entity_type": "company",
+      "id": 286,
+      "created_at": 1717869580,
+      "target": "A9",
+      "target_type": "hex"
+    },
+    {
+      "hex": "B6",
+      "tile": "6-4",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 287,
+      "user": 17510,
+      "created_at": 1717869585
+    },
+    {
+      "hex": "C7",
+      "tile": "57-2",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 288,
+      "user": 17510,
+      "created_at": 1717869600
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 289,
+      "user": 17510,
+      "created_at": 1717869609
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 290,
+      "user": 17510,
+      "created_at": 1717869647
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 291,
+      "created_at": 1717869650,
+      "hex": "B6",
+      "tile": "57-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 292,
+      "created_at": 1717869677,
+      "hex": "C5",
+      "tile": "8-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 293,
+      "created_at": 1717869774
+    },
+    {
+      "type": "buy_train",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 294,
+      "created_at": 1717869775,
+      "train": "2-7",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 295,
+      "created_at": 1717869775,
+      "train": "2-8",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 296,
+      "created_at": 1717869802
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 297,
+      "created_at": 1717869822
+    },
+    {
+      "type": "lay_tile",
+      "entity": "JLBC",
+      "entity_type": "company",
+      "id": 298,
+      "created_at": 1717876662,
+      "hex": "D2",
+      "tile": "14-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 299,
+      "created_at": 1717876673,
+      "hex": "C1",
+      "tile": "8-1",
+      "rotation": 3
+    },
+    {
+      "type": "take_loan",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 300,
+      "created_at": 1717876681,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 301,
+      "created_at": 1717876683,
+      "train": "2-9",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "take_loan",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 302,
+      "created_at": 1717876697,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 303,
+      "created_at": 1717876698,
+      "train": "2-10",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 304,
+      "created_at": 1717876700
+    },
+    {
+      "type": "pass",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 305,
+      "created_at": 1717876715
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 306,
+      "created_at": 1717905722
+    },
+    {
+      "type": "buy_train",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 307,
+      "created_at": 1717905735,
+      "train": "2-11",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 308,
+      "created_at": 1717905736,
+      "train": "2-12",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 309,
+      "created_at": 1717905739
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 310,
+      "created_at": 1717905742
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MB",
+      "entity_type": "company",
+      "id": 311,
+      "created_at": 1717906467,
+      "hex": "D6",
+      "tile": "X00H-0",
+      "rotation": 1
+    },
+    {
+      "hex": "E5",
+      "tile": "8-2",
+      "type": "lay_tile",
+      "entity": "PLE",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 312,
+      "user": 17510,
+      "created_at": 1717906483
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 313,
+      "user": 17510,
+      "created_at": 1717906488
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 314,
+      "user": 17510,
+      "created_at": 1717906491
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 315,
+      "user": 17510,
+      "created_at": 1717906503
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 316,
+      "user": 17510,
+      "created_at": 1717906610
+    },
+    {
+      "city": "57-2-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "PLE",
+      "tokener": "PLE",
+      "entity_type": "corporation",
+      "id": 317,
+      "user": 17510,
+      "created_at": 1717906620
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 318,
+      "user": 17510,
+      "created_at": 1717906688
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 319,
+      "user": 17510,
+      "created_at": 1717906691
+    },
+    {
+      "city": "57-2-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "PLE",
+      "tokener": "PLE",
+      "entity_type": "corporation",
+      "id": 320,
+      "user": 17510,
+      "created_at": 1717906700
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 321,
+      "user": 17510,
+      "created_at": 1717906744
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 322,
+      "user": 17510,
+      "created_at": 1717906749
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 323,
+      "user": 17510,
+      "created_at": 1717906756
+    },
+    {
+      "hex": "E5",
+      "tile": "8-2",
+      "type": "lay_tile",
+      "entity": "PLE",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 324,
+      "user": 17510,
+      "created_at": 1717906762
+    },
+    {
+      "city": "57-2-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "PLE",
+      "tokener": "PLE",
+      "entity_type": "corporation",
+      "id": 325,
+      "user": 17510,
+      "created_at": 1717906768
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 326,
+      "user": 17510,
+      "created_at": 1717906798
+    },
+    {
+      "type": "buy_train",
+      "price": 100,
+      "train": "2-13",
+      "entity": "PLE",
+      "variant": "2",
+      "entity_type": "corporation",
+      "id": 327,
+      "user": 17510,
+      "created_at": 1717906962
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 328,
+      "user": 17510,
+      "created_at": 1717906964
+    },
+    {
+      "type": "buy_train",
+      "price": 100,
+      "train": "2-7",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 329,
+      "user": 17510,
+      "created_at": 1717906969
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 330,
+      "user": 17510,
+      "created_at": 1717906999
+    },
+    {
+      "type": "buy_train",
+      "price": 100,
+      "train": "2-13",
+      "entity": "PLE",
+      "variant": "2",
+      "entity_type": "corporation",
+      "id": 331,
+      "user": 17510,
+      "created_at": 1717907004
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 332,
+      "user": 17510,
+      "created_at": 1717907008
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 333,
+      "user": 17510,
+      "created_at": 1717907011
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 334,
+      "user": 17510,
+      "created_at": 1717907015
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 335,
+      "user": 17510,
+      "created_at": 1717907017
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 336,
+      "user": 17510,
+      "created_at": 1717907018
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 337,
+      "user": 17510,
+      "created_at": 1717907019
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 338,
+      "user": 17510,
+      "created_at": 1717907020
+    },
+    {
+      "type": "redo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 339,
+      "user": 17510,
+      "created_at": 1717907024
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 340,
+      "user": 17510,
+      "created_at": 1717907035
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 341,
+      "user": 17510,
+      "created_at": 1717907036
+    },
+    {
+      "hex": "E5",
+      "tile": "8-2",
+      "type": "lay_tile",
+      "entity": "PLE",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 342,
+      "user": 17510,
+      "created_at": 1717907057
+    },
+    {
+      "city": "57-2-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "PLE",
+      "tokener": "PLE",
+      "entity_type": "corporation",
+      "id": 343,
+      "user": 17510,
+      "created_at": 1717907064
+    },
+    {
+      "type": "buy_train",
+      "price": 100,
+      "train": "2-13",
+      "entity": "PLE",
+      "variant": "2",
+      "entity_type": "corporation",
+      "id": 344,
+      "user": 17510,
+      "created_at": 1717907075
+    },
+    {
+      "type": "buy_train",
+      "price": 100,
+      "train": "2-14",
+      "entity": "PLE",
+      "variant": "2",
+      "entity_type": "corporation",
+      "id": 345,
+      "user": 17510,
+      "created_at": 1717907076
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 346,
+      "user": 17510,
+      "created_at": 1717907096
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 347,
+      "user": 17510,
+      "created_at": 1717907101
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 348,
+      "user": 17510,
+      "created_at": 1717907107
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 349,
+      "user": 17510,
+      "created_at": 1717907109
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 350,
+      "user": 17510,
+      "created_at": 1717907109
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 351,
+      "user": 17510,
+      "created_at": 1717907110
+    },
+    {
+      "type": "take_loan",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 352,
+      "created_at": 1717907121,
+      "loan": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 353,
+      "created_at": 1717907142,
+      "hex": "E5",
+      "tile": "8-2",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 354,
+      "created_at": 1717907153,
+      "city": "57-2-0",
+      "slot": 0,
+      "tokener": "PLE"
+    },
+    {
+      "type": "buy_train",
+      "price": 100,
+      "train": "2-13",
+      "entity": "PLE",
+      "variant": "2",
+      "entity_type": "corporation",
+      "id": 355,
+      "user": 17510,
+      "created_at": 1717907164
+    },
+    {
+      "type": "undo",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 356,
+      "user": 17510,
+      "created_at": 1717907166
+    },
+    {
+      "type": "buy_train",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 357,
+      "created_at": 1717907168,
+      "train": "2-13",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 358,
+      "created_at": 1717907190
+    },
+    {
+      "type": "pass",
+      "entity": "PLE",
+      "entity_type": "corporation",
+      "id": 359,
+      "created_at": 1717907197
+    },
+    {
+      "hex": "F4",
+      "tile": "57-3",
+      "type": "lay_tile",
+      "entity": "R",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 360,
+      "user": 1152,
+      "created_at": 1717907595
+    },
+    {
+      "hex": "F2",
+      "tile": "7-0",
+      "type": "lay_tile",
+      "entity": "R",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 361,
+      "user": 1152,
+      "created_at": 1717907623
+    },
+    {
+      "type": "undo",
+      "entity": "R",
+      "action_id": 359,
+      "entity_type": "corporation",
+      "id": 362,
+      "user": 1152,
+      "created_at": 1717907627
+    },
+    {
+      "type": "lay_tile",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 363,
+      "created_at": 1717907638,
+      "hex": "F4",
+      "tile": "57-3",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "FU",
+      "entity_type": "company",
+      "id": 364,
+      "created_at": 1717907657,
+      "hex": "F2",
+      "tile": "7-0",
+      "rotation": 3
+    },
+    {
+      "type": "take_loan",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 365,
+      "created_at": 1717907667,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 366,
+      "created_at": 1717907688,
+      "loan": 0
+    },
+    {
+      "type": "pass",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 367,
+      "created_at": 1717907694
+    },
+    {
+      "type": "buy_train",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 368,
+      "created_at": 1717907696,
+      "train": "2-14",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 369,
+      "created_at": 1717907696,
+      "train": "2-15",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 370,
+      "created_at": 1717907703
+    },
+    {
+      "type": "pass",
+      "entity": "R",
+      "entity_type": "corporation",
+      "id": 371,
+      "created_at": 1717907718
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 372,
+      "user": 16104,
+      "created_at": 1717909498
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 373,
+      "user": 16104,
+      "created_at": 1717909510
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 374,
+      "user": 16104,
+      "created_at": 1717909515
+    },
+    {
+      "type": "undo",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 375,
+      "user": 16104,
+      "created_at": 1717909518
+    },
+    {
+      "type": "undo",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 376,
+      "user": 16104,
+      "created_at": 1717909519
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 377,
+      "user": 16104,
+      "created_at": 1717909521
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 378,
+      "created_at": 1717909579
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 379,
+      "created_at": 1717909580
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 380,
+      "created_at": 1717909583
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 381,
+      "created_at": 1717911587
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 382,
+      "created_at": 1718074103
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 383,
+      "created_at": 1718074863
+    },
+    {
+      "type": "merge",
+      "entity": "UR",
+      "corporation": "PLE",
+      "entity_type": "corporation",
+      "id": 384,
+      "user": 17510,
+      "created_at": 1718075215
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2091,
+      "shares": [
+        "UR_2"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 385,
+      "user": 2091,
+      "created_at": 1718075244
+    },
+    {
+      "type": "undo",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 386,
+      "user": 17510,
+      "created_at": 1718075250
+    },
+    {
+      "type": "undo",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 387,
+      "user": 17510,
+      "created_at": 1718075252
+    },
+    {
+      "type": "merge",
+      "entity": "UR",
+      "corporation": "PLE",
+      "entity_type": "corporation",
+      "id": 388,
+      "user": 17510,
+      "created_at": 1718075254
+    },
+    {
+      "type": "undo",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 389,
+      "user": 17510,
+      "created_at": 1718075256
+    },
+    {
+      "type": "merge",
+      "entity": "UR",
+      "corporation": "PLE",
+      "entity_type": "corporation",
+      "id": 390,
+      "user": 17510,
+      "created_at": 1718075314
+    },
+    {
+      "type": "undo",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 391,
+      "user": 17510,
+      "created_at": 1718075380
+    },
+    {
+      "type": "merge",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 392,
+      "created_at": 1718075384,
+      "corporation": "PLE"
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 393,
+      "created_at": 1718075590
+    },
+    {
+      "type": "undo",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 394,
+      "user": 17510,
+      "created_at": 1718075927
+    },
+    {
+      "type": "redo",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 395,
+      "user": 17510,
+      "created_at": 1718075929
+    },
+    {
+      "type": "buy_shares",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 396,
+      "created_at": 1718110227,
+      "shares": [
+        "UR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 397,
+      "created_at": 1718110271
+    },
+    {
+      "type": "pass",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 398,
+      "created_at": 1718110941
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 399,
+      "created_at": 1718155461
+    },
+    {
+      "type": "bid",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 400,
+      "created_at": 1718155782,
+      "corporation": "R",
+      "price": 10
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 401,
+      "created_at": 1718161491,
+      "corporation": "R",
+      "price": 30
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 402,
+      "created_at": 1718161776,
+      "corporation": "R",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 403,
+      "created_at": 1718195857,
+      "corporation": "R",
+      "price": 70
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 404,
+      "created_at": 1718199241
+    },
+    {
+      "type": "bid",
+      "price": 80,
+      "entity": 17510,
+      "corporation": "R",
+      "entity_type": "player",
+      "id": 405,
+      "user": 17510,
+      "created_at": 1718209108
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 406,
+      "user": 17510,
+      "created_at": 1718209205
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 407,
+      "user": 17510,
+      "created_at": 1718209206
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 408,
+      "user": 17510,
+      "created_at": 1718209235
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 409,
+      "created_at": 1718209312,
+      "corporation": "R",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 410,
+      "created_at": 1718220763
+    },
+    {
+      "type": "bid",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 411,
+      "created_at": 1718223028,
+      "corporation": "R",
+      "price": 90
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 412,
+      "user": 17510,
+      "created_at": 1718223186
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 413,
+      "user": 17510,
+      "created_at": 1718223196
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 414,
+      "user": 17510,
+      "created_at": 1718223215
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 415,
+      "user": 17510,
+      "created_at": 1718223249
+    },
+    {
+      "type": "bid",
+      "price": 100,
+      "entity": 17510,
+      "corporation": "R",
+      "entity_type": "player",
+      "id": 416,
+      "user": 17510,
+      "created_at": 1718223254
+    },
+    {
+      "type": "undo",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 417,
+      "user": 17510,
+      "created_at": 1718223262
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 418,
+      "user": 17510,
+      "created_at": 1718223264
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17510,
+      "shares": [
+        "NYOW_3"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 419,
+      "user": 17510,
+      "created_at": 1718223349
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 420,
+      "user": 17510,
+      "created_at": 1718223355
+    },
+    {
+      "type": "undo",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 421,
+      "user": 17510,
+      "created_at": 1718223372
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 422,
+      "user": 17510,
+      "created_at": 1718223392
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 423,
+      "user": 17510,
+      "created_at": 1718223394
+    },
+    {
+      "type": "bid",
+      "price": 100,
+      "entity": 17510,
+      "corporation": "R",
+      "entity_type": "player",
+      "id": 424,
+      "user": 17510,
+      "created_at": 1718223415
+    },
+    {
+      "type": "undo",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 425,
+      "user": 17510,
+      "created_at": 1718223434
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 426,
+      "user": 17510,
+      "created_at": 1718223450
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17510,
+      "shares": [
+        "DL&W_14"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 427,
+      "user": 17510,
+      "created_at": 1718223525
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 428,
+      "user": 17510,
+      "created_at": 1718223579
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 429,
+      "user": 17510,
+      "created_at": 1718223584
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 430,
+      "user": 17510,
+      "created_at": 1718223613
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17510,
+      "shares": [
+        "DL&W_14"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 431,
+      "user": 17510,
+      "created_at": 1718223621
+    },
+    {
+      "type": "assign",
+      "entity": 17510,
+      "target": "UR",
+      "entity_type": "player",
+      "target_type": "corporation",
+      "id": 432,
+      "user": 17510,
+      "created_at": 1718223625
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 433,
+      "user": 17510,
+      "created_at": 1718223628
+    },
+    {
+      "type": "assign",
+      "entity": 17510,
+      "target": "UR",
+      "entity_type": "player",
+      "target_type": "corporation",
+      "id": 434,
+      "user": 17510,
+      "created_at": 1718223637
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 435,
+      "user": 17510,
+      "created_at": 1718223676
+    },
+    {
+      "type": "assign",
+      "entity": 17510,
+      "target": "UR",
+      "entity_type": "player",
+      "target_type": "corporation",
+      "id": 436,
+      "user": 17510,
+      "created_at": 1718223681
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 437,
+      "user": 17510,
+      "created_at": 1718223686
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 438,
+      "user": 17510,
+      "created_at": 1718223783
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 439,
+      "user": 17510,
+      "created_at": 1718223809
+    },
+    {
+      "type": "bid",
+      "price": 100,
+      "entity": 17510,
+      "corporation": "R",
+      "entity_type": "player",
+      "id": 440,
+      "user": 17510,
+      "created_at": 1718223813
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 441,
+      "user": 17510,
+      "created_at": 1718223848
+    },
+    {
+      "type": "discard_train",
+      "train": "2-14",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 442,
+      "user": 17510,
+      "created_at": 1718223861
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 443,
+      "user": 17510,
+      "created_at": 1718223876
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 444,
+      "user": 17510,
+      "created_at": 1718223879
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 445,
+      "user": 17510,
+      "created_at": 1718223879
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 446,
+      "user": 17510,
+      "created_at": 1718223881
+    },
+    {
+      "type": "undo",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 447,
+      "user": 17510,
+      "created_at": 1718223920
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 448,
+      "user": 17510,
+      "created_at": 1718223921
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 449,
+      "user": 17510,
+      "created_at": 1718223933
+    },
+    {
+      "type": "bid",
+      "price": 100,
+      "entity": 17510,
+      "corporation": "R",
+      "entity_type": "player",
+      "id": 450,
+      "user": 17510,
+      "created_at": 1718223964
+    },
+    {
+      "type": "bid",
+      "price": 110,
+      "entity": 1152,
+      "corporation": "R",
+      "entity_type": "player",
+      "id": 451,
+      "user": 17510,
+      "created_at": 1718223970
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 452,
+      "user": 17510,
+      "created_at": 1718223972
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 453,
+      "user": 17510,
+      "created_at": 1718223981
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 454,
+      "user": 17510,
+      "created_at": 1718223985
+    },
+    {
+      "type": "bid",
+      "price": 110,
+      "entity": 1152,
+      "corporation": "R",
+      "entity_type": "player",
+      "id": 455,
+      "user": 17510,
+      "created_at": 1718223989
+    },
+    {
+      "type": "bid",
+      "price": 130,
+      "entity": 17510,
+      "corporation": "R",
+      "entity_type": "player",
+      "id": 456,
+      "user": 17510,
+      "created_at": 1718223994
+    },
+    {
+      "type": "discard_train",
+      "train": "2-14",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 457,
+      "user": 17510,
+      "created_at": 1718224000
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 458,
+      "user": 17510,
+      "created_at": 1718224011
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 459,
+      "user": 17510,
+      "created_at": 1718224022
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 460,
+      "user": 17510,
+      "created_at": 1718224024
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 461,
+      "user": 17510,
+      "created_at": 1718224025
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 462,
+      "user": 17510,
+      "created_at": 1718224027
+    },
+    {
+      "type": "undo",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 463,
+      "user": 17510,
+      "created_at": 1718224029
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 464,
+      "created_at": 1718224048
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 465,
+      "created_at": 1718224050,
+      "shares": [
+        "DL&W_14"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 466,
+      "created_at": 1718224052
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 467,
+      "created_at": 1718228927
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 468,
+      "created_at": 1718232225
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 469,
+      "created_at": 1718233346
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 470,
+      "created_at": 1718239598
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 471,
+      "created_at": 1718239601
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 472,
+      "created_at": 1718239605
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 473,
+      "created_at": 1718239621,
+      "hex": "E3",
+      "tile": "8-3",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 474,
+      "created_at": 1718239630,
+      "hex": "B2",
+      "tile": "9-0",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 475,
+      "created_at": 1718239631,
+      "city": "14-0-0",
+      "slot": 1,
+      "tokener": "DL&W"
+    },
+    {
+      "type": "run_routes",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 476,
+      "created_at": 1718239638,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C3",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "C3",
+            "D2"
+          ],
+          "revenue": 50,
+          "revenue_str": "C3-D2",
+          "nodes": [
+            "C3-0",
+            "D2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 477,
+      "created_at": 1718239651,
+      "kind": "payout"
+    },
+    {
+      "type": "take_loan",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 478,
+      "created_at": 1718239653,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 479,
+      "created_at": 1718239656,
+      "train": "2+-0",
+      "price": 100,
+      "variant": "2+"
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 480,
+      "created_at": 1718239663
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 481,
+      "created_at": 1718239666
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 482,
+      "created_at": 1718239679
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 483,
+      "created_at": 1718239695,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "G9"
+          ],
+          "revenue": 60,
+          "revenue_str": "H8-G9",
+          "nodes": [
+            "G9-0",
+            "H8-0"
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "H10",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "H8",
+            "H10"
+          ],
+          "revenue": 60,
+          "revenue_str": "H8-H10",
+          "nodes": [
+            "H10-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 484,
+      "created_at": 1718239700,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 485,
+      "created_at": 1718239705
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 486,
+      "created_at": 1718239707
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 487,
+      "created_at": 1718239721
+    },
+    {
+      "type": "run_routes",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 488,
+      "created_at": 1718239739,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E7",
+              "F8"
+            ]
+          ],
+          "hexes": [
+            "F8",
+            "E7"
+          ],
+          "revenue": 40,
+          "revenue_str": "F8-E7",
+          "nodes": [
+            "E7-0",
+            "F8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 489,
+      "created_at": 1718239742,
+      "kind": "payout"
+    },
+    {
+      "type": "take_loan",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 490,
+      "created_at": 1718239746,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 491,
+      "created_at": 1718239748,
+      "train": "2+-1",
+      "price": 100,
+      "variant": "2+"
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 492,
+      "created_at": 1718239757
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 493,
+      "created_at": 1718239759
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 494,
+      "created_at": 1718243787,
+      "hex": "G5",
+      "tile": "8-4",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 495,
+      "created_at": 1718243791,
+      "hex": "H4",
+      "tile": "57-4",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 496,
+      "created_at": 1718243818
+    },
+    {
+      "type": "run_routes",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 497,
+      "created_at": 1718243822,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "G7",
+              "F6"
+            ]
+          ],
+          "hexes": [
+            "G7",
+            "F6"
+          ],
+          "revenue": 40,
+          "revenue_str": "G7-F6",
+          "nodes": [
+            "G7-0",
+            "F6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 498,
+      "created_at": 1718243830,
+      "kind": "payout"
+    },
+    {
+      "type": "take_loan",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 499,
+      "created_at": 1718243838,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 500,
+      "created_at": 1718243842,
+      "train": "2+-2",
+      "price": 100,
+      "variant": "2+"
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 501,
+      "created_at": 1718243845
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 502,
+      "created_at": 1718243855
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 503,
+      "created_at": 1718245085
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 504,
+      "created_at": 1718245087,
+      "routes": [
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "H10",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "H8"
+          ],
+          "revenue": 60,
+          "revenue_str": "H10-H8",
+          "nodes": [
+            "H10-0",
+            "H8-0"
+          ]
+        },
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "H10",
+              "I11"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "I11"
+          ],
+          "revenue": 60,
+          "revenue_str": "H10-I11",
+          "nodes": [
+            "H10-0",
+            "I11-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 505,
+      "created_at": 1718245097,
+      "kind": "half"
+    },
+    {
+      "type": "take_loan",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 506,
+      "created_at": 1718245102,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 507,
+      "created_at": 1718245103,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 508,
+      "created_at": 1718245105,
+      "train": "3-0",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 509,
+      "created_at": 1718245107
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 510,
+      "created_at": 1718245111
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 511,
+      "created_at": 1718251993,
+      "hex": "F8",
+      "tile": "15-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 512,
+      "created_at": 1718251999
+    },
+    {
+      "type": "run_routes",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 513,
+      "created_at": 1718252004,
+      "routes": [
+        {
+          "train": "2-12",
+          "connections": [
+            [
+              "F8",
+              "E7"
+            ]
+          ],
+          "hexes": [
+            "F8",
+            "E7"
+          ],
+          "revenue": 50,
+          "revenue_str": "F8-E7",
+          "nodes": [
+            "F8-0",
+            "E7-0"
+          ]
+        },
+        {
+          "train": "2-11",
+          "connections": [
+            [
+              "F8",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "F8",
+            "G9"
+          ],
+          "revenue": 70,
+          "revenue_str": "F8-G9",
+          "nodes": [
+            "F8-0",
+            "G9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 514,
+      "created_at": 1718252012,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 515,
+      "created_at": 1718252015,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 516,
+      "created_at": 1718252017,
+      "loan": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 517,
+      "created_at": 1718252026,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 518,
+      "created_at": 1718252030,
+      "train": "3-1",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 519,
+      "created_at": 1718252035
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 520,
+      "created_at": 1718252039
+    },
+    {
+      "hex": "D6",
+      "tile": "592H2-0",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 521,
+      "user": 17510,
+      "created_at": 1718253463
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 522,
+      "user": 17510,
+      "created_at": 1718253507
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "routes": [
+        {
+          "hexes": [
+            "A7",
+            "B6"
+          ],
+          "nodes": [
+            "A7-0",
+            "B6-0"
+          ],
+          "train": "2-13",
+          "revenue": 80,
+          "connections": [
+            [
+              "A7",
+              "B6"
+            ]
+          ],
+          "revenue_str": "A7-B6"
+        },
+        {
+          "hexes": [
+            "D6",
+            "D10"
+          ],
+          "nodes": [
+            "D6-0",
+            "D10-0"
+          ],
+          "train": "2-8",
+          "revenue": 80,
+          "connections": [
+            [
+              "D6",
+              "D8",
+              "D10"
+            ]
+          ],
+          "revenue_str": "D6-D10"
+        },
+        {
+          "hexes": [
+            "A7",
+            "A9"
+          ],
+          "nodes": [
+            "A7-0",
+            "A9-0"
+          ],
+          "train": "2-7",
+          "revenue": 100,
+          "connections": [
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "revenue_str": "A7-A9"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 523,
+      "user": 17510,
+      "created_at": 1718253529
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 524,
+      "user": 17510,
+      "created_at": 1718253535
+    },
+    {
+      "type": "buy_train",
+      "price": 250,
+      "train": "3-2",
+      "entity": "UR",
+      "variant": "3",
+      "entity_type": "corporation",
+      "id": 525,
+      "user": 17510,
+      "created_at": 1718253543
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 526,
+      "user": 17510,
+      "created_at": 1718253550
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 527,
+      "user": 17510,
+      "created_at": 1718253552
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 528,
+      "user": 17510,
+      "created_at": 1718253569
+    },
+    {
+      "type": "buy_train",
+      "price": 250,
+      "train": "3-2",
+      "entity": "UR",
+      "variant": "3",
+      "entity_type": "corporation",
+      "id": 529,
+      "user": 17510,
+      "created_at": 1718253571
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 530,
+      "user": 17510,
+      "created_at": 1718253575
+    },
+    {
+      "type": "buy_train",
+      "price": 250,
+      "train": "3-2",
+      "entity": "UR",
+      "variant": "3",
+      "entity_type": "corporation",
+      "id": 531,
+      "user": 17510,
+      "created_at": 1718253577
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 532,
+      "user": 17510,
+      "created_at": 1718253579
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 533,
+      "user": 17510,
+      "created_at": 1718253586
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 534,
+      "user": 17510,
+      "created_at": 1718253588
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 535,
+      "user": 17510,
+      "created_at": 1718253590
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 536,
+      "user": 17510,
+      "created_at": 1718253591
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 537,
+      "user": 17510,
+      "created_at": 1718253594
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 538,
+      "user": 17510,
+      "created_at": 1718253612
+    },
+    {
+      "hex": "D6",
+      "tile": "592H2-0",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 539,
+      "user": 17510,
+      "created_at": 1718253617
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 540,
+      "user": 17510,
+      "created_at": 1718253629
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "routes": [
+        {
+          "hexes": [
+            "A7",
+            "B6"
+          ],
+          "nodes": [
+            "A7-0",
+            "B6-0"
+          ],
+          "train": "2-13",
+          "revenue": 80,
+          "connections": [
+            [
+              "A7",
+              "B6"
+            ]
+          ],
+          "revenue_str": "A7-B6"
+        },
+        {
+          "hexes": [
+            "D6",
+            "D10"
+          ],
+          "nodes": [
+            "D6-0",
+            "D10-0"
+          ],
+          "train": "2-8",
+          "revenue": 80,
+          "connections": [
+            [
+              "D6",
+              "D8",
+              "D10"
+            ]
+          ],
+          "revenue_str": "D6-D10"
+        },
+        {
+          "hexes": [
+            "A7",
+            "A9"
+          ],
+          "nodes": [
+            "A7-0",
+            "A9-0"
+          ],
+          "train": "2-7",
+          "revenue": 100,
+          "connections": [
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "revenue_str": "A7-A9"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 541,
+      "user": 17510,
+      "created_at": 1718253632
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 542,
+      "user": 17510,
+      "created_at": 1718253636
+    },
+    {
+      "type": "buy_train",
+      "price": 250,
+      "train": "3-2",
+      "entity": "UR",
+      "variant": "3",
+      "entity_type": "corporation",
+      "id": 543,
+      "user": 17510,
+      "created_at": 1718253636
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 544,
+      "user": 17510,
+      "created_at": 1718253654
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 545,
+      "user": 17510,
+      "created_at": 1718253660
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 546,
+      "user": 17510,
+      "created_at": 1718253661
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 547,
+      "user": 17510,
+      "created_at": 1718253662
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 548,
+      "user": 17510,
+      "created_at": 1718253663
+    },
+    {
+      "hex": "D6",
+      "tile": "592H2-0",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 549,
+      "user": 17510,
+      "created_at": 1718253696
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 550,
+      "user": 17510,
+      "created_at": 1718253698
+    },
+    {
+      "hex": "E3",
+      "tile": "81-0",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 551,
+      "user": 17510,
+      "created_at": 1718253701
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 552,
+      "user": 17510,
+      "created_at": 1718253708
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 553,
+      "created_at": 1718253713,
+      "hex": "D6",
+      "tile": "592H2-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 554,
+      "created_at": 1718253716
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "routes": [
+        {
+          "hexes": [
+            "A7",
+            "B6"
+          ],
+          "nodes": [
+            "A7-0",
+            "B6-0"
+          ],
+          "train": "2-13",
+          "revenue": 80,
+          "connections": [
+            [
+              "A7",
+              "B6"
+            ]
+          ],
+          "revenue_str": "A7-B6"
+        },
+        {
+          "hexes": [
+            "D6",
+            "D10"
+          ],
+          "nodes": [
+            "D6-0",
+            "D10-0"
+          ],
+          "train": "2-8",
+          "revenue": 80,
+          "connections": [
+            [
+              "D6",
+              "D8",
+              "D10"
+            ]
+          ],
+          "revenue_str": "D6-D10"
+        },
+        {
+          "hexes": [
+            "A7",
+            "A9"
+          ],
+          "nodes": [
+            "A7-0",
+            "A9-0"
+          ],
+          "train": "2-7",
+          "revenue": 100,
+          "connections": [
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "revenue_str": "A7-A9"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 555,
+      "user": 17510,
+      "created_at": 1718253719
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 556,
+      "user": 17510,
+      "created_at": 1718253729
+    },
+    {
+      "type": "buy_train",
+      "price": 250,
+      "train": "3-2",
+      "entity": "UR",
+      "variant": "3",
+      "entity_type": "corporation",
+      "id": 557,
+      "user": 17510,
+      "created_at": 1718253733
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 558,
+      "user": 17510,
+      "created_at": 1718253748
+    },
+    {
+      "type": "buy_train",
+      "price": 250,
+      "train": "3-2",
+      "entity": "UR",
+      "variant": "3",
+      "entity_type": "corporation",
+      "id": 559,
+      "user": 17510,
+      "created_at": 1718253755
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 560,
+      "user": 17510,
+      "created_at": 1718253756
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 561,
+      "user": 17510,
+      "created_at": 1718253765
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 562,
+      "user": 17510,
+      "created_at": 1718253765
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 563,
+      "user": 17510,
+      "created_at": 1718253766
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 564,
+      "user": 17510,
+      "created_at": 1718253767
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 565,
+      "created_at": 1718253769,
+      "routes": [
+        {
+          "train": "2-13",
+          "connections": [
+            [
+              "A7",
+              "B6"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "B6"
+          ],
+          "revenue": 80,
+          "revenue_str": "A7-B6",
+          "nodes": [
+            "A7-0",
+            "B6-0"
+          ]
+        },
+        {
+          "train": "2-8",
+          "connections": [
+            [
+              "D6",
+              "D8",
+              "D10"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "D10"
+          ],
+          "revenue": 80,
+          "revenue_str": "D6-D10",
+          "nodes": [
+            "D6-0",
+            "D10-0"
+          ]
+        },
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "A9"
+          ],
+          "revenue": 100,
+          "revenue_str": "A7-A9",
+          "nodes": [
+            "A7-0",
+            "A9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 566,
+      "user": 17510,
+      "created_at": 1718253771
+    },
+    {
+      "type": "buy_train",
+      "price": 250,
+      "train": "3-2",
+      "entity": "UR",
+      "variant": "3",
+      "entity_type": "corporation",
+      "id": 567,
+      "user": 17510,
+      "created_at": 1718253772
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 568,
+      "user": 17510,
+      "created_at": 1718253776
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 569,
+      "user": 17510,
+      "created_at": 1718253790
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 570,
+      "user": 17510,
+      "created_at": 1718253791
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 571,
+      "user": 17510,
+      "created_at": 1718253791
+    },
+    {
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 572,
+      "created_at": 1718253793,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 573,
+      "created_at": 1718253795,
+      "train": "3-2",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 574,
+      "created_at": 1718253797
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 575,
+      "created_at": 1718253799
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 576,
+      "created_at": 1718290133,
+      "hex": "B2",
+      "tile": "82-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 577,
+      "created_at": 1718290153
+    },
+    {
+      "type": "pass",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 578,
+      "created_at": 1718290159
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 579,
+      "created_at": 1718290177,
+      "routes": [
+        {
+          "train": "2-9",
+          "connections": [
+            [
+              "D2",
+              "C1",
+              "B2",
+              "A1"
+            ]
+          ],
+          "hexes": [
+            "A1",
+            "D2"
+          ],
+          "revenue": 70,
+          "revenue_str": "A1-D2",
+          "nodes": [
+            "D2-0",
+            "A1-0"
+          ]
+        },
+        {
+          "train": "2-10",
+          "connections": [
+            [
+              "D2",
+              "C3"
+            ]
+          ],
+          "hexes": [
+            "C3",
+            "D2"
+          ],
+          "revenue": 50,
+          "revenue_str": "C3-D2",
+          "nodes": [
+            "D2-0",
+            "C3-0"
+          ]
+        },
+        {
+          "train": "2-14",
+          "connections": [
+            [
+              "D2",
+              "E1"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "D2"
+          ],
+          "revenue": 70,
+          "revenue_str": "E1-D2",
+          "nodes": [
+            "D2-0",
+            "E1-0"
+          ]
+        },
+        {
+          "train": "2-15",
+          "connections": [
+            [
+              "D2",
+              "E3",
+              "F2",
+              "F4"
+            ]
+          ],
+          "hexes": [
+            "F4",
+            "D2"
+          ],
+          "revenue": 60,
+          "revenue_str": "F4-D2",
+          "nodes": [
+            "D2-0",
+            "F4-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 580,
+      "user": 1152,
+      "created_at": 1718290184
+    },
+    {
+      "type": "undo",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 581,
+      "user": 1152,
+      "created_at": 1718290209
+    },
+    {
+      "type": "dividend",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 582,
+      "created_at": 1718290215,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 583,
+      "created_at": 1718290247
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 584,
+      "created_at": 1718290250,
+      "loan": 63
+    },
+    {
+      "type": "pass",
+      "entity": "NYSW",
+      "entity_type": "corporation",
+      "id": 585,
+      "created_at": 1718290251
+    },
+    {
+      "type": "merge",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 586,
+      "created_at": 1718292779,
+      "corporation": "DL&W"
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 587,
+      "created_at": 1718322370
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 588,
+      "created_at": 1718322651
+    },
+    {
+      "type": "buy_shares",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 589,
+      "created_at": 1718323958,
+      "shares": [
+        "NYOW_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "shares": [
+        "NYOW_8"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 590,
+      "user": 17510,
+      "created_at": 1718329206
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 591,
+      "user": 17510,
+      "created_at": 1718329215
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "shares": [
+        "NYOW_8"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 592,
+      "user": 17510,
+      "created_at": 1718329219
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 593,
+      "user": 17510,
+      "created_at": 1718329222
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 594,
+      "user": 17510,
+      "created_at": 1718329365
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 595,
+      "user": 17510,
+      "created_at": 1718329377
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 596,
+      "user": 17510,
+      "created_at": 1718329403
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 597,
+      "user": 17510,
+      "created_at": 1718329413
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 598,
+      "created_at": 1718329464,
+      "shares": [
+        "NYOW_8"
+      ],
+      "percent": 10
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 599,
+      "user": 16104,
+      "created_at": 1718330258
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 600,
+      "user": 16104,
+      "created_at": 1718330263
+    },
+    {
+      "type": "undo",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 601,
+      "user": 16104,
+      "created_at": 1718330265
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 602,
+      "user": 16104,
+      "created_at": 1718330266
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 603,
+      "created_at": 1718330271
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 604,
+      "created_at": 1718330290
+    },
+    {
+      "type": "merge",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 605,
+      "created_at": 1718331463,
+      "corporation": "H"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 606,
+      "created_at": 1718331621,
+      "shares": [
+        "J_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 607,
+      "created_at": 1718333110
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 608,
+      "created_at": 1718333137
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 609,
+      "created_at": 1718372845
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 610,
+      "created_at": 1718388746
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 611,
+      "created_at": 1718496621
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 612,
+      "created_at": 1718497252
+    },
+    {
+      "type": "bid",
+      "price": 10,
+      "entity": 17510,
+      "corporation": "NYSW",
+      "entity_type": "player",
+      "id": 613,
+      "user": 17510,
+      "created_at": 1718498184
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 614,
+      "user": 17510,
+      "created_at": 1718498204
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 615,
+      "created_at": 1718498289,
+      "corporation": "NYSW",
+      "price": 10
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 616,
+      "created_at": 1718498358
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 617,
+      "user": 17510,
+      "created_at": 1718498498
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 618,
+      "user": 17510,
+      "created_at": 1718498503
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 619,
+      "user": 17510,
+      "created_at": 1718498512
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 620,
+      "user": 17510,
+      "created_at": 1718498513
+    },
+    {
+      "type": "take_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 621,
+      "created_at": 1718498520,
+      "loan": 0
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 622,
+      "user": 17510,
+      "created_at": 1718498559
+    },
+    {
+      "type": "undo",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 623,
+      "user": 17510,
+      "created_at": 1718498600
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 624,
+      "user": 17510,
+      "created_at": 1718498604
+    },
+    {
+      "type": "undo",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 625,
+      "user": 17510,
+      "created_at": 1718498676
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 626,
+      "user": 17510,
+      "created_at": 1718498702
+    },
+    {
+      "type": "undo",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 627,
+      "user": 17510,
+      "created_at": 1718498703
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 628,
+      "user": 17510,
+      "created_at": 1718498710
+    },
+    {
+      "type": "undo",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 629,
+      "user": 17510,
+      "created_at": 1718498762
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 630,
+      "user": 17510,
+      "created_at": 1718498765
+    },
+    {
+      "type": "bankrupt",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 631,
+      "user": 17510,
+      "created_at": 1718498771
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 632,
+      "user": 17510,
+      "created_at": 1718498788
+    },
+    {
+      "type": "undo",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 633,
+      "user": 17510,
+      "created_at": 1718498802
+    },
+    {
+      "type": "undo",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 634,
+      "user": 17510,
+      "created_at": 1718498804
+    },
+    {
+      "type": "undo",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 635,
+      "user": 17510,
+      "created_at": 1718498820
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 636,
+      "created_at": 1718498830
+    },
+    {
+      "type": "bankrupt",
+      "entity": 1152,
+      "entity_type": "player",
+      "id": 637,
+      "created_at": 1718500468
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 638,
+      "created_at": 1718503789
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 639,
+      "created_at": 1718503826
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 640,
+      "created_at": 1718507662
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 641,
+      "created_at": 1718508459
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 642,
+      "created_at": 1718508462
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 643,
+      "created_at": 1718508477
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 644,
+      "created_at": 1718523177
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17510,
+      "shares": [
+        "NYOW_3"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 645,
+      "user": 17510,
+      "created_at": 1718532468
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "shares": [
+        "J_13"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 646,
+      "user": 17510,
+      "created_at": 1718532474
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 647,
+      "user": 17510,
+      "created_at": 1718532487
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 648,
+      "user": 17510,
+      "created_at": 1718532488
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "corporation": "PSNR",
+      "entity_type": "player",
+      "id": 649,
+      "user": 17510,
+      "created_at": 1718532531
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 650,
+      "user": 17510,
+      "created_at": 1718532575
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 651,
+      "created_at": 1718532633,
+      "corporation": "J"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 652,
+      "created_at": 1718532680,
+      "shares": [
+        "NYOW_11"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "short",
+      "entity": 16104,
+      "corporation": "GT",
+      "entity_type": "player",
+      "id": 653,
+      "user": 16104,
+      "created_at": 1718534084
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 654,
+      "user": 16104,
+      "created_at": 1718534088
+    },
+    {
+      "type": "short",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 655,
+      "created_at": 1718534096,
+      "corporation": "J"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 656,
+      "created_at": 1718534107,
+      "shares": [
+        "UR_11"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 657,
+      "created_at": 1718567306,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1718567306
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 658,
+      "created_at": 1718567578
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "corporation": "J",
+      "entity_type": "player",
+      "id": 659,
+      "user": 17510,
+      "created_at": 1718585235
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 660,
+      "user": 17510,
+      "created_at": 1718585298
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "corporation": "J",
+      "entity_type": "player",
+      "id": 661,
+      "user": 17510,
+      "created_at": 1718585304
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 662,
+      "user": 17510,
+      "created_at": 1718585519
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 663,
+      "created_at": 1718585634,
+      "corporation": "J"
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 664,
+      "created_at": 1718585794
+    },
+    {
+      "type": "buy_shares",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 665,
+      "created_at": 1718586947,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1718586946,
+          "reason": "Short bought"
+        }
+      ],
+      "shares": [
+        "NYOW_15"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 666,
+      "created_at": 1718587916
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 667,
+      "created_at": 1718588208
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "corporation": "J",
+      "entity_type": "player",
+      "id": 668,
+      "user": 17510,
+      "created_at": 1718590475
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "shares": [
+        "NYOW_13"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 669,
+      "user": 17510,
+      "created_at": 1718590500
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 670,
+      "user": 17510,
+      "created_at": 1718590566
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 671,
+      "user": 17510,
+      "created_at": 1718590567
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 672,
+      "created_at": 1718590621,
+      "corporation": "J"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 673,
+      "created_at": 1718590629,
+      "shares": [
+        "NYOW_13"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "short",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 674,
+      "created_at": 1718590676,
+      "corporation": "J"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 675,
+      "created_at": 1718590683,
+      "shares": [
+        "UR_13"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 676,
+      "created_at": 1718590843
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 677,
+      "created_at": 1718623992
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "corporation": "J",
+      "entity_type": "player",
+      "id": 678,
+      "user": 17510,
+      "created_at": 1718624813
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17510,
+      "shares": [
+        "GT_10",
+        "GT_12",
+        "GT_14"
+      ],
+      "percent": 60,
+      "entity_type": "player",
+      "id": 679,
+      "user": 17510,
+      "created_at": 1718624864
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "shares": [
+        "NYOW_15"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 680,
+      "user": 17510,
+      "created_at": 1718624905
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 681,
+      "user": 17510,
+      "created_at": 1718624909
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 682,
+      "user": 17510,
+      "created_at": 1718624955
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17510,
+      "shares": [
+        "GT_10"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 683,
+      "user": 17510,
+      "created_at": 1718624980
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 684,
+      "user": 17510,
+      "created_at": 1718624984
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 685,
+      "user": 17510,
+      "created_at": 1718625025
+    },
+    {
+      "type": "short",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 686,
+      "created_at": 1718625041,
+      "corporation": "J"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17510,
+      "shares": [
+        "GT_10"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 687,
+      "user": 17510,
+      "created_at": 1718625095
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 688,
+      "user": 17510,
+      "created_at": 1718625101
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 689,
+      "created_at": 1718625202
+    },
+    {
+      "type": "short",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 690,
+      "created_at": 1718638897,
+      "corporation": "J"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 691,
+      "created_at": 1718638904,
+      "shares": [
+        "UR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 692,
+      "created_at": 1718643706
+    },
+    {
+      "type": "pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 693,
+      "created_at": 1718644333
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 694,
+      "created_at": 1718645396
+    },
+    {
+      "type": "short",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 695,
+      "created_at": 1718645581,
+      "corporation": "GT"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 696,
+      "created_at": 1718645587,
+      "shares": [
+        "UR_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 697,
+      "created_at": 1718649226
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 698,
+      "created_at": 1718655951,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 11123,
+          "entity_type": "player",
+          "created_at": 1718655951
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17510,
+      "shares": [
+        "GT_10",
+        "GT_12",
+        "GT_14"
+      ],
+      "percent": 60,
+      "entity_type": "player",
+      "id": 699,
+      "user": 17510,
+      "created_at": 1718656509
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 700,
+      "user": 17510,
+      "created_at": 1718656562
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 701,
+      "created_at": 1718656572
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 702,
+      "created_at": 1718656620
+    },
+    {
+      "hex": "C3",
+      "tile": "14-1",
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 703,
+      "user": 16104,
+      "created_at": 1718656635
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 704,
+      "user": 16104,
+      "created_at": 1718656651
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 705,
+      "created_at": 1718656657,
+      "hex": "E3",
+      "tile": "81-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 706,
+      "created_at": 1718656667
+    },
+    {
+      "type": "place_token",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 707,
+      "created_at": 1718656685,
+      "city": "592H2-0-0",
+      "slot": 1,
+      "tokener": "NYOW"
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 708,
+      "created_at": 1718656725,
+      "routes": [
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "H8"
+          ],
+          "revenue": 60,
+          "revenue_str": "G9-H8",
+          "nodes": [
+            "G9-0",
+            "H8-0"
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "H10",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "H8"
+          ],
+          "revenue": 60,
+          "revenue_str": "H10-H8",
+          "nodes": [
+            "H10-0",
+            "H8-0"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D6",
+              "D8",
+              "D10"
+            ]
+          ],
+          "hexes": [
+            "D10",
+            "D6"
+          ],
+          "revenue": 80,
+          "revenue_str": "D10-D6",
+          "nodes": [
+            "D6-0",
+            "D10-0"
+          ]
+        },
+        {
+          "train": "2+-0",
+          "connections": [
+            [
+              "D6",
+              "E5",
+              "E3",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "D2",
+            "D6"
+          ],
+          "revenue": 80,
+          "revenue_str": "D2-D6",
+          "nodes": [
+            "D6-0",
+            "D2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 709,
+      "created_at": 1718656745,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 710,
+      "created_at": 1718656746,
+      "train": "3-4",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "take_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 711,
+      "created_at": 1718656753,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 712,
+      "created_at": 1718656756,
+      "train": "3-5",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 713,
+      "created_at": 1718656762
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 714,
+      "created_at": 1718656768
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 715,
+      "created_at": 1718656780,
+      "hex": "G7",
+      "tile": "15-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 716,
+      "created_at": 1718656782,
+      "hex": "H6",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 717,
+      "created_at": 1718656798,
+      "city": "6-1-0",
+      "slot": 0,
+      "tokener": "PSNR"
+    },
+    {
+      "type": "run_routes",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 718,
+      "created_at": 1718656816,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E7",
+              "F8"
+            ]
+          ],
+          "hexes": [
+            "E7",
+            "F8"
+          ],
+          "revenue": 50,
+          "revenue_str": "E7-F8",
+          "nodes": [
+            "E7-0",
+            "F8-0"
+          ]
+        },
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "E7",
+              "D8",
+              "D10"
+            ]
+          ],
+          "hexes": [
+            "D10",
+            "E7"
+          ],
+          "revenue": 50,
+          "revenue_str": "D10-E7",
+          "nodes": [
+            "E7-0",
+            "D10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 719,
+      "created_at": 1718656825,
+      "kind": "payout"
+    },
+    {
+      "type": "take_loan",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 720,
+      "created_at": 1718656827,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 721,
+      "created_at": 1718656828,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 722,
+      "created_at": 1718656831,
+      "train": "3-6",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 723,
+      "created_at": 1718656837
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 724,
+      "created_at": 1718656840
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 725,
+      "user": 17510,
+      "created_at": 1718657203
+    },
+    {
+      "type": "redo",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 726,
+      "user": 17510,
+      "created_at": 1718657206
+    },
+    {
+      "hex": "B6",
+      "tile": "619-0",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 727,
+      "user": 17510,
+      "created_at": 1718657229
+    },
+    {
+      "hex": "A5",
+      "tile": "57-1",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 728,
+      "user": 17510,
+      "created_at": 1718657249
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 729,
+      "user": 17510,
+      "created_at": 1718657257
+    },
+    {
+      "hex": "A5",
+      "tile": "57-1",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 730,
+      "user": 17510,
+      "created_at": 1718657261
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 731,
+      "user": 17510,
+      "created_at": 1718657270
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "routes": [
+        {
+          "hexes": [
+            "A7",
+            "B6",
+            "D6"
+          ],
+          "nodes": [
+            "A7-0",
+            "B6-0",
+            "D6-0"
+          ],
+          "train": "3-2",
+          "revenue": 140,
+          "connections": [
+            [
+              "A7",
+              "B6"
+            ],
+            [
+              "B6",
+              "C5",
+              "D6"
+            ]
+          ],
+          "revenue_str": "A7-B6-D6"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 732,
+      "user": 17510,
+      "created_at": 1718657276
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 733,
+      "user": 17510,
+      "created_at": 1718657281
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 734,
+      "user": 17510,
+      "created_at": 1718657288
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 735,
+      "user": 17510,
+      "created_at": 1718657290
+    },
+    {
+      "type": "buy_train",
+      "price": 250,
+      "train": "3-7",
+      "entity": "UR",
+      "variant": "3",
+      "entity_type": "corporation",
+      "id": 736,
+      "user": 17510,
+      "created_at": 1718657291
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 737,
+      "user": 17510,
+      "created_at": 1718657297
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 738,
+      "user": 17510,
+      "created_at": 1718657341
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 739,
+      "user": 17510,
+      "created_at": 1718657342
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 740,
+      "user": 17510,
+      "created_at": 1718657347
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 741,
+      "user": 17510,
+      "created_at": 1718657355
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 742,
+      "user": 17510,
+      "created_at": 1718657361
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 743,
+      "user": 17510,
+      "created_at": 1718657363
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 744,
+      "user": 17510,
+      "created_at": 1718657365
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 745,
+      "created_at": 1718657371,
+      "hex": "B6",
+      "tile": "619-0",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 746,
+      "created_at": 1718657374,
+      "hex": "A5",
+      "tile": "57-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 747,
+      "created_at": 1718657407
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 748,
+      "created_at": 1718657420,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "A7",
+              "B6"
+            ],
+            [
+              "B6",
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "B6",
+            "D6"
+          ],
+          "revenue": 140,
+          "revenue_str": "A7-B6-D6",
+          "nodes": [
+            "A7-0",
+            "B6-0",
+            "D6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 749,
+      "user": 17510,
+      "created_at": 1718657421
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 750,
+      "user": 17510,
+      "created_at": 1718657423
+    },
+    {
+      "loan": 65,
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 751,
+      "user": 17510,
+      "created_at": 1718657426
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 752,
+      "user": 17510,
+      "created_at": 1718657437
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 753,
+      "user": 17510,
+      "created_at": 1718657439
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 754,
+      "user": 17510,
+      "created_at": 1718657444
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 755,
+      "user": 17510,
+      "created_at": 1718657445
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 756,
+      "user": 17510,
+      "created_at": 1718657447
+    },
+    {
+      "loan": 65,
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 757,
+      "user": 17510,
+      "created_at": 1718657449
+    },
+    {
+      "loan": 65,
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 758,
+      "user": 17510,
+      "created_at": 1718657450
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 759,
+      "user": 17510,
+      "created_at": 1718657587
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 760,
+      "user": 17510,
+      "created_at": 1718657588
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 761,
+      "user": 17510,
+      "created_at": 1718657591
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 762,
+      "user": 17510,
+      "created_at": 1718657593
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 763,
+      "user": 17510,
+      "created_at": 1718657600
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 764,
+      "user": 17510,
+      "created_at": 1718657602
+    },
+    {
+      "type": "buy_train",
+      "price": 250,
+      "train": "3-7",
+      "entity": "UR",
+      "variant": "3",
+      "entity_type": "corporation",
+      "id": 765,
+      "user": 17510,
+      "created_at": 1718657604
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 766,
+      "user": 17510,
+      "created_at": 1718657624
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 767,
+      "user": 17510,
+      "created_at": 1718657627
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 768,
+      "user": 17510,
+      "created_at": 1718657630
+    },
+    {
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 769,
+      "created_at": 1718657631,
+      "kind": "half"
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 770,
+      "created_at": 1718657654
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 771,
+      "created_at": 1718657656,
+      "loan": 65
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 772,
+      "created_at": 1718657662,
+      "loan": 65
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 773,
+      "created_at": 1718657684
+    },
+    {
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 774,
+      "user": 17510,
+      "created_at": 1718657710
+    },
+    {
+      "type": "redo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 775,
+      "user": 17510,
+      "created_at": 1718657724
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 776,
+      "created_at": 1718658158,
+      "hex": "H10",
+      "tile": "592H-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 777,
+      "created_at": 1718658174
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 778,
+      "created_at": 1718658181,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "H10"
+            ],
+            [
+              "H10",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G13",
+            "H10",
+            "H8"
+          ],
+          "revenue": 70,
+          "revenue_str": "G13-H10-H8",
+          "nodes": [
+            "G13-0",
+            "H10-0",
+            "H8-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "I11",
+              "I13"
+            ]
+          ],
+          "hexes": [
+            "I11",
+            "I13"
+          ],
+          "revenue": 50,
+          "revenue_str": "I11-I13",
+          "nodes": [
+            "I11-0",
+            "I13-0"
+          ]
+        },
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "H10",
+              "I11"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "I11"
+          ],
+          "revenue": 40,
+          "revenue_str": "H10-I11",
+          "nodes": [
+            "H10-0",
+            "I11-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 779,
+      "created_at": 1718658182,
+      "kind": "payout"
+    },
+    {
+      "type": "bankrupt",
+      "entity": 11123,
+      "entity_type": "player",
+      "id": 781,
+      "created_at": 1718659437
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 782,
+      "created_at": 1718660714
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 783,
+      "created_at": 1718660719
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 785,
+      "created_at": 1718664111
+    },
+    {
+      "type": "convert",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 786,
+      "created_at": 1718664160
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 787,
+      "created_at": 1718664169,
+      "shares": [
+        "GT_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 788,
+      "created_at": 1718664171,
+      "shares": [
+        "GT_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 789,
+      "created_at": 1718664171,
+      "shares": [
+        "GT_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17510,
+      "shares": [
+        "GT_10",
+        "GT_12"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 790,
+      "user": 17510,
+      "created_at": 1718678615
+    },
+    {
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 791,
+      "user": 17510,
+      "created_at": 1718678620
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "shares": [
+        "GT_5"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 792,
+      "user": 17510,
+      "created_at": 1718678624
+    },
+    {
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 793,
+      "user": 17510,
+      "created_at": 1718678633
+    },
+    {
+      "type": "undo",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 794,
+      "user": 2091,
+      "created_at": 1718678645
+    },
+    {
+      "type": "redo",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 795,
+      "user": 17510,
+      "created_at": 1718678656
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "shares": [
+        "GT_5"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 796,
+      "user": 17510,
+      "created_at": 1718678709
+    },
+    {
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 797,
+      "user": 17510,
+      "created_at": 1718684206
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 798,
+      "created_at": 1718684216,
+      "shares": [
+        "GT_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 799,
+      "created_at": 1718684242
+    },
+    {
+      "type": "bid",
+      "price": 10,
+      "entity": 17510,
+      "corporation": "J",
+      "entity_type": "player",
+      "id": 800,
+      "user": 17510,
+      "created_at": 1718684270
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 801,
+      "user": 17510,
+      "created_at": 1718684320
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 802,
+      "created_at": 1718684326,
+      "corporation": "J",
+      "price": 10
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 803,
+      "user": 17510,
+      "created_at": 1718684335
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 804,
+      "user": 17510,
+      "created_at": 1718684336
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 805,
+      "user": 17510,
+      "created_at": 1718684350
+    },
+    {
+      "type": "undo",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 806,
+      "user": 17510,
+      "created_at": 1718684359
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 807,
+      "user": 17510,
+      "created_at": 1718684360
+    },
+    {
+      "type": "undo",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 808,
+      "user": 17510,
+      "created_at": 1718684361
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 809,
+      "created_at": 1718684371,
+      "corporation": "J",
+      "price": 20
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 810,
+      "created_at": 1718684382
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 811,
+      "created_at": 1718684386,
+      "corporation": "J",
+      "price": 30
+    },
+    {
+      "type": "bid",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 812,
+      "created_at": 1718684399,
+      "corporation": "J",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 813,
+      "created_at": 1718684404,
+      "corporation": "J",
+      "price": 50
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 814,
+      "created_at": 1718684417
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 815,
+      "created_at": 1718684428
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 816,
+      "created_at": 1718684442
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 817,
+      "created_at": 1718684448
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 818,
+      "created_at": 1718684473,
+      "hex": "F6",
+      "tile": "619-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 819,
+      "created_at": 1718684477,
+      "hex": "C7",
+      "tile": "57-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 820,
+      "created_at": 1718684550,
+      "routes": [
+        {
+          "train": "2+-0",
+          "connections": [
+            [
+              "D6",
+              "D8",
+              "D10"
+            ]
+          ],
+          "hexes": [
+            "D10",
+            "D6"
+          ],
+          "revenue": 80,
+          "revenue_str": "D10-D6",
+          "nodes": [
+            "D6-0",
+            "D10-0"
+          ]
+        },
+        {
+          "train": "3-5",
+          "connections": [
+            [
+              "B6",
+              "C5",
+              "D6"
+            ],
+            [
+              "A7",
+              "B6"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "B6",
+            "A7"
+          ],
+          "revenue": 140,
+          "revenue_str": "D6-B6-A7",
+          "nodes": [
+            "B6-0",
+            "D6-0",
+            "A7-0"
+          ]
+        },
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "D2",
+              "E1"
+            ],
+            [
+              "D6",
+              "E5",
+              "E3",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "D2",
+            "D6"
+          ],
+          "revenue": 120,
+          "revenue_str": "E1-D2-D6",
+          "nodes": [
+            "D2-0",
+            "E1-0",
+            "D6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 821,
+      "created_at": 1718684558,
+      "kind": "half"
+    },
+    {
+      "type": "take_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 822,
+      "created_at": 1718684624,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 823,
+      "created_at": 1718684624,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 824,
+      "created_at": 1718684629,
+      "train": "3-8",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 825,
+      "created_at": 1718684651
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 826,
+      "user": 17510,
+      "created_at": 1718684662
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 827,
+      "user": 17510,
+      "created_at": 1718684664
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 828,
+      "user": 17510,
+      "created_at": 1718684688
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 829,
+      "user": 17510,
+      "created_at": 1718684692
+    },
+    {
+      "hex": "G9",
+      "tile": "592H-1",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 830,
+      "user": 17510,
+      "created_at": 1718684697
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 831,
+      "user": 17510,
+      "created_at": 1718684700
+    },
+    {
+      "hex": "A3",
+      "tile": "8-5",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "id": 832,
+      "user": 17510,
+      "created_at": 1718684703
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 833,
+      "user": 17510,
+      "created_at": 1718684726
+    },
+    {
+      "hex": "A3",
+      "tile": "9-2",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 834,
+      "user": 17510,
+      "created_at": 1718684728
+    },
+    {
+      "hex": "G9",
+      "tile": "592H-1",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 835,
+      "user": 17510,
+      "created_at": 1718684739
+    },
+    {
+      "city": "57-1-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "UR",
+      "tokener": "UR",
+      "entity_type": "corporation",
+      "id": 836,
+      "user": 17510,
+      "created_at": 1718684742
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 837,
+      "user": 17510,
+      "created_at": 1718684805
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 838,
+      "user": 17510,
+      "created_at": 1718684816
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 839,
+      "user": 17510,
+      "created_at": 1718684821
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 840,
+      "created_at": 1718684823,
+      "hex": "A3",
+      "tile": "8-5",
+      "rotation": 4
+    },
+    {
+      "hex": "G9",
+      "tile": "592H-1",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 841,
+      "user": 17510,
+      "created_at": 1718684828
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 842,
+      "user": 17510,
+      "created_at": 1718684833
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 843,
+      "created_at": 1718684861,
+      "hex": "C7",
+      "tile": "15-2",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 844,
+      "created_at": 1718684863
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 845,
+      "created_at": 1718684887,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "D6",
+              "E5",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "E1"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "D2",
+            "E1"
+          ],
+          "revenue": 120,
+          "revenue_str": "D6-D2-E1",
+          "nodes": [
+            "D6-0",
+            "D2-0",
+            "E1-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "A7",
+              "B6"
+            ],
+            [
+              "B6",
+              "C5",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "B6",
+            "D6"
+          ],
+          "revenue": 140,
+          "revenue_str": "A7-B6-D6",
+          "nodes": [
+            "A7-0",
+            "B6-0",
+            "D6-0"
+          ]
+        },
+        {
+          "train": "2+-2",
+          "connections": [
+            [
+              "D6",
+              "D8",
+              "D10"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "D10"
+          ],
+          "revenue": 80,
+          "revenue_str": "D6-D10",
+          "nodes": [
+            "D6-0",
+            "D10-0"
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "A9"
+          ],
+          "revenue": 100,
+          "revenue_str": "A7-A9",
+          "nodes": [
+            "A7-0",
+            "A9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 846,
+      "user": 17510,
+      "created_at": 1718684892
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 847,
+      "user": 17510,
+      "created_at": 1718684894
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 848,
+      "user": 17510,
+      "created_at": 1718684896
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 849,
+      "user": 17510,
+      "created_at": 1718684900
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 850,
+      "user": 17510,
+      "created_at": 1718684907
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 851,
+      "user": 17510,
+      "created_at": 1718684909
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 852,
+      "user": 17510,
+      "created_at": 1718684911
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 853,
+      "user": 17510,
+      "created_at": 1718684914
+    },
+    {
+      "loan": 65,
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 854,
+      "user": 17510,
+      "created_at": 1718684916
+    },
+    {
+      "loan": 65,
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 855,
+      "user": 17510,
+      "created_at": 1718684917
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 856,
+      "user": 17510,
+      "created_at": 1718684924
+    },
+    {
+      "loan": 65,
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 857,
+      "user": 17510,
+      "created_at": 1718684984
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 858,
+      "user": 17510,
+      "created_at": 1718684993
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 859,
+      "user": 17510,
+      "created_at": 1718685002
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 860,
+      "user": 17510,
+      "created_at": 1718685004
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 861,
+      "user": 17510,
+      "created_at": 1718685006
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 862,
+      "user": 17510,
+      "created_at": 1718685007
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 863,
+      "user": 17510,
+      "created_at": 1718685008
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 864,
+      "user": 17510,
+      "created_at": 1718685016
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 865,
+      "user": 17510,
+      "created_at": 1718685022
+    },
+    {
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 866,
+      "created_at": 1718685023,
+      "kind": "half"
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 867,
+      "created_at": 1718685023
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 868,
+      "created_at": 1718685024,
+      "loan": 65
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 869,
+      "created_at": 1718685026
+    },
+    {
+      "hex": "F4",
+      "tile": "14-1",
+      "type": "lay_tile",
+      "entity": "PSNR",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 870,
+      "user": 16104,
+      "created_at": 1718685061
+    },
+    {
+      "hex": "I5",
+      "tile": "6-4",
+      "type": "lay_tile",
+      "entity": "PSNR",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 871,
+      "user": 16104,
+      "created_at": 1718685068
+    },
+    {
+      "type": "undo",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 872,
+      "user": 16104,
+      "created_at": 1718685113
+    },
+    {
+      "type": "undo",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 873,
+      "user": 16104,
+      "created_at": 1718685115
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 874,
+      "created_at": 1718685121,
+      "hex": "E7",
+      "tile": "619-2",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 875,
+      "created_at": 1718685123,
+      "hex": "I5",
+      "tile": "6-4",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 876,
+      "created_at": 1718685134,
+      "routes": [
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "E7",
+              "D8",
+              "D10"
+            ]
+          ],
+          "hexes": [
+            "E7",
+            "D10"
+          ],
+          "revenue": 60,
+          "revenue_str": "E7-D10",
+          "nodes": [
+            "E7-0",
+            "D10-0"
+          ]
+        },
+        {
+          "train": "3-6",
+          "connections": [
+            [
+              "F8",
+              "G9"
+            ],
+            [
+              "E7",
+              "F8"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "F8",
+            "E7"
+          ],
+          "revenue": 100,
+          "revenue_str": "G9-F8-E7",
+          "nodes": [
+            "F8-0",
+            "G9-0",
+            "E7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 877,
+      "created_at": 1718685159,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 878,
+      "created_at": 1718685202
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 879,
+      "created_at": 1718685205
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 880,
+      "created_at": 1718685311,
+      "hex": "H8",
+      "tile": "14-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 881,
+      "created_at": 1718685321
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 882,
+      "created_at": 1718685324
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "routes": [
+        {
+          "hexes": [
+            "G13",
+            "H10",
+            "H8"
+          ],
+          "nodes": [
+            "G13-0",
+            "H10-0",
+            "H8-0"
+          ],
+          "train": "3-0",
+          "revenue": 80,
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "H10"
+            ],
+            [
+              "H10",
+              "H8"
+            ]
+          ],
+          "revenue_str": "G13-H10-H8"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 883,
+      "user": 2091,
+      "created_at": 1718685326
+    },
+    {
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 884,
+      "user": 2091,
+      "created_at": 1718685330
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 885,
+      "created_at": 1718685337,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "H10",
+              "H8"
+            ],
+            [
+              "H8",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "H8",
+            "G9"
+          ],
+          "revenue": 90,
+          "revenue_str": "H10-H8-G9",
+          "nodes": [
+            "H10-0",
+            "H8-0",
+            "G9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 886,
+      "created_at": 1718685358,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 887,
+      "created_at": 1718685362,
+      "train": "3-9",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 888,
+      "created_at": 1718685365
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 889,
+      "created_at": 1718685371
+    },
+    {
+      "type": "discard_train",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 890,
+      "created_at": 1718685389,
+      "train": "2+-0"
+    },
+    {
+      "type": "convert",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 891,
+      "created_at": 1718685394
+    },
+    {
+      "type": "buy_shares",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 892,
+      "created_at": 1718685396,
+      "shares": [
+        "PSNR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 893,
+      "created_at": 1718685397,
+      "shares": [
+        "PSNR_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 894,
+      "created_at": 1718685398,
+      "shares": [
+        "PSNR_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 895,
+      "created_at": 1718685423
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 896,
+      "created_at": 1718685432
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 898,
+      "created_at": 1718685446
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 899,
+      "created_at": 1718685450
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 900,
+      "created_at": 1718686563
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 901,
+      "created_at": 1718686573,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1718686573
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "shares": [
+        "GT_18"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 902,
+      "user": 17510,
+      "created_at": 1718686845
+    },
+    {
+      "type": "undo",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 903,
+      "user": 17510,
+      "created_at": 1718686868
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 904,
+      "created_at": 1718686869,
+      "shares": [
+        "NYOW_15"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 905,
+      "created_at": 1718686958,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1718686957
+        }
+      ],
+      "shares": [
+        "UR_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 906,
+      "created_at": 1718687200,
+      "shares": [
+        "GT_18"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 907,
+      "created_at": 1718687293,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2091,
+          "entity_type": "player",
+          "created_at": 1718687292
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 17510,
+      "entity_type": "player",
+      "id": 908,
+      "created_at": 1718687566
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 909,
+      "created_at": 1718689401,
+      "hex": "D6",
+      "tile": "593H2-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 910,
+      "created_at": 1718689408
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 911,
+      "created_at": 1718689449,
+      "routes": [
+        {
+          "train": "3-5",
+          "connections": [
+            [
+              "B6",
+              "C5",
+              "D6"
+            ],
+            [
+              "A7",
+              "B6"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "B6",
+            "A7"
+          ],
+          "revenue": 130,
+          "revenue_str": "D6-B6-A7",
+          "nodes": [
+            "B6-0",
+            "D6-0",
+            "A7-0"
+          ]
+        },
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "D2",
+              "E1"
+            ],
+            [
+              "D6",
+              "E5",
+              "E3",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "D2",
+            "D6"
+          ],
+          "revenue": 130,
+          "revenue_str": "E1-D2-D6",
+          "nodes": [
+            "D2-0",
+            "E1-0",
+            "D6-0"
+          ]
+        },
+        {
+          "train": "3-8",
+          "connections": [
+            [
+              "D6",
+              "D8",
+              "D10"
+            ],
+            [
+              "C7",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "D10",
+            "D6",
+            "C7"
+          ],
+          "revenue": 140,
+          "revenue_str": "D10-D6-C7",
+          "nodes": [
+            "D6-0",
+            "D10-0",
+            "C7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 912,
+      "user": 16104,
+      "created_at": 1718689456
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 913,
+      "user": 16104,
+      "created_at": 1718689469
+    },
+    {
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 914,
+      "user": 16104,
+      "created_at": 1718689471
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 915,
+      "user": 16104,
+      "created_at": 1718689474
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 916,
+      "user": 16104,
+      "created_at": 1718689476
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 917,
+      "user": 16104,
+      "created_at": 1718689487
+    },
+    {
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 918,
+      "created_at": 1718689503,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 919,
+      "created_at": 1718689514
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 920,
+      "created_at": 1718689882,
+      "hex": "B2",
+      "tile": "544-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 921,
+      "created_at": 1718689898
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 922,
+      "created_at": 1718689901
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 923,
+      "created_at": 1718689930,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "B6",
+              "A7"
+            ],
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "B6",
+            "A7",
+            "A9"
+          ],
+          "revenue": 130,
+          "revenue_str": "B6-A7-A9",
+          "nodes": [
+            "B6-0",
+            "A7-0",
+            "A9-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "D6",
+              "E5",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "C1",
+              "B2",
+              "A1"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "D2",
+            "A1"
+          ],
+          "revenue": 140,
+          "revenue_str": "D6-D2-A1",
+          "nodes": [
+            "D6-0",
+            "D2-0",
+            "A1-0"
+          ]
+        },
+        {
+          "train": "2+-2",
+          "connections": [
+            [
+              "D6",
+              "D8",
+              "D10"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "D10"
+          ],
+          "revenue": 110,
+          "revenue_str": "D6-D10",
+          "nodes": [
+            "D6-0",
+            "D10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 924,
+      "user": 17510,
+      "created_at": 1718689934
+    },
+    {
+      "type": "buy_train",
+      "price": 400,
+      "train": "4-1",
+      "entity": "UR",
+      "variant": "4",
+      "entity_type": "corporation",
+      "id": 925,
+      "user": 17510,
+      "created_at": 1718689935
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 926,
+      "user": 17510,
+      "created_at": 1718689947
+    },
+    {
+      "type": "undo",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 927,
+      "user": 17510,
+      "created_at": 1718689961
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 928,
+      "user": 17510,
+      "created_at": 1718689963
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 929,
+      "user": 17510,
+      "created_at": 1718689968
+    },
+    {
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 930,
+      "created_at": 1718689970,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 931,
+      "created_at": 1718689975,
+      "train": "4-1",
+      "price": 400,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 932,
+      "created_at": 1718689979
+    },
+    {
+      "hex": "E7",
+      "tile": "611-0",
+      "type": "lay_tile",
+      "entity": "PSNR",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "id": 933,
+      "user": 16104,
+      "created_at": 1718691887
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 934,
+      "user": 16104,
+      "created_at": 1718691891
+    },
+    {
+      "city": "6-4-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "PSNR",
+      "tokener": "PSNR",
+      "entity_type": "corporation",
+      "id": 935,
+      "user": 16104,
+      "created_at": 1718691907
+    },
+    {
+      "type": "undo",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 936,
+      "user": 16104,
+      "created_at": 1718691919
+    },
+    {
+      "type": "undo",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 937,
+      "user": 16104,
+      "created_at": 1718691926
+    },
+    {
+      "type": "undo",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 938,
+      "user": 16104,
+      "created_at": 1718691928
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 939,
+      "created_at": 1718691953,
+      "hex": "E7",
+      "tile": "611-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 940,
+      "created_at": 1718691955
+    },
+    {
+      "type": "place_token",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 941,
+      "created_at": 1718691969,
+      "city": "57-4-0",
+      "slot": 0,
+      "tokener": "PSNR"
+    },
+    {
+      "type": "run_routes",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 942,
+      "created_at": 1718691977,
+      "routes": [
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "E7",
+              "D8",
+              "D10"
+            ]
+          ],
+          "hexes": [
+            "E7",
+            "D10"
+          ],
+          "revenue": 90,
+          "revenue_str": "E7-D10",
+          "nodes": [
+            "E7-0",
+            "D10-0"
+          ]
+        },
+        {
+          "train": "3-6",
+          "connections": [
+            [
+              "F8",
+              "G9"
+            ],
+            [
+              "E7",
+              "F8"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "F8",
+            "E7"
+          ],
+          "revenue": 110,
+          "revenue_str": "G9-F8-E7",
+          "nodes": [
+            "F8-0",
+            "G9-0",
+            "E7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 943,
+      "created_at": 1718691984,
+      "kind": "half"
+    },
+    {
+      "type": "take_loan",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 944,
+      "created_at": 1718691987,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 945,
+      "created_at": 1718691989,
+      "loan": 0
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 946,
+      "user": 16104,
+      "created_at": 1718691994
+    },
+    {
+      "type": "buy_train",
+      "price": 400,
+      "train": "4-2",
+      "entity": "PSNR",
+      "variant": "4",
+      "entity_type": "corporation",
+      "id": 947,
+      "user": 16104,
+      "created_at": 1718691997
+    },
+    {
+      "type": "undo",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 948,
+      "user": 16104,
+      "created_at": 1718692001
+    },
+    {
+      "type": "undo",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 949,
+      "user": 16104,
+      "created_at": 1718692002
+    },
+    {
+      "type": "take_loan",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 950,
+      "created_at": 1718692011,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 951,
+      "created_at": 1718692014,
+      "train": "4-2",
+      "price": 400,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 952,
+      "created_at": 1718692019
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 953,
+      "created_at": 1718692024
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 954,
+      "created_at": 1718756464,
+      "hex": "H6",
+      "tile": "82-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 955,
+      "created_at": 1718756470
+    },
+    {
+      "type": "place_token",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 956,
+      "created_at": 1718756474,
+      "city": "6-4-0",
+      "slot": 0,
+      "tokener": "GT"
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 957,
+      "created_at": 1718756486,
+      "routes": [
+        {
+          "train": "3-9",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "H10"
+            ],
+            [
+              "H10",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G13",
+            "H10",
+            "H8"
+          ],
+          "revenue": 90,
+          "revenue_str": "G13-H10-H8",
+          "nodes": [
+            "G13-0",
+            "H10-0",
+            "H8-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "I3",
+              "I5"
+            ],
+            [
+              "I5",
+              "H6",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "I3",
+            "I5",
+            "H8"
+          ],
+          "revenue": 110,
+          "revenue_str": "I3-I5-H8",
+          "nodes": [
+            "I3-0",
+            "I5-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 958,
+      "created_at": 1718756489,
+      "kind": "half"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 959,
+      "created_at": 1718756510
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 960,
+      "created_at": 1718756515,
+      "loan": 67
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 961,
+      "created_at": 1718756520
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 962,
+      "created_at": 1718758005,
+      "hex": "C7",
+      "tile": "448-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 963,
+      "created_at": 1718758009
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 964,
+      "created_at": 1718758019,
+      "routes": [
+        {
+          "train": "3-5",
+          "connections": [
+            [
+              "B6",
+              "C5",
+              "D6"
+            ],
+            [
+              "A7",
+              "B6"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "B6",
+            "A7"
+          ],
+          "revenue": 130,
+          "revenue_str": "D6-B6-A7",
+          "nodes": [
+            "B6-0",
+            "D6-0",
+            "A7-0"
+          ]
+        },
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "D2",
+              "E1"
+            ],
+            [
+              "D6",
+              "E5",
+              "E3",
+              "D2"
+            ]
+          ],
+          "hexes": [
+            "E1",
+            "D2",
+            "D6"
+          ],
+          "revenue": 130,
+          "revenue_str": "E1-D2-D6",
+          "nodes": [
+            "D2-0",
+            "E1-0",
+            "D6-0"
+          ]
+        },
+        {
+          "train": "3-8",
+          "connections": [
+            [
+              "D6",
+              "D8",
+              "D10"
+            ],
+            [
+              "C7",
+              "D6"
+            ]
+          ],
+          "hexes": [
+            "D10",
+            "D6",
+            "C7"
+          ],
+          "revenue": 150,
+          "revenue_str": "D10-D6-C7",
+          "nodes": [
+            "D6-0",
+            "D10-0",
+            "C7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 965,
+      "user": 16104,
+      "created_at": 1718758035
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 966,
+      "user": 16104,
+      "created_at": 1718758048
+    },
+    {
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 967,
+      "created_at": 1718758057,
+      "kind": "half"
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 968,
+      "created_at": 1718758065,
+      "loan": 68
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 969,
+      "created_at": 1718758084
+    },
+    {
+      "hex": "A5",
+      "tile": "15-2",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "id": 970,
+      "user": 17510,
+      "created_at": 1718760478
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 971,
+      "user": 17510,
+      "created_at": 1718760483
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 972,
+      "user": 17510,
+      "created_at": 1718760485
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 973,
+      "user": 17510,
+      "created_at": 1718760531
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 974,
+      "user": 17510,
+      "created_at": 1718760534
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 975,
+      "user": 17510,
+      "created_at": 1718760537
+    },
+    {
+      "hex": "E5",
+      "tile": "83-0",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "id": 976,
+      "user": 17510,
+      "created_at": 1718760556
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 977,
+      "user": 17510,
+      "created_at": 1718760586
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 978,
+      "user": 17510,
+      "created_at": 1718760587
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "routes": [
+        {
+          "hexes": [
+            "D6",
+            "B6",
+            "A7",
+            "A9"
+          ],
+          "nodes": [
+            "D6-0",
+            "B6-0",
+            "A7-0",
+            "A9-0"
+          ],
+          "train": "4-1",
+          "revenue": 190,
+          "connections": [
+            [
+              "D6",
+              "C5",
+              "B6"
+            ],
+            [
+              "B6",
+              "A7"
+            ],
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "revenue_str": "D6-B6-A7-A9"
+        },
+        {
+          "hexes": [
+            "D6",
+            "D2",
+            "A1"
+          ],
+          "nodes": [
+            "D6-0",
+            "D2-0",
+            "A1-0"
+          ],
+          "train": "3-1",
+          "revenue": 140,
+          "connections": [
+            [
+              "D6",
+              "E5",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "C1",
+              "B2",
+              "A1"
+            ]
+          ],
+          "revenue_str": "D6-D2-A1"
+        },
+        {
+          "hexes": [
+            "D10",
+            "D6",
+            "C7"
+          ],
+          "nodes": [
+            "D10-0",
+            "D6-0",
+            "C7-0"
+          ],
+          "train": "3-2",
+          "revenue": 150,
+          "connections": [
+            [
+              "D10",
+              "D8",
+              "D6"
+            ],
+            [
+              "D6",
+              "C7"
+            ]
+          ],
+          "revenue_str": "D10-D6-C7"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 979,
+      "user": 17510,
+      "created_at": 1718760631
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 980,
+      "user": 17510,
+      "created_at": 1718760635
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 981,
+      "user": 17510,
+      "created_at": 1718760683
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 982,
+      "user": 17510,
+      "created_at": 1718760684
+    },
+    {
+      "loan": 65,
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 983,
+      "user": 17510,
+      "created_at": 1718760686
+    },
+    {
+      "loan": 65,
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 984,
+      "user": 17510,
+      "created_at": 1718760687
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 985,
+      "user": 17510,
+      "created_at": 1718760759
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 986,
+      "user": 17510,
+      "created_at": 1718760760
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 987,
+      "user": 17510,
+      "created_at": 1718760761
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 988,
+      "user": 17510,
+      "created_at": 1718760762
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 989,
+      "user": 17510,
+      "created_at": 1718760763
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 990,
+      "user": 17510,
+      "created_at": 1718760767
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 991,
+      "user": 17510,
+      "created_at": 1718760768
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 992,
+      "user": 17510,
+      "created_at": 1718768113
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 993,
+      "user": 17510,
+      "created_at": 1718768113
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 994,
+      "user": 17510,
+      "created_at": 1718768194
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 995,
+      "user": 17510,
+      "created_at": 1718768198
+    },
+    {
+      "hex": "D2",
+      "tile": "611-1",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 996,
+      "user": 17510,
+      "created_at": 1718768206
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 997,
+      "user": 17510,
+      "created_at": 1718768219
+    },
+    {
+      "hex": "E3",
+      "tile": "546-0",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "id": 998,
+      "user": 17510,
+      "created_at": 1718768224
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 999,
+      "user": 17510,
+      "created_at": 1718768226
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1000,
+      "user": 17510,
+      "created_at": 1718768227
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1001,
+      "user": 17510,
+      "created_at": 1718768387
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1002,
+      "user": 17510,
+      "created_at": 1718768389
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1003,
+      "user": 17510,
+      "created_at": 1718768392
+    },
+    {
+      "hex": "F4",
+      "tile": "14-2",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 1004,
+      "user": 17510,
+      "created_at": 1718768403
+    },
+    {
+      "hex": "G3",
+      "tile": "9-2",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 1005,
+      "user": 17510,
+      "created_at": 1718768406
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1006,
+      "user": 17510,
+      "created_at": 1718768413
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1007,
+      "user": 17510,
+      "created_at": 1718768415
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1008,
+      "user": 17510,
+      "created_at": 1718768417
+    },
+    {
+      "type": "redo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 1009,
+      "user": 17510,
+      "created_at": 1718768420
+    },
+    {
+      "hex": "F4",
+      "tile": "14-2",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 1010,
+      "user": 17510,
+      "created_at": 1718768439
+    },
+    {
+      "hex": "G3",
+      "tile": "9-2",
+      "type": "lay_tile",
+      "entity": "UR",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 1011,
+      "user": 17510,
+      "created_at": 1718768441
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1012,
+      "user": 17510,
+      "created_at": 1718768444
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1013,
+      "user": 17510,
+      "created_at": 1718768446
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1014,
+      "created_at": 1718768449,
+      "hex": "D2",
+      "tile": "611-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1015,
+      "created_at": 1718768450
+    },
+    {
+      "type": "place_token",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1016,
+      "created_at": 1718768453,
+      "city": "448-0-0",
+      "slot": 1,
+      "tokener": "UR"
+    },
+    {
+      "type": "run_routes",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1017,
+      "created_at": 1718768506,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "D6",
+              "C5",
+              "B6"
+            ],
+            [
+              "B6",
+              "A7"
+            ],
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "B6",
+            "A7",
+            "A9"
+          ],
+          "revenue": 190,
+          "revenue_str": "D6-B6-A7-A9",
+          "nodes": [
+            "D6-0",
+            "B6-0",
+            "A7-0",
+            "A9-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "D6",
+              "E5",
+              "E3",
+              "D2"
+            ],
+            [
+              "D2",
+              "C1",
+              "B2",
+              "A1"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "D2",
+            "A1"
+          ],
+          "revenue": 150,
+          "revenue_str": "D6-D2-A1",
+          "nodes": [
+            "D6-0",
+            "D2-0",
+            "A1-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "C7",
+              "D6"
+            ],
+            [
+              "D6",
+              "D8",
+              "D10"
+            ]
+          ],
+          "hexes": [
+            "C7",
+            "D6",
+            "D10"
+          ],
+          "revenue": 150,
+          "revenue_str": "C7-D6-D10",
+          "nodes": [
+            "C7-0",
+            "D6-0",
+            "D10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1018,
+      "user": 17510,
+      "created_at": 1718768562
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1019,
+      "user": 17510,
+      "created_at": 1718768568
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1020,
+      "user": 17510,
+      "created_at": 1718768569
+    },
+    {
+      "loan": 65,
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1021,
+      "user": 17510,
+      "created_at": 1718768570
+    },
+    {
+      "loan": 65,
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1022,
+      "user": 17510,
+      "created_at": 1718768571
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1023,
+      "user": 17510,
+      "created_at": 1718768582
+    },
+    {
+      "type": "undo",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 1024,
+      "user": 17510,
+      "created_at": 1718768588
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1025,
+      "user": 17510,
+      "created_at": 1718768589
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1026,
+      "user": 17510,
+      "created_at": 1718768591
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1027,
+      "user": 17510,
+      "created_at": 1718768593
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1028,
+      "user": 17510,
+      "created_at": 1718768594
+    },
+    {
+      "type": "undo",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1029,
+      "user": 17510,
+      "created_at": 1718768598
+    },
+    {
+      "type": "dividend",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1030,
+      "created_at": 1718768599,
+      "kind": "half"
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1031,
+      "created_at": 1718768600,
+      "loan": 65
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1032,
+      "created_at": 1718768600,
+      "loan": 65
+    },
+    {
+      "type": "pass",
+      "entity": "UR",
+      "entity_type": "corporation",
+      "id": 1033,
+      "created_at": 1718768610
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 1034,
+      "created_at": 1718775969,
+      "hex": "I11",
+      "tile": "15-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 1035,
+      "created_at": 1718775982
+    },
+    {
+      "type": "assign",
+      "entity": "FC",
+      "entity_type": "company",
+      "id": 1036,
+      "created_at": 1718775993,
+      "target": "D10",
+      "target_type": "hex"
+    },
+    {
+      "type": "place_token",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 1037,
+      "created_at": 1718776031,
+      "city": "611-0-0",
+      "slot": 1,
+      "tokener": "GT"
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 1038,
+      "created_at": 1718776042,
+      "routes": [
+        {
+          "train": "3-9",
+          "connections": [
+            [
+              "G13",
+              "H12",
+              "I11"
+            ],
+            [
+              "I11",
+              "I13"
+            ]
+          ],
+          "hexes": [
+            "G13",
+            "I11",
+            "I13"
+          ],
+          "revenue": 110,
+          "revenue_str": "G13-I11-I13",
+          "nodes": [
+            "G13-0",
+            "I11-0",
+            "I13-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "D10",
+              "D8",
+              "E7"
+            ],
+            [
+              "E7",
+              "F6"
+            ]
+          ],
+          "hexes": [
+            "D10",
+            "E7",
+            "F6"
+          ],
+          "revenue": 130,
+          "revenue_str": "D10-E7-F6",
+          "nodes": [
+            "D10-0",
+            "E7-0",
+            "F6-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 1039,
+      "created_at": 1718776046,
+      "kind": "half"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 1040,
+      "created_at": 1718776055
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 1041,
+      "created_at": 1718776057,
+      "loan": 67
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 1042,
+      "created_at": 1718776073
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 1043,
+      "created_at": 1718776256,
+      "hex": "F6",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 1044,
+      "created_at": 1718776272,
+      "hex": "I9",
+      "tile": "6-1",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 1045,
+      "created_at": 1718776300,
+      "city": "15-0-0",
+      "slot": 1,
+      "tokener": "PSNR"
+    },
+    {
+      "type": "run_routes",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 1046,
+      "created_at": 1718776383,
+      "routes": [
+        {
+          "train": "3-6",
+          "connections": [
+            [
+              "F6",
+              "G7"
+            ],
+            [
+              "E7",
+              "F6"
+            ]
+          ],
+          "hexes": [
+            "G7",
+            "F6",
+            "E7"
+          ],
+          "revenue": 110,
+          "revenue_str": "G7-F6-E7",
+          "nodes": [
+            "F6-0",
+            "G7-0",
+            "E7-0"
+          ]
+        },
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "F8",
+              "G9"
+            ],
+            [
+              "E7",
+              "F8"
+            ],
+            [
+              "D10",
+              "D8",
+              "E7"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "F8",
+            "E7",
+            "D10"
+          ],
+          "revenue": 160,
+          "revenue_str": "G9-F8-E7-D10",
+          "nodes": [
+            "F8-0",
+            "G9-0",
+            "E7-0",
+            "D10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 1047,
+      "user": 16104,
+      "created_at": 1718776389
+    },
+    {
+      "type": "undo",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 1048,
+      "user": 16104,
+      "created_at": 1718776428
+    },
+    {
+      "type": "dividend",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 1049,
+      "created_at": 1718776434,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 1050,
+      "created_at": 1718776449
+    },
+    {
+      "type": "pass",
+      "entity": "PSNR",
+      "entity_type": "corporation",
+      "id": 1051,
+      "created_at": 1718776453
+    },
+    {
+      "type": "pass",
+      "entity": 16104,
+      "entity_type": "player",
+      "id": 1052,
+      "created_at": 1718776494
+    },
+    {
+      "type": "pass",
+      "entity": 2091,
+      "entity_type": "player",
+      "id": 1053,
+      "created_at": 1718776516
+    }
+  ],
+  "loaded": true,
+  "created_at": 1716338451,
+  "updated_at": 1718776516,
+  "finished_at": 1718776516
+}

--- a/public/fixtures/18 Hiawatha/164606.json
+++ b/public/fixtures/18 Hiawatha/164606.json
@@ -1,0 +1,6744 @@
+{
+  "id": 164606,
+  "description": "Gunnar 'MF-MVP' Henderson !",
+  "user": {
+    "id": 5649,
+    "name": "caveman67"
+  },
+  "players": [
+    {
+      "id": 621,
+      "name": "WyoBadger"
+    },
+    {
+      "id": 5649,
+      "name": "caveman67"
+    },
+    {
+      "id": 2006,
+      "name": "Ledgeoflove"
+    },
+    {
+      "id": 2072,
+      "name": "PeteCal"
+    }
+  ],
+  "min_players": 4,
+  "max_players": 4,
+  "title": "18 Hiawatha",
+  "settings": {
+    "seed": 87,
+    "is_async": true,
+    "unlisted": true,
+    "auto_routing": true,
+    "player_order": null,
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "status": "finished",
+  "turn": 4,
+  "round": "Acquisition Round",
+  "acting": [
+    2072
+  ],
+  "result": {
+    "621": 2107,
+    "2006": 1542,
+    "2072": 3055,
+    "5649": 2334
+  },
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1716388919,
+      "company": "US",
+      "price": 40
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1716388955
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1716388992,
+      "company": "US",
+      "price": 45
+    },
+    {
+      "type": "pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1716389947
+    },
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1716390651,
+      "company": "US",
+      "price": 50
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1716392326,
+      "company": "US",
+      "price": 55
+    },
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1716392375,
+      "company": "US",
+      "price": 60
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1716392415
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1716392474
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1716392885,
+      "company": "RR",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1716393060,
+      "company": "RR",
+      "price": 75
+    },
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1716393179,
+      "company": "RR",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1716393253
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1716395903,
+      "company": "RR",
+      "price": 85
+    },
+    {
+      "type": "bid",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1716396922,
+      "company": "RR",
+      "price": 90
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1716396970
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1716397148,
+      "company": "RR",
+      "price": 95
+    },
+    {
+      "type": "bid",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1716400042,
+      "company": "RR",
+      "price": 100
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1716400071,
+      "company": "RR",
+      "price": 105
+    },
+    {
+      "type": "bid",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1716400519,
+      "company": "RR",
+      "price": 110
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1716400827,
+      "company": "RR",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1716400894,
+      "company": "RR",
+      "price": 125
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 23,
+      "created_at": 1716401131
+    },
+    {
+      "type": "bid",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 24,
+      "created_at": 1716401269,
+      "company": "FC",
+      "price": 40
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1716401604
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 26,
+      "created_at": 1716404352
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1716406860
+    },
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 28,
+      "created_at": 1716407861,
+      "company": "GLS",
+      "price": 20
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 29,
+      "created_at": 1716408156
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 30,
+      "created_at": 1716412533,
+      "company": "GLS",
+      "price": 25
+    },
+    {
+      "type": "pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 31,
+      "created_at": 1716412588
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 32,
+      "created_at": 1716412622
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 33,
+      "created_at": 1716412652
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1716412707,
+      "company": "MB",
+      "price": 40
+    },
+    {
+      "type": "pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1716412904
+    },
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1716414412,
+      "company": "MB",
+      "price": 45
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 37,
+      "created_at": 1716416219
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 38,
+      "created_at": 1716429124,
+      "company": "MB",
+      "price": 50
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 39,
+      "created_at": 1716465204
+    },
+    {
+      "type": "bid",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 40,
+      "created_at": 1716465677,
+      "company": "JLBC",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 41,
+      "created_at": 1716465919,
+      "company": "JLBC",
+      "price": 45
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 42,
+      "created_at": 1716466405
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 43,
+      "created_at": 1716466545,
+      "company": "JLBC",
+      "price": 50
+    },
+    {
+      "type": "pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 44,
+      "created_at": 1716469280
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 45,
+      "created_at": 1716469655
+    },
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 46,
+      "created_at": 1716469663,
+      "company": "PC",
+      "price": 30
+    },
+    {
+      "type": "bid",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 47,
+      "created_at": 1716469894,
+      "company": "PC",
+      "price": 35
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 48,
+      "created_at": 1716470252
+    },
+    {
+      "type": "bid",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 49,
+      "created_at": 1716471640,
+      "company": "PC",
+      "price": 45
+    },
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 50,
+      "created_at": 1716471683,
+      "company": "PC",
+      "price": 50
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 51,
+      "created_at": 1716472408
+    },
+    {
+      "type": "bid",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 52,
+      "created_at": 1716472455,
+      "company": "PC",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 53,
+      "created_at": 1716472580,
+      "company": "PC",
+      "price": 70
+    },
+    {
+      "type": "bid",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 54,
+      "created_at": 1716472637,
+      "company": "PC",
+      "price": 75
+    },
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 55,
+      "created_at": 1716472664,
+      "company": "PC",
+      "price": 80
+    },
+    {
+      "type": "pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 56,
+      "created_at": 1716472682
+    },
+    {
+      "type": "bid",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 57,
+      "created_at": 1716474700,
+      "company": "FU",
+      "price": 0
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 58,
+      "created_at": 1716479449,
+      "company": "FU",
+      "price": 5
+    },
+    {
+      "type": "bid",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 59,
+      "created_at": 1716479738,
+      "company": "FU",
+      "price": 30
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 60,
+      "created_at": 1716481581
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 61,
+      "created_at": 1716481922
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 62,
+      "created_at": 1716481972
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 63,
+      "created_at": 1716482007,
+      "corporation": "DL&W",
+      "price": 100
+    },
+    {
+      "type": "place_token",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 64,
+      "created_at": 1716482036,
+      "city": "B6-0-0",
+      "slot": 0,
+      "tokener": "DL&W"
+    },
+    {
+      "type": "pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 65,
+      "created_at": 1716482089
+    },
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 66,
+      "created_at": 1716482695,
+      "corporation": "DL&W",
+      "price": 110
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 67,
+      "created_at": 1716482731
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 68,
+      "created_at": 1716482782,
+      "corporation": "DL&W",
+      "price": 150
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 69,
+      "created_at": 1716483867
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 70,
+      "created_at": 1716483928,
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 71,
+      "created_at": 1716483931
+    },
+    {
+      "type": "program_disable",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 72,
+      "created_at": 1716483941,
+      "reason": "user",
+      "original_type": "program_share_pass"
+    },
+    {
+      "type": "bid",
+      "price": 100,
+      "entity": 2072,
+      "corporation": "J",
+      "entity_type": "player",
+      "id": 73,
+      "user": 2072,
+      "created_at": 1716484668
+    },
+    {
+      "type": "undo",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 74,
+      "user": 2072,
+      "created_at": 1716484670
+    },
+    {
+      "type": "bid",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 75,
+      "created_at": 1716484680,
+      "corporation": "J",
+      "price": 200
+    },
+    {
+      "type": "place_token",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 76,
+      "created_at": 1716484682,
+      "city": "H4-10-0",
+      "slot": 0,
+      "tokener": "J"
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 77,
+      "created_at": 1716486372
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 78,
+      "created_at": 1716486421
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 79,
+      "created_at": 1716487366
+    },
+    {
+      "type": "assign",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 80,
+      "created_at": 1716488184,
+      "target": "RR",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 81,
+      "created_at": 1716488186,
+      "target": "FC",
+      "target_type": "company"
+    },
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 82,
+      "created_at": 1716488297,
+      "corporation": "NYOW",
+      "price": 200
+    },
+    {
+      "type": "place_token",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 83,
+      "created_at": 1716488309,
+      "city": "H10-0-0",
+      "slot": 0,
+      "tokener": "NYOW"
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 84,
+      "created_at": 1716488360
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 85,
+      "created_at": 1716491332
+    },
+    {
+      "type": "assign",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 86,
+      "created_at": 1716491371,
+      "target": "PC",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 87,
+      "created_at": 1716491389,
+      "target": "US",
+      "target_type": "company"
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 88,
+      "created_at": 1716560727
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 89,
+      "created_at": 1716562671
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 90,
+      "created_at": 1716562925,
+      "shares": [
+        "J_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 91,
+      "created_at": 1716562975,
+      "shares": [
+        "NYOW_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 92,
+      "created_at": 1716563440,
+      "shares": [
+        "DL&W_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 93,
+      "created_at": 1716563467
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 94,
+      "created_at": 1716563574,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716563575
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "take_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 95,
+      "created_at": 1716563949,
+      "loan": 0
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 96,
+      "created_at": 1716563954
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 97,
+      "created_at": 1716564236,
+      "shares": [
+        "NYOW_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "short",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 98,
+      "created_at": 1716565011,
+      "corporation": "J"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 99,
+      "created_at": 1716565022,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716565021,
+          "reason": "Short bought"
+        }
+      ],
+      "shares": [
+        "DL&W_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "take_loan",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 100,
+      "created_at": 1716565948,
+      "loan": 0
+    },
+    {
+      "type": "buy_shares",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 101,
+      "created_at": 1716565955,
+      "shares": [
+        "J_10"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 102,
+      "created_at": 1716566273,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 621,
+          "entity_type": "player",
+          "created_at": 1716566273
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 103,
+      "created_at": 1716566426,
+      "shares": [
+        "J_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "short",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 104,
+      "created_at": 1716566757,
+      "corporation": "NYOW"
+    },
+    {
+      "type": "bid",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 105,
+      "created_at": 1716566780,
+      "corporation": "GT",
+      "price": 170
+    },
+    {
+      "type": "place_token",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 106,
+      "created_at": 1716566793,
+      "city": "A7-0-0",
+      "slot": 1,
+      "tokener": "GT"
+    },
+    {
+      "type": "assign",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 107,
+      "created_at": 1716566801,
+      "target": "GLS",
+      "target_type": "company"
+    },
+    {
+      "type": "assign",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 108,
+      "created_at": 1716566814,
+      "target": "MB",
+      "target_type": "company"
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 109,
+      "created_at": 1716566815
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 110,
+      "created_at": 1716567475,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716567475
+        },
+        {
+          "type": "program_disable",
+          "entity": 621,
+          "entity_type": "player",
+          "created_at": 1716567475,
+          "reason": "Short bought"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "short",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 111,
+      "created_at": 1716567527,
+      "corporation": "GT"
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 112,
+      "created_at": 1716567532
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 113,
+      "created_at": 1716567651
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 114,
+      "created_at": 1716569539,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716569539,
+          "reason": "Short bought"
+        }
+      ],
+      "shares": [
+        "GT_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 115,
+      "created_at": 1716569581
+    },
+    {
+      "type": "short",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 116,
+      "created_at": 1716569616,
+      "corporation": "GT"
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 117,
+      "created_at": 1716569622
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 118,
+      "created_at": 1716570602,
+      "shares": [
+        "DL&W_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 119,
+      "created_at": 1716570834
+    },
+    {
+      "type": "pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 120,
+      "created_at": 1716571691
+    },
+    {
+      "type": "short",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 121,
+      "created_at": 1716571739,
+      "corporation": "GT"
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 122,
+      "created_at": 1716571743
+    },
+    {
+      "type": "sell_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 123,
+      "created_at": 1716573835,
+      "shares": [
+        "DL&W_1",
+        "DL&W_3"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 124,
+      "created_at": 1716573843,
+      "shares": [
+        "GT_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 125,
+      "created_at": 1716575274,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2006,
+          "entity_type": "player",
+          "created_at": 1716575274
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 126,
+      "created_at": 1716575393,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716575394
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "short",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 127,
+      "created_at": 1716575434,
+      "corporation": "GT"
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 128,
+      "created_at": 1716575438
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 129,
+      "created_at": 1716575524,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716575524
+        },
+        {
+          "type": "program_disable",
+          "entity": 2006,
+          "entity_type": "player",
+          "created_at": 1716575524,
+          "reason": "Short bought"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 130,
+      "created_at": 1716575819,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2006,
+          "entity_type": "player",
+          "created_at": 1716575819
+        },
+        {
+          "type": "program_disable",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716575819,
+          "reason": "Short bought"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 131,
+      "created_at": 1716576081,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716576082
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "short",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 132,
+      "created_at": 1716576132,
+      "corporation": "GT"
+    },
+    {
+      "type": "bid",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 133,
+      "created_at": 1716576171,
+      "corporation": "H",
+      "price": 200
+    },
+    {
+      "type": "place_token",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 134,
+      "created_at": 1716576180,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716576179,
+          "reason": "Short bought"
+        }
+      ],
+      "city": "G9-0-0",
+      "slot": 0,
+      "tokener": "H"
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 135,
+      "created_at": 1716576462,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716576462
+        },
+        {
+          "type": "program_disable",
+          "entity": 2006,
+          "entity_type": "player",
+          "created_at": 1716576462,
+          "reason": "Short bought"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 136,
+      "created_at": 1716576935,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2006,
+          "entity_type": "player",
+          "created_at": 1716576934
+        },
+        {
+          "type": "program_disable",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716576934,
+          "reason": "Short bought"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 137,
+      "created_at": 1716577014,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716577014
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 138,
+      "created_at": 1716577058
+    },
+    {
+      "type": "take_loan",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 139,
+      "created_at": 1716577070,
+      "loan": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 140,
+      "created_at": 1716577082,
+      "hex": "H8",
+      "tile": "5-0",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 141,
+      "created_at": 1716577085,
+      "hex": "F8",
+      "tile": "57-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 142,
+      "created_at": 1716577094
+    },
+    {
+      "type": "buy_train",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 143,
+      "created_at": 1716577095,
+      "train": "2-1",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 144,
+      "created_at": 1716577096,
+      "train": "2-2",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 145,
+      "created_at": 1716577099
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 146,
+      "created_at": 1716577102
+    },
+    {
+      "type": "assign",
+      "entity": "FC",
+      "entity_type": "company",
+      "id": 147,
+      "created_at": 1716577203,
+      "target": "I3",
+      "target_type": "hex"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 148,
+      "created_at": 1716577214,
+      "hex": "H4",
+      "tile": "5-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 149,
+      "created_at": 1716577218,
+      "hex": "H2",
+      "tile": "7-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 150,
+      "created_at": 1716577221,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "H4",
+              "H2",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I3"
+          ],
+          "revenue": 60,
+          "revenue_str": "H4-I3",
+          "nodes": [
+            "H4-0",
+            "I3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 151,
+      "created_at": 1716577224,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 152,
+      "created_at": 1716577233,
+      "train": "2-3",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 153,
+      "created_at": 1716577240
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 154,
+      "created_at": 1716577243
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 155,
+      "created_at": 1716577282,
+      "hex": "I11",
+      "tile": "6-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 156,
+      "created_at": 1716577287
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 157,
+      "created_at": 1716577295
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 158,
+      "created_at": 1716577298,
+      "train": "2-4",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 159,
+      "created_at": 1716577300,
+      "train": "2-5",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 160,
+      "created_at": 1716577305
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 161,
+      "created_at": 1716577306,
+      "loan": 69
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 162,
+      "created_at": 1716577309
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 163,
+      "created_at": 1716577349,
+      "hex": "B6",
+      "tile": "6-1",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 164,
+      "created_at": 1716577354,
+      "hex": "C7",
+      "tile": "57-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 165,
+      "created_at": 1716577363
+    },
+    {
+      "type": "buy_train",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 166,
+      "created_at": 1716577365,
+      "train": "2-6",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 167,
+      "created_at": 1716577367,
+      "train": "2-7",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 168,
+      "created_at": 1716577368
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 169,
+      "created_at": 1716577371
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 170,
+      "created_at": 1716577380,
+      "hex": "A5",
+      "tile": "57-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 171,
+      "created_at": 1716577387
+    },
+    {
+      "type": "assign",
+      "entity": "GLS",
+      "entity_type": "company",
+      "id": 172,
+      "created_at": 1716577392,
+      "target": "A9",
+      "target_type": "hex"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 173,
+      "created_at": 1716577396
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 174,
+      "created_at": 1716577398,
+      "train": "2-8",
+      "price": 100,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 175,
+      "created_at": 1716577402
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 176,
+      "created_at": 1716577404
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 177,
+      "created_at": 1716577424
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 178,
+      "created_at": 1716577436
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 179,
+      "created_at": 1716577436
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 180,
+      "created_at": 1716577498
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 181,
+      "created_at": 1716577504
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 182,
+      "created_at": 1716577519
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 183,
+      "created_at": 1716577523
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 184,
+      "created_at": 1716577880
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 185,
+      "created_at": 1716577882
+    },
+    {
+      "type": "pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 186,
+      "created_at": 1716577943
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 187,
+      "created_at": 1716577950
+    },
+    {
+      "type": "run_routes",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 188,
+      "created_at": 1716577954,
+      "routes": [
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "H4",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I3"
+          ],
+          "revenue": 60,
+          "revenue_str": "H4-I3",
+          "nodes": [
+            "H4-0",
+            "I3-0"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "H4",
+              "H2",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I3"
+          ],
+          "revenue": 60,
+          "revenue_str": "H4-I3",
+          "nodes": [
+            "H4-0",
+            "I3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 189,
+      "created_at": 1716577955,
+      "kind": "payout"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 190,
+      "created_at": 1716577975,
+      "shares": [
+        "GT_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_train",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 191,
+      "created_at": 1716577985,
+      "train": "2+-0",
+      "price": 100,
+      "variant": "2+"
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 192,
+      "created_at": 1716577988
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 193,
+      "created_at": 1716577996
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 194,
+      "created_at": 1716578034,
+      "hex": "E7",
+      "tile": "6-2",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 195,
+      "created_at": 1716578038
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 196,
+      "created_at": 1716578048
+    },
+    {
+      "type": "run_routes",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 197,
+      "created_at": 1716578051,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "H8"
+          ],
+          "revenue": 60,
+          "revenue_str": "G9-H8",
+          "nodes": [
+            "G9-0",
+            "H8-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G9",
+              "F8"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "F8"
+          ],
+          "revenue": 60,
+          "revenue_str": "G9-F8",
+          "nodes": [
+            "G9-0",
+            "F8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 198,
+      "created_at": 1716578053,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 199,
+      "created_at": 1716578061
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 200,
+      "created_at": 1716578066
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 201,
+      "created_at": 1716578074
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 202,
+      "created_at": 1716578076
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 203,
+      "created_at": 1716578079,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "H10",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "H8"
+          ],
+          "revenue": 60,
+          "revenue_str": "H10-H8",
+          "nodes": [
+            "H10-0",
+            "H8-0"
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "H10",
+              "I11"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "I11"
+          ],
+          "revenue": 60,
+          "revenue_str": "H10-I11",
+          "nodes": [
+            "H10-0",
+            "I11-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 204,
+      "created_at": 1716578080,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 205,
+      "created_at": 1716578094
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 206,
+      "created_at": 1716578098
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 207,
+      "created_at": 1716578146
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 208,
+      "created_at": 1716578155
+    },
+    {
+      "type": "run_routes",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 209,
+      "created_at": 1716578159,
+      "routes": [
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "B6",
+              "A7"
+            ]
+          ],
+          "hexes": [
+            "B6",
+            "A7"
+          ],
+          "revenue": 40,
+          "revenue_str": "B6-A7",
+          "nodes": [
+            "B6-0",
+            "A7-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "B6",
+              "C7"
+            ]
+          ],
+          "hexes": [
+            "B6",
+            "C7"
+          ],
+          "revenue": 40,
+          "revenue_str": "B6-C7",
+          "nodes": [
+            "B6-0",
+            "C7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 210,
+      "created_at": 1716578160,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 211,
+      "created_at": 1716578168
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 212,
+      "created_at": 1716578170
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 213,
+      "created_at": 1716578180,
+      "hex": "A3",
+      "tile": "9-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 214,
+      "created_at": 1716578182
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 215,
+      "created_at": 1716578208
+    },
+    {
+      "type": "run_routes",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 216,
+      "created_at": 1716578212,
+      "routes": [
+        {
+          "train": "2-8",
+          "connections": [
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "A9"
+          ],
+          "revenue": 50,
+          "revenue_str": "A7-A9",
+          "nodes": [
+            "A7-0",
+            "A9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 217,
+      "created_at": 1716578216,
+      "kind": "payout"
+    },
+    {
+      "type": "take_loan",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 218,
+      "created_at": 1716578225,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 219,
+      "created_at": 1716578227,
+      "train": "2+-1",
+      "price": 100,
+      "variant": "2+"
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 220,
+      "created_at": 1716578234
+    },
+    {
+      "type": "pass",
+      "entity": "GT",
+      "entity_type": "corporation",
+      "id": 221,
+      "created_at": 1716578246
+    },
+    {
+      "type": "program_merger_pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 222,
+      "created_at": 1716578429,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "J",
+          "entity_type": "corporation",
+          "created_at": 1716578429
+        }
+      ],
+      "corporations_by_round": {
+        "AR": [
+          "J"
+        ],
+        "MR": [
+          "J"
+        ]
+      },
+      "options": []
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 223,
+      "created_at": 1716578454
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 224,
+      "created_at": 1716578463
+    },
+    {
+      "type": "merge",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 225,
+      "created_at": 1716578477,
+      "corporation": "GT"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 226,
+      "created_at": 1716578495,
+      "shares": [
+        "DL&W_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 227,
+      "created_at": 1716580998
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 228,
+      "created_at": 1716581107
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 229,
+      "created_at": 1716581110
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 230,
+      "created_at": 1716581140
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 231,
+      "created_at": 1716581141,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716581141
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 232,
+      "created_at": 1716581242,
+      "shares": [
+        "H_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "short",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 233,
+      "created_at": 1716581399,
+      "corporation": "NYOW"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 234,
+      "created_at": 1716581405,
+      "shares": [
+        "J_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 235,
+      "created_at": 1716581925,
+      "shares": [
+        "H_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 236,
+      "created_at": 1716581930,
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 237,
+      "created_at": 1716581974,
+      "shares": [
+        "DL&W_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 238,
+      "created_at": 1716582139,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716582138
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "short",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 239,
+      "created_at": 1716582264,
+      "corporation": "NYOW"
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 240,
+      "created_at": 1716582273,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716582272,
+          "reason": "Short bought"
+        }
+      ]
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 241,
+      "created_at": 1716582346,
+      "corporation": "DL&W",
+      "until_condition": 0,
+      "from_market": true,
+      "auto_pass_after": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 242,
+      "created_at": 1716582437,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716582437
+        },
+        {
+          "type": "buy_shares",
+          "entity": 621,
+          "entity_type": "player",
+          "created_at": 1716582437,
+          "shares": [
+            "DL&W_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716582437,
+          "reason": "Short bought"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 243,
+      "created_at": 1716582646,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716582646
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 244,
+      "created_at": 1716582806,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2006,
+          "entity_type": "player",
+          "created_at": 1716582806
+        },
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716582806
+        },
+        {
+          "type": "buy_shares",
+          "entity": 621,
+          "entity_type": "player",
+          "created_at": 1716582806,
+          "shares": [
+            "DL&W_6"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716582806
+        },
+        {
+          "type": "pass",
+          "entity": 2006,
+          "entity_type": "player",
+          "created_at": 1716582806
+        },
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716582806
+        },
+        {
+          "type": "buy_shares",
+          "entity": 621,
+          "entity_type": "player",
+          "created_at": 1716582806,
+          "shares": [
+            "DL&W_11"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716582806
+        },
+        {
+          "type": "pass",
+          "entity": 2006,
+          "entity_type": "player",
+          "created_at": 1716582806
+        },
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716582806
+        },
+        {
+          "type": "buy_shares",
+          "entity": 621,
+          "entity_type": "player",
+          "created_at": 1716582806,
+          "shares": [
+            "DL&W_13"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716582806
+        },
+        {
+          "type": "pass",
+          "entity": 2006,
+          "entity_type": "player",
+          "created_at": 1716582806
+        },
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716582806
+        },
+        {
+          "type": "program_disable",
+          "entity": 621,
+          "entity_type": "player",
+          "created_at": 1716582806,
+          "reason": "0 share(s) bought in DL&W, end condition met"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "take_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 245,
+      "created_at": 1716582901,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 246,
+      "created_at": 1716582904,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 247,
+      "created_at": 1716582907,
+      "loan": 0
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 248,
+      "created_at": 1716582915,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716582914,
+          "reason": "NYOW took a loan"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 249,
+      "created_at": 1716583062,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716583062
+        },
+        {
+          "type": "program_disable",
+          "entity": 2006,
+          "entity_type": "player",
+          "created_at": 1716583062,
+          "reason": "NYOW took a loan"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 250,
+      "created_at": 1716583240,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716583240,
+          "reason": "NYOW took a loan"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 251,
+      "created_at": 1716583448,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716583448
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 252,
+      "created_at": 1716583816
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 253,
+      "created_at": 1716583921
+    },
+    {
+      "type": "run_routes",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 254,
+      "created_at": 1716583924,
+      "routes": [
+        {
+          "train": "2+-0",
+          "connections": [
+            [
+              "H4",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I3"
+          ],
+          "revenue": 60,
+          "revenue_str": "H4-I3",
+          "nodes": [
+            "H4-0",
+            "I3-0"
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "H4",
+              "H2",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I3"
+          ],
+          "revenue": 60,
+          "revenue_str": "H4-I3",
+          "nodes": [
+            "H4-0",
+            "I3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 255,
+      "created_at": 1716583926,
+      "kind": "payout"
+    },
+    {
+      "type": "take_loan",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 256,
+      "created_at": 1716583944,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 257,
+      "created_at": 1716583948,
+      "train": "3-0",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 258,
+      "created_at": 1716583960
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 259,
+      "created_at": 1716584323,
+      "hex": "G9",
+      "tile": "592H-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 260,
+      "created_at": 1716584335
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 261,
+      "created_at": 1716584337
+    },
+    {
+      "type": "run_routes",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 262,
+      "created_at": 1716584341,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "H8"
+          ],
+          "revenue": 40,
+          "revenue_str": "G9-H8",
+          "nodes": [
+            "G9-0",
+            "H8-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G9",
+              "G11",
+              "G13"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "G13"
+          ],
+          "revenue": 50,
+          "revenue_str": "G9-G13",
+          "nodes": [
+            "G9-0",
+            "G13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 263,
+      "created_at": 1716584346,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 264,
+      "created_at": 1716584349,
+      "train": "3-1",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 265,
+      "created_at": 1716584354
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 266,
+      "created_at": 1716584357
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 267,
+      "created_at": 1716584367,
+      "hex": "H10",
+      "tile": "592H-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 268,
+      "created_at": 1716584371
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 269,
+      "created_at": 1716584375
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 270,
+      "created_at": 1716584379,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "H10",
+              "I11"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "I11"
+          ],
+          "revenue": 40,
+          "revenue_str": "H10-I11",
+          "nodes": [
+            "H10-0",
+            "I11-0"
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "H10",
+              "G11",
+              "G13"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "G13"
+          ],
+          "revenue": 50,
+          "revenue_str": "H10-G13",
+          "nodes": [
+            "H10-0",
+            "G13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 271,
+      "created_at": 1716584381,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 272,
+      "created_at": 1716584388,
+      "train": "3-2",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 273,
+      "created_at": 1716584393
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 274,
+      "created_at": 1716584397,
+      "loan": 66
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 275,
+      "created_at": 1716584402
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 276,
+      "created_at": 1716584482,
+      "hex": "C7",
+      "tile": "15-0",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MB",
+      "entity_type": "company",
+      "id": 277,
+      "created_at": 1716584494,
+      "hex": "D6",
+      "tile": "X00H-0",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 278,
+      "created_at": 1716584496,
+      "city": "X00H-0-0",
+      "slot": 0,
+      "tokener": "DL&W"
+    },
+    {
+      "type": "run_routes",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 279,
+      "created_at": 1716584504,
+      "routes": [
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "D6",
+              "C7"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "C7"
+          ],
+          "revenue": 60,
+          "revenue_str": "D6-C7",
+          "nodes": [
+            "D6-0",
+            "C7-0"
+          ]
+        },
+        {
+          "train": "2-8",
+          "connections": [
+            [
+              "A7",
+              "B6"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "B6"
+          ],
+          "revenue": 80,
+          "revenue_str": "A7-B6",
+          "nodes": [
+            "A7-0",
+            "B6-0"
+          ]
+        },
+        {
+          "train": "2-7",
+          "connections": [
+            [
+              "A7",
+              "A5"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "A5"
+          ],
+          "revenue": 80,
+          "revenue_str": "A7-A5",
+          "nodes": [
+            "A7-0",
+            "A5-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "A9"
+          ],
+          "revenue": 100,
+          "revenue_str": "A7-A9",
+          "nodes": [
+            "A7-0",
+            "A9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 280,
+      "user": 2006,
+      "created_at": 1716584516
+    },
+    {
+      "type": "undo",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 281,
+      "user": 2006,
+      "created_at": 1716584520
+    },
+    {
+      "type": "dividend",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 282,
+      "created_at": 1716584523,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 283,
+      "created_at": 1716584524,
+      "train": "3-3",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 284,
+      "created_at": 1716584533
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 285,
+      "created_at": 1716584536,
+      "loan": 69
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 286,
+      "created_at": 1716584540
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 287,
+      "created_at": 1716584763
+    },
+    {
+      "type": "program_merger_pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 288,
+      "created_at": 1716585083,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": "J",
+          "entity_type": "corporation",
+          "created_at": 1716585084
+        }
+      ],
+      "corporations_by_round": {
+        "AR": [
+          "J"
+        ],
+        "MR": [
+          "J"
+        ]
+      },
+      "options": []
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 289,
+      "created_at": 1716585459
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 290,
+      "created_at": 1716585460,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716585460
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 291,
+      "created_at": 1716585461
+    },
+    {
+      "hex": "H8",
+      "tile": "619-0",
+      "type": "lay_tile",
+      "entity": "H",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 292,
+      "user": 621,
+      "created_at": 1716585480
+    },
+    {
+      "type": "undo",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 293,
+      "user": 621,
+      "created_at": 1716585487
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 294,
+      "created_at": 1716585494,
+      "hex": "H8",
+      "tile": "15-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 295,
+      "created_at": 1716585498,
+      "hex": "H6",
+      "tile": "8-0",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 296,
+      "created_at": 1716585508,
+      "city": "592H-1-0",
+      "slot": 1,
+      "tokener": "H"
+    },
+    {
+      "type": "run_routes",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 297,
+      "created_at": 1716585520,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "G9"
+            ],
+            [
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G13",
+            "G9",
+            "H8"
+          ],
+          "revenue": 80,
+          "revenue_str": "G13-G9-H8",
+          "nodes": [
+            "G13-0",
+            "G9-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 298,
+      "created_at": 1716585525,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 299,
+      "created_at": 1716585530
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 300,
+      "created_at": 1716585536
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 301,
+      "created_at": 1716585594,
+      "hex": "H4",
+      "tile": "15-2",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 302,
+      "created_at": 1716585599,
+      "hex": "I5",
+      "tile": "5-2",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 303,
+      "created_at": 1716585600,
+      "city": "5-2-0",
+      "slot": 0,
+      "tokener": "J"
+    },
+    {
+      "type": "run_routes",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 304,
+      "created_at": 1716585609,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "H4",
+              "I5"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I5"
+          ],
+          "revenue": 50,
+          "revenue_str": "H4-I5",
+          "nodes": [
+            "H4-0",
+            "I5-0"
+          ]
+        },
+        {
+          "train": "2+-0",
+          "connections": [
+            [
+              "I5",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "I5",
+            "I3"
+          ],
+          "revenue": 70,
+          "revenue_str": "I5-I3",
+          "nodes": [
+            "I5-0",
+            "I3-0"
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "H4",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I3"
+          ],
+          "revenue": 80,
+          "revenue_str": "H4-I3",
+          "nodes": [
+            "H4-0",
+            "I3-0"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "H4",
+              "H2",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I3"
+          ],
+          "revenue": 80,
+          "revenue_str": "H4-I3",
+          "nodes": [
+            "H4-0",
+            "I3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 305,
+      "created_at": 1716585611,
+      "kind": "payout"
+    },
+    {
+      "type": "undo",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 306,
+      "user": 2072,
+      "created_at": 1716585624
+    },
+    {
+      "type": "redo",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 307,
+      "user": 2072,
+      "created_at": 1716585627
+    },
+    {
+      "type": "take_loan",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 308,
+      "created_at": 1716585633,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 309,
+      "created_at": 1716585635,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 310,
+      "created_at": 1716585639,
+      "train": "3-5",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 311,
+      "created_at": 1716585665
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 312,
+      "created_at": 1716585730,
+      "hex": "G7",
+      "tile": "57-3",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 313,
+      "created_at": 1716585735
+    },
+    {
+      "type": "place_token",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 314,
+      "created_at": 1716585740,
+      "city": "592H-0-0",
+      "slot": 1,
+      "tokener": "NYOW"
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 315,
+      "created_at": 1716585744,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "G9"
+            ],
+            [
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G13",
+            "G9",
+            "H8"
+          ],
+          "revenue": 80,
+          "revenue_str": "G13-G9-H8",
+          "nodes": [
+            "G13-0",
+            "G9-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 316,
+      "created_at": 1716585749,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 317,
+      "created_at": 1716585753
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 318,
+      "created_at": 1716585778
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 319,
+      "created_at": 1716585786,
+      "hex": "D6",
+      "tile": "592H2-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 320,
+      "created_at": 1716585792
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 321,
+      "created_at": 1716585798
+    },
+    {
+      "type": "run_routes",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 322,
+      "created_at": 1716585804,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "A7",
+              "A5"
+            ],
+            [
+              "A5",
+              "A3",
+              "A1"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "A5",
+            "A1"
+          ],
+          "revenue": 120,
+          "revenue_str": "A7-A5-A1",
+          "nodes": [
+            "A7-0",
+            "A5-0",
+            "A1-0"
+          ]
+        },
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "A9"
+          ],
+          "revenue": 100,
+          "revenue_str": "A7-A9",
+          "nodes": [
+            "A7-0",
+            "A9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 323,
+      "user": 2006,
+      "created_at": 1716585810
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 324,
+      "user": 2006,
+      "created_at": 1716585815
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 325,
+      "user": 2006,
+      "created_at": 1716585820
+    },
+    {
+      "type": "undo",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 326,
+      "user": 2006,
+      "created_at": 1716585914
+    },
+    {
+      "type": "undo",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 327,
+      "user": 2006,
+      "created_at": 1716585916
+    },
+    {
+      "type": "undo",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 328,
+      "user": 2006,
+      "created_at": 1716585918
+    },
+    {
+      "type": "dividend",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 329,
+      "created_at": 1716585920,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 330,
+      "created_at": 1716585922
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 331,
+      "created_at": 1716585924
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 332,
+      "created_at": 1716585986
+    },
+    {
+      "type": "convert",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 333,
+      "created_at": 1716587716
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 334,
+      "created_at": 1716587717,
+      "shares": [
+        "J_10"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 335,
+      "created_at": 1716587718,
+      "shares": [
+        "J_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 336,
+      "created_at": 1716587719,
+      "shares": [
+        "J_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 337,
+      "created_at": 1716588900
+    },
+    {
+      "type": "undo",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 338,
+      "user": 5649,
+      "created_at": 1716895431
+    },
+    {
+      "type": "redo",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 339,
+      "user": 5649,
+      "created_at": 1716895684
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 340,
+      "created_at": 1716895691,
+      "shares": [
+        "J_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 341,
+      "created_at": 1716895731
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 342,
+      "created_at": 1716899635
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 343,
+      "created_at": 1716900926
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 344,
+      "created_at": 1716901341
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 345,
+      "created_at": 1716901456
+    },
+    {
+      "type": "pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 346,
+      "created_at": 1716904045
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 347,
+      "created_at": 1716908437
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 348,
+      "created_at": 1716908704,
+      "shares": [
+        "J_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 349,
+      "created_at": 1716910615,
+      "shares": [
+        "NYOW_10"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 350,
+      "created_at": 1716910822,
+      "shares": [
+        "H_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 351,
+      "created_at": 1716910831,
+      "shares": [
+        "DL&W_15"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 352,
+      "created_at": 1716910978,
+      "corporation": "DL&W",
+      "until_condition": 2,
+      "from_market": true,
+      "auto_pass_after": true
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 353,
+      "created_at": 1716910982,
+      "corporation": "DL&W",
+      "until_condition": 2,
+      "from_market": true,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 354,
+      "created_at": 1716911182,
+      "shares": [
+        "H_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 355,
+      "created_at": 1716911282,
+      "shares": [
+        "NYOW_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 356,
+      "created_at": 1716911286,
+      "shares": [
+        "J_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 357,
+      "created_at": 1716919520,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716919519,
+          "reason": "Shares were sold"
+        }
+      ],
+      "shares": [
+        "NYOW_12"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 358,
+      "created_at": 1716919615,
+      "shares": [
+        "DL&W_17"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 359,
+      "created_at": 1716919670,
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 360,
+      "created_at": 1716920332,
+      "shares": [
+        "DL&W_19"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 361,
+      "created_at": 1716920408,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716920407
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 362,
+      "created_at": 1716923150,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2072,
+          "entity_type": "player",
+          "created_at": 1716923150
+        }
+      ],
+      "shares": [
+        "NYOW_14"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 363,
+      "created_at": 1716923328,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 621,
+          "entity_type": "player",
+          "created_at": 1716923327
+        },
+        {
+          "type": "pass",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716923327
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 364,
+      "created_at": 1716924176,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2006,
+          "entity_type": "player",
+          "created_at": 1716924176
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "hex": "G3",
+      "tile": "8-1",
+      "type": "lay_tile",
+      "entity": "J",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 365,
+      "user": 2072,
+      "created_at": 1716924235
+    },
+    {
+      "hex": "F4",
+      "tile": "6-3",
+      "type": "lay_tile",
+      "entity": "J",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 366,
+      "user": 2072,
+      "created_at": 1716924241
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 367,
+      "user": 2072,
+      "created_at": 1716924243
+    },
+    {
+      "type": "run_routes",
+      "entity": "J",
+      "routes": [
+        {
+          "hexes": [
+            "H4",
+            "I5",
+            "I3"
+          ],
+          "nodes": [
+            "H4-0",
+            "I5-0",
+            "I3-0"
+          ],
+          "train": "3-5",
+          "revenue": 100,
+          "connections": [
+            [
+              "H4",
+              "I5"
+            ],
+            [
+              "I5",
+              "I3"
+            ]
+          ],
+          "revenue_str": "H4-I5-I3"
+        },
+        {
+          "hexes": [
+            "I3",
+            "H4",
+            "F4"
+          ],
+          "nodes": [
+            "I3-0",
+            "H4-0",
+            "F4-0"
+          ],
+          "train": "3-0",
+          "revenue": 100,
+          "connections": [
+            [
+              "I3",
+              "H4"
+            ],
+            [
+              "H4",
+              "G3",
+              "F4"
+            ]
+          ],
+          "revenue_str": "I3-H4-F4"
+        },
+        {
+          "hexes": [
+            "H4",
+            "I3"
+          ],
+          "nodes": [
+            "H4-0",
+            "I3-0"
+          ],
+          "train": "2+-0",
+          "revenue": 80,
+          "connections": [
+            [
+              "H4",
+              "H2",
+              "I3"
+            ]
+          ],
+          "revenue_str": "H4-I3"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 368,
+      "user": 2072,
+      "created_at": 1716924254
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 369,
+      "user": 2072,
+      "created_at": 1716924263
+    },
+    {
+      "type": "undo",
+      "entity": "J",
+      "action_id": 364,
+      "entity_type": "corporation",
+      "id": 370,
+      "user": 2072,
+      "created_at": 1716924298
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 371,
+      "created_at": 1716924300,
+      "hex": "G3",
+      "tile": "8-1",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 372,
+      "created_at": 1716924303,
+      "hex": "F4",
+      "tile": "6-3",
+      "rotation": 4
+    },
+    {
+      "type": "place_token",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 373,
+      "created_at": 1716924314,
+      "city": "6-3-0",
+      "slot": 0,
+      "tokener": "J"
+    },
+    {
+      "type": "run_routes",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 374,
+      "created_at": 1716924318,
+      "routes": [
+        {
+          "train": "3-5",
+          "connections": [
+            [
+              "H4",
+              "I5"
+            ],
+            [
+              "I5",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I5",
+            "I3"
+          ],
+          "revenue": 100,
+          "revenue_str": "H4-I5-I3",
+          "nodes": [
+            "H4-0",
+            "I5-0",
+            "I3-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "F4",
+              "G3",
+              "H4"
+            ],
+            [
+              "H4",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "F4",
+            "H4",
+            "I3"
+          ],
+          "revenue": 100,
+          "revenue_str": "F4-H4-I3",
+          "nodes": [
+            "F4-0",
+            "H4-0",
+            "I3-0"
+          ]
+        },
+        {
+          "train": "2+-0",
+          "connections": [
+            [
+              "H4",
+              "H2",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I3"
+          ],
+          "revenue": 80,
+          "revenue_str": "H4-I3",
+          "nodes": [
+            "H4-0",
+            "I3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 375,
+      "created_at": 1716924319,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 376,
+      "created_at": 1716924325,
+      "train": "3-7",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 377,
+      "created_at": 1716924331,
+      "loan": 68
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 378,
+      "created_at": 1716924336,
+      "loan": 68
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 379,
+      "created_at": 1716924338,
+      "loan": 68
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 380,
+      "created_at": 1716924347
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 381,
+      "created_at": 1716924470,
+      "hex": "G7",
+      "tile": "14-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 382,
+      "created_at": 1716924475,
+      "hex": "F6",
+      "tile": "57-4",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 383,
+      "created_at": 1716924491,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "G9"
+            ],
+            [
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G13",
+            "G9",
+            "H8"
+          ],
+          "revenue": 80,
+          "revenue_str": "G13-G9-H8",
+          "nodes": [
+            "G13-0",
+            "G9-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 384,
+      "created_at": 1716924493,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 385,
+      "created_at": 1716924519
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 386,
+      "created_at": 1716924520,
+      "loan": 67
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 387,
+      "created_at": 1716924522
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 388,
+      "created_at": 1716924577,
+      "hex": "B6",
+      "tile": "14-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 389,
+      "created_at": 1716924585
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 390,
+      "created_at": 1716924588
+    },
+    {
+      "type": "run_routes",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 391,
+      "created_at": 1716924599,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "A7",
+              "A5"
+            ],
+            [
+              "A5",
+              "A3",
+              "A1"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "A5",
+            "A1"
+          ],
+          "revenue": 120,
+          "revenue_str": "A7-A5-A1",
+          "nodes": [
+            "A7-0",
+            "A5-0",
+            "A1-0"
+          ]
+        },
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "A9"
+          ],
+          "revenue": 100,
+          "revenue_str": "A7-A9",
+          "nodes": [
+            "A7-0",
+            "A9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 392,
+      "created_at": 1716924603,
+      "kind": "half"
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 393,
+      "created_at": 1716924607
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 394,
+      "created_at": 1716924616
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 395,
+      "created_at": 1716924673,
+      "hex": "F6",
+      "tile": "619-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 396,
+      "created_at": 1716924678
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 397,
+      "created_at": 1716924680
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 398,
+      "created_at": 1716924685,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "G9"
+            ],
+            [
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G13",
+            "G9",
+            "H8"
+          ],
+          "revenue": 80,
+          "revenue_str": "G13-G9-H8",
+          "nodes": [
+            "G13-0",
+            "G9-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 399,
+      "created_at": 1716924690,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 400,
+      "created_at": 1716924695
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 401,
+      "created_at": 1716924700
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 402,
+      "created_at": 1716924704
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 403,
+      "created_at": 1716924706
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 404,
+      "created_at": 1716924708
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 405,
+      "created_at": 1716924718
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 406,
+      "created_at": 1716924739
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 407,
+      "created_at": 1716924760,
+      "hex": "F4",
+      "tile": "619-1",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 408,
+      "created_at": 1716924762,
+      "hex": "G5",
+      "tile": "8-2",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 409,
+      "created_at": 1716924768
+    },
+    {
+      "type": "run_routes",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 410,
+      "created_at": 1716924778,
+      "routes": [
+        {
+          "train": "3-7",
+          "connections": [
+            [
+              "F4",
+              "G5",
+              "G7"
+            ],
+            [
+              "G7",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "F4",
+            "G7",
+            "H8"
+          ],
+          "revenue": 90,
+          "revenue_str": "F4-G7-H8",
+          "nodes": [
+            "F4-0",
+            "G7-0",
+            "H8-0"
+          ]
+        },
+        {
+          "train": "3-5",
+          "connections": [
+            [
+              "H4",
+              "I5"
+            ],
+            [
+              "I5",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I5",
+            "I3"
+          ],
+          "revenue": 100,
+          "revenue_str": "H4-I5-I3",
+          "nodes": [
+            "H4-0",
+            "I5-0",
+            "I3-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "F4",
+              "G3",
+              "H4"
+            ],
+            [
+              "H4",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "F4",
+            "H4",
+            "I3"
+          ],
+          "revenue": 110,
+          "revenue_str": "F4-H4-I3",
+          "nodes": [
+            "F4-0",
+            "H4-0",
+            "I3-0"
+          ]
+        },
+        {
+          "train": "2+-0",
+          "connections": [
+            [
+              "H4",
+              "H2",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I3"
+          ],
+          "revenue": 80,
+          "revenue_str": "H4-I3",
+          "nodes": [
+            "H4-0",
+            "I3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 411,
+      "created_at": 1716924799,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 412,
+      "created_at": 1716924824
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 413,
+      "created_at": 1716924955,
+      "hex": "E7",
+      "tile": "14-2",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 414,
+      "created_at": 1716924960
+    },
+    {
+      "type": "run_routes",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 415,
+      "created_at": 1716924973,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "G9"
+            ],
+            [
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G13",
+            "G9",
+            "H8"
+          ],
+          "revenue": 80,
+          "revenue_str": "G13-G9-H8",
+          "nodes": [
+            "G13-0",
+            "G9-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 416,
+      "created_at": 1716924977,
+      "kind": "payout"
+    },
+    {
+      "type": "take_loan",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 417,
+      "created_at": 1716924989,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 418,
+      "created_at": 1716924990,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 419,
+      "created_at": 1716924991,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 420,
+      "created_at": 1716924993,
+      "train": "3-9",
+      "price": 250,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 421,
+      "created_at": 1716924997
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 422,
+      "created_at": 1716925007
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 423,
+      "created_at": 1716925021
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 424,
+      "created_at": 1716925030
+    },
+    {
+      "type": "run_routes",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 425,
+      "created_at": 1716925037,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "A7",
+              "A5"
+            ],
+            [
+              "A5",
+              "A3",
+              "A1"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "A5",
+            "A1"
+          ],
+          "revenue": 120,
+          "revenue_str": "A7-A5-A1",
+          "nodes": [
+            "A7-0",
+            "A5-0",
+            "A1-0"
+          ]
+        },
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "A9"
+          ],
+          "revenue": 100,
+          "revenue_str": "A7-A9",
+          "nodes": [
+            "A7-0",
+            "A9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 426,
+      "created_at": 1716925041,
+      "loan": 0
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 427,
+      "user": 2006,
+      "created_at": 1716925042
+    },
+    {
+      "type": "undo",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 428,
+      "user": 2006,
+      "created_at": 1716925054
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 429,
+      "user": 2006,
+      "created_at": 1716925059
+    },
+    {
+      "type": "undo",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 430,
+      "user": 2006,
+      "created_at": 1716925062
+    },
+    {
+      "type": "take_loan",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 431,
+      "created_at": 1716925065,
+      "loan": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 432,
+      "created_at": 1716925066,
+      "kind": "half"
+    },
+    {
+      "type": "buy_train",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 433,
+      "created_at": 1716925067,
+      "train": "4-0",
+      "price": 400,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 434,
+      "created_at": 1716925071
+    },
+    {
+      "type": "discard_train",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 435,
+      "created_at": 1716925298,
+      "train": "2+-0"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 436,
+      "created_at": 1716925807,
+      "hex": "H10",
+      "tile": "593H-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 437,
+      "created_at": 1716925810
+    },
+    {
+      "type": "place_token",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 438,
+      "created_at": 1716925820,
+      "city": "592H2-0-0",
+      "slot": 1,
+      "tokener": "NYOW"
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 439,
+      "created_at": 1716925825,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "H10"
+            ],
+            [
+              "H10",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "G13",
+            "H10",
+            "H8"
+          ],
+          "revenue": 130,
+          "revenue_str": "G13-H10-H8",
+          "nodes": [
+            "G13-0",
+            "H10-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 440,
+      "user": 621,
+      "created_at": 1716925827
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 441,
+      "user": 621,
+      "created_at": 1716925837
+    },
+    {
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 442,
+      "created_at": 1716925839,
+      "kind": "withhold"
+    },
+    {
+      "type": "take_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 443,
+      "created_at": 1716925847,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 444,
+      "created_at": 1716925849,
+      "loan": 0
+    },
+    {
+      "type": "take_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 445,
+      "created_at": 1716925850,
+      "loan": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 446,
+      "created_at": 1716925853,
+      "train": "4-1",
+      "price": 400,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 447,
+      "created_at": 1716925856
+    },
+    {
+      "type": "convert",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 448,
+      "created_at": 1716925876
+    },
+    {
+      "type": "buy_shares",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 449,
+      "created_at": 1716925882,
+      "shares": [
+        "H_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 450,
+      "created_at": 1716925883,
+      "shares": [
+        "H_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 451,
+      "created_at": 1716925884,
+      "shares": [
+        "H_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 452,
+      "created_at": 1716926586,
+      "shares": [
+        "H_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 453,
+      "created_at": 1716926846
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 454,
+      "created_at": 1716928349,
+      "shares": [
+        "H_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 455,
+      "created_at": 1716928442
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 456,
+      "created_at": 1716928451
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 457,
+      "created_at": 1716928452
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 458,
+      "created_at": 1716928533
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 459,
+      "created_at": 1716928636
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 460,
+      "created_at": 1716932967,
+      "shares": [
+        "NYOW_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 461,
+      "created_at": 1716933774,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 621,
+          "entity_type": "player",
+          "created_at": 1716933772
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 462,
+      "created_at": 1716934727,
+      "shares": [
+        "H_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 463,
+      "user": 2006,
+      "created_at": 1716935078
+    },
+    {
+      "type": "undo",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 464,
+      "user": 2006,
+      "created_at": 1716935082
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 465,
+      "created_at": 1716935113,
+      "shares": [
+        "NYOW_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 466,
+      "created_at": 1716935666,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 621,
+          "entity_type": "player",
+          "created_at": 1716935664
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 467,
+      "created_at": 1716991326,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 5649,
+          "entity_type": "player",
+          "created_at": 1716991325
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 468,
+      "created_at": 1716992687,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2006,
+          "entity_type": "player",
+          "created_at": 1716992685
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 469,
+      "created_at": 1716993662,
+      "hex": "H4",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 470,
+      "created_at": 1716993675,
+      "hex": "E3",
+      "tile": "8-3",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 471,
+      "created_at": 1716993683
+    },
+    {
+      "type": "run_routes",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 472,
+      "created_at": 1716993701,
+      "routes": [
+        {
+          "train": "3-7",
+          "connections": [
+            [
+              "H4",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I3"
+          ],
+          "revenue": 110,
+          "revenue_str": "H4-I3",
+          "nodes": [
+            "H4-0",
+            "I3-0"
+          ]
+        },
+        {
+          "train": "3-5",
+          "connections": [
+            [
+              "H4",
+              "I5"
+            ],
+            [
+              "I5",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H4",
+            "I5",
+            "I3"
+          ],
+          "revenue": 130,
+          "revenue_str": "H4-I5-I3",
+          "nodes": [
+            "H4-0",
+            "I5-0",
+            "I3-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "F4",
+              "G3",
+              "H4"
+            ],
+            [
+              "H4",
+              "H2",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "F4",
+            "H4",
+            "I3"
+          ],
+          "revenue": 140,
+          "revenue_str": "F4-H4-I3",
+          "nodes": [
+            "F4-0",
+            "H4-0",
+            "I3-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 473,
+      "created_at": 1716993731,
+      "kind": "half"
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 474,
+      "created_at": 1716993734,
+      "loan": 68
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 475,
+      "created_at": 1716993743
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 476,
+      "created_at": 1716994409,
+      "hex": "G9",
+      "tile": "593H-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 477,
+      "created_at": 1716994417
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 478,
+      "created_at": 1716994419
+    },
+    {
+      "type": "run_routes",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 479,
+      "created_at": 1716994430,
+      "routes": [
+        {
+          "train": "3-9",
+          "connections": [
+            [
+              "G9",
+              "H8"
+            ],
+            [
+              "H8",
+              "H10"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "H8",
+            "H10"
+          ],
+          "revenue": 150,
+          "revenue_str": "G9-H8-H10",
+          "nodes": [
+            "G9-0",
+            "H8-0",
+            "H10-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "H10",
+              "G9"
+            ],
+            [
+              "G9",
+              "G11",
+              "G13"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "G9",
+            "G13"
+          ],
+          "revenue": 160,
+          "revenue_str": "H10-G9-G13",
+          "nodes": [
+            "H10-0",
+            "G9-0",
+            "G13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 480,
+      "user": 621,
+      "created_at": 1716994433
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 481,
+      "user": 621,
+      "created_at": 1716994439
+    },
+    {
+      "type": "undo",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 482,
+      "user": 621,
+      "created_at": 1716994448
+    },
+    {
+      "type": "undo",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 483,
+      "user": 621,
+      "created_at": 1716994449
+    },
+    {
+      "type": "dividend",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 484,
+      "created_at": 1716994452,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 485,
+      "created_at": 1716994453
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 486,
+      "created_at": 1716994468,
+      "loan": 67
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 487,
+      "created_at": 1716994469,
+      "loan": 67
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 488,
+      "created_at": 1716994477
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 489,
+      "created_at": 1716994688,
+      "hex": "A5",
+      "tile": "15-2",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 490,
+      "created_at": 1716994690
+    },
+    {
+      "type": "place_token",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 491,
+      "created_at": 1716994699,
+      "city": "15-0-0",
+      "slot": 0,
+      "tokener": "DL&W"
+    },
+    {
+      "type": "run_routes",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 492,
+      "created_at": 1716994706,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "D6",
+              "E7"
+            ],
+            [
+              "E7",
+              "F8"
+            ],
+            [
+              "F8",
+              "G9"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "E7",
+            "F8",
+            "G9"
+          ],
+          "revenue": 160,
+          "revenue_str": "D6-E7-F8-G9",
+          "nodes": [
+            "D6-0",
+            "E7-0",
+            "F8-0",
+            "G9-0"
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "D6",
+              "C7"
+            ],
+            [
+              "C7",
+              "D8",
+              "D10"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "C7",
+            "D10"
+          ],
+          "revenue": 130,
+          "revenue_str": "D6-C7-D10",
+          "nodes": [
+            "D6-0",
+            "C7-0",
+            "D10-0"
+          ]
+        },
+        {
+          "train": "2+-1",
+          "connections": [
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "A7",
+            "A9"
+          ],
+          "revenue": 100,
+          "revenue_str": "A7-A9",
+          "nodes": [
+            "A7-0",
+            "A9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 493,
+      "created_at": 1716994714,
+      "kind": "half"
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 494,
+      "created_at": 1716994719
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 495,
+      "created_at": 1716994720,
+      "loan": 64
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 496,
+      "created_at": 1716994723,
+      "loan": 64
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 497,
+      "created_at": 1716994728
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 498,
+      "created_at": 1716994787,
+      "hex": "G7",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 499,
+      "created_at": 1716994793
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 500,
+      "created_at": 1716994796,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "H10",
+              "H8"
+            ],
+            [
+              "H8",
+              "G9"
+            ],
+            [
+              "G9",
+              "F8"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "H8",
+            "G9",
+            "F8"
+          ],
+          "revenue": 170,
+          "revenue_str": "H10-H8-G9-F8",
+          "nodes": [
+            "H10-0",
+            "H8-0",
+            "G9-0",
+            "F8-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "H10",
+              "G9"
+            ],
+            [
+              "G9",
+              "G11",
+              "G13"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "G9",
+            "G13"
+          ],
+          "revenue": 160,
+          "revenue_str": "H10-G9-G13",
+          "nodes": [
+            "H10-0",
+            "G9-0",
+            "G13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 501,
+      "created_at": 1716994801,
+      "kind": "half"
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 502,
+      "created_at": 1716994804
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 503,
+      "created_at": 1716994806,
+      "loan": 66
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 504,
+      "created_at": 1716994807,
+      "loan": 66
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 505,
+      "created_at": 1716994812
+    },
+    {
+      "type": "convert",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 506,
+      "created_at": 1716994824
+    },
+    {
+      "type": "buy_shares",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 507,
+      "created_at": 1716994826,
+      "shares": [
+        "NYOW_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 508,
+      "created_at": 1716994827,
+      "shares": [
+        "NYOW_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 509,
+      "created_at": 1716994828,
+      "shares": [
+        "NYOW_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 5649,
+      "entity_type": "player",
+      "id": 510,
+      "created_at": 1716999860,
+      "shares": [
+        "NYOW_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2006,
+      "entity_type": "player",
+      "id": 511,
+      "created_at": 1717001194,
+      "shares": [
+        "NYOW_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 512,
+      "created_at": 1717001881
+    },
+    {
+      "type": "program_merger_pass",
+      "entity": 2072,
+      "entity_type": "player",
+      "id": 513,
+      "created_at": 1717001886,
+      "corporations_by_round": {
+        "AR": [
+          "J"
+        ],
+        "MR": [
+          "J"
+        ]
+      },
+      "options": []
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 514,
+      "created_at": 1717002226
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 515,
+      "created_at": 1717002228
+    },
+    {
+      "hex": "G5",
+      "tile": "81-0",
+      "type": "lay_tile",
+      "entity": "J",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 516,
+      "user": 2072,
+      "created_at": 1717005261
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 517,
+      "user": 2072,
+      "created_at": 1717005275
+    },
+    {
+      "city": "593H-1-0",
+      "slot": 2,
+      "type": "place_token",
+      "entity": "J",
+      "tokener": "J",
+      "entity_type": "corporation",
+      "id": 518,
+      "user": 2072,
+      "created_at": 1717005281
+    },
+    {
+      "type": "undo",
+      "entity": "J",
+      "action_id": 515,
+      "entity_type": "corporation",
+      "id": 519,
+      "user": 2072,
+      "created_at": 1717005302
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 520,
+      "created_at": 1717005342,
+      "hex": "G5",
+      "tile": "81-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 521,
+      "created_at": 1717005347
+    },
+    {
+      "type": "place_token",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 522,
+      "created_at": 1717005350,
+      "city": "593H-1-0",
+      "slot": 2,
+      "tokener": "J"
+    },
+    {
+      "type": "run_routes",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 523,
+      "created_at": 1717005405,
+      "routes": [
+        {
+          "train": "3-7",
+          "connections": [
+            [
+              "G9",
+              "H8"
+            ],
+            [
+              "H8",
+              "H10"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "H8",
+            "H10"
+          ],
+          "revenue": 150,
+          "revenue_str": "G9-H8-H10",
+          "nodes": [
+            "G9-0",
+            "H8-0",
+            "H10-0"
+          ]
+        },
+        {
+          "train": "3-5",
+          "connections": [
+            [
+              "I3",
+              "H4"
+            ],
+            [
+              "H4",
+              "G5",
+              "G7"
+            ]
+          ],
+          "hexes": [
+            "I3",
+            "H4",
+            "G7"
+          ],
+          "revenue": 150,
+          "revenue_str": "I3-H4-G7",
+          "nodes": [
+            "I3-0",
+            "H4-0",
+            "G7-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "G13",
+              "G11",
+              "G9"
+            ],
+            [
+              "G9",
+              "H10"
+            ]
+          ],
+          "hexes": [
+            "G13",
+            "G9",
+            "H10"
+          ],
+          "revenue": 160,
+          "revenue_str": "G13-G9-H10",
+          "nodes": [
+            "G13-0",
+            "G9-0",
+            "H10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "half",
+      "type": "dividend",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 524,
+      "user": 2072,
+      "created_at": 1717005426
+    },
+    {
+      "loan": 68,
+      "type": "payoff_loan",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 525,
+      "user": 2072,
+      "created_at": 1717005429
+    },
+    {
+      "type": "undo",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 526,
+      "user": 2072,
+      "created_at": 1717005446
+    },
+    {
+      "type": "undo",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 527,
+      "user": 2072,
+      "created_at": 1717005449
+    },
+    {
+      "type": "dividend",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 528,
+      "created_at": 1717005450,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 529,
+      "created_at": 1717005464
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 530,
+      "created_at": 1717017100,
+      "hex": "H8",
+      "tile": "63-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 531,
+      "created_at": 1717017105
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 532,
+      "created_at": 1717017122
+    },
+    {
+      "type": "run_routes",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 533,
+      "created_at": 1717017124,
+      "routes": [
+        {
+          "train": "3-9",
+          "connections": [
+            [
+              "G9",
+              "H8"
+            ],
+            [
+              "H8",
+              "H10"
+            ]
+          ],
+          "hexes": [
+            "G9",
+            "H8",
+            "H10"
+          ],
+          "revenue": 160,
+          "revenue_str": "G9-H8-H10",
+          "nodes": [
+            "G9-0",
+            "H8-0",
+            "H10-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "H10",
+              "G9"
+            ],
+            [
+              "G9",
+              "G11",
+              "G13"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "G9",
+            "G13"
+          ],
+          "revenue": 160,
+          "revenue_str": "H10-G9-G13",
+          "nodes": [
+            "H10-0",
+            "G9-0",
+            "G13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 534,
+      "created_at": 1717017131,
+      "kind": "half"
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 535,
+      "created_at": 1717017133
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 536,
+      "created_at": 1717017143,
+      "loan": 67
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 537,
+      "created_at": 1717017144
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 538,
+      "created_at": 1717019495,
+      "hex": "D6",
+      "tile": "593H2-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 539,
+      "created_at": 1717019497
+    },
+    {
+      "type": "run_routes",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 540,
+      "created_at": 1717019500,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "A1",
+              "A3",
+              "A5"
+            ],
+            [
+              "A5",
+              "A7"
+            ],
+            [
+              "A7",
+              "A9"
+            ]
+          ],
+          "hexes": [
+            "A1",
+            "A5",
+            "A7",
+            "A9"
+          ],
+          "revenue": 180,
+          "revenue_str": "A1-A5-A7-A9",
+          "nodes": [
+            "A1-0",
+            "A5-0",
+            "A7-0",
+            "A9-0"
+          ]
+        },
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "D6",
+              "E7"
+            ],
+            [
+              "E7",
+              "D8",
+              "D10"
+            ]
+          ],
+          "hexes": [
+            "D6",
+            "E7",
+            "D10"
+          ],
+          "revenue": 140,
+          "revenue_str": "D6-E7-D10",
+          "nodes": [
+            "D6-0",
+            "E7-0",
+            "D10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 541,
+      "created_at": 1717019502,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 542,
+      "created_at": 1717019502
+    },
+    {
+      "type": "pass",
+      "entity": "DL&W",
+      "entity_type": "corporation",
+      "id": 543,
+      "created_at": 1717019504
+    },
+    {
+      "type": "lay_tile",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 544,
+      "created_at": 1717027013,
+      "hex": "I5",
+      "tile": "15-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 545,
+      "created_at": 1717027023
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 546,
+      "created_at": 1717027023
+    },
+    {
+      "type": "run_routes",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 547,
+      "created_at": 1717027041,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "H10",
+              "H8"
+            ],
+            [
+              "H8",
+              "H6",
+              "I5"
+            ],
+            [
+              "I5",
+              "I3"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "H8",
+            "I5",
+            "I3"
+          ],
+          "revenue": 190,
+          "revenue_str": "H10-H8-I5-I3",
+          "nodes": [
+            "H10-0",
+            "H8-0",
+            "I5-0",
+            "I3-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "H10",
+              "G9"
+            ],
+            [
+              "G9",
+              "H8"
+            ]
+          ],
+          "hexes": [
+            "H10",
+            "G9",
+            "H8"
+          ],
+          "revenue": 160,
+          "revenue_str": "H10-G9-H8",
+          "nodes": [
+            "H10-0",
+            "G9-0",
+            "H8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 548,
+      "created_at": 1717027042,
+      "kind": "half"
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 549,
+      "created_at": 1717027052
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 550,
+      "created_at": 1717027053,
+      "loan": 66
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 551,
+      "created_at": 1717027059,
+      "loan": 66
+    },
+    {
+      "loan": 66,
+      "type": "payoff_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 552,
+      "user": 621,
+      "created_at": 1717027059
+    },
+    {
+      "loan": 0,
+      "type": "take_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 553,
+      "user": 621,
+      "created_at": 1717027060
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 554,
+      "user": 621,
+      "created_at": 1717027064
+    },
+    {
+      "type": "undo",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 555,
+      "user": 621,
+      "created_at": 1717027065
+    },
+    {
+      "type": "payoff_loan",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 556,
+      "created_at": 1717027066,
+      "loan": 66
+    },
+    {
+      "type": "pass",
+      "entity": "NYOW",
+      "entity_type": "corporation",
+      "id": 557,
+      "created_at": 1717027071
+    },
+    {
+      "type": "pass",
+      "entity": 621,
+      "entity_type": "player",
+      "id": 558,
+      "created_at": 1717027072
+    }
+  ],
+  "loaded": true,
+  "created_at": 1716387983,
+  "updated_at": 1717027072,
+  "finished_at": 1717027072
+}


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [n/a] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Adds a couple of fixture files for 18 Hiawatha

### Screenshots

### Any Assumptions / Hacks
