### PR TITLE
Fix issue checking playercount 

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -408,14 +408,9 @@ module View
     end
 
     def submit
-      title = selected_game_or_variant.title
-      return if !title && @mode != :json
+      return if !selected_game_or_variant && @mode != :json
 
       game_params = params
-      if game_params[:min_players].to_i < @min_p[title] || game_params[:max_players].to_i > @max_p[title]
-        return store(:flash_opts,
-                     'Invalid playercount')
-      end
 
       if @mode == :multi
         game_params[:seed] = game_params[:seed].to_i
@@ -522,9 +517,9 @@ module View
         max_players = max_p
         min_players = min_p
       else
-        # NOTE: Letters resolve to 0 when converted to integers
-        max_players = max_players_elm&.value.to_i
-        min_players = min_players_elm&.value.to_i
+        # Letters resolve to 0 when converted to integers
+        max_players = (val = max_players_elm&.value.to_i).zero? ? nil : val
+        min_players = (val = min_players_elm&.value.to_i).zero? ? nil : val
       end
       if max_players
         max_players = [max_players, min_p].max

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -412,7 +412,6 @@ module View
 
       game_params = params
 
-
       case @mode
       when :multi
         title = selected_game_or_variant&.title

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -412,10 +412,10 @@ module View
 
       game_params = params
 
-      title = selected_game_or_variant&.title
 
       case @mode
       when :multi
+        title = selected_game_or_variant&.title
         if game_params[:min_players].to_i < @min_p[title] || game_params[:max_players].to_i > @max_p[title]
           return store(:flash_opts,
                        'Invalid playercount')
@@ -444,8 +444,7 @@ module View
 
       players = game_params
       .select { |k, _| k.start_with?('player_') }
-      .values
-      .map { |name| name.gsub(/\s+/, ' ').strip }
+      .map { |_, name| name.gsub(/\s+/, ' ').strip }
 
       return store(:flash_opts, 'Cannot have duplicate player names') if players.uniq.size != players.size
 


### PR DESCRIPTION
Fixes #11064

After this change, JSON import and game creation all work

In the case of imported games, `selected_game_or_variant` is Nil so the code was bailing when `title` was set.

This was due to where I was checking playercount, as part of a codepath that handled all 3 game types (multi, hotseat, json)

Now it only checks playercount for multiplayer 

I refactored this function to be (hopefully) more readable. 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

To confirm that game creation and import works:

[import game.webm](https://github.com/user-attachments/assets/9ee0e72c-4961-4c59-8d4b-eae3a65ee0fd)

[create_multi_and_hotseat.webm](https://github.com/user-attachments/assets/095cf2d8-aad1-46b1-b21e-9977cc94f31c)


### Any Assumptions / Hacks
