### PR TITLE
[1846] optional rules are XOR

### DIFF
--- a/lib/engine/game/g_1846/meta.rb
+++ b/lib/engine/game/g_1846/meta.rb
@@ -40,6 +40,17 @@ module Engine
             players: [2, 3, 4, 5],
           },
         ].freeze
+
+        MUTEX_RULES = [
+          %i[first_ed second_ed_co],
+].freeze
+
+        def self.check_options(options, _min_players, _max_players)
+          optional_rules = (options || []).map(&:to_sym)
+          return unless (optional_rules & %i[first_ed second_ed_co]).length == 2
+
+          { error: 'Cannot guarantee 2nd Edition companies if using 1st Edition' }
+        end
       end
     end
   end


### PR DESCRIPTION
Currently one can create a '46 in which only 1E privates are allowed and also 2E privates are guaranteed.

This implements the 'check options' feature and prevents that at the frontend level. 

Also will throw an error if a game is imported with such options

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

![image](https://github.com/user-attachments/assets/d4613db3-80c2-464e-874b-b6127bca07e4)

![Screenshot 2024-07-26 5 16 07 PM](https://github.com/user-attachments/assets/b9709b4c-34fc-4404-b4c1-4ecb443f0490)


### Any Assumptions / Hacks
