### PR TITLE
[18Ardennes] Bankruptcy

### DIFF
--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -450,6 +450,10 @@ module Engine
           end
         end
 
+        def unowned_purchasable_companies
+          minor_companies.select { |company| company.owner == bank }
+        end
+
         def buyable_bank_owned_companies
           # Do not show the GL after a corporation grows up.
           @round.operating? ? [] : super

--- a/lib/engine/game/g_18_ardennes/entities.rb
+++ b/lib/engine/game/g_18_ardennes/entities.rb
@@ -438,6 +438,7 @@ module Engine
 
         def exchange_corporations(exchange_ability)
           minor = exchange_ability.owner
+          return [] if minor.receivership?
           return [] if minor.share_price.price.zero?
           return [] if under_obligation?(minor.owner)
 

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -195,6 +195,10 @@ module Engine
           super + player.companies.sum(&:value)
         end
 
+        def can_buy_presidents_share_directly_from_market?(_corporation)
+          true
+        end
+
         # Checks whether a player really is bankrupt.
         def can_go_bankrupt?(player, _corporation)
           return super if @round.operating?

--- a/lib/engine/game/g_18_ardennes/step/bankrupt.rb
+++ b/lib/engine/game/g_18_ardennes/step/bankrupt.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/bankrupt'
+require_relative '../../../step/train'
+
+module Engine
+  module Game
+    module G18Ardennes
+      module Step
+        class Bankrupt < Engine::Step::Bankrupt
+          include Engine::Step::Train
+
+          def process_bankrupt(action)
+            corporation = action.entity
+            player = corporation.player
+            @game.declare_bankrupt(player, corporation)
+            receivership_buy_train(corporation)
+          end
+
+          private
+
+          def receivership_buy_train(corporation)
+            return unless corporation.receivership?
+
+            train = @game.depot.min_depot_train
+            price = train.price
+            if price > corporation.cash
+              @log << 'The bank '
+              @game.bank.spend(price - corporation.cash, corporation)
+            end
+            buy_train_action(Engine::Action::BuyTrain.new(corporation,
+                                                          train: train,
+                                                          price: price))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_ardennes/step/bankrupt.rb
+++ b/lib/engine/game/g_18_ardennes/step/bankrupt.rb
@@ -24,9 +24,11 @@ module Engine
 
             train = @game.depot.min_depot_train
             price = train.price
-            if price > corporation.cash
-              @log << 'The bank '
-              @game.bank.spend(price - corporation.cash, corporation)
+            shortfall = price - corporation.cash
+            if shortfall.positive?
+              @log << "The bank gives #{@game.format_currency(shortfall)} " \
+                      "to #{corporation.name} to allow it to purchase a train."
+              @game.bank.spend(shortfall, corporation)
             end
             buy_train_action(Engine::Action::BuyTrain.new(corporation,
                                                           train: train,

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -172,18 +172,7 @@ module Engine
           end
 
           def process_bankrupt(action)
-            player = action.entity
-
-            # All shares and the GL go to the bank pool.
-            # Concessions can be purchased by another player in a future auction.
-            sell_bankrupt_shares(player)
-            player.companies.each do |company|
-              company.owner = company.type == :minor ? @game.bank : nil
-            end
-            player.companies.clear
-
-            player.spend(player.cash, @game.bank) if player.cash.positive?
-            @game.declare_bankrupt(player)
+            @game.declare_bankrupt(action.entity)
           end
 
           def log_skip(entity)
@@ -214,27 +203,6 @@ module Engine
               %w[sell_shares sell_company]
             else
               %w[sell_shares]
-            end
-          end
-
-          def sell_bankrupt_shares(player)
-            @log << "-- #{player.name} goes bankrupt and sells remaining shares --"
-
-            player.shares_by_corporation.each do |corporation, shares|
-              next if shares.empty?
-
-              bundles = @game.bundles_for_corporation(player, corporation)
-              pool = @game.share_pool
-              pool.sell_shares(bundles.last)
-
-              # `SharePool.sell_shares` doesn't correctly handle selling the
-              # president's certificate to the market when a player bankrupts.
-              # The certificate is sold to the market, but the corporation's
-              # president (owner) is not changed.
-              if corporation.presidents_share.owner == pool
-                corporation.owner = pool
-                @log << "#{corporation.name} enters receivership"
-              end
             end
           end
 

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -133,16 +133,12 @@ module Engine
           end
 
           # Corporations whose cards are visible in the stock round.
-          # Hide public companies whose concessions have not yet been auctioned,
-          # and show the current player's minor companies.
+          # Hide public companies whose concessions have not yet been auctioned.
           def visible_corporations
-            minors = @game.minor_corporations.select do |corporation|
-              corporation.owner == current_entity
-            end
             majors = @game.sorted_corporations.select do |corporation|
               corporation.floated || !corporation.par_via_exchange.owner.nil?
             end
-            majors.sort + minors.sort
+            majors.sort + @game.minor_corporations.sort
           end
 
           # Valid par prices for public companies.

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -13,6 +13,7 @@ module Engine
           def actions(entity)
             return [] unless entity == current_entity
             return [] if bought?
+            return [] if entity.bankrupt
             return %w[bankrupt] if @game.bankrupt?(entity)
             return limit_actions(entity) if must_sell?(entity)
             return par_actions(entity) if @game.under_obligation?(entity)

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -223,7 +223,17 @@ module Engine
               next if shares.empty?
 
               bundles = @game.bundles_for_corporation(player, corporation)
-              @game.share_pool.sell_shares(bundles.last)
+              pool = @game.share_pool
+              pool.sell_shares(bundles.last)
+
+              # `SharePool.sell_shares` doesn't correctly handle selling the
+              # president's certificate to the market when a player bankrupts.
+              # The certificate is sold to the market, but the corporation's
+              # president (owner) is not changed.
+              if corporation.presidents_share.owner == pool
+                corporation.owner = pool
+                @log << "#{corporation.name} enters receivership"
+              end
             end
           end
 

--- a/lib/engine/game/g_18_ardennes/step/buy_train.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_train.rb
@@ -8,6 +8,8 @@ module Engine
       module Step
         class BuyTrain < Engine::Step::BuyTrain
           def actions(entity)
+            return [] if entity.receivership?
+
             actions = super
             actions << 'sell_company' if actions.include?('sell_shares') &&
                                          can_sell_any_companies?(entity)

--- a/lib/engine/game/g_18_ardennes/step/buy_train.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_train.rb
@@ -32,6 +32,10 @@ module Engine
             @log << "#{player.name} sells #{company.name} to bank for #{@game.format_currency(price)}"
           end
 
+          def log_skip(entity)
+            super unless entity.receivership?
+          end
+
           private
 
           def can_sell_any_companies?(entity)

--- a/lib/engine/game/g_18_ardennes/step/convert.rb
+++ b/lib/engine/game/g_18_ardennes/step/convert.rb
@@ -11,6 +11,7 @@ module Engine
 
           def actions(entity)
             return [] unless entity == current_entity
+            return [] if entity.receivership?
             return [] unless can_convert?(entity)
 
             ACTIONS

--- a/lib/engine/game/g_18_ardennes/step/dividend.rb
+++ b/lib/engine/game/g_18_ardennes/step/dividend.rb
@@ -7,6 +7,12 @@ module Engine
     module G18Ardennes
       module Step
         class Dividend < Engine::Step::Dividend
+          def auto_actions(entity)
+            return super unless entity.receivership?
+
+            [Action::Dividend.new(entity, kind: 'payout')]
+          end
+
           def payout(entity, revenue)
             return half(entity, revenue) if entity.type == :minor
 

--- a/lib/engine/game/g_18_ardennes/step/dividend.rb
+++ b/lib/engine/game/g_18_ardennes/step/dividend.rb
@@ -40,6 +40,12 @@ module Engine
               {}
             end
           end
+
+          def holder_for_corporation(entity)
+            # This is needed to stop minor companies in receivership being
+            # paid for their president's certificate in the share pool.
+            entity
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_ardennes/step/route.rb
+++ b/lib/engine/game/g_18_ardennes/step/route.rb
@@ -7,6 +7,16 @@ module Engine
     module G18Ardennes
       module Step
         class Route < Engine::Step::Route
+          def help
+            return super unless current_entity.receivership?
+
+            "#{current_entity.type == :minor ? 'Minor ' : ''}" \
+              "#{current_entity.name} is on autopilot as it does not have a " \
+              'president. It may not place any track or tokens or buy a ' \
+              'train. It will run its trains and pay out dividends. Please ' \
+              'select the best route you can see.'
+          end
+
           def log_extra_revenue(entity, extra_revenue)
             return unless extra_revenue&.nonzero?
 

--- a/lib/engine/game/g_18_ardennes/step/token.rb
+++ b/lib/engine/game/g_18_ardennes/step/token.rb
@@ -11,6 +11,7 @@ module Engine
 
           def actions(entity)
             return [] unless entity == current_entity
+            return [] if entity.receivership?
             return [] unless can_place_token?(entity)
 
             ACTIONS

--- a/lib/engine/game/g_18_ardennes/step/track.rb
+++ b/lib/engine/game/g_18_ardennes/step/track.rb
@@ -9,6 +9,12 @@ module Engine
         class Track < Engine::Step::Track
           MINOR_TILE_COLORS = %w[yellow green].freeze
 
+          def actions(entity)
+            return [] if entity.receivership?
+
+            super
+          end
+
           def potential_tiles(entity, hex)
             colors = @game.phase.tiles
             colors &= MINOR_TILE_COLORS if entity.type == :minor


### PR DESCRIPTION
## Implementation Notes

### Explanation of Change

It is pretty much impossible to go bankrupt in 18Ardennes, unless you‘re actually trying to do so. Nevertheless, there are rules for bankruptcy, so this pull request implements them.

There are two possible ways to go bankrupt: not being able to afford a train after emergency money raising, or not being able to start a public company that you’ve won in an auction. In both cases all your assets get sold to the market.

If the presidencies of any companies end up in the market these companies run on autopilot. They skip all steps in an operating round apart from running trains and paying out dividends.


### Any Assumptions / Hacks

If a company is on autopilot someone needs to select the routes its trains run. To speed up play the player selected to do this is the player who just operated the preceding company in the operating round, or who will operate the next one (or, if every single company has managed to end up in receivership, the player with the priority deal). The code for working out which player to act for the company feels a bit hackish. There might be a cleaner way of doing this.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
