### PR TITLE
[18SJ] Set in production

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -17,6 +17,7 @@ module View
     def render_notification
       message = <<~MESSAGE
         <p>18 India and 18Uruguay are in alpha.</p>
+        <p>18 SJ is now in production.</p>
 
         <p>Report bugs and make feature requests <a href='https://github.com/tobymao/18xx/issues'>on GitHub</a>.</p>
       MESSAGE

--- a/lib/engine/game/g_18_sj/meta.rb
+++ b/lib/engine/game/g_18_sj/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :beta
+        DEV_STAGE = :production
         PROTOTYPE = false
 
         GAME_SUBTITLE = 'Railways in the Frozen North'

--- a/public/fixtures/18SJ/166116.json
+++ b/public/fixtures/18SJ/166116.json
@@ -1,0 +1,12568 @@
+{
+  "id": 166116,
+  "description": "(3/10) Fast Play Only (5+ MPD) | NA Timezones preferred",
+  "user": {
+    "id": 149,
+    "name": "Kenkuhn"
+  },
+  "players": [
+    {
+      "id": 17876,
+      "name": "beeman"
+    },
+    {
+      "id": 15550,
+      "name": "pigclimber"
+    },
+    {
+      "id": 3041,
+      "name": "damana"
+    },
+    {
+      "id": 149,
+      "name": "Kenkuhn"
+    }
+  ],
+  "min_players": 2,
+  "max_players": 4,
+  "title": "18SJ",
+  "settings": {
+    "seed": 1012549268,
+    "is_async": true,
+    "unlisted": false,
+    "auto_routing": true,
+    "player_order": null,
+    "optional_rules": []
+  },
+  "user_settings": null,
+  "status": "finished",
+  "turn": 6,
+  "round": "Operating Round",
+  "acting": [
+    17876,
+    15550,
+    3041,
+    149
+  ],
+  "result": {
+    "149": 7717,
+    "3041": 8315,
+    "15550": 7039,
+    "17876": 3157
+  },
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1717612427,
+      "company": "NE",
+      "price": 225
+    },
+    {
+      "type": "bid",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1717612658,
+      "company": "GKB",
+      "price": 45
+    },
+    {
+      "type": "bid",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1717613728,
+      "company": "GC",
+      "price": 75
+    },
+    {
+      "type": "bid",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1717614084,
+      "company": "MV",
+      "price": 95
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1717615599
+    },
+    {
+      "type": "bid",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1717616013,
+      "company": "KHJ",
+      "price": 145
+    },
+    {
+      "type": "bid",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1717621999,
+      "company": "FRY",
+      "price": 20
+    },
+    {
+      "type": "par",
+      "entity": 17876,
+      "corporation": "SNJ",
+      "entity_type": "player",
+      "share_price": "71,4,2",
+      "id": 8,
+      "user": 17876,
+      "created_at": 1717654644
+    },
+    {
+      "type": "choose",
+      "choice": "wait",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 9,
+      "user": 17876,
+      "created_at": 1717654661
+    },
+    {
+      "type": "undo",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 10,
+      "user": 17876,
+      "created_at": 1717657204
+    },
+    {
+      "type": "undo",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 11,
+      "user": 17876,
+      "created_at": 1717657209
+    },
+    {
+      "type": "par",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1717657282,
+      "corporation": "SNJ",
+      "share_price": "90,1,2"
+    },
+    {
+      "type": "choose",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1717657293,
+      "choice": "wait"
+    },
+    {
+      "type": "par",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1717767466,
+      "corporation": "TGOJ",
+      "share_price": "67,5,2"
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1717767475,
+      "corporation": "TGOJ",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1717768408,
+      "shares": [
+        "SNJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1717775133,
+      "corporation": "ÖKJ",
+      "share_price": "67,5,2"
+    },
+    {
+      "type": "par",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1717775343,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 149,
+          "entity_type": "player",
+          "created_at": 1717775342,
+          "shares": [
+            "TGOJ_1"
+          ],
+          "percent": 10
+        }
+      ],
+      "corporation": "STJ",
+      "share_price": "82,2,2"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1717777497,
+      "shares": [
+        "SNJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1717778593,
+      "shares": [
+        "ÖKJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1717779055,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 149,
+          "entity_type": "player",
+          "created_at": 1717779055,
+          "shares": [
+            "TGOJ_2"
+          ],
+          "percent": 10
+        }
+      ],
+      "shares": [
+        "STJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1717780723,
+      "shares": [
+        "SNJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 23,
+      "created_at": 1717781932,
+      "shares": [
+        "ÖKJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 24,
+      "created_at": 1717875450,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 149,
+          "entity_type": "player",
+          "created_at": 1717875450,
+          "shares": [
+            "TGOJ_3"
+          ],
+          "percent": 10
+        }
+      ],
+      "shares": [
+        "STJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1717875456,
+      "corporation": "STJ",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 26,
+      "created_at": 1717878976,
+      "shares": [
+        "SNJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1717879092,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1717879092,
+          "shares": [
+            "STJ_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "buy_shares",
+          "entity": 149,
+          "entity_type": "player",
+          "created_at": 1717879092,
+          "shares": [
+            "TGOJ_4"
+          ],
+          "percent": 10
+        }
+      ],
+      "shares": [
+        "ÖKJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 28,
+      "created_at": 1717879104,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1717879104,
+          "shares": [
+            "STJ_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 149,
+          "entity_type": "player",
+          "created_at": 1717879104,
+          "reason": "TGOJ is floated"
+        }
+      ],
+      "shares": [
+        "ÖKJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 29,
+      "created_at": 1717912035,
+      "shares": [
+        "STJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 30,
+      "created_at": 1717926616,
+      "hex": "C16",
+      "tile": "6-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 31,
+      "created_at": 1717926622
+    },
+    {
+      "type": "run_routes",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 32,
+      "created_at": 1717926633,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D15",
+              "C16"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "C16"
+          ],
+          "revenue": 40,
+          "revenue_str": "D15-C16",
+          "nodes": [
+            "D15-0",
+            "C16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 33,
+      "created_at": 1717926901,
+      "hex": "F25",
+      "tile": "9-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 34,
+      "created_at": 1717926913,
+      "hex": "E24",
+      "tile": "7-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 35,
+      "created_at": 1717926958
+    },
+    {
+      "type": "buy_train",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 36,
+      "created_at": 1717926977,
+      "train": "2-1",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 37,
+      "created_at": 1717926978,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 38,
+      "created_at": 1717926982
+    },
+    {
+      "hex": "E18",
+      "tile": "7-1",
+      "type": "lay_tile",
+      "entity": "STJ",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "id": 39,
+      "user": 3041,
+      "created_at": 1717944437
+    },
+    {
+      "hex": "E20",
+      "tile": "57-0",
+      "type": "lay_tile",
+      "entity": "STJ",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 40,
+      "user": 3041,
+      "created_at": 1717944439
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 41,
+      "user": 3041,
+      "created_at": 1717944460
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 42,
+      "user": 3041,
+      "created_at": 1717944461
+    },
+    {
+      "hex": "E20",
+      "tile": "6-1",
+      "type": "lay_tile",
+      "entity": "STJ",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "id": 43,
+      "user": 3041,
+      "created_at": 1717957251
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 44,
+      "user": 3041,
+      "created_at": 1717957262
+    },
+    {
+      "hex": "E18",
+      "tile": "7-1",
+      "type": "lay_tile",
+      "entity": "STJ",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "id": 45,
+      "user": 3041,
+      "created_at": 1717957266
+    },
+    {
+      "hex": "E20",
+      "tile": "57-0",
+      "type": "lay_tile",
+      "entity": "STJ",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 46,
+      "user": 3041,
+      "created_at": 1717957268
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 47,
+      "user": 3041,
+      "created_at": 1717957269
+    },
+    {
+      "type": "buy_train",
+      "price": 80,
+      "train": "2-3",
+      "entity": "STJ",
+      "variant": "2",
+      "entity_type": "corporation",
+      "id": 48,
+      "user": 3041,
+      "created_at": 1717957271
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 49,
+      "user": 3041,
+      "created_at": 1717957272
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 50,
+      "user": 3041,
+      "created_at": 1717957818
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 51,
+      "user": 3041,
+      "created_at": 1717957819
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 52,
+      "user": 3041,
+      "created_at": 1717957820
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 53,
+      "user": 3041,
+      "created_at": 1717957822
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 54,
+      "user": 3041,
+      "created_at": 1717957823
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 55,
+      "created_at": 1717957828,
+      "hex": "E20",
+      "tile": "6-1",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 56,
+      "created_at": 1717957836,
+      "hex": "E22",
+      "tile": "9-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 57,
+      "created_at": 1717957844
+    },
+    {
+      "type": "buy_train",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 58,
+      "created_at": 1717957845,
+      "train": "2-3",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 59,
+      "user": 3041,
+      "created_at": 1717957846
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 60,
+      "user": 3041,
+      "created_at": 1717957885
+    },
+    {
+      "type": "buy_train",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 61,
+      "created_at": 1717957886,
+      "train": "2-4",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 62,
+      "created_at": 1717957887
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 63,
+      "created_at": 1717958478,
+      "hex": "E18",
+      "tile": "8-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 64,
+      "created_at": 1717958485,
+      "hex": "E16",
+      "tile": "9-2",
+      "rotation": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 65,
+      "created_at": 1717958499,
+      "train": "2-5",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 66,
+      "created_at": 1717958500
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 67,
+      "created_at": 1717959073,
+      "hex": "C12",
+      "tile": "6-2",
+      "rotation": 0
+    },
+    {
+      "hex": "B11",
+      "tile": "57-0",
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 68,
+      "user": 15550,
+      "created_at": 1717959110
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 69,
+      "user": 15550,
+      "created_at": 1717959120
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 70,
+      "created_at": 1717959134,
+      "hex": "B11",
+      "tile": "57-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 71,
+      "created_at": 1717959137
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 72,
+      "created_at": 1717959150,
+      "train": "2-6",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 73,
+      "created_at": 1717959152,
+      "train": "3-0",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 74,
+      "created_at": 1717959154
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 75,
+      "created_at": 1717959186
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 76,
+      "created_at": 1717986730
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 77,
+      "created_at": 1717986861
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 78,
+      "created_at": 1718003705
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 79,
+      "created_at": 1718024723,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 149,
+          "entity_type": "player",
+          "created_at": 1718024723
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "hex": "D13",
+      "tile": "9-3",
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "rotation": 1,
+      "entity_type": "minor",
+      "id": 80,
+      "user": 15550,
+      "created_at": 1718024781
+    },
+    {
+      "type": "undo",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 81,
+      "user": 15550,
+      "created_at": 1718024796
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 82,
+      "created_at": 1718024856,
+      "hex": "D13",
+      "tile": "8-1",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 83,
+      "created_at": 1718024862,
+      "hex": "C12",
+      "tile": "15-0",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 84,
+      "created_at": 1718024873,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D15",
+              "D13",
+              "C12"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "C12"
+          ],
+          "revenue": 50,
+          "revenue_str": "D15-C12",
+          "nodes": [
+            "D15-0",
+            "C12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 85,
+      "created_at": 1718026012,
+      "hex": "E22",
+      "tile": "23-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 86,
+      "created_at": 1718026083
+    },
+    {
+      "type": "place_token",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 87,
+      "created_at": 1718026086,
+      "city": "6-1-0",
+      "slot": 0,
+      "tokener": "SNJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 88,
+      "created_at": 1718026102,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "E20",
+              "E22",
+              "F23"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F23"
+          ],
+          "revenue": 40,
+          "revenue_str": "E20-F23",
+          "nodes": [
+            "E20-0",
+            "F23-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19"
+          ],
+          "revenue": 40,
+          "revenue_str": "E20-F19",
+          "nodes": [
+            "E20-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 89,
+      "created_at": 1718026111,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 90,
+      "created_at": 1718026131,
+      "train": "3-1",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 91,
+      "created_at": 1718026134,
+      "train": "3-2",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 92,
+      "created_at": 1718026142
+    },
+    {
+      "hex": "E20",
+      "tile": "619-0",
+      "type": "lay_tile",
+      "entity": "STJ",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 93,
+      "user": 3041,
+      "created_at": 1718028798
+    },
+    {
+      "hex": "E24",
+      "tile": "29-0",
+      "type": "lay_tile",
+      "entity": "STJ",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "id": 94,
+      "user": 3041,
+      "created_at": 1718028810
+    },
+    {
+      "type": "buy_company",
+      "price": 140,
+      "entity": "STJ",
+      "company": "GC",
+      "entity_type": "corporation",
+      "id": 95,
+      "user": 3041,
+      "created_at": 1718028839
+    },
+    {
+      "type": "buy_company",
+      "price": 40,
+      "entity": "STJ",
+      "company": "FRY",
+      "entity_type": "corporation",
+      "id": 96,
+      "user": 3041,
+      "created_at": 1718028881
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 97,
+      "user": 3041,
+      "created_at": 1718028922
+    },
+    {
+      "city": "619-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "STJ",
+      "tokener": "STJ",
+      "entity_type": "corporation",
+      "id": 98,
+      "user": 3041,
+      "created_at": 1718028924
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "action_id": 92,
+      "entity_type": "corporation",
+      "id": 99,
+      "user": 3041,
+      "created_at": 1718028929
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 100,
+      "created_at": 1718028935,
+      "hex": "E20",
+      "tile": "619-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 101,
+      "created_at": 1718028938,
+      "hex": "E24",
+      "tile": "29-0",
+      "rotation": 5
+    },
+    {
+      "type": "buy_company",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 102,
+      "created_at": 1718028946,
+      "company": "GC",
+      "price": 140
+    },
+    {
+      "type": "buy_company",
+      "price": 40,
+      "entity": "STJ",
+      "company": "FRY",
+      "entity_type": "corporation",
+      "id": 103,
+      "user": 3041,
+      "created_at": 1718028948
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 104,
+      "user": 3041,
+      "created_at": 1718028978
+    },
+    {
+      "city": "619-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "STJ",
+      "tokener": "STJ",
+      "entity_type": "corporation",
+      "id": 105,
+      "user": 3041,
+      "created_at": 1718028980
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "routes": [
+        {
+          "hexes": [
+            "E20",
+            "F23"
+          ],
+          "nodes": [
+            "E20-0",
+            "F23-0"
+          ],
+          "train": "2-4",
+          "revenue": 50,
+          "connections": [
+            [
+              "E20",
+              "E22",
+              "F23"
+            ]
+          ],
+          "revenue_str": "E20-F23"
+        },
+        {
+          "hexes": [
+            "E20",
+            "F19"
+          ],
+          "nodes": [
+            "E20-0",
+            "F19-0"
+          ],
+          "train": "2-3",
+          "revenue": 50,
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ]
+          ],
+          "revenue_str": "E20-F19"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 106,
+      "user": 3041,
+      "created_at": 1718028982
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 107,
+      "user": 3041,
+      "created_at": 1718029009
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 108,
+      "user": 3041,
+      "created_at": 1718029010
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 109,
+      "user": 3041,
+      "created_at": 1718029012
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 110,
+      "user": 3041,
+      "created_at": 1718029015
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 111,
+      "created_at": 1718029020
+    },
+    {
+      "type": "place_token",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 112,
+      "created_at": 1718029022,
+      "city": "619-0-0",
+      "slot": 1,
+      "tokener": "STJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 113,
+      "created_at": 1718029026,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "E20",
+              "E22",
+              "F23"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F23"
+          ],
+          "revenue": 50,
+          "revenue_str": "E20-F23",
+          "nodes": [
+            "E20-0",
+            "F23-0"
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19"
+          ],
+          "revenue": 50,
+          "revenue_str": "E20-F19",
+          "nodes": [
+            "E20-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 114,
+      "created_at": 1718029027,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 115,
+      "created_at": 1718029029,
+      "train": "3-3",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 116,
+      "created_at": 1718029030
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 117,
+      "created_at": 1718029033
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 118,
+      "created_at": 1718029437,
+      "hex": "D19",
+      "tile": "15-1",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 119,
+      "created_at": 1718029444
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 120,
+      "created_at": 1718029446,
+      "routes": [
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "D19",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "E20"
+          ],
+          "revenue": 60,
+          "revenue_str": "D19-E20",
+          "nodes": [
+            "D19-0",
+            "E20-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 121,
+      "created_at": 1718029452,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 122,
+      "created_at": 1718029454,
+      "train": "3-4",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 123,
+      "created_at": 1718029480
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 124,
+      "created_at": 1718029506
+    },
+    {
+      "hex": "D11",
+      "tile": "6-3",
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 125,
+      "user": 15550,
+      "created_at": 1718029640
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 126,
+      "user": 15550,
+      "created_at": 1718029656
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 127,
+      "created_at": 1718029669,
+      "hex": "D15",
+      "tile": "619-1",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 128,
+      "created_at": 1718029696,
+      "hex": "D13",
+      "tile": "25-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 129,
+      "created_at": 1718029707
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 130,
+      "created_at": 1718029710,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "C12",
+              "B11"
+            ],
+            [
+              "B11",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "C12",
+            "B11",
+            "A10"
+          ],
+          "revenue": 90,
+          "revenue_str": "C12-B11-A10",
+          "nodes": [
+            "C12-0",
+            "B11-0",
+            "A10-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "C12",
+              "D13",
+              "D15"
+            ]
+          ],
+          "hexes": [
+            "C12",
+            "D15"
+          ],
+          "revenue": 60,
+          "revenue_str": "C12-D15",
+          "nodes": [
+            "C12-0",
+            "D15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 131,
+      "created_at": 1718029715,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 132,
+      "created_at": 1718029721
+    },
+    {
+      "type": "buy_company",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 133,
+      "created_at": 1718029737,
+      "company": "KHJ",
+      "price": 127
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 134,
+      "created_at": 1718029761
+    },
+    {
+      "hex": "F27",
+      "tile": "9-3",
+      "type": "lay_tile",
+      "entity": "GC",
+      "rotation": 0,
+      "entity_type": "company",
+      "id": 135,
+      "user": 3041,
+      "created_at": 1718029854
+    },
+    {
+      "hex": "E28",
+      "tile": "9-1",
+      "type": "lay_tile",
+      "entity": "STJ",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 136,
+      "user": 3041,
+      "created_at": 1718029860
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 137,
+      "user": 3041,
+      "created_at": 1718030133
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 138,
+      "user": 3041,
+      "created_at": 1718030134
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GC",
+      "entity_type": "company",
+      "id": 139,
+      "created_at": 1718030141,
+      "hex": "F27",
+      "tile": "9-3",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GC",
+      "entity_type": "company",
+      "id": 140,
+      "created_at": 1718030146,
+      "hex": "E28",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 141,
+      "created_at": 1718030153,
+      "hex": "D29",
+      "tile": "57-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 142,
+      "created_at": 1718030162
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 143,
+      "created_at": 1718030181,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "G26",
+            "D29"
+          ],
+          "revenue": 120,
+          "revenue_str": "E20-G26-D29 + m/M",
+          "nodes": [
+            "E20-0",
+            "G26-0",
+            "D29-0"
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19"
+          ],
+          "revenue": 50,
+          "revenue_str": "E20-F19",
+          "nodes": [
+            "E20-0",
+            "F19-0"
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E20",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "D19"
+          ],
+          "revenue": 60,
+          "revenue_str": "E20-D19",
+          "nodes": [
+            "E20-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 144,
+      "created_at": 1718030183,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 145,
+      "created_at": 1718030190
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 146,
+      "created_at": 1718030196
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 147,
+      "created_at": 1718054725,
+      "hex": "E14",
+      "tile": "8-2",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 148,
+      "created_at": 1718054753,
+      "hex": "E16",
+      "tile": "23-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 149,
+      "created_at": 1718054780,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E20",
+              "E22",
+              "F23"
+            ],
+            [
+              "F23",
+              "E24",
+              "F25",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F23",
+            "G26"
+          ],
+          "revenue": 70,
+          "revenue_str": "E20-F23-G26",
+          "nodes": [
+            "E20-0",
+            "F23-0",
+            "G26-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E20",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "E16",
+              "D15"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "D19",
+            "D15"
+          ],
+          "revenue": 90,
+          "revenue_str": "E20-D19-D15",
+          "nodes": [
+            "E20-0",
+            "D19-0",
+            "D15-0"
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19"
+          ],
+          "revenue": 50,
+          "revenue_str": "E20-F19",
+          "nodes": [
+            "E20-0",
+            "F19-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "D29"
+          ],
+          "revenue": 90,
+          "revenue_str": "G26-D29 + m/M",
+          "nodes": [
+            "G26-0",
+            "D29-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 150,
+      "created_at": 1718054784,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 151,
+      "created_at": 1718054805
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 152,
+      "created_at": 1718054838,
+      "hex": "B15",
+      "tile": "8-1",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 153,
+      "created_at": 1718054862,
+      "hex": "E12",
+      "tile": "57-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 154,
+      "created_at": 1718054869
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 155,
+      "created_at": 1718054886,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "D15",
+              "C16"
+            ],
+            [
+              "C16",
+              "B15",
+              "A16"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "C16",
+            "A16"
+          ],
+          "revenue": 90,
+          "revenue_str": "D15-C16-A16",
+          "nodes": [
+            "D15-0",
+            "C16-0",
+            "A16-0"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C12",
+              "D13",
+              "D15"
+            ]
+          ],
+          "hexes": [
+            "C12",
+            "D15"
+          ],
+          "revenue": 60,
+          "revenue_str": "C12-D15",
+          "nodes": [
+            "C12-0",
+            "D15-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "D15",
+              "E16",
+              "E18",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "D19"
+          ],
+          "revenue": 60,
+          "revenue_str": "D15-D19",
+          "nodes": [
+            "D15-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 156,
+      "created_at": 1718054910,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 157,
+      "created_at": 1718054914
+    },
+    {
+      "type": "buy_company",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 158,
+      "created_at": 1718054924,
+      "company": "GKB",
+      "price": 80
+    },
+    {
+      "type": "assign",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 159,
+      "created_at": 1718054960,
+      "target": "C12",
+      "target_type": "hex"
+    },
+    {
+      "type": "assign",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 160,
+      "created_at": 1718054963,
+      "target": "C16",
+      "target_type": "hex"
+    },
+    {
+      "type": "assign",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 161,
+      "created_at": 1718054985,
+      "target": "C8",
+      "target_type": "hex"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 162,
+      "created_at": 1718054994
+    },
+    {
+      "hex": "F13",
+      "tile": "57-3",
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 163,
+      "user": 149,
+      "created_at": 1718059933
+    },
+    {
+      "hex": "F13",
+      "tile": "619-2",
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 164,
+      "user": 149,
+      "created_at": 1718059948
+    },
+    {
+      "city": "619-2-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "TGOJ",
+      "tokener": "TGOJ",
+      "entity_type": "corporation",
+      "id": 165,
+      "user": 149,
+      "created_at": 1718059948
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "action_id": 162,
+      "entity_type": "corporation",
+      "id": 166,
+      "user": 149,
+      "created_at": 1718059973
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 167,
+      "created_at": 1718059984,
+      "hex": "C10",
+      "tile": "8-3",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 168,
+      "created_at": 1718059997,
+      "hex": "F13",
+      "tile": "57-3",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 169,
+      "created_at": 1718059999,
+      "city": "15-0-0",
+      "slot": 1,
+      "tokener": "TGOJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 170,
+      "created_at": 1718060003,
+      "routes": [
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "C12",
+              "B11"
+            ],
+            [
+              "B11",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "C12",
+            "B11",
+            "A10"
+          ],
+          "revenue": 90,
+          "revenue_str": "C12-B11-A10",
+          "nodes": [
+            "C12-0",
+            "B11-0",
+            "A10-0"
+          ]
+        },
+        {
+          "train": "2-5",
+          "connections": [
+            [
+              "D19",
+              "E18",
+              "E16",
+              "D15"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "D15"
+          ],
+          "revenue": 60,
+          "revenue_str": "D19-D15",
+          "nodes": [
+            "D19-0",
+            "D15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 171,
+      "created_at": 1718060004,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 172,
+      "created_at": 1718060008
+    },
+    {
+      "type": "buy_company",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 173,
+      "created_at": 1718060022,
+      "company": "MV",
+      "price": 180
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 174,
+      "created_at": 1718063204,
+      "shares": [
+        "TGOJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 175,
+      "created_at": 1718063208
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 176,
+      "created_at": 1718063625,
+      "shares": [
+        "SNJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 177,
+      "created_at": 1718063629
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 178,
+      "created_at": 1718068856,
+      "shares": [
+        "SNJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 179,
+      "created_at": 1718068860
+    },
+    {
+      "type": "sell_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 180,
+      "created_at": 1718072411,
+      "shares": [
+        "STJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 181,
+      "created_at": 1718072650,
+      "corporation": "MÖJ",
+      "share_price": "90,1,2"
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 182,
+      "user": 149,
+      "created_at": 1718072655
+    },
+    {
+      "type": "undo",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 183,
+      "user": 149,
+      "created_at": 1718072659
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 184,
+      "created_at": 1718072662
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 185,
+      "created_at": 1718131436,
+      "shares": [
+        "TGOJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 186,
+      "created_at": 1718131444
+    },
+    {
+      "type": "par",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 187,
+      "created_at": 1718131931,
+      "corporation": "KFJ",
+      "share_price": "71,4,2"
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 188,
+      "created_at": 1718131935
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "shares": [
+        "MÖJ_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 189,
+      "user": 3041,
+      "created_at": 1718138975
+    },
+    {
+      "type": "undo",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 190,
+      "user": 3041,
+      "created_at": 1718138978
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 191,
+      "created_at": 1718138982,
+      "shares": [
+        "ÖKJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 192,
+      "created_at": 1718138984
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 193,
+      "created_at": 1718139005,
+      "shares": [
+        "MÖJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 194,
+      "created_at": 1718139006
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 195,
+      "created_at": 1718275623,
+      "shares": [
+        "TGOJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 196,
+      "created_at": 1718275630
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 197,
+      "created_at": 1718275709,
+      "shares": [
+        "KFJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 198,
+      "created_at": 1718275713
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 199,
+      "created_at": 1718276610,
+      "shares": [
+        "TGOJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 200,
+      "created_at": 1718276620
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 201,
+      "created_at": 1718284286,
+      "shares": [
+        "MÖJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 202,
+      "created_at": 1718284328
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 203,
+      "created_at": 1718294744
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 204,
+      "created_at": 1718296137,
+      "shares": [
+        "KFJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 205,
+      "created_at": 1718296140
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "shares": [
+        "SNJ_7"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 206,
+      "user": 3041,
+      "created_at": 1718298343
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3041,
+      "shares": [
+        "SNJ_6",
+        "SNJ_7"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 207,
+      "user": 3041,
+      "created_at": 1718298345
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3041,
+      "shares": [
+        "ÖKJ_5"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 208,
+      "user": 3041,
+      "created_at": 1718298350
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3041,
+      "shares": [
+        "TGOJ_8"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 209,
+      "user": 3041,
+      "created_at": 1718298354
+    },
+    {
+      "type": "undo",
+      "entity": 3041,
+      "action_id": 205,
+      "entity_type": "player",
+      "id": 210,
+      "user": 3041,
+      "created_at": 1718298383
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 211,
+      "created_at": 1718298418,
+      "shares": [
+        "KFJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 212,
+      "created_at": 1718298425
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 213,
+      "created_at": 1718299505,
+      "shares": [
+        "MÖJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 214,
+      "created_at": 1718299523
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 215,
+      "created_at": 1718302507
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 216,
+      "created_at": 1718302570,
+      "shares": [
+        "KFJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 217,
+      "created_at": 1718302574
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 218,
+      "created_at": 1718306733,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1718306732
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 219,
+      "created_at": 1718308421,
+      "shares": [
+        "TGOJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 220,
+      "created_at": 1718308423,
+      "shares": [
+        "MÖJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 221,
+      "created_at": 1718308434
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 222,
+      "created_at": 1718308438,
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 223,
+      "created_at": 1718334718,
+      "shares": [
+        "TGOJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 224,
+      "created_at": 1718334724
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 225,
+      "created_at": 1718365450,
+      "shares": [
+        "KFJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 226,
+      "created_at": 1718365452,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1718365452,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 227,
+      "created_at": 1718372466,
+      "shares": [
+        "MÖJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 228,
+      "created_at": 1718372468,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1718372467
+        },
+        {
+          "type": "pass",
+          "entity": 149,
+          "entity_type": "player",
+          "created_at": 1718372467
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 229,
+      "created_at": 1718384237
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 230,
+      "created_at": 1718387489,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1718387488
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 231,
+      "created_at": 1718437976,
+      "hex": "G12",
+      "tile": "8-4",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 232,
+      "created_at": 1718438012,
+      "hex": "D21",
+      "tile": "57-4",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 233,
+      "created_at": 1718438042,
+      "city": "G10-0-3",
+      "slot": 0,
+      "tokener": "SNJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 234,
+      "created_at": 1718438055,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E20",
+              "E22",
+              "F23"
+            ],
+            [
+              "F23",
+              "E24",
+              "F25",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F23",
+            "G26"
+          ],
+          "revenue": 70,
+          "revenue_str": "E20-F23-G26",
+          "nodes": [
+            "E20-0",
+            "F23-0",
+            "G26-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E20",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "E16",
+              "D15"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "D19",
+            "D15"
+          ],
+          "revenue": 90,
+          "revenue_str": "E20-D19-D15",
+          "nodes": [
+            "E20-0",
+            "D19-0",
+            "D15-0"
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "E20",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "F19"
+          ],
+          "revenue": 50,
+          "revenue_str": "E20-F19",
+          "nodes": [
+            "E20-0",
+            "F19-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "D29"
+          ],
+          "revenue": 90,
+          "revenue_str": "G26-D29 + m/M",
+          "nodes": [
+            "G26-0",
+            "D29-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 235,
+      "created_at": 1718438059,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 236,
+      "created_at": 1718438067
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 237,
+      "created_at": 1718459166,
+      "hex": "E8",
+      "tile": "6-3",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 238,
+      "created_at": 1718459172,
+      "hex": "F9",
+      "tile": "9-4",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 239,
+      "created_at": 1718459172,
+      "city": "G10-0-1",
+      "slot": 0,
+      "tokener": "MÖJ"
+    },
+    {
+      "type": "buy_train",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 240,
+      "created_at": 1718459177,
+      "train": "4-0",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 241,
+      "user": 149,
+      "created_at": 1718459212
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 242,
+      "user": 149,
+      "created_at": 1718459213
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 243,
+      "user": 149,
+      "created_at": 1718459226
+    },
+    {
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 244,
+      "user": 149,
+      "created_at": 1718459227
+    },
+    {
+      "type": "buy_train",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 245,
+      "created_at": 1718459238,
+      "train": "3-4",
+      "price": 20
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 246,
+      "created_at": 1718459323
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 247,
+      "created_at": 1718459325
+    },
+    {
+      "type": "buy_shares",
+      "entity": "STJ",
+      "shares": [
+        "STJ_5"
+      ],
+      "percent": 10,
+      "entity_type": "corporation",
+      "share_price": 82,
+      "id": 248,
+      "user": 3041,
+      "created_at": 1718466448
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 249,
+      "user": 3041,
+      "created_at": 1718466455
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 250,
+      "created_at": 1718466456
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 251,
+      "created_at": 1718466465,
+      "hex": "D29",
+      "tile": "619-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 252,
+      "created_at": 1718466475
+    },
+    {
+      "type": "place_token",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 253,
+      "created_at": 1718466478,
+      "city": "G26-0-0",
+      "slot": 1,
+      "tokener": "STJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 254,
+      "created_at": 1718466482,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "G26",
+            "D29"
+          ],
+          "revenue": 130,
+          "revenue_str": "E20-G26-D29 + m/M",
+          "nodes": [
+            "E20-0",
+            "G26-0",
+            "D29-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 255,
+      "created_at": 1718466485,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 256,
+      "created_at": 1718466487
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 257,
+      "created_at": 1718466493
+    },
+    {
+      "hex": "D11",
+      "tile": "6-2",
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 258,
+      "user": 15550,
+      "created_at": 1718470202
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 259,
+      "user": 15550,
+      "created_at": 1718470233
+    },
+    {
+      "hex": "E12",
+      "tile": "15-2",
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 260,
+      "user": 15550,
+      "created_at": 1718470244
+    },
+    {
+      "hex": "F11",
+      "tile": "9-5",
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 261,
+      "user": 15550,
+      "created_at": 1718470249
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 262,
+      "user": 15550,
+      "created_at": 1718470259
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "routes": [
+        {
+          "hexes": [
+            "C12",
+            "D15",
+            "C16"
+          ],
+          "nodes": [
+            "C12-0",
+            "D15-0",
+            "C16-0"
+          ],
+          "train": "3-0",
+          "revenue": 160,
+          "connections": [
+            [
+              "C12",
+              "D13",
+              "D15"
+            ],
+            [
+              "D15",
+              "C16"
+            ]
+          ],
+          "revenue_str": "C12-D15-C16 + GKB50(C12) + GKB30(C16)"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 263,
+      "user": 15550,
+      "created_at": 1718470263
+    },
+    {
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 264,
+      "user": 15550,
+      "created_at": 1718470266
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 265,
+      "user": 15550,
+      "created_at": 1718470270
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 266,
+      "user": 15550,
+      "created_at": 1718470271
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 267,
+      "user": 15550,
+      "created_at": 1718470272
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 268,
+      "user": 15550,
+      "created_at": 1718470276
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 269,
+      "user": 15550,
+      "created_at": 1718470281
+    },
+    {
+      "hex": "E12",
+      "tile": "15-2",
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 270,
+      "user": 15550,
+      "created_at": 1718470305
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 271,
+      "user": 15550,
+      "created_at": 1718470318
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 272,
+      "created_at": 1718470322,
+      "hex": "C16",
+      "tile": "14-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 273,
+      "created_at": 1718470327
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 274,
+      "created_at": 1718470328
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 275,
+      "created_at": 1718470331,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "C12",
+              "D13",
+              "D15"
+            ],
+            [
+              "D15",
+              "C16"
+            ]
+          ],
+          "hexes": [
+            "C12",
+            "D15",
+            "C16"
+          ],
+          "revenue": 170,
+          "revenue_str": "C12-D15-C16 + GKB50(C12) + GKB30(C16)",
+          "nodes": [
+            "C12-0",
+            "D15-0",
+            "C16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 276,
+      "created_at": 1718470333,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 277,
+      "created_at": 1718470337,
+      "train": "4-1",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 278,
+      "created_at": 1718470340
+    },
+    {
+      "hex": "D17",
+      "tile": "8-5",
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 279,
+      "user": 15550,
+      "created_at": 1718470400
+    },
+    {
+      "type": "undo",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 280,
+      "user": 15550,
+      "created_at": 1718470410
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 281,
+      "created_at": 1718470428,
+      "hex": "D17",
+      "tile": "8-5",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 282,
+      "created_at": 1718470461
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 283,
+      "created_at": 1718470467
+    },
+    {
+      "type": "buy_train",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 284,
+      "created_at": 1718470518,
+      "train": "4-2",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 285,
+      "created_at": 1718470520
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 286,
+      "created_at": 1718470529
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 287,
+      "created_at": 1718471577,
+      "hex": "B9",
+      "tile": "8-6",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 288,
+      "created_at": 1718471581
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 289,
+      "created_at": 1718471589
+    },
+    {
+      "type": "buy_train",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 290,
+      "created_at": 1718471599,
+      "train": "4-3",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 291,
+      "user": 149,
+      "created_at": 1718471616
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "routes": [
+        {
+          "hexes": [
+            "D19",
+            "D15",
+            "C12",
+            "A10"
+          ],
+          "nodes": [
+            "D19-0",
+            "D15-0",
+            "C12-0",
+            "A10-0"
+          ],
+          "train": "4-3",
+          "revenue": 180,
+          "connections": [
+            [
+              "D19",
+              "E18",
+              "E16",
+              "D15"
+            ],
+            [
+              "D15",
+              "D13",
+              "C12"
+            ],
+            [
+              "C12",
+              "C10",
+              "B9",
+              "A10"
+            ]
+          ],
+          "revenue_str": "D19-D15-C12-A10 + b/B"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 292,
+      "user": 149,
+      "created_at": 1718471619
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 293,
+      "user": 149,
+      "created_at": 1718471625
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 294,
+      "user": 149,
+      "created_at": 1718471666
+    },
+    {
+      "type": "undo",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 295,
+      "user": 149,
+      "created_at": 1718471673
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 296,
+      "user": 149,
+      "created_at": 1718471675
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 297,
+      "user": 149,
+      "created_at": 1718471681
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 298,
+      "user": 149,
+      "created_at": 1718471682
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 299,
+      "created_at": 1718471690
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 300,
+      "created_at": 1718471695,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "D19",
+              "E18",
+              "E16",
+              "D15"
+            ],
+            [
+              "D15",
+              "D13",
+              "C12"
+            ],
+            [
+              "C12",
+              "C10",
+              "B9",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "D15",
+            "C12",
+            "A10"
+          ],
+          "revenue": 180,
+          "revenue_str": "D19-D15-C12-A10 + b/B",
+          "nodes": [
+            "D19-0",
+            "D15-0",
+            "C12-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 301,
+      "created_at": 1718471696,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 302,
+      "created_at": 1718471700
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 303,
+      "created_at": 1718480878,
+      "hex": "F13",
+      "tile": "15-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 304,
+      "created_at": 1718480901
+    },
+    {
+      "type": "place_token",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 305,
+      "created_at": 1718480935,
+      "city": "15-2-0",
+      "slot": 1,
+      "tokener": "SNJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 306,
+      "created_at": 1718480950,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D19",
+              "D17",
+              "C16"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "D19",
+            "C16"
+          ],
+          "revenue": 90,
+          "revenue_str": "F13-D19-C16",
+          "nodes": [
+            "F13-0",
+            "D19-0",
+            "C16-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "G26",
+            "D29"
+          ],
+          "revenue": 130,
+          "revenue_str": "E20-G26-D29 + m/M",
+          "nodes": [
+            "E20-0",
+            "G26-0",
+            "D29-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 307,
+      "created_at": 1718480954,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 308,
+      "created_at": 1718480962
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 309,
+      "created_at": 1718480963
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 310,
+      "created_at": 1718480997,
+      "hex": "A14",
+      "tile": "9-5",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 311,
+      "created_at": 1718481003,
+      "hex": "E18",
+      "tile": "24-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 312,
+      "created_at": 1718481006,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "G26",
+            "D29"
+          ],
+          "revenue": 130,
+          "revenue_str": "E20-G26-D29 + m/M",
+          "nodes": [
+            "E20-0",
+            "G26-0",
+            "D29-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 313,
+      "created_at": 1718481009,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 314,
+      "created_at": 1718481011
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 315,
+      "created_at": 1718481015
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 316,
+      "created_at": 1718481159,
+      "hex": "G10",
+      "tile": "X2-0",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 317,
+      "created_at": 1718481164,
+      "hex": "E8",
+      "tile": "15-3",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 318,
+      "created_at": 1718481169,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G10",
+              "F9",
+              "E8"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "E8"
+          ],
+          "revenue": 70,
+          "revenue_str": "G10-E8",
+          "nodes": [
+            "G10-2",
+            "E8-0"
+          ]
+        },
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H9"
+          ],
+          "revenue": 70,
+          "revenue_str": "G10-H9",
+          "nodes": [
+            "G10-2",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 319,
+      "created_at": 1718481175,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 320,
+      "created_at": 1718481176
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 321,
+      "created_at": 1718481178
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 322,
+      "created_at": 1718481191,
+      "hex": "E12",
+      "tile": "14-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 323,
+      "created_at": 1718481195
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 324,
+      "created_at": 1718481202,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "D19",
+              "E18",
+              "E16",
+              "D15"
+            ],
+            [
+              "D15",
+              "D13",
+              "C12"
+            ],
+            [
+              "C12",
+              "C10",
+              "B9",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "D15",
+            "C12",
+            "A10"
+          ],
+          "revenue": 180,
+          "revenue_str": "D19-D15-C12-A10 + b/B",
+          "nodes": [
+            "D19-0",
+            "D15-0",
+            "C12-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 325,
+      "created_at": 1718481207,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 326,
+      "user": 149,
+      "created_at": 1718481209
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 327,
+      "user": 149,
+      "created_at": 1718481224
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 328,
+      "created_at": 1718481248
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 329,
+      "created_at": 1718481249
+    },
+    {
+      "hex": "D11",
+      "tile": "6-2",
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 330,
+      "user": 15550,
+      "created_at": 1718484158
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 331,
+      "user": 15550,
+      "created_at": 1718484197
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 332,
+      "created_at": 1718484281,
+      "hex": "D11",
+      "tile": "6-2",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 333,
+      "created_at": 1718484283
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 334,
+      "created_at": 1718484290,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "C10",
+              "C12"
+            ],
+            [
+              "C12",
+              "D13",
+              "D15"
+            ],
+            [
+              "D15",
+              "E16",
+              "E18",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "C12",
+            "D15",
+            "D19"
+          ],
+          "revenue": 180,
+          "revenue_str": "A10-C12-D15-D19 + b/B",
+          "nodes": [
+            "A10-0",
+            "C12-0",
+            "D15-0",
+            "D19-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "D15",
+              "C16"
+            ],
+            [
+              "C16",
+              "B15",
+              "A16"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "C16",
+            "A16"
+          ],
+          "revenue": 130,
+          "revenue_str": "D15-C16-A16 + GKB30(C16)",
+          "nodes": [
+            "D15-0",
+            "C16-0",
+            "A16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 335,
+      "created_at": 1718484298,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 336,
+      "created_at": 1718484303
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 337,
+      "created_at": 1718484318
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 338,
+      "created_at": 1718484356,
+      "hex": "E14",
+      "tile": "24-1",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 339,
+      "created_at": 1718484363
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 340,
+      "created_at": 1718484365
+    },
+    {
+      "type": "run_routes",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 341,
+      "created_at": 1718484368,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "A16",
+              "B15",
+              "C16"
+            ],
+            [
+              "C16",
+              "D15"
+            ],
+            [
+              "D15",
+              "E16",
+              "E18",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "A16",
+            "C16",
+            "D15",
+            "D19"
+          ],
+          "revenue": 130,
+          "revenue_str": "A16-C16-D15-D19",
+          "nodes": [
+            "A16-0",
+            "C16-0",
+            "D15-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 342,
+      "created_at": 1718484371,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 343,
+      "created_at": 1718484373
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 344,
+      "created_at": 1718484387
+    },
+    {
+      "type": "choose",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 345,
+      "created_at": 1718503239,
+      "choice": "wait"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 346,
+      "created_at": 1718516380,
+      "shares": [
+        "TGOJ_2",
+        "TGOJ_3",
+        "TGOJ_4",
+        "TGOJ_0"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "par",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 347,
+      "created_at": 1718516389,
+      "corporation": "SWB",
+      "share_price": "100,0,2"
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 348,
+      "created_at": 1718516414,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 149,
+          "entity_type": "player",
+          "created_at": 1718516412
+        }
+      ],
+      "corporation": "SWB",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "par",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 349,
+      "created_at": 1718531980,
+      "corporation": "UGJ",
+      "share_price": "76,3,2"
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 350,
+      "created_at": 1718531988
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 351,
+      "created_at": 1718532186,
+      "shares": [
+        "MÖJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 352,
+      "created_at": 1718532191
+    },
+    {
+      "type": "par",
+      "entity": 3041,
+      "corporation": "BJ",
+      "entity_type": "player",
+      "share_price": "100,0,2",
+      "id": 353,
+      "user": 3041,
+      "created_at": 1718536154
+    },
+    {
+      "type": "undo",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 354,
+      "user": 3041,
+      "created_at": 1718536171
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 355,
+      "created_at": 1718536223,
+      "shares": [
+        "TGOJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 356,
+      "created_at": 1718536234,
+      "shares": [
+        "KFJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 357,
+      "created_at": 1718536249,
+      "shares": [
+        "SNJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 358,
+      "created_at": 1718536252,
+      "corporation": "BJ",
+      "share_price": "100,0,2"
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 359,
+      "created_at": 1718536263,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 149,
+          "entity_type": "player",
+          "created_at": 1718536263,
+          "reason": "Corporation UGJ parred"
+        }
+      ]
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 360,
+      "created_at": 1718536417,
+      "corporation": "BJ",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 361,
+      "created_at": 1718546342,
+      "shares": [
+        "SWB_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 362,
+      "created_at": 1718546369
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 363,
+      "created_at": 1718555987,
+      "shares": [
+        "UGJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 364,
+      "created_at": 1718555990
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 365,
+      "created_at": 1718560064,
+      "shares": [
+        "TGOJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 366,
+      "created_at": 1718560069,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1718560068,
+          "shares": [
+            "BJ_1"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1718560068
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 367,
+      "created_at": 1718561603,
+      "shares": [
+        "SWB_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 368,
+      "created_at": 1718561605
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "shares": [
+        "UGJ_2"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 369,
+      "user": 17876,
+      "created_at": 1718562801
+    },
+    {
+      "type": "undo",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 370,
+      "user": 17876,
+      "created_at": 1718562804
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 371,
+      "created_at": 1718562816,
+      "shares": [
+        "UGJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 372,
+      "created_at": 1718562819
+    },
+    {
+      "type": "par",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 373,
+      "created_at": 1718562884,
+      "corporation": "ÖSJ",
+      "share_price": "76,3,2"
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 374,
+      "created_at": 1718562889,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1718562888,
+          "reason": "Corporation ÖSJ parred"
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 375,
+      "created_at": 1718574809,
+      "shares": [
+        "BJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 376,
+      "created_at": 1718574811
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 377,
+      "created_at": 1718575500,
+      "shares": [
+        "SWB_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 378,
+      "created_at": 1718575503
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 379,
+      "created_at": 1718580264,
+      "shares": [
+        "UGJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 380,
+      "created_at": 1718580266
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 381,
+      "created_at": 1718580632
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 382,
+      "created_at": 1718582624,
+      "shares": [
+        "BJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 383,
+      "created_at": 1718582626
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 384,
+      "created_at": 1718582630,
+      "corporation": "BJ",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 385,
+      "created_at": 1718583854,
+      "shares": [
+        "SWB_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 386,
+      "created_at": 1718583856
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 387,
+      "created_at": 1718585178,
+      "shares": [
+        "UGJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 388,
+      "created_at": 1718585185
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 389,
+      "created_at": 1718585388,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 15550,
+          "entity_type": "player",
+          "created_at": 1718585387
+        },
+        {
+          "type": "buy_shares",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1718585388,
+          "shares": [
+            "BJ_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1718585388,
+          "reason": "BJ is floated"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 390,
+      "created_at": 1718585408,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1718585408
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 391,
+      "created_at": 1718635883
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 392,
+      "created_at": 1718637581,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 15550,
+          "entity_type": "player",
+          "created_at": 1718637581
+        },
+        {
+          "type": "pass",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1718637581
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 393,
+      "created_at": 1718637634
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 394,
+      "created_at": 1718637658,
+      "hex": "E10",
+      "tile": "9-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 395,
+      "created_at": 1718637804
+    },
+    {
+      "type": "run_routes",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 396,
+      "created_at": 1718637814,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "F13",
+              "G12",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "G10",
+            "H9"
+          ],
+          "revenue": 100,
+          "revenue_str": "F13-G10-H9",
+          "nodes": [
+            "F13-0",
+            "G10-0",
+            "H9-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "G26",
+            "D29"
+          ],
+          "revenue": 130,
+          "revenue_str": "E20-G26-D29 + m/M",
+          "nodes": [
+            "E20-0",
+            "G26-0",
+            "D29-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 397,
+      "created_at": 1718637838,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 398,
+      "created_at": 1718637866
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 399,
+      "created_at": 1718637869
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 400,
+      "created_at": 1718637892
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 401,
+      "created_at": 1718637895,
+      "hex": "C30",
+      "tile": "9-6",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 402,
+      "created_at": 1718637898
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 403,
+      "created_at": 1718637900,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "D29",
+            "B31"
+          ],
+          "revenue": 180,
+          "revenue_str": "G26-D29-B31 + m/M/m",
+          "nodes": [
+            "G26-0",
+            "D29-0",
+            "B31-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 404,
+      "created_at": 1718637902,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 405,
+      "created_at": 1718637903
+    },
+    {
+      "type": "buy_company",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 406,
+      "created_at": 1718637907,
+      "company": "FRY",
+      "price": 40
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 407,
+      "created_at": 1718638964,
+      "hex": "F11",
+      "tile": "9-7",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 408,
+      "created_at": 1718638968
+    },
+    {
+      "type": "place_token",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 409,
+      "created_at": 1718638970,
+      "city": "15-3-0",
+      "slot": 1,
+      "tokener": "SWB"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 410,
+      "created_at": 1718639004,
+      "shares": [
+        "TGOJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_train",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 411,
+      "created_at": 1718639007,
+      "train": "5-0",
+      "price": 530,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 412,
+      "created_at": 1718639029,
+      "hex": "A12",
+      "tile": "9-8",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 413,
+      "created_at": 1718639043,
+      "hex": "E20",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 414,
+      "created_at": 1718639045,
+      "city": "619-1-0",
+      "slot": 1,
+      "tokener": "BJ"
+    },
+    {
+      "type": "buy_train",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 415,
+      "created_at": 1718639046,
+      "train": "5-1",
+      "price": 530,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 416,
+      "created_at": 1718654456,
+      "hex": "G10",
+      "tile": "X4-0",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 417,
+      "created_at": 1718654461,
+      "hex": "D7",
+      "tile": "9-9",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 418,
+      "created_at": 1718654469,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G10",
+              "F9",
+              "E8"
+            ],
+            [
+              "E8",
+              "E10",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "E8",
+            "E12",
+            "E20"
+          ],
+          "revenue": 170,
+          "revenue_str": "G10-E8-E12-E20",
+          "nodes": [
+            "G10-2",
+            "E8-0",
+            "E12-0",
+            "E20-0"
+          ]
+        },
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "H9"
+          ],
+          "revenue": 110,
+          "revenue_str": "G10-H9",
+          "nodes": [
+            "G10-2",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 419,
+      "user": 149,
+      "created_at": 1718654477
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 420,
+      "user": 149,
+      "created_at": 1718654481
+    },
+    {
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 421,
+      "created_at": 1718654493,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 422,
+      "created_at": 1718671606,
+      "hex": "E12",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 423,
+      "created_at": 1718671649
+    },
+    {
+      "city": "14-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "UGJ",
+      "tokener": "UGJ",
+      "entity_type": "corporation",
+      "id": 424,
+      "user": 17876,
+      "created_at": 1718671654
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17876,
+      "shares": [
+        "SNJ_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 425,
+      "user": 17876,
+      "created_at": 1718671757
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17876,
+      "shares": [
+        "UGJ_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 426,
+      "user": 17876,
+      "created_at": 1718671759
+    },
+    {
+      "type": "buy_train",
+      "price": 530,
+      "train": "5-2",
+      "entity": "UGJ",
+      "variant": "5",
+      "entity_type": "corporation",
+      "id": 427,
+      "user": 17876,
+      "created_at": 1718671762
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 428,
+      "user": 17876,
+      "created_at": 1718671800
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 429,
+      "user": 17876,
+      "created_at": 1718671803
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 430,
+      "user": 17876,
+      "created_at": 1718671806
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 431,
+      "user": 17876,
+      "created_at": 1718671809
+    },
+    {
+      "type": "place_token",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 432,
+      "created_at": 1718671810,
+      "city": "A16-0-0",
+      "slot": 0,
+      "tokener": "UGJ"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 433,
+      "created_at": 1718671832,
+      "shares": [
+        "SNJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 434,
+      "created_at": 1718671833,
+      "shares": [
+        "UGJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_train",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 435,
+      "created_at": 1718671835,
+      "train": "5-2",
+      "price": 530,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 436,
+      "created_at": 1718671852,
+      "hex": "D23",
+      "tile": "8-7",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 437,
+      "created_at": 1718671860
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 438,
+      "created_at": 1718671880,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "D19",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "E12",
+              "D13",
+              "C12"
+            ],
+            [
+              "C12",
+              "C10",
+              "B9",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "E12",
+            "C12",
+            "A10"
+          ],
+          "revenue": 220,
+          "revenue_str": "D19-E12-C12-A10 + b/B",
+          "nodes": [
+            "D19-0",
+            "E12-0",
+            "C12-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 439,
+      "created_at": 1718671949,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 440,
+      "created_at": 1718671956
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 441,
+      "created_at": 1718672013,
+      "hex": "D15",
+      "tile": "611-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 442,
+      "created_at": 1718672016
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 443,
+      "created_at": 1718672040
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 444,
+      "created_at": 1718672065,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "C10",
+              "C12"
+            ],
+            [
+              "C12",
+              "D13",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "C12",
+            "E12",
+            "D19"
+          ],
+          "revenue": 220,
+          "revenue_str": "A10-C12-E12-D19 + b/B",
+          "nodes": [
+            "A10-0",
+            "C12-0",
+            "E12-0",
+            "D19-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "C12",
+              "B11"
+            ],
+            [
+              "B11",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "C12",
+            "B11",
+            "A10"
+          ],
+          "revenue": 120,
+          "revenue_str": "C12-B11-A10",
+          "nodes": [
+            "C12-0",
+            "B11-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 445,
+      "created_at": 1718672070,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 446,
+      "created_at": 1718672089
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 447,
+      "created_at": 1718672124,
+      "hex": "C16",
+      "tile": "611-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 448,
+      "created_at": 1718672128
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 449,
+      "created_at": 1718672130
+    },
+    {
+      "type": "run_routes",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 450,
+      "created_at": 1718672135,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "C16",
+              "D17",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "C16",
+            "D19",
+            "E12",
+            "G10"
+          ],
+          "revenue": 180,
+          "revenue_str": "C16-D19-E12-G10",
+          "nodes": [
+            "C16-0",
+            "D19-0",
+            "E12-0",
+            "G10-3"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 451,
+      "created_at": 1718672138,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 452,
+      "created_at": 1718672143
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 453,
+      "created_at": 1718672194,
+      "hex": "B15",
+      "tile": "23-2",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 454,
+      "created_at": 1718672197
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 455,
+      "created_at": 1718672201,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "D29",
+            "B31"
+          ],
+          "revenue": 220,
+          "revenue_str": "G26-D29-B31 + m/M/m",
+          "nodes": [
+            "G26-0",
+            "D29-0",
+            "B31-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 456,
+      "user": 3041,
+      "created_at": 1718672218
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 457,
+      "user": 3041,
+      "created_at": 1718672260
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 458,
+      "created_at": 1718672266,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 459,
+      "created_at": 1718672267
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 460,
+      "created_at": 1718676346,
+      "hex": "C6",
+      "tile": "9-10",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 461,
+      "created_at": 1718676347,
+      "hex": "B5",
+      "tile": "57-1",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 462,
+      "created_at": 1718676350,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E10",
+              "E8"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "E12",
+            "E8",
+            "B5"
+          ],
+          "revenue": 160,
+          "revenue_str": "G10-E12-E8-B5",
+          "nodes": [
+            "G10-3",
+            "E12-0",
+            "E8-0",
+            "B5-0"
+          ]
+        },
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "E8",
+              "F9",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "E8",
+            "G10",
+            "H9"
+          ],
+          "revenue": 140,
+          "revenue_str": "E8-G10-H9",
+          "nodes": [
+            "E8-0",
+            "G10-2",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 463,
+      "created_at": 1718676351,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 464,
+      "created_at": 1718683180
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 465,
+      "created_at": 1718683224,
+      "hex": "C24",
+      "tile": "6-1",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 466,
+      "created_at": 1718683227
+    },
+    {
+      "type": "run_routes",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 467,
+      "created_at": 1718683247,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "E12",
+            "G10"
+          ],
+          "revenue": 150,
+          "revenue_str": "E20-E12-G10",
+          "nodes": [
+            "E20-0",
+            "E12-0",
+            "G10-3"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "D29",
+            "B31"
+          ],
+          "revenue": 220,
+          "revenue_str": "G26-D29-B31 + m/M/m",
+          "nodes": [
+            "G26-0",
+            "D29-0",
+            "B31-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 468,
+      "created_at": 1718683280,
+      "kind": "withhold"
+    },
+    {
+      "hex": "A4",
+      "tile": "8-8",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "id": 469,
+      "user": 149,
+      "created_at": 1718716366
+    },
+    {
+      "hex": "B5",
+      "tile": "619-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 470,
+      "user": 149,
+      "created_at": 1718716386
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "action_id": 468,
+      "entity_type": "corporation",
+      "id": 471,
+      "user": 149,
+      "created_at": 1718716422
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 472,
+      "created_at": 1718716450,
+      "hex": "B5",
+      "tile": "619-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 473,
+      "created_at": 1718716467,
+      "hex": "A4",
+      "tile": "8-8",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 474,
+      "created_at": 1718716469,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D19",
+              "D17",
+              "C16"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "D19",
+            "C16"
+          ],
+          "revenue": 270,
+          "revenue_str": "H9-G10-E12-D19-C16 + b/B",
+          "nodes": [
+            "H9-0",
+            "G10-3",
+            "E12-0",
+            "D19-0",
+            "C16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 475,
+      "created_at": 1718716470,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 476,
+      "created_at": 1718716474
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 477,
+      "created_at": 1718716524,
+      "hex": "E16",
+      "tile": "41-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 478,
+      "created_at": 1718716530
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 479,
+      "created_at": 1718716533,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "D15"
+            ],
+            [
+              "D15",
+              "C16"
+            ],
+            [
+              "C16",
+              "D17",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "E12",
+            "D15",
+            "C16",
+            "D19"
+          ],
+          "revenue": 220,
+          "revenue_str": "G10-E12-D15-C16-D19",
+          "nodes": [
+            "G10-3",
+            "E12-0",
+            "D15-0",
+            "C16-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 480,
+      "created_at": 1718716534,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 481,
+      "created_at": 1718716540
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 482,
+      "created_at": 1718716881,
+      "hex": "A14",
+      "tile": "23-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 483,
+      "created_at": 1718716899
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 484,
+      "created_at": 1718716900
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 485,
+      "created_at": 1718716907,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "A10",
+              "B9",
+              "C10",
+              "C12"
+            ],
+            [
+              "C12",
+              "D13",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "C12",
+            "E12",
+            "D19"
+          ],
+          "revenue": 220,
+          "revenue_str": "A10-C12-E12-D19 + b/B",
+          "nodes": [
+            "A10-0",
+            "C12-0",
+            "E12-0",
+            "D19-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "D15",
+              "C16"
+            ],
+            [
+              "C16",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "C16",
+            "A10"
+          ],
+          "revenue": 150,
+          "revenue_str": "D15-C16-A10",
+          "nodes": [
+            "D15-0",
+            "C16-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 486,
+      "user": 15550,
+      "created_at": 1718716920
+    },
+    {
+      "type": "undo",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 487,
+      "user": 15550,
+      "created_at": 1718716929
+    },
+    {
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 488,
+      "user": 15550,
+      "created_at": 1718716930
+    },
+    {
+      "type": "undo",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 489,
+      "user": 15550,
+      "created_at": 1718716932
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 490,
+      "created_at": 1718716949,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 491,
+      "created_at": 1718716953
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 492,
+      "created_at": 1718717019,
+      "hex": "D21",
+      "tile": "14-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 493,
+      "created_at": 1718717021
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 494,
+      "created_at": 1718717022
+    },
+    {
+      "type": "run_routes",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 495,
+      "created_at": 1718717031,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "B15",
+              "C16"
+            ],
+            [
+              "C16",
+              "D17",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "E16",
+              "D15"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "C16",
+            "D19",
+            "D15"
+          ],
+          "revenue": 230,
+          "revenue_str": "A10-C16-D19-D15 + b/B",
+          "nodes": [
+            "A10-0",
+            "C16-0",
+            "D19-0",
+            "D15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 496,
+      "created_at": 1718717038,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 497,
+      "created_at": 1718717105,
+      "train": "3-0",
+      "price": 200
+    },
+    {
+      "type": "buy_shares",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 498,
+      "created_at": 1718731349,
+      "shares": [
+        "TGOJ_4"
+      ],
+      "percent": 10,
+      "share_price": 67
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 499,
+      "created_at": 1718731403,
+      "hex": "B9",
+      "tile": "25-1",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 500,
+      "created_at": 1718731411
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 501,
+      "created_at": 1718731444
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 502,
+      "created_at": 1718731462,
+      "routes": [
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "B15",
+              "C16"
+            ],
+            [
+              "C16",
+              "D17",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "E16",
+              "D15"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "C16",
+            "D19",
+            "D15"
+          ],
+          "revenue": 230,
+          "revenue_str": "A10-C16-D19-D15 + b/B",
+          "nodes": [
+            "A10-0",
+            "C16-0",
+            "D19-0",
+            "D15-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 503,
+      "created_at": 1718731470,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 504,
+      "created_at": 1718731479
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 505,
+      "created_at": 1718731493,
+      "hex": "C26",
+      "tile": "9-11",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 506,
+      "created_at": 1718731535
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 507,
+      "created_at": 1718731539,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "B15",
+              "C16"
+            ],
+            [
+              "C16",
+              "D17",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "E16",
+              "E14",
+              "F13"
+            ],
+            [
+              "F13",
+              "G12",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "C16",
+            "D19",
+            "F13",
+            "G10"
+          ],
+          "revenue": 290,
+          "revenue_str": "A10-C16-D19-F13-G10 + b/B",
+          "nodes": [
+            "A10-0",
+            "C16-0",
+            "D19-0",
+            "F13-0",
+            "G10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 508,
+      "created_at": 1718731542,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 509,
+      "created_at": 1718731556
+    },
+    {
+      "type": "choose",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 510,
+      "created_at": 1718731573,
+      "choice": "wait"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 511,
+      "created_at": 1718731687,
+      "shares": [
+        "BJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 512,
+      "created_at": 1718731690
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 513,
+      "created_at": 1718731730,
+      "shares": [
+        "TGOJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 514,
+      "created_at": 1718731740
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 515,
+      "created_at": 1718736594,
+      "shares": [
+        "ÖSJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 516,
+      "created_at": 1718736598
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 517,
+      "created_at": 1718736661
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 518,
+      "created_at": 1718736731,
+      "shares": [
+        "ÖKJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 519,
+      "created_at": 1718736739
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 520,
+      "created_at": 1718754716,
+      "shares": [
+        "ÖKJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 521,
+      "created_at": 1718754724
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 522,
+      "created_at": 1718758093,
+      "shares": [
+        "ÖSJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 523,
+      "created_at": 1718758589
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 524,
+      "created_at": 1718758859,
+      "shares": [
+        "SWB_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 525,
+      "created_at": 1718758867
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 526,
+      "created_at": 1718760911,
+      "shares": [
+        "ÖKJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 527,
+      "created_at": 1718760934
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 528,
+      "created_at": 1718779280,
+      "shares": [
+        "UGJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 529,
+      "created_at": 1718779285
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 530,
+      "created_at": 1718790729,
+      "shares": [
+        "ÖSJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 531,
+      "created_at": 1718790782
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "shares": [
+        "SWB_6"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 532,
+      "user": 3041,
+      "created_at": 1718794491
+    },
+    {
+      "type": "undo",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 533,
+      "user": 3041,
+      "created_at": 1718794498
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 534,
+      "created_at": 1718794502,
+      "shares": [
+        "SNJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 535,
+      "created_at": 1718794505
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 536,
+      "created_at": 1718802254,
+      "shares": [
+        "UGJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 537,
+      "created_at": 1718802259
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 538,
+      "created_at": 1718808222,
+      "shares": [
+        "KFJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 539,
+      "created_at": 1718808225
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 540,
+      "created_at": 1718810435,
+      "shares": [
+        "ÖSJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 541,
+      "created_at": 1718810438
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 542,
+      "created_at": 1718811467,
+      "shares": [
+        "UGJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 543,
+      "created_at": 1718811482
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 544,
+      "created_at": 1718818493,
+      "shares": [
+        "KFJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 545,
+      "created_at": 1718818499
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 546,
+      "created_at": 1718825761
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 547,
+      "created_at": 1718828273,
+      "shares": [
+        "BJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 548,
+      "created_at": 1718828283
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 549,
+      "created_at": 1718834894,
+      "shares": [
+        "KFJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 550,
+      "created_at": 1718835102
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 551,
+      "created_at": 1718835568,
+      "shares": [
+        "TGOJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 552,
+      "created_at": 1718835593
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 553,
+      "created_at": 1718835626,
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 554,
+      "created_at": 1718835659
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 555,
+      "created_at": 1718835760,
+      "shares": [
+        "SWB_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 556,
+      "created_at": 1718835763
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 557,
+      "created_at": 1718844073,
+      "shares": [
+        "SWB_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 558,
+      "created_at": 1718844075,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 149,
+          "entity_type": "player",
+          "created_at": 1718844074
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 559,
+      "created_at": 1718844341,
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 560,
+      "created_at": 1718849229
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 561,
+      "created_at": 1718849280,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 15550,
+          "entity_type": "player",
+          "created_at": 1718849279
+        },
+        {
+          "type": "pass",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1718849279
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 562,
+      "created_at": 1718849341,
+      "hex": "E18",
+      "tile": "46-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 563,
+      "created_at": 1718849344
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 564,
+      "created_at": 1718849353
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 565,
+      "created_at": 1718849357,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "D29",
+            "B31"
+          ],
+          "revenue": 220,
+          "revenue_str": "G26-D29-B31 + m/M/m",
+          "nodes": [
+            "G26-0",
+            "D29-0",
+            "B31-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 566,
+      "created_at": 1718849377,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 567,
+      "created_at": 1718849383,
+      "train": "5-1",
+      "price": 187
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 568,
+      "created_at": 1718849439,
+      "hex": "C6",
+      "tile": "24-2",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 569,
+      "created_at": 1718849444
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 570,
+      "created_at": 1718849447,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "G10",
+              "F9",
+              "E8"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "E8",
+            "B5",
+            "A2"
+          ],
+          "revenue": 180,
+          "revenue_str": "G10-E8-B5-A2",
+          "nodes": [
+            "G10-2",
+            "E8-0",
+            "B5-0",
+            "A2-0"
+          ]
+        },
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "E8",
+              "E10",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "E8",
+            "E12",
+            "G10"
+          ],
+          "revenue": 140,
+          "revenue_str": "E8-E12-G10",
+          "nodes": [
+            "E8-0",
+            "E12-0",
+            "G10-3"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 571,
+      "created_at": 1718849448,
+      "kind": "payout"
+    },
+    {
+      "hex": "C4",
+      "tile": "8-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 572,
+      "user": 149,
+      "created_at": 1718849459
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 573,
+      "user": 149,
+      "created_at": 1718849468
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "routes": [
+        {
+          "hexes": [
+            "G10",
+            "E12",
+            "D19",
+            "C16",
+            "A10"
+          ],
+          "nodes": [
+            "G10-3",
+            "E12-0",
+            "D19-0",
+            "C16-0",
+            "A10-0"
+          ],
+          "train": "5-0",
+          "revenue": 300,
+          "connections": [
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D19",
+              "D17",
+              "C16"
+            ],
+            [
+              "C16",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "revenue_str": "G10-E12-D19-C16-A10 + b/B"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 574,
+      "user": 149,
+      "created_at": 1718849471
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 575,
+      "user": 149,
+      "created_at": 1718849472
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "action_id": 571,
+      "entity_type": "corporation",
+      "id": 576,
+      "user": 149,
+      "created_at": 1718849495
+    },
+    {
+      "hex": "E14",
+      "tile": "42-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 577,
+      "user": 149,
+      "created_at": 1718849512
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 578,
+      "user": 149,
+      "created_at": 1718849522
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 579,
+      "created_at": 1718849539,
+      "hex": "A14",
+      "tile": "41-1",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 580,
+      "created_at": 1718849545
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 581,
+      "created_at": 1718849547,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D19",
+              "D17",
+              "C16"
+            ],
+            [
+              "C16",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "E12",
+            "D19",
+            "C16",
+            "A10"
+          ],
+          "revenue": 300,
+          "revenue_str": "G10-E12-D19-C16-A10 + b/B",
+          "nodes": [
+            "G10-3",
+            "E12-0",
+            "D19-0",
+            "C16-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 582,
+      "user": 149,
+      "created_at": 1718849548
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 583,
+      "user": 149,
+      "created_at": 1718849549
+    },
+    {
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 584,
+      "user": 149,
+      "created_at": 1718849563
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 585,
+      "user": 149,
+      "created_at": 1718849567
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 586,
+      "created_at": 1718849587,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 587,
+      "created_at": 1718849597,
+      "train": "3-4",
+      "price": 467
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 588,
+      "created_at": 1718849619,
+      "hex": "C28",
+      "tile": "8-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 589,
+      "created_at": 1718849625
+    },
+    {
+      "type": "place_token",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 590,
+      "created_at": 1718849626,
+      "city": "15-1-0",
+      "slot": 1,
+      "tokener": "BJ"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 591,
+      "created_at": 1718849644,
+      "shares": [
+        "SNJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_train",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 592,
+      "created_at": 1718849646,
+      "train": "6-0",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 593,
+      "created_at": 1718877445,
+      "hex": "C18",
+      "tile": "9-12",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 594,
+      "created_at": 1718877468
+    },
+    {
+      "type": "run_routes",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 595,
+      "created_at": 1718877478,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "B15",
+              "C16"
+            ],
+            [
+              "C16",
+              "D17",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "C16",
+            "D19"
+          ],
+          "revenue": 190,
+          "revenue_str": "A10-C16-D19 + b/B",
+          "nodes": [
+            "A10-0",
+            "C16-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 596,
+      "created_at": 1718877483,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 597,
+      "created_at": 1718877498
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 598,
+      "created_at": 1718877530,
+      "hex": "B7",
+      "tile": "9-13",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 599,
+      "created_at": 1718877606
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 600,
+      "created_at": 1718877633
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 601,
+      "created_at": 1718877638,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "B15",
+              "C16"
+            ],
+            [
+              "C16",
+              "D15"
+            ],
+            [
+              "D15",
+              "E16",
+              "E18",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "C16",
+            "D15",
+            "D19"
+          ],
+          "revenue": 230,
+          "revenue_str": "A10-C16-D15-D19 + b/B",
+          "nodes": [
+            "A10-0",
+            "C16-0",
+            "D15-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 602,
+      "created_at": 1718877641,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 603,
+      "created_at": 1718877747,
+      "train": "D-0",
+      "price": 1000,
+      "variant": "E",
+      "exchange": "4-1"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 604,
+      "created_at": 1718877753
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 605,
+      "created_at": 1718877795,
+      "hex": "C4",
+      "tile": "8-2",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 606,
+      "created_at": 1718877854
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 607,
+      "created_at": 1718877855
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 608,
+      "created_at": 1718877864,
+      "train": "6-1",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 609,
+      "created_at": 1718884420
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 610,
+      "created_at": 1718884476,
+      "hex": "C24",
+      "tile": "14-3",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 611,
+      "created_at": 1718884480
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 612,
+      "created_at": 1718884484
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 613,
+      "created_at": 1718884565,
+      "shares": [
+        "ÖKJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 614,
+      "created_at": 1718884566,
+      "shares": [
+        "KFJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 615,
+      "created_at": 1718884583,
+      "shares": [
+        "UGJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 616,
+      "created_at": 1718884600,
+      "shares": [
+        "TGOJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 617,
+      "created_at": 1718884604,
+      "shares": [
+        "UGJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 618,
+      "created_at": 1718884608,
+      "shares": [
+        "TGOJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 619,
+      "created_at": 1718884610,
+      "shares": [
+        "UGJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_train",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 620,
+      "created_at": 1718884615,
+      "train": "D-1",
+      "price": 1100,
+      "variant": "D"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 621,
+      "created_at": 1718884625
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 622,
+      "created_at": 1718884638,
+      "hex": "D11",
+      "tile": "619-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 623,
+      "created_at": 1718884642
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 624,
+      "created_at": 1718884661
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 625,
+      "created_at": 1718884666,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "A16"
+            ],
+            [
+              "A16",
+              "B15",
+              "C16"
+            ],
+            [
+              "C16",
+              "D17",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "A16",
+            "C16",
+            "D19"
+          ],
+          "revenue": 210,
+          "revenue_str": "A10-A16-C16-D19 + b/B",
+          "nodes": [
+            "A10-0",
+            "A16-0",
+            "C16-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 626,
+      "created_at": 1718884678,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 627,
+      "created_at": 1718884691
+    },
+    {
+      "hex": "D9",
+      "tile": "9-5",
+      "type": "lay_tile",
+      "entity": "STJ",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 628,
+      "user": 3041,
+      "created_at": 1718885194
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 629,
+      "user": 3041,
+      "created_at": 1718885197
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "routes": [
+        {
+          "hexes": [
+            "B31",
+            "D29",
+            "G26",
+            "E20",
+            "D15"
+          ],
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "G26-0",
+            "E20-0",
+            "D15-0"
+          ],
+          "train": "5-1",
+          "revenue": 300,
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "G26",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "D15"
+            ]
+          ],
+          "revenue_str": "B31-D29-G26-E20-D15 + m/M/m"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 630,
+      "user": 3041,
+      "created_at": 1718885200
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 631,
+      "user": 3041,
+      "created_at": 1718885202
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 632,
+      "user": 3041,
+      "created_at": 1718885204
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 633,
+      "user": 3041,
+      "created_at": 1718885978
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "action_id": 627,
+      "entity_type": "corporation",
+      "id": 634,
+      "user": 3041,
+      "created_at": 1718885980
+    },
+    {
+      "hex": "G10",
+      "tile": "X5-0",
+      "type": "lay_tile",
+      "entity": "STJ",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "id": 635,
+      "user": 3041,
+      "created_at": 1718885993
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 636,
+      "user": 3041,
+      "created_at": 1718885996
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "routes": [
+        {
+          "hexes": [
+            "B31",
+            "D29",
+            "G26",
+            "E20",
+            "D15"
+          ],
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "G26-0",
+            "E20-0",
+            "D15-0"
+          ],
+          "train": "5-1",
+          "revenue": 300,
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "G26",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "D15"
+            ]
+          ],
+          "revenue_str": "B31-D29-G26-E20-D15 + m/M/m"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 637,
+      "user": 3041,
+      "created_at": 1718886012
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "action_id": 627,
+      "entity_type": "corporation",
+      "id": 638,
+      "user": 3041,
+      "created_at": 1718886014
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 639,
+      "created_at": 1718886019,
+      "hex": "E12",
+      "tile": "X6-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 640,
+      "created_at": 1718886020
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 641,
+      "created_at": 1718886024,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "G26",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "G26",
+            "E20",
+            "E12"
+          ],
+          "revenue": 320,
+          "revenue_str": "B31-D29-G26-E20-E12 + m/M/m",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "G26-0",
+            "E20-0",
+            "E12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 642,
+      "created_at": 1718886025,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 643,
+      "created_at": 1718886029
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 644,
+      "created_at": 1718888360,
+      "hex": "G10",
+      "tile": "X5-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 645,
+      "created_at": 1718888366
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 646,
+      "created_at": 1718888372,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F9",
+              "E8"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E8",
+            "B5",
+            "A2"
+          ],
+          "revenue": 360,
+          "revenue_str": "H9-G10-E8-B5-A2 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E8-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 647,
+      "created_at": 1718888373,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 648,
+      "created_at": 1718888379
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 649,
+      "created_at": 1718888456,
+      "hex": "D29",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 650,
+      "created_at": 1718888457
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 651,
+      "created_at": 1718888466,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "B15",
+              "C16"
+            ],
+            [
+              "C16",
+              "D17",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "C16",
+            "D19",
+            "E12",
+            "G10",
+            "H9"
+          ],
+          "revenue": 550,
+          "revenue_str": "A10-C16-D19-E12-G10-H9 + Ö/V + b/B/b",
+          "nodes": [
+            "A10-0",
+            "C16-0",
+            "D19-0",
+            "E12-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 652,
+      "created_at": 1718888468,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 653,
+      "created_at": 1718888470
+    },
+    {
+      "type": "buy_shares",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 654,
+      "created_at": 1718893495,
+      "shares": [
+        "KFJ_3"
+      ],
+      "percent": 10,
+      "share_price": 82
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 655,
+      "created_at": 1718893507,
+      "hex": "C20",
+      "tile": "9-5",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 656,
+      "created_at": 1718893514
+    },
+    {
+      "type": "sell_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 657,
+      "created_at": 1718893684,
+      "shares": [
+        "SWB_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 658,
+      "created_at": 1718893717,
+      "shares": [
+        "BJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 659,
+      "created_at": 1718893742,
+      "shares": [
+        "ÖSJ_1",
+        "ÖSJ_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_train",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 660,
+      "created_at": 1718893749,
+      "train": "D-2",
+      "price": 1100,
+      "variant": "D"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 661,
+      "created_at": 1718894323,
+      "hex": "C22",
+      "tile": "9-14",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 662,
+      "created_at": 1718894325
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 663,
+      "created_at": 1718894378,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "G26",
+              "F25",
+              "E24",
+              "F23"
+            ],
+            [
+              "F23",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "D21"
+            ],
+            [
+              "D21",
+              "D23",
+              "C24"
+            ],
+            [
+              "C24",
+              "C22",
+              "C20",
+              "C18",
+              "C16"
+            ],
+            [
+              "C16",
+              "D15"
+            ],
+            [
+              "D15",
+              "E16",
+              "E14",
+              "F13"
+            ],
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "E12",
+              "D11"
+            ],
+            [
+              "D11",
+              "C12"
+            ],
+            [
+              "C12",
+              "C10",
+              "B9",
+              "B7",
+              "B5"
+            ],
+            [
+              "B5",
+              "C6",
+              "D7",
+              "E8"
+            ],
+            [
+              "E8",
+              "F9",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "G26",
+            "F23",
+            "E20",
+            "D21",
+            "C24",
+            "C16",
+            "D15",
+            "F13",
+            "E12",
+            "D11",
+            "C12",
+            "B5",
+            "E8",
+            "G10",
+            "H9"
+          ],
+          "revenue": 940,
+          "revenue_str": "B31-D29-G26-F23-E20-D21-C24-C16-D15-F13-E12-D11-C12-B5-E8-G10-H9 + N/S + m/M/m",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "G26-0",
+            "F23-0",
+            "E20-0",
+            "D21-0",
+            "C24-0",
+            "C16-0",
+            "D15-0",
+            "F13-0",
+            "E12-0",
+            "D11-0",
+            "C12-0",
+            "B5-0",
+            "E8-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 664,
+      "created_at": 1718894380,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 665,
+      "created_at": 1718894388
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 666,
+      "created_at": 1718986872
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 667,
+      "created_at": 1718986878,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "D23",
+              "C24"
+            ],
+            [
+              "C24",
+              "C22",
+              "C20",
+              "C18",
+              "C16"
+            ],
+            [
+              "C16",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "D19",
+            "D21",
+            "C24",
+            "C16",
+            "A10"
+          ],
+          "revenue": 610,
+          "revenue_str": "H9-G10-E12-D19-D21-C24-C16-A10 + Ö/V + b/B/b",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "D19-0",
+            "D21-0",
+            "C24-0",
+            "C16-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 668,
+      "created_at": 1718986882,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 669,
+      "created_at": 1718986909
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 670,
+      "created_at": 1718986925
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 671,
+      "created_at": 1718986939
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 672,
+      "created_at": 1718986955
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 673,
+      "created_at": 1718986961,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "F13",
+            "E12",
+            "D19"
+          ],
+          "revenue": 300,
+          "revenue_str": "H9-G10-F13-E12-D19 + b/B",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "F13-0",
+            "E12-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 674,
+      "created_at": 1718986972,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 675,
+      "created_at": 1718986981
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 676,
+      "created_at": 1718987478,
+      "hex": "B3",
+      "tile": "7-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 677,
+      "created_at": 1718987526
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 678,
+      "created_at": 1718987529,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "A2",
+              "B3",
+              "B1",
+              "C2"
+            ],
+            [
+              "C2",
+              "C4",
+              "B5"
+            ],
+            [
+              "B5",
+              "C6",
+              "D7",
+              "E8"
+            ]
+          ],
+          "hexes": [
+            "A2",
+            "C2",
+            "B5",
+            "E8"
+          ],
+          "revenue": 130,
+          "revenue_str": "A2-C2-B5-E8",
+          "nodes": [
+            "A2-0",
+            "C2-0",
+            "B5-0",
+            "E8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 679,
+      "created_at": 1718987535,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 680,
+      "created_at": 1718987538
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 681,
+      "created_at": 1718992727
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 682,
+      "created_at": 1718992731,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "G26",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "G26",
+            "E20",
+            "E12"
+          ],
+          "revenue": 330,
+          "revenue_str": "B31-D29-G26-E20-E12 + m/M/m",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "G26-0",
+            "E20-0",
+            "E12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 683,
+      "created_at": 1718992732,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 684,
+      "created_at": 1718992736
+    },
+    {
+      "hex": "C2",
+      "tile": "X1-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "id": 685,
+      "user": 149,
+      "created_at": 1718993635
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 686,
+      "user": 149,
+      "created_at": 1718993638
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 687,
+      "created_at": 1718993648
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 688,
+      "created_at": 1718993652,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F9",
+              "E8"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E8",
+            "B5",
+            "A2"
+          ],
+          "revenue": 360,
+          "revenue_str": "H9-G10-E8-B5-A2 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E8-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 689,
+      "created_at": 1718993654,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 690,
+      "created_at": 1718993656
+    },
+    {
+      "type": "buy_shares",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 691,
+      "created_at": 1718993672,
+      "shares": [
+        "BJ_6"
+      ],
+      "percent": 10,
+      "share_price": 110
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 692,
+      "created_at": 1718993693
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 693,
+      "created_at": 1718993701,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "B15",
+              "C16"
+            ],
+            [
+              "C16",
+              "D17",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "C16",
+            "D19",
+            "E12",
+            "G10",
+            "H9"
+          ],
+          "revenue": 550,
+          "revenue_str": "A10-C16-D19-E12-G10-H9 + Ö/V + b/B/b",
+          "nodes": [
+            "A10-0",
+            "C16-0",
+            "D19-0",
+            "E12-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 694,
+      "created_at": 1718993702,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 695,
+      "created_at": 1718993705
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 696,
+      "created_at": 1718993782,
+      "hex": "D7",
+      "tile": "24-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 697,
+      "created_at": 1718993794
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 698,
+      "created_at": 1718993832,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "G26",
+              "F25",
+              "E24",
+              "F23"
+            ],
+            [
+              "F23",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "D21"
+            ],
+            [
+              "D21",
+              "D23",
+              "C24"
+            ],
+            [
+              "C24",
+              "C22",
+              "C20",
+              "C18",
+              "C16"
+            ],
+            [
+              "C16",
+              "D15"
+            ],
+            [
+              "D15",
+              "E16",
+              "E14",
+              "F13"
+            ],
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "E12",
+              "D11"
+            ],
+            [
+              "D11",
+              "C12"
+            ],
+            [
+              "C12",
+              "C10",
+              "B9",
+              "B7",
+              "B5"
+            ],
+            [
+              "B5",
+              "C6",
+              "D7",
+              "E8"
+            ],
+            [
+              "E8",
+              "F9",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "G26",
+            "F23",
+            "E20",
+            "D21",
+            "C24",
+            "C16",
+            "D15",
+            "F13",
+            "E12",
+            "D11",
+            "C12",
+            "B5",
+            "E8",
+            "G10",
+            "H9"
+          ],
+          "revenue": 940,
+          "revenue_str": "B31-D29-G26-F23-E20-D21-C24-C16-D15-F13-E12-D11-C12-B5-E8-G10-H9 + N/S + m/M/m",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "G26-0",
+            "F23-0",
+            "E20-0",
+            "D21-0",
+            "C24-0",
+            "C16-0",
+            "D15-0",
+            "F13-0",
+            "E12-0",
+            "D11-0",
+            "C12-0",
+            "B5-0",
+            "E8-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 699,
+      "created_at": 1718993836,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 700,
+      "created_at": 1718993840
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 701,
+      "created_at": 1718993962,
+      "hex": "D17",
+      "tile": "31-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 702,
+      "created_at": 1718993964
+    },
+    {
+      "type": "run_routes",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 703,
+      "created_at": 1718993968,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "C28",
+              "C26",
+              "C24"
+            ],
+            [
+              "C24",
+              "C22",
+              "C20",
+              "C18",
+              "C16"
+            ],
+            [
+              "C16",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "C24",
+            "C16",
+            "A10"
+          ],
+          "revenue": 300,
+          "revenue_str": "B31-D29-C24-C16-A10 + m/M",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "C24-0",
+            "C16-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 704,
+      "created_at": 1718993971,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 705,
+      "created_at": 1718993973
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 706,
+      "created_at": 1718995562
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 707,
+      "created_at": 1718995571,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "D23",
+              "C24"
+            ],
+            [
+              "C24",
+              "C22",
+              "C20",
+              "C18",
+              "C16"
+            ],
+            [
+              "C16",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "D19",
+            "D21",
+            "C24",
+            "C16",
+            "A10"
+          ],
+          "revenue": 610,
+          "revenue_str": "H9-G10-E12-D19-D21-C24-C16-A10 + Ö/V + b/B/b",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "D19-0",
+            "D21-0",
+            "C24-0",
+            "C16-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 708,
+      "created_at": 1718995575,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 709,
+      "created_at": 1718995579
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 710,
+      "created_at": 1718996989,
+      "hex": "D9",
+      "tile": "9-10",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 711,
+      "created_at": 1718996995
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 712,
+      "created_at": 1718996996
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 713,
+      "created_at": 1718997003,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "D11"
+            ],
+            [
+              "D11",
+              "D9",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "C4",
+              "C2"
+            ],
+            [
+              "C2",
+              "B1",
+              "B3",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "E12",
+            "D11",
+            "B5",
+            "C2",
+            "A2"
+          ],
+          "revenue": 280,
+          "revenue_str": "G10-E12-D11-B5-C2-A2",
+          "nodes": [
+            "G10-0",
+            "E12-0",
+            "D11-0",
+            "B5-0",
+            "C2-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 714,
+      "user": 15550,
+      "created_at": 1718997006
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 715,
+      "user": 15550,
+      "created_at": 1718997008
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 716,
+      "user": 15550,
+      "created_at": 1718997044
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 717,
+      "user": 15550,
+      "created_at": 1718997046
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 718,
+      "created_at": 1718997048,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 719,
+      "created_at": 1718997049
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 720,
+      "created_at": 1718997142
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 721,
+      "created_at": 1718997155,
+      "hex": "B7",
+      "tile": "23-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 722,
+      "created_at": 1718997175
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 723,
+      "created_at": 1718997178
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 724,
+      "created_at": 1718997183,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "F13",
+            "E12",
+            "D19"
+          ],
+          "revenue": 300,
+          "revenue_str": "H9-G10-F13-E12-D19 + b/B",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "F13-0",
+            "E12-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 725,
+      "created_at": 1718997192,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 726,
+      "created_at": 1718997196,
+      "train": "D-3",
+      "price": 800,
+      "variant": "D",
+      "exchange": "5-2"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 727,
+      "created_at": 1718997198
+    },
+    {
+      "type": "choose",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 728,
+      "created_at": 1718997203,
+      "choice": "wait"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 729,
+      "created_at": 1718998303,
+      "shares": [
+        "BJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 730,
+      "created_at": 1718998305
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 731,
+      "created_at": 1718998649,
+      "shares": [
+        "UGJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 732,
+      "created_at": 1718998655
+    },
+    {
+      "type": "buy_shares",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 733,
+      "created_at": 1719001306,
+      "shares": [
+        "SWB_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 734,
+      "created_at": 1719001309
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 735,
+      "created_at": 1719002692,
+      "shares": [
+        "UGJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 736,
+      "created_at": 1719002697
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 737,
+      "created_at": 1719005402,
+      "shares": [
+        "BJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 738,
+      "created_at": 1719005409
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 739,
+      "created_at": 1719005489,
+      "shares": [
+        "UGJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 740,
+      "created_at": 1719005493
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 741,
+      "created_at": 1719005929
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 742,
+      "created_at": 1719008277,
+      "shares": [
+        "UGJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 743,
+      "created_at": 1719008300
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "shares": [
+        "BJ_6"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 744,
+      "user": 149,
+      "created_at": 1719011426
+    },
+    {
+      "type": "undo",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 745,
+      "user": 149,
+      "created_at": 1719011436
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 746,
+      "created_at": 1719011438,
+      "shares": [
+        "ÖKJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 747,
+      "created_at": 1719011461
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 748,
+      "created_at": 1719011986,
+      "shares": [
+        "TGOJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 749,
+      "created_at": 1719011994
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 750,
+      "created_at": 1719012102
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 751,
+      "created_at": 1719012978,
+      "shares": [
+        "UGJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 752,
+      "created_at": 1719012980
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 753,
+      "created_at": 1719024926,
+      "shares": [
+        "TGOJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 754,
+      "created_at": 1719024948
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 755,
+      "created_at": 1719042926,
+      "shares": [
+        "TGOJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 756,
+      "created_at": 1719042931
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 757,
+      "created_at": 1719056425
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 758,
+      "created_at": 1719060855,
+      "shares": [
+        "TGOJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3041,
+      "entity_type": "player",
+      "id": 759,
+      "created_at": 1719060866,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1719060865
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 760,
+      "created_at": 1719074656,
+      "shares": [
+        "STJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 761,
+      "created_at": 1719074662
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 762,
+      "created_at": 1719085385,
+      "shares": [
+        "TGOJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 763,
+      "created_at": 1719085390
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 764,
+      "created_at": 1719085440,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 15550,
+          "entity_type": "player",
+          "created_at": 1719085440
+        },
+        {
+          "type": "pass",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1719085440
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 149,
+      "entity_type": "player",
+      "id": 765,
+      "created_at": 1719086144,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 149,
+          "entity_type": "player",
+          "created_at": 1719086143
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 766,
+      "created_at": 1719086200,
+      "shares": [
+        "ÖSJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 767,
+      "created_at": 1719086206,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 15550,
+          "entity_type": "player",
+          "created_at": 1719086203,
+          "reason": "beeman bought on corporation ÖSJ and is unsecure"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 15550,
+      "entity_type": "player",
+      "id": 768,
+      "created_at": 1719086382,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3041,
+          "entity_type": "player",
+          "created_at": 1719086381
+        },
+        {
+          "type": "pass",
+          "entity": 149,
+          "entity_type": "player",
+          "created_at": 1719086381
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 769,
+      "created_at": 1719086696,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719086694
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 770,
+      "created_at": 1719086802,
+      "hex": "B17",
+      "tile": "7-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 771,
+      "created_at": 1719086803
+    },
+    {
+      "type": "place_token",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 772,
+      "created_at": 1719086805,
+      "city": "611-1-0",
+      "slot": 1,
+      "tokener": "STJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 773,
+      "created_at": 1719086811,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "G26",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "G26",
+            "E20",
+            "E12"
+          ],
+          "revenue": 330,
+          "revenue_str": "B31-D29-G26-E20-E12 + m/M/m",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "G26-0",
+            "E20-0",
+            "E12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 774,
+      "created_at": 1719086812,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 775,
+      "created_at": 1719086815
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 776,
+      "created_at": 1719089495
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 777,
+      "created_at": 1719089498,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F9",
+              "E8"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E8",
+            "B5",
+            "A2"
+          ],
+          "revenue": 360,
+          "revenue_str": "H9-G10-E8-B5-A2 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E8-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 778,
+      "created_at": 1719089499,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 779,
+      "created_at": 1719089509
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 780,
+      "created_at": 1719091566
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 781,
+      "created_at": 1719091587,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "D19",
+            "D21",
+            "E20"
+          ],
+          "revenue": 340,
+          "revenue_str": "H9-G10-E12-D19-D21-E20 + b/B",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "D19-0",
+            "D21-0",
+            "E20-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 782,
+      "created_at": 1719091588,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 783,
+      "created_at": 1719091592
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 784,
+      "created_at": 1719092208,
+      "hex": "C2",
+      "tile": "X1-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 785,
+      "created_at": 1719092211
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 786,
+      "created_at": 1719092239,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "E12",
+              "D11"
+            ],
+            [
+              "D11",
+              "D9",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "B7",
+              "B9",
+              "C10",
+              "C12"
+            ],
+            [
+              "C12",
+              "D13",
+              "D15"
+            ],
+            [
+              "D15",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "E22",
+              "F23"
+            ],
+            [
+              "F23",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "F13",
+            "E12",
+            "D11",
+            "B5",
+            "C12",
+            "D15",
+            "E20",
+            "F23",
+            "G26",
+            "D29",
+            "B31"
+          ],
+          "revenue": 810,
+          "revenue_str": "H9-G10-F13-E12-D11-B5-C12-D15-E20-F23-G26-D29-B31 + N/S + m/M/m",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "F13-0",
+            "E12-0",
+            "D11-0",
+            "B5-0",
+            "C12-0",
+            "D15-0",
+            "E20-0",
+            "F23-0",
+            "G26-0",
+            "D29-0",
+            "B31-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 787,
+      "created_at": 1719092244,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 788,
+      "created_at": 1719092249
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 789,
+      "created_at": 1719092448
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 790,
+      "created_at": 1719092449
+    },
+    {
+      "type": "run_routes",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 791,
+      "created_at": 1719092452,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "C28",
+              "C26",
+              "C24"
+            ],
+            [
+              "C24",
+              "C22",
+              "C20",
+              "C18",
+              "C16"
+            ],
+            [
+              "C16",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "C24",
+            "C16",
+            "A10"
+          ],
+          "revenue": 300,
+          "revenue_str": "B31-D29-C24-C16-A10 + m/M",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "C24-0",
+            "C16-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 792,
+      "created_at": 1719092459,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 793,
+      "created_at": 1719092460
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 794,
+      "created_at": 1719127011
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 795,
+      "created_at": 1719127013
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 796,
+      "created_at": 1719127038,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "C28",
+              "C26",
+              "C24"
+            ],
+            [
+              "C24",
+              "D23",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "C24",
+            "D21",
+            "D19",
+            "E12",
+            "G10",
+            "H9"
+          ],
+          "revenue": 590,
+          "revenue_str": "B31-D29-C24-D21-D19-E12-G10-H9 + N/S + b/B + m/M",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "C24-0",
+            "D21-0",
+            "D19-0",
+            "E12-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 797,
+      "created_at": 1719127042,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 798,
+      "created_at": 1719127045
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 799,
+      "created_at": 1719138501
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 800,
+      "created_at": 1719138571
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 801,
+      "created_at": 1719138572
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 802,
+      "created_at": 1719138588,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "D11"
+            ],
+            [
+              "D11",
+              "D9",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "C4",
+              "C2"
+            ],
+            [
+              "C2",
+              "B1",
+              "B3",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "E12",
+            "D11",
+            "B5",
+            "C2",
+            "A2"
+          ],
+          "revenue": 300,
+          "revenue_str": "G10-E12-D11-B5-C2-A2",
+          "nodes": [
+            "G10-0",
+            "E12-0",
+            "D11-0",
+            "B5-0",
+            "C2-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 803,
+      "created_at": 1719138591,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 804,
+      "created_at": 1719138598
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 805,
+      "created_at": 1719140173
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 806,
+      "created_at": 1719140182
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 807,
+      "created_at": 1719140186,
+      "routes": [
+        {
+          "train": "D-3",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "E12",
+              "D11"
+            ],
+            [
+              "D11",
+              "D9",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "C4",
+              "C2"
+            ],
+            [
+              "C2",
+              "B1",
+              "B3",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "F13",
+            "E12",
+            "D11",
+            "B5",
+            "C2",
+            "A2"
+          ],
+          "revenue": 490,
+          "revenue_str": "H9-G10-F13-E12-D11-B5-C2-A2 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "F13-0",
+            "E12-0",
+            "D11-0",
+            "B5-0",
+            "C2-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 808,
+      "created_at": 1719140188,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 809,
+      "created_at": 1719140192
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 810,
+      "created_at": 1719140244,
+      "hex": "B15",
+      "tile": "43-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 811,
+      "created_at": 1719140250
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 812,
+      "created_at": 1719140254,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "G26",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "G26",
+            "E20",
+            "E12"
+          ],
+          "revenue": 330,
+          "revenue_str": "B31-D29-G26-E20-E12 + m/M/m",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "G26-0",
+            "E20-0",
+            "E12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 813,
+      "created_at": 1719140257,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 814,
+      "created_at": 1719140262
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 815,
+      "created_at": 1719147969
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 816,
+      "created_at": 1719147971,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F9",
+              "E8"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E8",
+            "B5",
+            "A2"
+          ],
+          "revenue": 360,
+          "revenue_str": "H9-G10-E8-B5-A2 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E8-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 817,
+      "created_at": 1719147972,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 818,
+      "created_at": 1719147972
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 819,
+      "created_at": 1719148986,
+      "hex": "D17",
+      "tile": "70-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 820,
+      "created_at": 1719148996
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 821,
+      "created_at": 1719149002,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "D19",
+            "D21",
+            "E20"
+          ],
+          "revenue": 340,
+          "revenue_str": "H9-G10-E12-D19-D21-E20 + b/B",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "D19-0",
+            "D21-0",
+            "E20-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 822,
+      "created_at": 1719149003,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 823,
+      "created_at": 1719149006
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 824,
+      "created_at": 1719150536,
+      "hex": "B11",
+      "tile": "619-2",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 825,
+      "created_at": 1719150539
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 826,
+      "created_at": 1719150561,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "E12",
+              "D11"
+            ],
+            [
+              "D11",
+              "D9",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "B7",
+              "B9",
+              "C10",
+              "C12"
+            ],
+            [
+              "C12",
+              "D13",
+              "D15"
+            ],
+            [
+              "D15",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "E22",
+              "F23"
+            ],
+            [
+              "F23",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "F13",
+            "E12",
+            "D11",
+            "B5",
+            "C12",
+            "D15",
+            "E20",
+            "F23",
+            "G26",
+            "D29",
+            "B31"
+          ],
+          "revenue": 810,
+          "revenue_str": "H9-G10-F13-E12-D11-B5-C12-D15-E20-F23-G26-D29-B31 + N/S + m/M/m",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "F13-0",
+            "E12-0",
+            "D11-0",
+            "B5-0",
+            "C12-0",
+            "D15-0",
+            "E20-0",
+            "F23-0",
+            "G26-0",
+            "D29-0",
+            "B31-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 827,
+      "created_at": 1719150563,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 828,
+      "created_at": 1719150567
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 829,
+      "created_at": 1719150616
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 830,
+      "created_at": 1719150617
+    },
+    {
+      "type": "run_routes",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 831,
+      "created_at": 1719150620,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "C28",
+              "C26",
+              "C24"
+            ],
+            [
+              "C24",
+              "C22",
+              "C20",
+              "C18",
+              "C16"
+            ],
+            [
+              "C16",
+              "B17",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "C24",
+            "C16",
+            "A10"
+          ],
+          "revenue": 300,
+          "revenue_str": "B31-D29-C24-C16-A10 + m/M",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "C24-0",
+            "C16-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 832,
+      "created_at": 1719150622,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 833,
+      "created_at": 1719150623
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 834,
+      "created_at": 1719150688,
+      "hex": "B7",
+      "tile": "47-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 835,
+      "created_at": 1719150700
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 836,
+      "created_at": 1719150702
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 837,
+      "created_at": 1719150709,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "C28",
+              "C26",
+              "C24"
+            ],
+            [
+              "C24",
+              "D23",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "C24",
+            "D21",
+            "D19",
+            "E12",
+            "G10",
+            "H9"
+          ],
+          "revenue": 590,
+          "revenue_str": "B31-D29-C24-D21-D19-E12-G10-H9 + N/S + b/B + m/M",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "C24-0",
+            "D21-0",
+            "D19-0",
+            "E12-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 838,
+      "created_at": 1719150713,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 839,
+      "created_at": 1719150716
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 840,
+      "created_at": 1719150735
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 841,
+      "created_at": 1719150746,
+      "hex": "B9",
+      "tile": "45-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 842,
+      "created_at": 1719150759
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 843,
+      "created_at": 1719150761
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 844,
+      "created_at": 1719150776,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "D11"
+            ],
+            [
+              "D11",
+              "D9",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "C4",
+              "C2"
+            ],
+            [
+              "C2",
+              "B1",
+              "B3",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "E12",
+            "D11",
+            "B5",
+            "C2",
+            "A2"
+          ],
+          "revenue": 300,
+          "revenue_str": "G10-E12-D11-B5-C2-A2",
+          "nodes": [
+            "G10-0",
+            "E12-0",
+            "D11-0",
+            "B5-0",
+            "C2-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 845,
+      "created_at": 1719150781,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 846,
+      "created_at": 1719150782
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 847,
+      "created_at": 1719150877,
+      "hex": "D7",
+      "tile": "47-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 848,
+      "created_at": 1719150880
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 849,
+      "created_at": 1719150882
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 850,
+      "created_at": 1719150887,
+      "routes": [
+        {
+          "train": "D-3",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "E12",
+              "D11"
+            ],
+            [
+              "D11",
+              "D9",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "B7",
+              "B9",
+              "B11"
+            ],
+            [
+              "B11",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "F13",
+            "E12",
+            "D11",
+            "B5",
+            "B11",
+            "A10"
+          ],
+          "revenue": 500,
+          "revenue_str": "H9-G10-F13-E12-D11-B5-B11-A10 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "F13-0",
+            "E12-0",
+            "D11-0",
+            "B5-0",
+            "B11-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 851,
+      "created_at": 1719150888,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 852,
+      "created_at": 1719150892
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 853,
+      "created_at": 1719152276,
+      "hex": "C22",
+      "tile": "26-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 854,
+      "created_at": 1719152280
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 855,
+      "created_at": 1719152284,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "G26",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "G26",
+            "E20",
+            "E12"
+          ],
+          "revenue": 330,
+          "revenue_str": "B31-D29-G26-E20-E12 + m/M/m",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "G26-0",
+            "E20-0",
+            "E12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 856,
+      "created_at": 1719152285,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 857,
+      "created_at": 1719152287
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 858,
+      "created_at": 1719152592
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 859,
+      "created_at": 1719152593,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F9",
+              "E8"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E8",
+            "B5",
+            "A2"
+          ],
+          "revenue": 360,
+          "revenue_str": "H9-G10-E8-B5-A2 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E8-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 860,
+      "created_at": 1719152594,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 861,
+      "created_at": 1719152595
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 862,
+      "created_at": 1719152654,
+      "hex": "B17",
+      "tile": "28-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 863,
+      "created_at": 1719152661
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 864,
+      "created_at": 1719152661,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "D19",
+            "D21",
+            "E20"
+          ],
+          "revenue": 340,
+          "revenue_str": "H9-G10-E12-D19-D21-E20 + b/B",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "D19-0",
+            "D21-0",
+            "E20-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 865,
+      "created_at": 1719152662,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 866,
+      "created_at": 1719152664
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 867,
+      "created_at": 1719152835,
+      "hex": "A12",
+      "tile": "24-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 868,
+      "created_at": 1719152843
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 869,
+      "created_at": 1719152913,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "E12",
+              "D11"
+            ],
+            [
+              "D11",
+              "D9",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "B7",
+              "B9",
+              "B11"
+            ],
+            [
+              "B11",
+              "C12"
+            ],
+            [
+              "C12",
+              "D13",
+              "D15"
+            ],
+            [
+              "D15",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "E22",
+              "F23"
+            ],
+            [
+              "F23",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ],
+            [
+              "D29",
+              "C30",
+              "B31"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "F13",
+            "E12",
+            "D11",
+            "B5",
+            "B11",
+            "C12",
+            "D15",
+            "E20",
+            "F23",
+            "G26",
+            "D29",
+            "B31"
+          ],
+          "revenue": 840,
+          "revenue_str": "H9-G10-F13-E12-D11-B5-B11-C12-D15-E20-F23-G26-D29-B31 + N/S + m/M/m",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "F13-0",
+            "E12-0",
+            "D11-0",
+            "B5-0",
+            "B11-0",
+            "C12-0",
+            "D15-0",
+            "E20-0",
+            "F23-0",
+            "G26-0",
+            "D29-0",
+            "B31-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 870,
+      "created_at": 1719152915,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 871,
+      "created_at": 1719152917
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 872,
+      "created_at": 1719152934
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 873,
+      "created_at": 1719152935
+    },
+    {
+      "type": "run_routes",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 874,
+      "created_at": 1719152941,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "C28",
+              "C26",
+              "C24"
+            ],
+            [
+              "C24",
+              "D23",
+              "D21"
+            ],
+            [
+              "D21",
+              "C22",
+              "C20",
+              "C18",
+              "C16"
+            ],
+            [
+              "C16",
+              "B17",
+              "B15",
+              "A14",
+              "A12",
+              "B11"
+            ],
+            [
+              "B11",
+              "B9",
+              "B7",
+              "B5"
+            ],
+            [
+              "B5",
+              "C6",
+              "D7",
+              "D9",
+              "D11"
+            ],
+            [
+              "D11",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "C24",
+            "D21",
+            "C16",
+            "B11",
+            "B5",
+            "D11",
+            "E12",
+            "G10",
+            "H9"
+          ],
+          "revenue": 640,
+          "revenue_str": "B31-D29-C24-D21-C16-B11-B5-D11-E12-G10-H9 + N/S + m/M",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "C24-0",
+            "D21-0",
+            "C16-0",
+            "B11-0",
+            "B5-0",
+            "D11-0",
+            "E12-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 875,
+      "created_at": 1719152949,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 876,
+      "created_at": 1719152950
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 877,
+      "created_at": 1719153016
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 878,
+      "created_at": 1719153017
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 879,
+      "created_at": 1719153027,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "C28",
+              "C26",
+              "C24"
+            ],
+            [
+              "C24",
+              "D23",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "C24",
+            "D21",
+            "D19",
+            "E12",
+            "G10",
+            "H9"
+          ],
+          "revenue": 590,
+          "revenue_str": "B31-D29-C24-D21-D19-E12-G10-H9 + N/S + b/B + m/M",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "C24-0",
+            "D21-0",
+            "D19-0",
+            "E12-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 880,
+      "created_at": 1719153030,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 881,
+      "created_at": 1719153034
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 882,
+      "created_at": 1719153111
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 883,
+      "created_at": 1719153203,
+      "hex": "C18",
+      "tile": "23-2",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 884,
+      "created_at": 1719153206
+    },
+    {
+      "type": "place_token",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 885,
+      "created_at": 1719153210,
+      "city": "X6-0-0",
+      "slot": 0,
+      "tokener": "ÖSJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 886,
+      "created_at": 1719153222,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "D11"
+            ],
+            [
+              "D11",
+              "D9",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "D11",
+            "B5",
+            "A2"
+          ],
+          "revenue": 420,
+          "revenue_str": "H9-G10-E12-D11-B5-A2 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "D11-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 887,
+      "created_at": 1719153225,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 888,
+      "created_at": 1719153226
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 889,
+      "created_at": 1719153263
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 890,
+      "created_at": 1719153264
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 891,
+      "created_at": 1719153275,
+      "routes": [
+        {
+          "train": "D-3",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "C28",
+              "C26",
+              "C24"
+            ],
+            [
+              "C24",
+              "D23",
+              "D21"
+            ],
+            [
+              "D21",
+              "C22",
+              "C20",
+              "C18",
+              "B17",
+              "B15",
+              "A16"
+            ],
+            [
+              "A16",
+              "A14",
+              "A12",
+              "B11"
+            ],
+            [
+              "B11",
+              "B9",
+              "B7",
+              "B5"
+            ],
+            [
+              "B5",
+              "C6",
+              "D7",
+              "D9",
+              "D11"
+            ],
+            [
+              "D11",
+              "E12"
+            ],
+            [
+              "E12",
+              "F13"
+            ],
+            [
+              "F13",
+              "G12",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "C24",
+            "D21",
+            "A16",
+            "B11",
+            "B5",
+            "D11",
+            "E12",
+            "F13",
+            "G10",
+            "H9"
+          ],
+          "revenue": 650,
+          "revenue_str": "B31-D29-C24-D21-A16-B11-B5-D11-E12-F13-G10-H9 + N/S + m/M",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "C24-0",
+            "D21-0",
+            "A16-0",
+            "B11-0",
+            "B5-0",
+            "D11-0",
+            "E12-0",
+            "F13-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 892,
+      "created_at": 1719153277,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 893,
+      "created_at": 1719153280
+    }
+  ],
+  "loaded": true,
+  "created_at": 1717601350,
+  "updated_at": 1719153320,
+  "finished_at": 1719153320
+}

--- a/public/fixtures/18SJ/167041.json
+++ b/public/fixtures/18SJ/167041.json
@@ -1,0 +1,13609 @@
+{
+  "id": 167041,
+  "description": "Oscarian Era, 6 EU tz players",
+  "user": {
+    "id": 12106,
+    "name": "gardi"
+  },
+  "players": [
+    {
+      "id": 2170,
+      "name": "Conquer1989"
+    },
+    {
+      "id": 12106,
+      "name": "gardi"
+    },
+    {
+      "id": 1075,
+      "name": "jrype"
+    },
+    {
+      "id": 17876,
+      "name": "beeman"
+    },
+    {
+      "id": 14510,
+      "name": "khr2201"
+    },
+    {
+      "id": 3864,
+      "name": "Michal(UTC)"
+    }
+  ],
+  "min_players": 6,
+  "max_players": 6,
+  "title": "18SJ",
+  "settings": {
+    "seed": 795267900,
+    "is_async": true,
+    "unlisted": false,
+    "auto_routing": true,
+    "player_order": null,
+    "optional_rules": [
+      "oscarian_era"
+    ]
+  },
+  "user_settings": null,
+  "status": "finished",
+  "turn": 8,
+  "round": "Operating Round",
+  "acting": [
+    2170,
+    12106,
+    1075,
+    17876,
+    14510,
+    3864
+  ],
+  "result": {
+    "1075": 1828,
+    "2170": 3263,
+    "3864": 3178,
+    "12106": 3237,
+    "14510": 4967,
+    "17876": 2987
+  },
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1718606125,
+      "company": "SB",
+      "price": 50
+    },
+    {
+      "type": "bid",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1718619282,
+      "company": "MV",
+      "price": 95
+    },
+    {
+      "type": "bid",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1718624372,
+      "company": "MV",
+      "price": 100
+    },
+    {
+      "type": "bid",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1718624915,
+      "company": "AEvR",
+      "price": 225
+    },
+    {
+      "type": "bid",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1718626018,
+      "company": "SB",
+      "price": 55
+    },
+    {
+      "type": "bid",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1718630332,
+      "company": "AEvR",
+      "price": 230
+    },
+    {
+      "type": "bid",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1718632739,
+      "company": "KHJ",
+      "price": 145
+    },
+    {
+      "type": "bid",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1718632782,
+      "company": "GC",
+      "price": 75
+    },
+    {
+      "type": "bid",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1718643404,
+      "company": "GC",
+      "price": 80
+    },
+    {
+      "type": "bid",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1718643447,
+      "company": "AEvR",
+      "price": 235
+    },
+    {
+      "type": "bid",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1718651328,
+      "company": "NOJ",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1718652566,
+      "company": "SB",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1718653565,
+      "company": "SB",
+      "price": 65
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1718660272
+    },
+    {
+      "type": "bid",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1718661176,
+      "company": "GC",
+      "price": 85
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1718662041
+    },
+    {
+      "type": "bid",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 23,
+      "created_at": 1718671662,
+      "company": "MV",
+      "price": 105
+    },
+    {
+      "type": "bid",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 24,
+      "created_at": 1718695274,
+      "company": "MV",
+      "price": 110
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1718696245
+    },
+    {
+      "type": "pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 26,
+      "created_at": 1718701323
+    },
+    {
+      "type": "par",
+      "entity": 17876,
+      "corporation": "ÖKJ",
+      "entity_type": "player",
+      "share_price": "67,5,2",
+      "id": 27,
+      "user": 17876,
+      "created_at": 1718755251
+    },
+    {
+      "type": "undo",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 28,
+      "user": 17876,
+      "created_at": 1718755260
+    },
+    {
+      "type": "par",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 29,
+      "created_at": 1718755289,
+      "corporation": "ÖKJ",
+      "share_price": "82,2,2"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 30,
+      "created_at": 1718780198,
+      "shares": [
+        "ÖKJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 31,
+      "created_at": 1718788167,
+      "shares": [
+        "ÖKJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 32,
+      "created_at": 1718788724,
+      "shares": [
+        "ÖKJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 33,
+      "created_at": 1718788990,
+      "shares": [
+        "ÖKJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1718797790,
+      "shares": [
+        "ÖKJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 35,
+      "created_at": 1718805187,
+      "shares": [
+        "ÖKJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1718805290,
+      "shares": [
+        "ÖKJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 37,
+      "created_at": 1718809191,
+      "shares": [
+        "ÖKJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 12106,
+      "corporation": "TGOJ",
+      "entity_type": "player",
+      "share_price": "100,0,2",
+      "id": 38,
+      "user": 12106,
+      "created_at": 1718810851
+    },
+    {
+      "type": "undo",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 39,
+      "user": 12106,
+      "created_at": 1718810860
+    },
+    {
+      "type": "par",
+      "entity": 12106,
+      "corporation": "TGOJ",
+      "entity_type": "player",
+      "share_price": "90,1,2",
+      "id": 40,
+      "user": 12106,
+      "created_at": 1718810862
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12106,
+      "indefinite": false,
+      "entity_type": "player",
+      "unconditional": false,
+      "id": 41,
+      "user": 12106,
+      "created_at": 1718810875
+    },
+    {
+      "type": "undo",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 42,
+      "user": 12106,
+      "created_at": 1718810920
+    },
+    {
+      "type": "redo",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 43,
+      "user": 12106,
+      "created_at": 1718810924
+    },
+    {
+      "type": "undo",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 44,
+      "user": 12106,
+      "created_at": 1718810925
+    },
+    {
+      "type": "undo",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 45,
+      "user": 12106,
+      "created_at": 1718810928
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 46,
+      "user": 12106,
+      "created_at": 1718810946
+    },
+    {
+      "type": "undo",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 47,
+      "user": 12106,
+      "created_at": 1718810957
+    },
+    {
+      "type": "par",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 48,
+      "created_at": 1718810958,
+      "corporation": "TGOJ",
+      "share_price": "100,0,2"
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 49,
+      "created_at": 1718810962,
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 50,
+      "created_at": 1718822723,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1718822723
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 51,
+      "created_at": 1718831505,
+      "shares": [
+        "TGOJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 52,
+      "created_at": 1718831568,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1718831568
+        }
+      ],
+      "shares": [
+        "TGOJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 53,
+      "created_at": 1718831622,
+      "shares": [
+        "TGOJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 54,
+      "created_at": 1718834584,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1718834583
+        }
+      ],
+      "shares": [
+        "TGOJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "hex": "E16",
+      "tile": "7-0",
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "rotation": 1,
+      "entity_type": "minor",
+      "id": 55,
+      "user": 2170,
+      "created_at": 1718834676
+    },
+    {
+      "hex": "E14",
+      "tile": "8-0",
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "rotation": 4,
+      "entity_type": "minor",
+      "id": 56,
+      "user": 2170,
+      "created_at": 1718834682
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 57,
+      "user": 2170,
+      "created_at": 1718834690
+    },
+    {
+      "type": "undo",
+      "entity": "KHJ",
+      "action_id": 54,
+      "entity_type": "minor",
+      "id": 58,
+      "user": 2170,
+      "created_at": 1718834705
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 59,
+      "created_at": 1718834709,
+      "hex": "C16",
+      "tile": "57-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 60,
+      "created_at": 1718834728
+    },
+    {
+      "type": "run_routes",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 61,
+      "created_at": 1718834730,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D15",
+              "C16"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "C16"
+          ],
+          "revenue": 40,
+          "revenue_str": "D15-C16",
+          "nodes": [
+            "D15-0",
+            "C16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 62,
+      "created_at": 1718835059,
+      "hex": "E20",
+      "tile": "6-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 63,
+      "created_at": 1718835084,
+      "hex": "E22",
+      "tile": "9-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 64,
+      "created_at": 1718835089
+    },
+    {
+      "type": "buy_train",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 65,
+      "created_at": 1718835098,
+      "train": "2-1",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 66,
+      "created_at": 1718835099,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 67,
+      "created_at": 1718835109
+    },
+    {
+      "hex": "C12",
+      "tile": "6-1",
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 68,
+      "user": 17876,
+      "created_at": 1718835551
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 69,
+      "user": 17876,
+      "created_at": 1718835563
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 70,
+      "created_at": 1718835567,
+      "hex": "C12",
+      "tile": "57-1",
+      "rotation": 2
+    },
+    {
+      "hex": "D13",
+      "tile": "8-0",
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 71,
+      "user": 17876,
+      "created_at": 1718835580
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 72,
+      "user": 17876,
+      "created_at": 1718835602
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 73,
+      "created_at": 1718835617,
+      "hex": "D13",
+      "tile": "8-0",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 74,
+      "created_at": 1718835625,
+      "train": "2-3",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 75,
+      "created_at": 1718835626,
+      "train": "2-4",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 76,
+      "created_at": 1718835628
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2170,
+      "shares": [
+        "ÖKJ_2",
+        "ÖKJ_8"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 77,
+      "user": 2170,
+      "created_at": 1718865760
+    },
+    {
+      "type": "undo",
+      "entity": 2170,
+      "action_id": 76,
+      "entity_type": "player",
+      "id": 78,
+      "user": 2170,
+      "created_at": 1718865776
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 79,
+      "created_at": 1718865780,
+      "shares": [
+        "TGOJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 80,
+      "created_at": 1718865808
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12106,
+      "indefinite": false,
+      "entity_type": "player",
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "created_at": 1718866592,
+          "entity_type": "player"
+        }
+      ],
+      "unconditional": false,
+      "id": 81,
+      "user": 12106,
+      "created_at": 1718866593
+    },
+    {
+      "type": "undo",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 82,
+      "user": 12106,
+      "created_at": 1718866638
+    },
+    {
+      "type": "redo",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 83,
+      "user": 12106,
+      "created_at": 1718866643
+    },
+    {
+      "type": "program_disable",
+      "entity": 12106,
+      "reason": "user",
+      "entity_type": "player",
+      "original_type": "program_share_pass",
+      "id": 84,
+      "user": 12106,
+      "created_at": 1718866649
+    },
+    {
+      "type": "undo",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 85,
+      "user": 12106,
+      "created_at": 1718866757
+    },
+    {
+      "type": "undo",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 86,
+      "user": 12106,
+      "created_at": 1718866759
+    },
+    {
+      "type": "sell_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 87,
+      "created_at": 1718866761,
+      "shares": [
+        "ÖKJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 88,
+      "created_at": 1718866762,
+      "shares": [
+        "TGOJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 89,
+      "created_at": 1718866764,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1718866762
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 90,
+      "created_at": 1718869647,
+      "shares": [
+        "TGOJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 91,
+      "created_at": 1718869654
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 92,
+      "created_at": 1718988709,
+      "shares": [
+        "ÖKJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 93,
+      "created_at": 1718988718
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 94,
+      "created_at": 1719003591
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 95,
+      "created_at": 1719004413,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719004413
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 96,
+      "created_at": 1719009216,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719009217,
+          "reason": "jrype bought on corporation TGOJ and is unsecure"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 97,
+      "created_at": 1719010707,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719010705
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "shares": [
+        "TGOJ_8"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 98,
+      "user": 1075,
+      "created_at": 1719046431
+    },
+    {
+      "type": "undo",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 99,
+      "user": 1075,
+      "created_at": 1719046442
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 100,
+      "created_at": 1719046444,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1719046443
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 101,
+      "created_at": 1719047119,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719047120
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 102,
+      "created_at": 1719048263,
+      "hex": "E16",
+      "tile": "7-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 103,
+      "created_at": 1719048269,
+      "hex": "E14",
+      "tile": "8-1",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 104,
+      "created_at": 1719048314,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D15",
+              "C16"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "C16"
+          ],
+          "revenue": 40,
+          "revenue_str": "D15-C16",
+          "nodes": [
+            "D15-0",
+            "C16-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 105,
+      "created_at": 1719073694,
+      "hex": "E18",
+      "tile": "8-2",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 106,
+      "created_at": 1719073698,
+      "hex": "E24",
+      "tile": "8-3",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 107,
+      "created_at": 1719073704
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 108,
+      "created_at": 1719073706,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "D19",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "E20"
+          ],
+          "revenue": 40,
+          "revenue_str": "D19-E20",
+          "nodes": [
+            "D19-0",
+            "E20-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "D19",
+              "E18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "F19"
+          ],
+          "revenue": 40,
+          "revenue_str": "D19-F19",
+          "nodes": [
+            "D19-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 109,
+      "created_at": 1719073711,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 110,
+      "created_at": 1719073714
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 111,
+      "created_at": 1719073756,
+      "hex": "E12",
+      "tile": "57-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 112,
+      "created_at": 1719073773,
+      "hex": "F11",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 113,
+      "user": 17876,
+      "created_at": 1719073811
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 114,
+      "user": 17876,
+      "created_at": 1719073821
+    },
+    {
+      "type": "place_token",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 115,
+      "created_at": 1719073822,
+      "city": "57-2-0",
+      "slot": 0,
+      "tokener": "ÖKJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 116,
+      "created_at": 1719073835,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "E12",
+              "F11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "E12",
+            "G10"
+          ],
+          "revenue": 40,
+          "revenue_str": "E12-G10",
+          "nodes": [
+            "E12-0",
+            "G10-2"
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E12",
+              "D13",
+              "C12"
+            ]
+          ],
+          "hexes": [
+            "E12",
+            "C12"
+          ],
+          "revenue": 40,
+          "revenue_str": "E12-C12",
+          "nodes": [
+            "E12-0",
+            "C12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 117,
+      "created_at": 1719073843,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 118,
+      "created_at": 1719073864
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 119,
+      "created_at": 1719094534
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3864,
+      "shares": [
+        "TGOJ_2",
+        "TGOJ_4"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 120,
+      "user": 3864,
+      "created_at": 1719095741
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3864,
+      "shares": [
+        "ÖKJ_1",
+        "ÖKJ_7"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 121,
+      "user": 3864,
+      "created_at": 1719095747
+    },
+    {
+      "type": "undo",
+      "entity": 3864,
+      "action_id": 119,
+      "entity_type": "player",
+      "id": 122,
+      "user": 3864,
+      "created_at": 1719095771
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 123,
+      "created_at": 1719095938,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719095937
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2170,
+      "shares": [
+        "TGOJ_5"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 124,
+      "user": 2170,
+      "created_at": 1719119905
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2170,
+      "shares": [
+        "ÖKJ_2",
+        "ÖKJ_8"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 125,
+      "user": 2170,
+      "created_at": 1719119910
+    },
+    {
+      "type": "undo",
+      "entity": 2170,
+      "action_id": 123,
+      "entity_type": "player",
+      "id": 126,
+      "user": 2170,
+      "created_at": 1719119926
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 127,
+      "created_at": 1719119963
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 128,
+      "created_at": 1719121439,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719121437
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 129,
+      "created_at": 1719143001,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1719143000
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 130,
+      "created_at": 1719143282,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719143282
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "hex": "F13",
+      "tile": "57-3",
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "rotation": 0,
+      "entity_type": "minor",
+      "id": 131,
+      "user": 2170,
+      "created_at": 1719143301
+    },
+    {
+      "hex": "G12",
+      "tile": "8-4",
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "rotation": 1,
+      "entity_type": "minor",
+      "id": 132,
+      "user": 2170,
+      "created_at": 1719143307
+    },
+    {
+      "type": "undo",
+      "entity": "KHJ",
+      "action_id": 130,
+      "entity_type": "minor",
+      "id": 133,
+      "user": 2170,
+      "created_at": 1719143310
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 134,
+      "created_at": 1719143313,
+      "hex": "B17",
+      "tile": "8-4",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 135,
+      "created_at": 1719143316,
+      "hex": "F13",
+      "tile": "57-3",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 136,
+      "created_at": 1719143320,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D15",
+              "E16",
+              "E14",
+              "F13"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "F13"
+          ],
+          "revenue": 40,
+          "revenue_str": "D15-F13",
+          "nodes": [
+            "D15-0",
+            "F13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 137,
+      "created_at": 1719167410,
+      "hex": "F25",
+      "tile": "7-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 138,
+      "created_at": 1719167412
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 139,
+      "created_at": 1719167417
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 140,
+      "created_at": 1719167418,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "D19",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "E20"
+          ],
+          "revenue": 40,
+          "revenue_str": "D19-E20",
+          "nodes": [
+            "D19-0",
+            "E20-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "D19",
+              "E18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "F19"
+          ],
+          "revenue": 40,
+          "revenue_str": "D19-F19",
+          "nodes": [
+            "D19-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 141,
+      "created_at": 1719167428,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 142,
+      "created_at": 1719167431
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 143,
+      "created_at": 1719167471
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 144,
+      "created_at": 1719167476,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "E12",
+              "F11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "E12",
+            "G10"
+          ],
+          "revenue": 40,
+          "revenue_str": "E12-G10",
+          "nodes": [
+            "E12-0",
+            "G10-2"
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E12",
+              "D13",
+              "C12"
+            ]
+          ],
+          "hexes": [
+            "E12",
+            "C12"
+          ],
+          "revenue": 40,
+          "revenue_str": "E12-C12",
+          "nodes": [
+            "E12-0",
+            "C12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 145,
+      "created_at": 1719167482,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 146,
+      "created_at": 1719167488
+    },
+    {
+      "type": "sell_shares",
+      "entity": 14510,
+      "shares": [
+        "TGOJ_1",
+        "TGOJ_3"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 147,
+      "user": 14510,
+      "created_at": 1719189086
+    },
+    {
+      "type": "sell_shares",
+      "entity": 14510,
+      "shares": [
+        "ÖKJ_6"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 148,
+      "user": 14510,
+      "created_at": 1719189090
+    },
+    {
+      "type": "undo",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 149,
+      "user": 14510,
+      "created_at": 1719189157
+    },
+    {
+      "type": "undo",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 150,
+      "user": 14510,
+      "created_at": 1719189157
+    },
+    {
+      "type": "sell_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 151,
+      "created_at": 1719189176,
+      "shares": [
+        "TGOJ_1",
+        "TGOJ_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 152,
+      "created_at": 1719189178,
+      "shares": [
+        "ÖKJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 153,
+      "created_at": 1719189181,
+      "corporation": "ÖSJ",
+      "share_price": "67,5,2"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3864,
+      "shares": [
+        "ÖKJ_1",
+        "ÖKJ_7"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 154,
+      "user": 3864,
+      "created_at": 1719209868
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3864,
+      "shares": [
+        "TGOJ_2",
+        "TGOJ_4"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 155,
+      "user": 3864,
+      "created_at": 1719209871
+    },
+    {
+      "type": "undo",
+      "entity": 3864,
+      "action_id": 153,
+      "entity_type": "player",
+      "id": 156,
+      "user": 3864,
+      "created_at": 1719209881
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 157,
+      "created_at": 1719210061,
+      "shares": [
+        "TGOJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 158,
+      "created_at": 1719210066,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719210066
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2170,
+      "shares": [
+        "ÖKJ_2",
+        "ÖKJ_8"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 159,
+      "user": 2170,
+      "created_at": 1719216502
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2170,
+      "shares": [
+        "TGOJ_5"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 160,
+      "user": 2170,
+      "created_at": 1719216508
+    },
+    {
+      "type": "undo",
+      "entity": 2170,
+      "action_id": 158,
+      "entity_type": "player",
+      "id": 161,
+      "user": 2170,
+      "created_at": 1719216593
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 162,
+      "created_at": 1719216645,
+      "shares": [
+        "TGOJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 163,
+      "created_at": 1719216659,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719216661
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 164,
+      "created_at": 1719219593,
+      "shares": [
+        "TGOJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 165,
+      "created_at": 1719219595,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719219592
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 166,
+      "created_at": 1719223715,
+      "shares": [
+        "ÖSJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 167,
+      "created_at": 1719223725
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 168,
+      "created_at": 1719224656,
+      "shares": [
+        "ÖKJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 169,
+      "created_at": 1719224659
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 170,
+      "created_at": 1719225837,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 14510,
+          "entity_type": "player",
+          "created_at": 1719225838,
+          "shares": [
+            "ÖSJ_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 14510,
+          "entity_type": "player",
+          "created_at": 1719225838
+        },
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719225838
+        },
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719225838
+        },
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719225838
+        }
+      ],
+      "corporation": "ÖSJ",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 171,
+      "created_at": 1719227882,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1719227881
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 172,
+      "created_at": 1719228360,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719228359
+        },
+        {
+          "type": "buy_shares",
+          "entity": 14510,
+          "entity_type": "player",
+          "created_at": 1719228359,
+          "shares": [
+            "ÖSJ_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 14510,
+          "entity_type": "player",
+          "created_at": 1719228359
+        },
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719228359
+        },
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719228359
+        },
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719228359
+        },
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1719228359
+        },
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719228359
+        },
+        {
+          "type": "buy_shares",
+          "entity": 14510,
+          "entity_type": "player",
+          "created_at": 1719228359,
+          "shares": [
+            "ÖSJ_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 14510,
+          "entity_type": "player",
+          "created_at": 1719228359,
+          "reason": "ÖSJ is floated"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 173,
+      "created_at": 1719230552,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719230553
+        },
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719230553
+        },
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719230553
+        },
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1719230553
+        },
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719230553
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 174,
+      "created_at": 1719230562,
+      "shares": [
+        "ÖSJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 175,
+      "created_at": 1719230564,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719230565
+        },
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719230565
+        },
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719230565
+        },
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1719230565
+        },
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719230565
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 176,
+      "created_at": 1719230566
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 177,
+      "created_at": 1719230635,
+      "hex": "A14",
+      "tile": "9-2",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 178,
+      "created_at": 1719230638,
+      "hex": "G12",
+      "tile": "8-5",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 179,
+      "created_at": 1719230641,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D15",
+              "E16",
+              "E14",
+              "F13"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "F13"
+          ],
+          "revenue": 40,
+          "revenue_str": "D15-F13",
+          "nodes": [
+            "D15-0",
+            "F13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 180,
+      "created_at": 1719257766
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 181,
+      "created_at": 1719257771,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "E12",
+              "F11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "E12",
+            "G10"
+          ],
+          "revenue": 40,
+          "revenue_str": "E12-G10",
+          "nodes": [
+            "E12-0",
+            "G10-2"
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "E12",
+              "D13",
+              "C12"
+            ]
+          ],
+          "hexes": [
+            "E12",
+            "C12"
+          ],
+          "revenue": 40,
+          "revenue_str": "E12-C12",
+          "nodes": [
+            "E12-0",
+            "C12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 182,
+      "created_at": 1719257774,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 183,
+      "created_at": 1719257787
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 184,
+      "created_at": 1719258004,
+      "hex": "E26",
+      "tile": "9-3",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 185,
+      "created_at": 1719258007
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 186,
+      "created_at": 1719258013
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 187,
+      "created_at": 1719258014,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "D19",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "E20"
+          ],
+          "revenue": 40,
+          "revenue_str": "D19-E20",
+          "nodes": [
+            "D19-0",
+            "E20-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "D19",
+              "E18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "F19"
+          ],
+          "revenue": 40,
+          "revenue_str": "D19-F19",
+          "nodes": [
+            "D19-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 188,
+      "user": 12106,
+      "created_at": 1719258016
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 189,
+      "user": 12106,
+      "created_at": 1719258099
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 190,
+      "created_at": 1719258100,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 191,
+      "created_at": 1719258101
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 192,
+      "created_at": 1719258905,
+      "hex": "B3",
+      "tile": "8-6",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 193,
+      "created_at": 1719258914
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 194,
+      "created_at": 1719258916
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 195,
+      "created_at": 1719258918,
+      "train": "2-5",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 196,
+      "created_at": 1719258919,
+      "train": "2-6",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 197,
+      "created_at": 1719259307,
+      "train": "3-0",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "buy_company",
+      "price": 40,
+      "entity": "ÖSJ",
+      "company": "NOJ",
+      "entity_type": "corporation",
+      "id": 198,
+      "user": 14510,
+      "created_at": 1719259325
+    },
+    {
+      "type": "buy_company",
+      "price": 90,
+      "entity": "ÖSJ",
+      "company": "SB",
+      "entity_type": "corporation",
+      "id": 199,
+      "user": 14510,
+      "created_at": 1719259332
+    },
+    {
+      "type": "assign",
+      "entity": "SB",
+      "target": "C2",
+      "entity_type": "company",
+      "target_type": "hex",
+      "id": 200,
+      "user": 14510,
+      "created_at": 1719259369
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 201,
+      "user": 14510,
+      "created_at": 1719259378
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 202,
+      "user": 14510,
+      "created_at": 1719259381
+    },
+    {
+      "type": "undo",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 203,
+      "user": 14510,
+      "created_at": 1719259418
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 204,
+      "user": 14510,
+      "created_at": 1719259421
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 205,
+      "user": 14510,
+      "created_at": 1719259425
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 206,
+      "user": 14510,
+      "created_at": 1719259428
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 207,
+      "user": 14510,
+      "created_at": 1719259429
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 208,
+      "created_at": 1719259464
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 209,
+      "created_at": 1719259473
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3864,
+      "shares": [
+        "ÖKJ_1",
+        "ÖKJ_7"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 210,
+      "user": 3864,
+      "created_at": 1719260777
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3864,
+      "shares": [
+        "TGOJ_2",
+        "TGOJ_4",
+        "TGOJ_1"
+      ],
+      "percent": 30,
+      "entity_type": "player",
+      "id": 211,
+      "user": 3864,
+      "created_at": 1719260780
+    },
+    {
+      "type": "undo",
+      "entity": 3864,
+      "action_id": 209,
+      "entity_type": "player",
+      "id": 212,
+      "user": 3864,
+      "created_at": 1719260805
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 213,
+      "created_at": 1719260820,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719260819
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2170,
+      "shares": [
+        "ÖKJ_2",
+        "ÖKJ_8"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 214,
+      "user": 2170,
+      "created_at": 1719261342
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2170,
+      "shares": [
+        "TGOJ_5",
+        "TGOJ_3"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 215,
+      "user": 2170,
+      "created_at": 1719261345
+    },
+    {
+      "type": "undo",
+      "entity": 2170,
+      "action_id": 213,
+      "entity_type": "player",
+      "id": 216,
+      "user": 2170,
+      "created_at": 1719261363
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 217,
+      "user": 2170,
+      "created_at": 1719261411
+    },
+    {
+      "type": "undo",
+      "entity": 12106,
+      "action_id": 213,
+      "entity_type": "player",
+      "id": 218,
+      "user": 2170,
+      "created_at": 1719261420
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2170,
+      "shares": [
+        "ÖKJ_2",
+        "ÖKJ_8"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 219,
+      "user": 2170,
+      "created_at": 1719261446
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "shares": [
+        "ÖSJ_6"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 220,
+      "user": 2170,
+      "created_at": 1719261449
+    },
+    {
+      "type": "undo",
+      "entity": 2170,
+      "action_id": 213,
+      "entity_type": "player",
+      "id": 221,
+      "user": 2170,
+      "created_at": 1719261454
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 222,
+      "created_at": 1719261456,
+      "shares": [
+        "ÖKJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 223,
+      "created_at": 1719261458,
+      "shares": [
+        "ÖSJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 224,
+      "created_at": 1719261470
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 225,
+      "created_at": 1719261763,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719261762
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 226,
+      "created_at": 1719263211
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 227,
+      "created_at": 1719269287,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719269285
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 228,
+      "created_at": 1719274088,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719274088,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 229,
+      "created_at": 1719299935,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719299934
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 230,
+      "created_at": 1719299955,
+      "shares": [
+        "ÖSJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 231,
+      "created_at": 1719300017,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719299986
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 232,
+      "created_at": 1719303520,
+      "shares": [
+        "ÖSJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 233,
+      "created_at": 1719303524,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719303523
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 234,
+      "created_at": 1719308877,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719308877
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 235,
+      "created_at": 1719316347,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719316347
+        },
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719316347
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 236,
+      "created_at": 1719319760,
+      "shares": [
+        "ÖKJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 237,
+      "created_at": 1719319763,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719319762
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 238,
+      "created_at": 1719320935,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719320935
+        },
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719320935
+        },
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719320935
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 239,
+      "created_at": 1719321714,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1719321714
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 240,
+      "created_at": 1719321988,
+      "hex": "D15",
+      "tile": "619-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 241,
+      "created_at": 1719322003
+    },
+    {
+      "type": "run_routes",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 242,
+      "created_at": 1719322016,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D15",
+              "E16",
+              "E14",
+              "F13"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "F13"
+          ],
+          "revenue": 50,
+          "revenue_str": "D15-F13",
+          "nodes": [
+            "D15-0",
+            "F13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 243,
+      "created_at": 1719330420,
+      "hex": "C12",
+      "tile": "15-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 244,
+      "created_at": 1719330436
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 245,
+      "created_at": 1719330505,
+      "routes": [
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "E12",
+              "F11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "E12",
+            "G10"
+          ],
+          "revenue": 40,
+          "revenue_str": "E12-G10",
+          "nodes": [
+            "E12-0",
+            "G10-2"
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "C12",
+              "D13",
+              "E12"
+            ]
+          ],
+          "hexes": [
+            "C12",
+            "E12"
+          ],
+          "revenue": 50,
+          "revenue_str": "C12-E12",
+          "nodes": [
+            "C12-0",
+            "E12-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 246,
+      "created_at": 1719330511,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 247,
+      "created_at": 1719330513,
+      "train": "3-1",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 248,
+      "created_at": 1719330522
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 249,
+      "created_at": 1719330528
+    },
+    {
+      "hex": "D27",
+      "tile": "8-7",
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "id": 250,
+      "user": 12106,
+      "created_at": 1719337365
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 251,
+      "user": 12106,
+      "created_at": 1719337513
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 252,
+      "user": 12106,
+      "created_at": 1719337535
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "action_id": 249,
+      "entity_type": "corporation",
+      "id": 253,
+      "user": 12106,
+      "created_at": 1719337563
+    },
+    {
+      "hex": "D19",
+      "tile": "619-1",
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 254,
+      "user": 12106,
+      "created_at": 1719337569
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 255,
+      "user": 12106,
+      "created_at": 1719337573
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 256,
+      "created_at": 1719337581,
+      "hex": "D27",
+      "tile": "8-7",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 257,
+      "created_at": 1719337633,
+      "hex": "E20",
+      "tile": "15-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 258,
+      "created_at": 1719337638
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 259,
+      "created_at": 1719337640
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 260,
+      "created_at": 1719337643,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "D19",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "E20"
+          ],
+          "revenue": 50,
+          "revenue_str": "D19-E20",
+          "nodes": [
+            "D19-0",
+            "E20-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "D19",
+              "E18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "F19"
+          ],
+          "revenue": 40,
+          "revenue_str": "D19-F19",
+          "nodes": [
+            "D19-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 261,
+      "created_at": 1719337645,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_company",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 262,
+      "created_at": 1719337752,
+      "company": "GC",
+      "price": 140
+    },
+    {
+      "type": "buy_train",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 263,
+      "created_at": 1719337758,
+      "train": "3-2",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 264,
+      "created_at": 1719337761
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 265,
+      "created_at": 1719337763
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 266,
+      "created_at": 1719341873,
+      "hex": "C4",
+      "tile": "8-8",
+      "rotation": 5
+    },
+    {
+      "type": "buy_company",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 267,
+      "created_at": 1719341906,
+      "company": "SB",
+      "price": 90
+    },
+    {
+      "type": "buy_company",
+      "price": 40,
+      "entity": "ÖSJ",
+      "company": "NOJ",
+      "entity_type": "corporation",
+      "id": 268,
+      "user": 14510,
+      "created_at": 1719341908
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 269,
+      "user": 14510,
+      "created_at": 1719341916
+    },
+    {
+      "type": "assign",
+      "entity": "SB",
+      "entity_type": "company",
+      "id": 270,
+      "created_at": 1719341922,
+      "target": "C2",
+      "target_type": "hex"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 271,
+      "created_at": 1719341927
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 272,
+      "created_at": 1719341976
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 273,
+      "created_at": 1719341998,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "C2",
+              "C4",
+              "D5"
+            ]
+          ],
+          "hexes": [
+            "C2",
+            "D5"
+          ],
+          "revenue": 70,
+          "revenue_str": "C2-D5 + Port",
+          "nodes": [
+            "C2-0",
+            "D5-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "C2",
+              "B3",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "C2",
+            "A2"
+          ],
+          "revenue": 90,
+          "revenue_str": "C2-A2 + Port",
+          "nodes": [
+            "C2-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 274,
+      "created_at": 1719342001,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 275,
+      "created_at": 1719342009
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 276,
+      "created_at": 1719342011
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 277,
+      "created_at": 1719344657,
+      "hex": "F13",
+      "tile": "14-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 278,
+      "created_at": 1719344659
+    },
+    {
+      "type": "run_routes",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 279,
+      "created_at": 1719344661,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D15",
+              "E16",
+              "E14",
+              "F13"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "F13"
+          ],
+          "revenue": 60,
+          "revenue_str": "D15-F13",
+          "nodes": [
+            "D15-0",
+            "F13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 280,
+      "created_at": 1719346865,
+      "hex": "D11",
+      "tile": "57-4",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 281,
+      "created_at": 1719346881
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 282,
+      "created_at": 1719346889,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E12",
+              "F11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "E12",
+            "G10"
+          ],
+          "revenue": 40,
+          "revenue_str": "E12-G10",
+          "nodes": [
+            "E12-0",
+            "G10-2"
+          ]
+        },
+        {
+          "train": "2-4",
+          "connections": [
+            [
+              "C12",
+              "D13",
+              "E12"
+            ]
+          ],
+          "hexes": [
+            "C12",
+            "E12"
+          ],
+          "revenue": 50,
+          "revenue_str": "C12-E12",
+          "nodes": [
+            "C12-0",
+            "E12-0"
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "C12",
+              "D11"
+            ]
+          ],
+          "hexes": [
+            "C12",
+            "D11"
+          ],
+          "revenue": 50,
+          "revenue_str": "C12-D11",
+          "nodes": [
+            "C12-0",
+            "D11-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 283,
+      "created_at": 1719346900,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 284,
+      "created_at": 1719346907
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 285,
+      "created_at": 1719346911
+    },
+    {
+      "hex": "F27",
+      "tile": "9-4",
+      "type": "lay_tile",
+      "entity": "GC",
+      "rotation": 0,
+      "entity_type": "company",
+      "id": 286,
+      "user": 12106,
+      "created_at": 1719348495
+    },
+    {
+      "hex": "E28",
+      "tile": "9-5",
+      "type": "lay_tile",
+      "entity": "GC",
+      "rotation": 0,
+      "entity_type": "company",
+      "id": 287,
+      "user": 12106,
+      "created_at": 1719348500
+    },
+    {
+      "hex": "D29",
+      "tile": "5-0",
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 288,
+      "user": 12106,
+      "created_at": 1719348503
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 289,
+      "user": 12106,
+      "created_at": 1719348510
+    },
+    {
+      "city": "5-0-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "TGOJ",
+      "tokener": "TGOJ",
+      "entity_type": "corporation",
+      "id": 290,
+      "user": 12106,
+      "created_at": 1719348512
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "routes": [
+        {
+          "hexes": [
+            "E20",
+            "D19",
+            "F19"
+          ],
+          "nodes": [
+            "E20-0",
+            "D19-0",
+            "F19-0"
+          ],
+          "train": "3-2",
+          "revenue": 70,
+          "connections": [
+            [
+              "E20",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "F19"
+            ]
+          ],
+          "revenue_str": "E20-D19-F19"
+        },
+        {
+          "hexes": [
+            "D29",
+            "E20"
+          ],
+          "nodes": [
+            "D29-0",
+            "E20-0"
+          ],
+          "train": "2-2",
+          "revenue": 50,
+          "connections": [
+            [
+              "D29",
+              "D27",
+              "E26",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ]
+          ],
+          "revenue_str": "D29-E20"
+        },
+        {
+          "hexes": [
+            "D29",
+            "G26"
+          ],
+          "nodes": [
+            "D29-0",
+            "G26-0"
+          ],
+          "train": "2-1",
+          "revenue": 90,
+          "connections": [
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ]
+          ],
+          "revenue_str": "D29-G26 + m/M"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 291,
+      "user": 12106,
+      "created_at": 1719348516
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 292,
+      "user": 12106,
+      "created_at": 1719348520
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 293,
+      "user": 12106,
+      "created_at": 1719348610
+    },
+    {
+      "kind": "withhold",
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 294,
+      "user": 12106,
+      "created_at": 1719348611
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "action_id": 285,
+      "entity_type": "corporation",
+      "id": 295,
+      "user": 12106,
+      "created_at": 1719348649
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GC",
+      "entity_type": "company",
+      "id": 296,
+      "created_at": 1719348653,
+      "hex": "F27",
+      "tile": "9-4",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GC",
+      "entity_type": "company",
+      "id": 297,
+      "created_at": 1719348660,
+      "hex": "E28",
+      "tile": "9-5",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 298,
+      "created_at": 1719348662,
+      "hex": "D29",
+      "tile": "5-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 299,
+      "created_at": 1719348670,
+      "hex": "E18",
+      "tile": "19-0",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 300,
+      "created_at": 1719348674,
+      "city": "5-0-0",
+      "slot": 0,
+      "tokener": "TGOJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 301,
+      "created_at": 1719348722,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E20",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "D19",
+            "F19"
+          ],
+          "revenue": 70,
+          "revenue_str": "E20-D19-F19",
+          "nodes": [
+            "E20-0",
+            "D19-0",
+            "F19-0"
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "D29",
+              "D27",
+              "E26",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ]
+          ],
+          "hexes": [
+            "D29",
+            "E20"
+          ],
+          "revenue": 50,
+          "revenue_str": "D29-E20",
+          "nodes": [
+            "D29-0",
+            "E20-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "D29",
+            "G26"
+          ],
+          "revenue": 90,
+          "revenue_str": "D29-G26 + m/M",
+          "nodes": [
+            "D29-0",
+            "G26-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 302,
+      "created_at": 1719348726,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 303,
+      "created_at": 1719348732
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 304,
+      "created_at": 1719348733
+    },
+    {
+      "hex": "C6",
+      "tile": "8-9",
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 305,
+      "user": 14510,
+      "created_at": 1719349420
+    },
+    {
+      "hex": "B5",
+      "tile": "57-1",
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 306,
+      "user": 14510,
+      "created_at": 1719349425
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 307,
+      "user": 14510,
+      "created_at": 1719349483
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 308,
+      "user": 14510,
+      "created_at": 1719349487
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 309,
+      "created_at": 1719349493,
+      "hex": "C2",
+      "tile": "X1-0",
+      "rotation": 5
+    },
+    {
+      "type": "buy_company",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 310,
+      "created_at": 1719349506,
+      "company": "NOJ",
+      "price": 40
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 311,
+      "created_at": 1719349524
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 312,
+      "created_at": 1719349526
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 313,
+      "created_at": 1719349532,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "C2",
+              "C4",
+              "D5"
+            ]
+          ],
+          "hexes": [
+            "C2",
+            "D5"
+          ],
+          "revenue": 90,
+          "revenue_str": "C2-D5 + Port",
+          "nodes": [
+            "C2-0",
+            "D5-0"
+          ]
+        },
+        {
+          "train": "2-6",
+          "connections": [
+            [
+              "C2",
+              "B3",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "C2",
+            "A2"
+          ],
+          "revenue": 110,
+          "revenue_str": "C2-A2 + Port",
+          "nodes": [
+            "C2-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 314,
+      "created_at": 1719349534,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 315,
+      "user": 14510,
+      "created_at": 1719349536
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 316,
+      "user": 14510,
+      "created_at": 1719349540
+    },
+    {
+      "type": "undo",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 317,
+      "user": 14510,
+      "created_at": 1719349569
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 318,
+      "user": 14510,
+      "created_at": 1719349573
+    },
+    {
+      "type": "buy_train",
+      "price": 180,
+      "train": "3-3",
+      "entity": "ÖSJ",
+      "variant": "3",
+      "entity_type": "corporation",
+      "id": 319,
+      "user": 14510,
+      "created_at": 1719349581
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 320,
+      "user": 14510,
+      "created_at": 1719349587
+    },
+    {
+      "type": "undo",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 321,
+      "user": 14510,
+      "created_at": 1719349716
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 322,
+      "user": 14510,
+      "created_at": 1719349720
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 323,
+      "user": 14510,
+      "created_at": 1719349728
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 324,
+      "user": 14510,
+      "created_at": 1719349741
+    },
+    {
+      "type": "undo",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 325,
+      "user": 14510,
+      "created_at": 1719349763
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 326,
+      "user": 14510,
+      "created_at": 1719349765
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 327,
+      "created_at": 1719349766,
+      "train": "3-3",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 328,
+      "created_at": 1719349769
+    },
+    {
+      "type": "par",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 329,
+      "created_at": 1719468747,
+      "corporation": "STJ",
+      "share_price": "82,2,2"
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 330,
+      "created_at": 1719468753
+    },
+    {
+      "type": "sell_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 331,
+      "created_at": 1719487809,
+      "shares": [
+        "ÖSJ_2",
+        "ÖSJ_3",
+        "ÖSJ_4",
+        "ÖSJ_5",
+        "ÖSJ_0"
+      ],
+      "percent": 50
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 332,
+      "created_at": 1719487844,
+      "shares": [
+        "STJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 333,
+      "created_at": 1719487848
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3864,
+      "shares": [
+        "ÖKJ_1",
+        "ÖKJ_7"
+      ],
+      "percent": 20,
+      "entity_type": "player",
+      "id": 334,
+      "user": 3864,
+      "created_at": 1719488495
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3864,
+      "shares": [
+        "TGOJ_2",
+        "TGOJ_4",
+        "TGOJ_1"
+      ],
+      "percent": 30,
+      "entity_type": "player",
+      "id": 335,
+      "user": 3864,
+      "created_at": 1719488497
+    },
+    {
+      "type": "undo",
+      "entity": 3864,
+      "action_id": 333,
+      "entity_type": "player",
+      "id": 336,
+      "user": 3864,
+      "created_at": 1719488511
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 337,
+      "created_at": 1719488519,
+      "shares": [
+        "ÖKJ_1",
+        "ÖKJ_7"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 338,
+      "created_at": 1719488537,
+      "shares": [
+        "TGOJ_2",
+        "TGOJ_4"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "par",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 339,
+      "created_at": 1719488612,
+      "corporation": "SWB",
+      "share_price": "100,0,2"
+    },
+    {
+      "type": "pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 340,
+      "created_at": 1719488614
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2170,
+      "shares": [
+        "ÖKJ_8"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 341,
+      "user": 2170,
+      "created_at": 1719488772
+    },
+    {
+      "type": "undo",
+      "entity": 2170,
+      "action_id": 340,
+      "entity_type": "player",
+      "id": 342,
+      "user": 2170,
+      "created_at": 1719488799
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "shares": [
+        "STJ_2"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 343,
+      "user": 2170,
+      "created_at": 1719488820
+    },
+    {
+      "type": "undo",
+      "entity": 2170,
+      "action_id": 340,
+      "entity_type": "player",
+      "id": 344,
+      "user": 2170,
+      "created_at": 1719488838
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 345,
+      "created_at": 1719488840,
+      "shares": [
+        "ÖKJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 346,
+      "created_at": 1719488842,
+      "shares": [
+        "TGOJ_5",
+        "TGOJ_3"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "par",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 347,
+      "created_at": 1719488850,
+      "corporation": "UGJ",
+      "share_price": "82,2,2"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 348,
+      "created_at": 1719489335,
+      "shares": [
+        "ÖSJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 349,
+      "created_at": 1719489338
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 350,
+      "created_at": 1719489951,
+      "shares": [
+        "ÖKJ_4",
+        "ÖKJ_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 351,
+      "created_at": 1719489958,
+      "shares": [
+        "ÖSJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 352,
+      "created_at": 1719489973,
+      "shares": [
+        "TGOJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 353,
+      "created_at": 1719490045,
+      "corporation": "KFJ",
+      "share_price": "82,2,2"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 354,
+      "created_at": 1719491837,
+      "shares": [
+        "STJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 355,
+      "created_at": 1719491839
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 356,
+      "created_at": 1719493065,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719493064,
+          "shares": [
+            "SWB_1"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719493064
+        }
+      ],
+      "corporation": "SWB",
+      "until_condition": 6,
+      "from_market": false,
+      "auto_pass_after": true
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 357,
+      "created_at": 1719493118,
+      "shares": [
+        "UGJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 358,
+      "created_at": 1719493135
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 359,
+      "created_at": 1719529478,
+      "shares": [
+        "ÖKJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 360,
+      "created_at": 1719529481,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719529479
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 361,
+      "created_at": 1719559232,
+      "shares": [
+        "KFJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 362,
+      "created_at": 1719559240
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 363,
+      "created_at": 1719568572,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719568571
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 364,
+      "created_at": 1719571276,
+      "shares": [
+        "STJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 365,
+      "created_at": 1719571282,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719571283,
+          "shares": [
+            "SWB_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719571283
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 366,
+      "created_at": 1719571725,
+      "shares": [
+        "UGJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 367,
+      "created_at": 1719571882,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719571883
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 368,
+      "created_at": 1719572333,
+      "shares": [
+        "KFJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 369,
+      "created_at": 1719572343,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719572343
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 370,
+      "created_at": 1719574308,
+      "shares": [
+        "STJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 371,
+      "created_at": 1719574398,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719574398,
+          "shares": [
+            "SWB_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719574398
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 372,
+      "created_at": 1719575059,
+      "shares": [
+        "UGJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 373,
+      "created_at": 1719575066,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719575067
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 374,
+      "created_at": 1719576043,
+      "shares": [
+        "KFJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 375,
+      "created_at": 1719576045,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719576045
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "shares": [
+        "STJ_5"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 376,
+      "user": 14510,
+      "created_at": 1719582856
+    },
+    {
+      "type": "undo",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 377,
+      "user": 14510,
+      "created_at": 1719582859
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 378,
+      "created_at": 1719582896,
+      "shares": [
+        "TGOJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 379,
+      "created_at": 1719582897,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719582897,
+          "shares": [
+            "SWB_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719582897,
+          "reason": "6 share(s) bought in SWB, end condition met"
+        },
+        {
+          "type": "program_share_pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719582897,
+          "unconditional": false,
+          "indefinite": false
+        },
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719582897
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 380,
+      "created_at": 1719582983,
+      "shares": [
+        "UGJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 381,
+      "created_at": 1719583016,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1719583018,
+          "reason": "khr2201 bought on corporation TGOJ and is unsecure"
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 382,
+      "created_at": 1719583253,
+      "shares": [
+        "UGJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 383,
+      "created_at": 1719583255
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 384,
+      "created_at": 1719583288,
+      "shares": [
+        "KFJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 385,
+      "created_at": 1719583292,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719583292
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 386,
+      "created_at": 1719587481,
+      "shares": [
+        "ÖKJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 387,
+      "created_at": 1719587484,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719587484
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 388,
+      "created_at": 1719587598
+    },
+    {
+      "type": "sell_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 389,
+      "created_at": 1719590909,
+      "shares": [
+        "ÖKJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 390,
+      "created_at": 1719590914,
+      "shares": [
+        "UGJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 391,
+      "created_at": 1719590917,
+      "shares": [
+        "UGJ_5",
+        "UGJ_6"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 392,
+      "created_at": 1719590919
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 393,
+      "created_at": 1719591529,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1719591529
+        },
+        {
+          "type": "program_disable",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719591529,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 394,
+      "created_at": 1719600253,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719600252
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 395,
+      "created_at": 1719600369,
+      "shares": [
+        "ÖKJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 396,
+      "created_at": 1719600371,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719600370,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 397,
+      "created_at": 1719600449,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719600448
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 398,
+      "created_at": 1719600499
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 399,
+      "created_at": 1719601546,
+      "shares": [
+        "SWB_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 400,
+      "created_at": 1719601547,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1719601546
+        },
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719601546
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 401,
+      "created_at": 1719609277,
+      "shares": [
+        "TGOJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 402,
+      "created_at": 1719609278,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719609277
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 403,
+      "created_at": 1719609341,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719609342
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 404,
+      "created_at": 1719612072,
+      "shares": [
+        "SWB_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 405,
+      "created_at": 1719612074,
+      "shares": [
+        "SWB_5",
+        "SWB_6"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 406,
+      "created_at": 1719612076,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1719612074,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 407,
+      "created_at": 1719615938,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719615938,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 408,
+      "created_at": 1719660871,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719660870
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 409,
+      "created_at": 1719662986,
+      "shares": [
+        "TGOJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 410,
+      "created_at": 1719662988,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719662988,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 411,
+      "created_at": 1719665000,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719664999
+        },
+        {
+          "type": "program_disable",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719664999,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 412,
+      "created_at": 1719665128,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719665128
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "shares": [
+        "TGOJ_3"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 413,
+      "user": 12106,
+      "created_at": 1719683112
+    },
+    {
+      "type": "undo",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 414,
+      "user": 12106,
+      "created_at": 1719683124
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 415,
+      "created_at": 1719683153,
+      "shares": [
+        "STJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 416,
+      "created_at": 1719683154
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 417,
+      "created_at": 1719739374,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1719739374
+        },
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719739374
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 418,
+      "created_at": 1719741387,
+      "shares": [
+        "TGOJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 419,
+      "created_at": 1719741390,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719741385
+        },
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719741385
+        }
+      ]
+    },
+    {
+      "type": "sell_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 420,
+      "created_at": 1719746025,
+      "shares": [
+        "STJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 421,
+      "created_at": 1719746026,
+      "shares": [
+        "TGOJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 422,
+      "created_at": 1719746028,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1719746028,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 423,
+      "created_at": 1719746586,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1719746586
+        },
+        {
+          "type": "program_disable",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719746586,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 424,
+      "created_at": 1719761491,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1719761491
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 425,
+      "created_at": 1719763831,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719763833,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 426,
+      "created_at": 1719765671,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719765669
+        },
+        {
+          "type": "program_disable",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719765669,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 427,
+      "created_at": 1719765733,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719765733
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "undo",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 428,
+      "user": 3864,
+      "created_at": 1719766814
+    },
+    {
+      "type": "undo",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 429,
+      "user": 3864,
+      "created_at": 1719766817
+    },
+    {
+      "type": "redo",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 430,
+      "user": 3864,
+      "created_at": 1719766847
+    },
+    {
+      "type": "redo",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 431,
+      "user": 3864,
+      "created_at": 1719766850
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 432,
+      "created_at": 1719771894
+    },
+    {
+      "type": "undo",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 433,
+      "user": 12106,
+      "created_at": 1719771906
+    },
+    {
+      "type": "redo",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 434,
+      "user": 2170,
+      "created_at": 1719771912
+    },
+    {
+      "hex": "A12",
+      "tile": "9-6",
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "rotation": 4,
+      "entity_type": "minor",
+      "id": 435,
+      "user": 2170,
+      "created_at": 1719771923
+    },
+    {
+      "type": "undo",
+      "entity": "KHJ",
+      "action_id": 432,
+      "entity_type": "minor",
+      "id": 436,
+      "user": 2170,
+      "created_at": 1719772009
+    },
+    {
+      "hex": "A12",
+      "tile": "8-9",
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "rotation": 4,
+      "entity_type": "minor",
+      "id": 437,
+      "user": 2170,
+      "created_at": 1719772017
+    },
+    {
+      "type": "undo",
+      "entity": "KHJ",
+      "action_id": 432,
+      "entity_type": "minor",
+      "id": 438,
+      "user": 2170,
+      "created_at": 1719772027
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 439,
+      "created_at": 1719772031,
+      "hex": "A12",
+      "tile": "9-6",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 440,
+      "created_at": 1719772043
+    },
+    {
+      "type": "run_routes",
+      "entity": "KHJ",
+      "entity_type": "minor",
+      "id": 441,
+      "created_at": 1719772056,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "D15",
+              "E16",
+              "E14",
+              "F13"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "F13"
+          ],
+          "revenue": 60,
+          "revenue_str": "D15-F13",
+          "nodes": [
+            "D15-0",
+            "F13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "buy_company",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 442,
+      "created_at": 1719773553,
+      "company": "MV",
+      "price": 180
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 443,
+      "created_at": 1719773575,
+      "hex": "G10",
+      "tile": "X2-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 444,
+      "created_at": 1719773597
+    },
+    {
+      "city": "X2-0-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "KFJ",
+      "tokener": "KFJ",
+      "entity_type": "corporation",
+      "id": 445,
+      "user": 1075,
+      "created_at": 1719773599
+    },
+    {
+      "type": "undo",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 446,
+      "user": 1075,
+      "created_at": 1719773616
+    },
+    {
+      "type": "place_token",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 447,
+      "created_at": 1719773628,
+      "city": "X2-0-0",
+      "slot": 0,
+      "tokener": "KFJ"
+    },
+    {
+      "type": "buy_train",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 448,
+      "created_at": 1719773634,
+      "train": "3-4",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "buy_train",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 449,
+      "created_at": 1719773636,
+      "train": "4-0",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 450,
+      "created_at": 1719773656
+    },
+    {
+      "type": "run_routes",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 451,
+      "created_at": 1719773662,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "A16"
+            ],
+            [
+              "A16",
+              "B17",
+              "C16"
+            ],
+            [
+              "C16",
+              "D15"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "A16",
+            "C16",
+            "D15"
+          ],
+          "revenue": 130,
+          "revenue_str": "A10-A16-C16-D15",
+          "nodes": [
+            "A10-0",
+            "A16-0",
+            "C16-0",
+            "D15-0"
+          ]
+        },
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "F13"
+          ],
+          "revenue": 100,
+          "revenue_str": "H9-G10-F13",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "F13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 452,
+      "user": 1075,
+      "created_at": 1719773665
+    },
+    {
+      "type": "undo",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 453,
+      "user": 1075,
+      "created_at": 1719773696
+    },
+    {
+      "type": "dividend",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 454,
+      "created_at": 1719773696,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 455,
+      "created_at": 1719773709
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 456,
+      "created_at": 1719777064,
+      "hex": "E12",
+      "tile": "619-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 457,
+      "created_at": 1719777103
+    },
+    {
+      "type": "place_token",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 458,
+      "created_at": 1719777105,
+      "city": "15-0-0",
+      "slot": 1,
+      "tokener": "SWB"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 459,
+      "created_at": 1719777108,
+      "train": "4-1",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 460,
+      "created_at": 1719777122
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 461,
+      "created_at": 1719777127
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 462,
+      "created_at": 1719779205,
+      "hex": "D29",
+      "tile": "15-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 463,
+      "created_at": 1719779209
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 464,
+      "user": 12106,
+      "created_at": 1719779212
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 465,
+      "user": 12106,
+      "created_at": 1719779217
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 466,
+      "created_at": 1719779235
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 467,
+      "created_at": 1719779239,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "E26",
+              "D27",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "D29",
+            "G26"
+          ],
+          "revenue": 130,
+          "revenue_str": "E20-D29-G26 + m/M",
+          "nodes": [
+            "E20-0",
+            "D29-0",
+            "G26-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 468,
+      "created_at": 1719779246,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 469,
+      "created_at": 1719779267
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 470,
+      "created_at": 1719779269
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 471,
+      "created_at": 1719783746,
+      "hex": "D19",
+      "tile": "15-3",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 472,
+      "created_at": 1719783754,
+      "hex": "E16",
+      "tile": "27-0",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 473,
+      "created_at": 1719783765,
+      "city": "14-0-0",
+      "slot": 1,
+      "tokener": "STJ"
+    },
+    {
+      "type": "buy_train",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 474,
+      "created_at": 1719783770,
+      "train": "4-2",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 475,
+      "created_at": 1719783772
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 476,
+      "created_at": 1719783775
+    },
+    {
+      "hex": "C16",
+      "tile": "14-1",
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 477,
+      "user": 2170,
+      "created_at": 1719784229
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 478,
+      "user": 2170,
+      "created_at": 1719784248
+    },
+    {
+      "city": "14-1-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "UGJ",
+      "tokener": "UGJ",
+      "entity_type": "corporation",
+      "id": 479,
+      "user": 2170,
+      "created_at": 1719784251
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 480,
+      "user": 2170,
+      "created_at": 1719784257
+    },
+    {
+      "city": "619-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "UGJ",
+      "tokener": "UGJ",
+      "entity_type": "corporation",
+      "id": 481,
+      "user": 2170,
+      "created_at": 1719784259
+    },
+    {
+      "type": "buy_train",
+      "price": 300,
+      "train": "4-3",
+      "entity": "UGJ",
+      "variant": "4",
+      "entity_type": "corporation",
+      "id": 482,
+      "user": 2170,
+      "created_at": 1719784279
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 483,
+      "user": 2170,
+      "created_at": 1719784287
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 484,
+      "user": 2170,
+      "created_at": 1719784289
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 485,
+      "user": 2170,
+      "created_at": 1719784292
+    },
+    {
+      "type": "buy_train",
+      "price": 300,
+      "train": "4-3",
+      "entity": "UGJ",
+      "variant": "4",
+      "entity_type": "corporation",
+      "id": 486,
+      "user": 2170,
+      "created_at": 1719784294
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 487,
+      "user": 2170,
+      "created_at": 1719784297
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 488,
+      "user": 2170,
+      "created_at": 1719784373
+    },
+    {
+      "city": "14-1-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "UGJ",
+      "tokener": "UGJ",
+      "entity_type": "corporation",
+      "id": 489,
+      "user": 2170,
+      "created_at": 1719784375
+    },
+    {
+      "type": "buy_train",
+      "price": 150,
+      "train": "3-0",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 490,
+      "user": 2170,
+      "created_at": 1719784480
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "action_id": 476,
+      "entity_type": "corporation",
+      "id": 491,
+      "user": 2170,
+      "created_at": 1719784540
+    },
+    {
+      "hex": "C16",
+      "tile": "14-1",
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 492,
+      "user": 2170,
+      "created_at": 1719784568
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 493,
+      "user": 2170,
+      "created_at": 1719784572
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 494,
+      "user": 2170,
+      "created_at": 1719784818
+    },
+    {
+      "type": "buy_train",
+      "price": 250,
+      "train": "3-0",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 495,
+      "user": 2170,
+      "created_at": 1719784822
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 496,
+      "user": 2170,
+      "created_at": 1719784828
+    },
+    {
+      "type": "buy_train",
+      "price": 300,
+      "train": "4-3",
+      "entity": "UGJ",
+      "variant": "4",
+      "entity_type": "corporation",
+      "id": 497,
+      "user": 2170,
+      "created_at": 1719784838
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 498,
+      "user": 2170,
+      "created_at": 1719784848
+    },
+    {
+      "type": "buy_train",
+      "price": 300,
+      "train": "4-3",
+      "entity": "UGJ",
+      "variant": "4",
+      "entity_type": "corporation",
+      "id": 499,
+      "user": 2170,
+      "created_at": 1719784855
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 500,
+      "user": 2170,
+      "created_at": 1719784989
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 501,
+      "user": 2170,
+      "created_at": 1719785003
+    },
+    {
+      "city": "14-1-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "UGJ",
+      "tokener": "UGJ",
+      "entity_type": "corporation",
+      "id": 502,
+      "user": 2170,
+      "created_at": 1719785004
+    },
+    {
+      "type": "buy_train",
+      "price": 150,
+      "train": "3-0",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 503,
+      "user": 2170,
+      "created_at": 1719785013
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 504,
+      "user": 2170,
+      "created_at": 1719785023
+    },
+    {
+      "type": "buy_train",
+      "price": 250,
+      "train": "3-0",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 505,
+      "user": 2170,
+      "created_at": 1719785031
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 506,
+      "user": 2170,
+      "created_at": 1719785178
+    },
+    {
+      "type": "buy_company",
+      "price": 280,
+      "entity": "UGJ",
+      "company": "KHJ",
+      "entity_type": "corporation",
+      "id": 507,
+      "user": 2170,
+      "created_at": 1719785198
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 508,
+      "user": 2170,
+      "created_at": 1719785211
+    },
+    {
+      "type": "redo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 509,
+      "user": 2170,
+      "created_at": 1719785218
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 510,
+      "user": 2170,
+      "created_at": 1719785226
+    },
+    {
+      "type": "buy_company",
+      "price": 90,
+      "entity": "UGJ",
+      "company": "KHJ",
+      "entity_type": "corporation",
+      "id": 511,
+      "user": 2170,
+      "created_at": 1719785235
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "action_id": 476,
+      "entity_type": "corporation",
+      "id": 512,
+      "user": 2170,
+      "created_at": 1719785286
+    },
+    {
+      "type": "buy_company",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 513,
+      "created_at": 1719785314,
+      "company": "KHJ",
+      "price": 70
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 514,
+      "created_at": 1719785327,
+      "hex": "C16",
+      "tile": "14-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 515,
+      "created_at": 1719785330
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 516,
+      "created_at": 1719785334
+    },
+    {
+      "type": "buy_train",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 517,
+      "created_at": 1719785335,
+      "train": "4-3",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "buy_train",
+      "price": 530,
+      "train": "5-0",
+      "entity": "UGJ",
+      "variant": "5",
+      "entity_type": "corporation",
+      "id": 518,
+      "user": 2170,
+      "created_at": 1719785335
+    },
+    {
+      "type": "undo",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 519,
+      "user": 2170,
+      "created_at": 1719785386
+    },
+    {
+      "type": "buy_train",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 520,
+      "created_at": 1719785396,
+      "train": "5-0",
+      "price": 530,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 521,
+      "created_at": 1719785974,
+      "hex": "E10",
+      "tile": "8-9",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 522,
+      "created_at": 1719785999
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 523,
+      "created_at": 1719786003,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "C12",
+              "D13",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ]
+          ],
+          "hexes": [
+            "C12",
+            "E12",
+            "G10"
+          ],
+          "revenue": 100,
+          "revenue_str": "C12-E12-G10",
+          "nodes": [
+            "C12-0",
+            "E12-0",
+            "G10-3"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 524,
+      "created_at": 1719786010,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 525,
+      "created_at": 1719786012
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 526,
+      "created_at": 1719808908,
+      "hex": "D7",
+      "tile": "8-2",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 527,
+      "created_at": 1719808913,
+      "hex": "E8",
+      "tile": "57-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 528,
+      "created_at": 1719808916
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 529,
+      "created_at": 1719808931,
+      "routes": [
+        {
+          "train": "3-3",
+          "connections": [
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "D5",
+              "D7",
+              "E8"
+            ]
+          ],
+          "hexes": [
+            "C2",
+            "D5",
+            "E8"
+          ],
+          "revenue": 80,
+          "revenue_str": "C2-D5-E8",
+          "nodes": [
+            "C2-0",
+            "D5-0",
+            "E8-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "C2",
+              "B3",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "C2",
+            "A2"
+          ],
+          "revenue": 90,
+          "revenue_str": "C2-A2",
+          "nodes": [
+            "C2-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 530,
+      "created_at": 1719808939,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 531,
+      "created_at": 1719820872,
+      "hex": "G12",
+      "tile": "29-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 532,
+      "created_at": 1719820898
+    },
+    {
+      "type": "pass",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 533,
+      "created_at": 1719820910
+    },
+    {
+      "type": "run_routes",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 534,
+      "created_at": 1719820914,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "A16"
+            ],
+            [
+              "A16",
+              "B17",
+              "C16"
+            ],
+            [
+              "C16",
+              "D15"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "A16",
+            "C16",
+            "D15"
+          ],
+          "revenue": 150,
+          "revenue_str": "A10-A16-C16-D15",
+          "nodes": [
+            "A10-0",
+            "A16-0",
+            "C16-0",
+            "D15-0"
+          ]
+        },
+        {
+          "train": "3-4",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "F13"
+          ],
+          "revenue": 110,
+          "revenue_str": "H9-G10-F13",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "F13-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KFJ",
+      "entity_type": "corporation",
+      "id": 535,
+      "created_at": 1719820967,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 536,
+      "created_at": 1719821524,
+      "hex": "C10",
+      "tile": "8-10",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 537,
+      "created_at": 1719821530
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 538,
+      "created_at": 1719821537,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "C12",
+              "D13",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "C12",
+            "E12",
+            "G10",
+            "H9"
+          ],
+          "revenue": 140,
+          "revenue_str": "C12-E12-G10-H9",
+          "nodes": [
+            "C12-0",
+            "E12-0",
+            "G10-3",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 539,
+      "created_at": 1719821538,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 540,
+      "created_at": 1719821539,
+      "train": "5-1",
+      "price": 530,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 541,
+      "created_at": 1719946809,
+      "hex": "B9",
+      "tile": "8-11",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 542,
+      "created_at": 1719946815
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 543,
+      "created_at": 1719946820,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "E12",
+              "D13",
+              "C12"
+            ],
+            [
+              "C12",
+              "C10",
+              "B9",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "E12",
+            "C12",
+            "A10"
+          ],
+          "revenue": 130,
+          "revenue_str": "E12-C12-A10",
+          "nodes": [
+            "E12-0",
+            "C12-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 544,
+      "created_at": 1719946838,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖKJ",
+      "entity_type": "corporation",
+      "id": 545,
+      "created_at": 1719946839
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 546,
+      "created_at": 1719947681,
+      "hex": "D29",
+      "tile": "611-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 547,
+      "created_at": 1719947682
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 548,
+      "created_at": 1719947683
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 549,
+      "created_at": 1719947685,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "E26",
+              "D27",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "E20",
+            "D29",
+            "G26"
+          ],
+          "revenue": 140,
+          "revenue_str": "E20-D29-G26 + m/M",
+          "nodes": [
+            "E20-0",
+            "D29-0",
+            "G26-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 550,
+      "created_at": 1719947687,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 551,
+      "created_at": 1719947687,
+      "train": "5-2",
+      "price": 530,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 552,
+      "created_at": 1719948962,
+      "hex": "E20",
+      "tile": "611-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 553,
+      "created_at": 1719948975
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 554,
+      "created_at": 1719948977
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 555,
+      "created_at": 1719948981,
+      "routes": [
+        {
+          "train": "4-2",
+          "connections": [
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "E26",
+              "D27",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "F13",
+            "E20",
+            "D29",
+            "G26"
+          ],
+          "revenue": 180,
+          "revenue_str": "F13-E20-D29-G26 + m/M",
+          "nodes": [
+            "F13-0",
+            "E20-0",
+            "D29-0",
+            "G26-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 556,
+      "user": 14510,
+      "created_at": 1719948983
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 557,
+      "user": 14510,
+      "created_at": 1719948988
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 558,
+      "created_at": 1719948994,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 559,
+      "created_at": 1719948996,
+      "train": "6-0",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 560,
+      "created_at": 1719955874,
+      "hex": "G10",
+      "tile": "X4-0",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 561,
+      "created_at": 1719955878
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 562,
+      "created_at": 1719955882,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "E26",
+              "D27",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "F13",
+            "E20",
+            "D29",
+            "G26"
+          ],
+          "revenue": 250,
+          "revenue_str": "G10-F13-E20-D29-G26 + m/M",
+          "nodes": [
+            "G10-0",
+            "F13-0",
+            "E20-0",
+            "D29-0",
+            "G26-0"
+          ]
+        },
+        {
+          "train": "4-3",
+          "connections": [
+            [
+              "D15",
+              "C16"
+            ],
+            [
+              "C16",
+              "B17",
+              "A16"
+            ],
+            [
+              "A16",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "D15",
+            "C16",
+            "A16",
+            "A10"
+          ],
+          "revenue": 150,
+          "revenue_str": "D15-C16-A16-A10",
+          "nodes": [
+            "D15-0",
+            "C16-0",
+            "A16-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 563,
+      "created_at": 1719955902,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 564,
+      "created_at": 1719955931,
+      "hex": "E8",
+      "tile": "15-2",
+      "rotation": 2
+    },
+    {
+      "hex": "F9",
+      "tile": "9-7",
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 565,
+      "user": 2170,
+      "created_at": 1719955933
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 566,
+      "user": 2170,
+      "created_at": 1719955934
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 567,
+      "created_at": 1719955935
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 568,
+      "created_at": 1719955935
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 569,
+      "created_at": 1719955994,
+      "train": "4-3",
+      "price": 224
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 570,
+      "user": 2170,
+      "created_at": 1719956001
+    },
+    {
+      "type": "redo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 571,
+      "user": 2170,
+      "created_at": 1719956003
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 572,
+      "created_at": 1719956018
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 573,
+      "created_at": 1719956876,
+      "shares": [
+        "STJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 574,
+      "created_at": 1719956906
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 575,
+      "created_at": 1719957270,
+      "shares": [
+        "SWB_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 576,
+      "created_at": 1719957272
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 577,
+      "created_at": 1719957675,
+      "shares": [
+        "STJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 578,
+      "created_at": 1719957676
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 579,
+      "created_at": 1719960752,
+      "shares": [
+        "UGJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 580,
+      "created_at": 1719960758,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1719960757
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 581,
+      "created_at": 1719997449,
+      "shares": [
+        "STJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 582,
+      "created_at": 1719997452,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1719997453
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 583,
+      "created_at": 1719997524,
+      "shares": [
+        "STJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 584,
+      "created_at": 1719997526
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 585,
+      "created_at": 1719997562,
+      "shares": [
+        "SWB_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 586,
+      "created_at": 1719997573
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 587,
+      "created_at": 1720084584,
+      "shares": [
+        "UGJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 588,
+      "created_at": 1720084586
+    },
+    {
+      "type": "sell_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 589,
+      "created_at": 1720088060,
+      "shares": [
+        "TGOJ_2",
+        "TGOJ_4",
+        "TGOJ_5",
+        "TGOJ_3"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "par",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 590,
+      "created_at": 1720088206,
+      "corporation": "BJ",
+      "share_price": "90,1,2"
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 591,
+      "created_at": 1720088219,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720088220,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 592,
+      "created_at": 1720094209,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720094209
+        },
+        {
+          "type": "program_disable",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720094209,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 593,
+      "created_at": 1720094659,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720094660
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 594,
+      "created_at": 1720095042,
+      "shares": [
+        "SWB_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 595,
+      "created_at": 1720095043,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1720095042
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 596,
+      "created_at": 1720099614,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1720099613
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 597,
+      "created_at": 1720101162,
+      "shares": [
+        "TGOJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 598,
+      "created_at": 1720101165
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "shares": [
+        "BJ_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 599,
+      "user": 14510,
+      "created_at": 1720104682
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "created_at": 1720104684,
+          "entity_type": "player"
+        },
+        {
+          "type": "pass",
+          "entity": 2170,
+          "created_at": 1720104684,
+          "entity_type": "player"
+        },
+        {
+          "type": "pass",
+          "entity": 12106,
+          "created_at": 1720104684,
+          "entity_type": "player"
+        },
+        {
+          "type": "pass",
+          "entity": 1075,
+          "created_at": 1720104684,
+          "entity_type": "player"
+        }
+      ],
+      "id": 600,
+      "user": 14510,
+      "created_at": 1720104683
+    },
+    {
+      "type": "undo",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 601,
+      "user": 14510,
+      "created_at": 1720104862
+    },
+    {
+      "type": "undo",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 602,
+      "user": 14510,
+      "created_at": 1720104868
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 603,
+      "created_at": 1720104871,
+      "shares": [
+        "SWB_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 604,
+      "created_at": 1720104874,
+      "shares": [
+        "SWB_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 605,
+      "created_at": 1720104877,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720104877,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 606,
+      "created_at": 1720107519,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720107518
+        },
+        {
+          "type": "program_disable",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720107518,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 607,
+      "created_at": 1720108539,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720108540
+        },
+        {
+          "type": "program_disable",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1720108540,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 608,
+      "created_at": 1720108739,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1720108737
+        },
+        {
+          "type": "program_disable",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1720108737,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 609,
+      "created_at": 1720111401,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1720111400
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 610,
+      "created_at": 1720132936,
+      "shares": [
+        "SWB_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 611,
+      "created_at": 1720132939
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "shares": [
+        "UGJ_7"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 612,
+      "user": 14510,
+      "created_at": 1720144756
+    },
+    {
+      "type": "undo",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 613,
+      "user": 14510,
+      "created_at": 1720144778
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 614,
+      "created_at": 1720144791,
+      "shares": [
+        "BJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 615,
+      "created_at": 1720144793,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720144792
+        },
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720144792
+        },
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1720144792
+        },
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1720144792
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 616,
+      "created_at": 1720145212,
+      "shares": [
+        "TGOJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 617,
+      "created_at": 1720145215
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 618,
+      "created_at": 1720145397,
+      "shares": [
+        "BJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 619,
+      "created_at": 1720145399,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720145398
+        },
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720145398
+        },
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1720145398
+        },
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1720145398
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 620,
+      "created_at": 1720145593,
+      "shares": [
+        "TGOJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 621,
+      "created_at": 1720145600
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 622,
+      "created_at": 1720145997,
+      "shares": [
+        "BJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 623,
+      "created_at": 1720145999,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720145998
+        },
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720145998
+        },
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1720145998
+        },
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1720145998
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 624,
+      "created_at": 1720168789,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1720168789
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "sell_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 625,
+      "created_at": 1720173008,
+      "shares": [
+        "STJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 626,
+      "created_at": 1720173025,
+      "shares": [
+        "KFJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 627,
+      "created_at": 1720173030,
+      "shares": [
+        "KFJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 628,
+      "created_at": 1720173037,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720173035,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 629,
+      "created_at": 1720178026,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720178025
+        },
+        {
+          "type": "program_disable",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720178025,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 630,
+      "created_at": 1720179378,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720179378
+        },
+        {
+          "type": "program_disable",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1720179378,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 631,
+      "created_at": 1720180603,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1720180600
+        },
+        {
+          "type": "program_disable",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1720180600,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 632,
+      "created_at": 1720181689,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1720181688
+        },
+        {
+          "type": "program_disable",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1720181688,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 633,
+      "created_at": 1720184955,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1720184954
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 634,
+      "user": 14510,
+      "created_at": 1720185399
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 635,
+      "user": 14510,
+      "created_at": 1720185418
+    },
+    {
+      "type": "sell_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 636,
+      "created_at": 1720185433,
+      "shares": [
+        "STJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 637,
+      "created_at": 1720185435,
+      "shares": [
+        "BJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 638,
+      "created_at": 1720185438,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720185438,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 639,
+      "created_at": 1720188540,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720188539
+        },
+        {
+          "type": "program_disable",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720188539,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 640,
+      "created_at": 1720188668,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720188668
+        },
+        {
+          "type": "program_disable",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1720188668,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 641,
+      "created_at": 1720196494,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1720196491,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 642,
+      "created_at": 1720217037,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1720217035
+        },
+        {
+          "type": "program_disable",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1720217035,
+          "reason": "Shares were sold"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 643,
+      "created_at": 1720217307,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1720217306
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 644,
+      "created_at": 1720221362
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 645,
+      "created_at": 1720222692,
+      "hex": "E16",
+      "tile": "41-0",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 646,
+      "created_at": 1720222708,
+      "hex": "F25",
+      "tile": "27-0",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 647,
+      "created_at": 1720222711,
+      "city": "619-0-0",
+      "slot": 1,
+      "tokener": "BJ"
+    },
+    {
+      "type": "buy_train",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 648,
+      "created_at": 1720222716,
+      "train": "4-2",
+      "price": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 649,
+      "created_at": 1720222718,
+      "train": "D-0",
+      "price": 800,
+      "variant": "D",
+      "exchange": "4-2"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 650,
+      "created_at": 1720223158
+    },
+    {
+      "hex": "G10",
+      "tile": "X5-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "id": 651,
+      "user": 3864,
+      "created_at": 1720230005
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 652,
+      "user": 3864,
+      "created_at": 1720230009
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "routes": [
+        {
+          "hexes": [
+            "A10",
+            "C12",
+            "E12",
+            "G10",
+            "H9"
+          ],
+          "nodes": [
+            "C12-0",
+            "A10-0",
+            "E12-0",
+            "G10-0",
+            "H9-0"
+          ],
+          "train": "5-1",
+          "revenue": 380,
+          "connections": [
+            [
+              "C12",
+              "C10",
+              "B9",
+              "A10"
+            ],
+            [
+              "E12",
+              "D13",
+              "C12"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "H9",
+              "G10"
+            ]
+          ],
+          "revenue_str": "A10-C12-E12-G10-H9 + Ö/V"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 653,
+      "user": 3864,
+      "created_at": 1720230018
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 654,
+      "user": 3864,
+      "created_at": 1720230052
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 655,
+      "user": 3864,
+      "created_at": 1720230078
+    },
+    {
+      "type": "undo",
+      "entity": "TGOJ",
+      "action_id": 650,
+      "entity_type": "corporation",
+      "id": 656,
+      "user": 3864,
+      "created_at": 1720230094
+    },
+    {
+      "hex": "E12",
+      "tile": "63-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 657,
+      "user": 3864,
+      "created_at": 1720230170
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "action_id": 650,
+      "entity_type": "corporation",
+      "id": 658,
+      "user": 3864,
+      "created_at": 1720230206
+    },
+    {
+      "hex": "E12",
+      "tile": "63-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 659,
+      "user": 3864,
+      "created_at": 1720230453
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 660,
+      "user": 3864,
+      "created_at": 1720230563
+    },
+    {
+      "hex": "E14",
+      "tile": "17-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 661,
+      "user": 3864,
+      "created_at": 1720230574
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 662,
+      "user": 3864,
+      "created_at": 1720230586
+    },
+    {
+      "hex": "E14",
+      "tile": "21-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 4,
+      "entity_type": "corporation",
+      "id": 663,
+      "user": 3864,
+      "created_at": 1720230594
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 664,
+      "user": 3864,
+      "created_at": 1720230601
+    },
+    {
+      "hex": "E14",
+      "tile": "30-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 665,
+      "user": 3864,
+      "created_at": 1720230616
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 666,
+      "user": 3864,
+      "created_at": 1720230622
+    },
+    {
+      "hex": "F9",
+      "tile": "9-7",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 667,
+      "user": 3864,
+      "created_at": 1720230627
+    },
+    {
+      "hex": "D7",
+      "tile": "24-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "id": 668,
+      "user": 3864,
+      "created_at": 1720230632
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "action_id": 650,
+      "entity_type": "corporation",
+      "id": 669,
+      "user": 3864,
+      "created_at": 1720230762
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 670,
+      "created_at": 1720230765,
+      "hex": "G10",
+      "tile": "X5-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 671,
+      "created_at": 1720230776
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 672,
+      "created_at": 1720230782,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "D13",
+              "C12"
+            ],
+            [
+              "C12",
+              "C10",
+              "B9",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "C12",
+            "A10"
+          ],
+          "revenue": 380,
+          "revenue_str": "H9-G10-E12-C12-A10 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "C12-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 673,
+      "created_at": 1720230783,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 674,
+      "created_at": 1720230786
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 675,
+      "created_at": 1720250017,
+      "hex": "D19",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 676,
+      "created_at": 1720250021
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 677,
+      "created_at": 1720250026
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 678,
+      "created_at": 1720250029,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ],
+            [
+              "D29",
+              "D27",
+              "E26",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "D19"
+            ],
+            [
+              "D19",
+              "E18",
+              "F19"
+            ]
+          ],
+          "hexes": [
+            "G26",
+            "D29",
+            "E20",
+            "D19",
+            "F19"
+          ],
+          "revenue": 210,
+          "revenue_str": "G26-D29-E20-D19-F19 + m/M",
+          "nodes": [
+            "G26-0",
+            "D29-0",
+            "E20-0",
+            "D19-0",
+            "F19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 679,
+      "created_at": 1720250030,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 680,
+      "created_at": 1720250032
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 681,
+      "created_at": 1720250079,
+      "hex": "F13",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 682,
+      "created_at": 1720250082
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 683,
+      "created_at": 1720250084
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 684,
+      "created_at": 1720250086,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "F13",
+            "E20",
+            "D19"
+          ],
+          "revenue": 300,
+          "revenue_str": "H9-G10-F13-E20-D19 + b/B",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "F13-0",
+            "E20-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 685,
+      "created_at": 1720250087,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 686,
+      "created_at": 1720250089,
+      "train": "6-1",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 687,
+      "created_at": 1720258327,
+      "hex": "F13",
+      "tile": "X6-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 688,
+      "created_at": 1720258331
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 689,
+      "created_at": 1720258347,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "E26",
+              "D27",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "F13",
+            "E20",
+            "D29",
+            "G26"
+          ],
+          "revenue": 340,
+          "revenue_str": "H9-G10-F13-E20-D29-G26 + m/M",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "F13-0",
+            "E20-0",
+            "D29-0",
+            "G26-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 690,
+      "created_at": 1720258349,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 691,
+      "created_at": 1720258355
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 692,
+      "created_at": 1720258720,
+      "hex": "C2",
+      "tile": "X3-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 693,
+      "created_at": 1720258720
+    },
+    {
+      "type": "buy_train",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 694,
+      "created_at": 1720258727,
+      "train": "5-0",
+      "price": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 695,
+      "created_at": 1720265288,
+      "hex": "E12",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 696,
+      "created_at": 1720265324
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 697,
+      "created_at": 1720265339,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "D13",
+              "C12"
+            ],
+            [
+              "C12",
+              "C10",
+              "B9",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "C12",
+            "A10"
+          ],
+          "revenue": 390,
+          "revenue_str": "H9-G10-E12-C12-A10 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "C12-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 698,
+      "created_at": 1720265340,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 699,
+      "created_at": 1720265343
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 700,
+      "created_at": 1720265870,
+      "hex": "D17",
+      "tile": "9-7",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 701,
+      "created_at": 1720265881
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 702,
+      "created_at": 1720265886,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "A16"
+            ],
+            [
+              "A16",
+              "B17",
+              "C16"
+            ],
+            [
+              "C16",
+              "D15"
+            ],
+            [
+              "D15",
+              "D17",
+              "D19"
+            ],
+            [
+              "D19",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "F13"
+            ],
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "A16",
+            "C16",
+            "D15",
+            "D19",
+            "E20",
+            "F13",
+            "E12",
+            "G10",
+            "H9"
+          ],
+          "revenue": 680,
+          "revenue_str": "A10-A16-C16-D15-D19-E20-F13-E12-G10-H9 + Ö/V + b/B/b",
+          "nodes": [
+            "A10-0",
+            "A16-0",
+            "C16-0",
+            "D15-0",
+            "D19-0",
+            "E20-0",
+            "F13-0",
+            "E12-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 703,
+      "created_at": 1720265887,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 704,
+      "created_at": 1720265893
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 705,
+      "created_at": 1720269358,
+      "hex": "C18",
+      "tile": "9-8",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 706,
+      "created_at": 1720269361
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 707,
+      "created_at": 1720269365
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 708,
+      "created_at": 1720269378,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "D19",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "F13"
+            ],
+            [
+              "F13",
+              "G12",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "E20",
+            "F13",
+            "G10",
+            "H9"
+          ],
+          "revenue": 320,
+          "revenue_str": "D19-E20-F13-G10-H9 + b/B",
+          "nodes": [
+            "D19-0",
+            "E20-0",
+            "F13-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 709,
+      "created_at": 1720269380,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 710,
+      "created_at": 1720269383
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 711,
+      "user": 2170,
+      "created_at": 1720269451
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "action_id": 710,
+      "entity_type": "corporation",
+      "id": 712,
+      "user": 2170,
+      "created_at": 1720269463
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 713,
+      "created_at": 1720269475,
+      "hex": "D11",
+      "tile": "15-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 714,
+      "created_at": 1720269480
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 715,
+      "created_at": 1720269483,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "F13",
+            "E20",
+            "D19"
+          ],
+          "revenue": 360,
+          "revenue_str": "H9-G10-E12-F13-E20-D19 + b/B",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "F13-0",
+            "E20-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 716,
+      "created_at": 1720269484,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 717,
+      "created_at": 1720269485
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 718,
+      "created_at": 1720270593,
+      "hex": "D21",
+      "tile": "5-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 719,
+      "created_at": 1720270600
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 720,
+      "created_at": 1720270605,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "F13",
+            "E20",
+            "D19"
+          ],
+          "revenue": 360,
+          "revenue_str": "H9-G10-E12-F13-E20-D19 + b/B",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "F13-0",
+            "E20-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 721,
+      "created_at": 1720270607,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 722,
+      "created_at": 1720270613
+    },
+    {
+      "hex": "E10",
+      "tile": "24-0",
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 723,
+      "user": 2170,
+      "created_at": 1720271302
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 724,
+      "user": 2170,
+      "created_at": 1720271304
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "action_id": 722,
+      "entity_type": "corporation",
+      "id": 725,
+      "user": 2170,
+      "created_at": 1720271316
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 726,
+      "created_at": 1720271319,
+      "hex": "E10",
+      "tile": "25-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 727,
+      "created_at": 1720271324
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 728,
+      "created_at": 1720271327,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "A2",
+              "B3",
+              "C2"
+            ],
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "D5",
+              "D7",
+              "E8"
+            ],
+            [
+              "E8",
+              "E10",
+              "D11"
+            ]
+          ],
+          "hexes": [
+            "A2",
+            "C2",
+            "D5",
+            "E8",
+            "D11"
+          ],
+          "revenue": 190,
+          "revenue_str": "A2-C2-D5-E8-D11",
+          "nodes": [
+            "A2-0",
+            "C2-0",
+            "D5-0",
+            "E8-0",
+            "D11-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 729,
+      "created_at": 1720271328,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 730,
+      "created_at": 1720271329
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 731,
+      "created_at": 1720274723,
+      "hex": "D7",
+      "tile": "24-0",
+      "rotation": 5
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 732,
+      "created_at": 1720274735,
+      "hex": "C6",
+      "tile": "9-9",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 733,
+      "created_at": 1720274737,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "D13",
+              "C12"
+            ],
+            [
+              "C12",
+              "C10",
+              "B9",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "C12",
+            "A10"
+          ],
+          "revenue": 390,
+          "revenue_str": "H9-G10-E12-C12-A10 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "C12-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 734,
+      "created_at": 1720274739,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 735,
+      "created_at": 1720274743
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 736,
+      "user": 14510,
+      "created_at": 1720274850
+    },
+    {
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 737,
+      "user": 14510,
+      "created_at": 1720274992
+    },
+    {
+      "hex": "F11",
+      "tile": "24-1",
+      "type": "lay_tile",
+      "entity": "BJ",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 738,
+      "user": 14510,
+      "created_at": 1720274996
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 739,
+      "user": 14510,
+      "created_at": 1720274999
+    },
+    {
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 740,
+      "user": 14510,
+      "created_at": 1720275043
+    },
+    {
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 741,
+      "user": 14510,
+      "created_at": 1720275049
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 742,
+      "created_at": 1720275059,
+      "hex": "D21",
+      "tile": "14-2",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 743,
+      "created_at": 1720275066
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 744,
+      "created_at": 1720275079,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "A16"
+            ],
+            [
+              "A16",
+              "B17",
+              "C16"
+            ],
+            [
+              "C16",
+              "D15"
+            ],
+            [
+              "D15",
+              "D17",
+              "D19"
+            ],
+            [
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "F13"
+            ],
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "A16",
+            "C16",
+            "D15",
+            "D19",
+            "D21",
+            "E20",
+            "F13",
+            "E12",
+            "G10",
+            "H9"
+          ],
+          "revenue": 710,
+          "revenue_str": "A10-A16-C16-D15-D19-D21-E20-F13-E12-G10-H9 + Ö/V + b/B/b",
+          "nodes": [
+            "A10-0",
+            "A16-0",
+            "C16-0",
+            "D15-0",
+            "D19-0",
+            "D21-0",
+            "E20-0",
+            "F13-0",
+            "E12-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 745,
+      "created_at": 1720275084,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 746,
+      "created_at": 1720275109
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 747,
+      "created_at": 1720275249,
+      "hex": "B17",
+      "tile": "16-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 748,
+      "created_at": 1720275251
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 749,
+      "created_at": 1720275252
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 750,
+      "created_at": 1720275265,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "D19",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "F13"
+            ],
+            [
+              "F13",
+              "G12",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "D19",
+            "E20",
+            "F13",
+            "G10",
+            "H9"
+          ],
+          "revenue": 320,
+          "revenue_str": "D19-E20-F13-G10-H9 + b/B",
+          "nodes": [
+            "D19-0",
+            "E20-0",
+            "F13-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 751,
+      "created_at": 1720275266,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 752,
+      "created_at": 1720275269
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 753,
+      "created_at": 1720275558,
+      "hex": "F11",
+      "tile": "24-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 754,
+      "created_at": 1720275569
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 755,
+      "created_at": 1720275572,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "F13",
+            "E20",
+            "D19"
+          ],
+          "revenue": 360,
+          "revenue_str": "H9-G10-E12-F13-E20-D19 + b/B",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "F13-0",
+            "E20-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 756,
+      "created_at": 1720275573,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 757,
+      "created_at": 1720275574
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 758,
+      "created_at": 1720279502,
+      "hex": "D23",
+      "tile": "8-5",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 759,
+      "created_at": 1720279541
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 760,
+      "created_at": 1720279560
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 761,
+      "created_at": 1720279563,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "F13",
+            "E20",
+            "D19"
+          ],
+          "revenue": 360,
+          "revenue_str": "H9-G10-E12-F13-E20-D19 + b/B",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "F13-0",
+            "E20-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 762,
+      "created_at": 1720279564,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 763,
+      "created_at": 1720279567
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 764,
+      "created_at": 1720279960
+    },
+    {
+      "type": "place_token",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 765,
+      "created_at": 1720279971,
+      "city": "X6-0-0",
+      "slot": 2,
+      "tokener": "ÖSJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 766,
+      "created_at": 1720279979,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D19"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "F13",
+            "E20",
+            "D19"
+          ],
+          "revenue": 320,
+          "revenue_str": "H9-G10-F13-E20-D19 + b/B",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "F13-0",
+            "E20-0",
+            "D19-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 767,
+      "created_at": 1720279980,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 768,
+      "created_at": 1720279981
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 769,
+      "created_at": 1720299602,
+      "shares": [
+        "TGOJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 770,
+      "created_at": 1720299606,
+      "shares": [
+        "UGJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 771,
+      "created_at": 1720299618,
+      "corporation": "MÖJ",
+      "share_price": "100,0,2"
+    },
+    {
+      "type": "pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 772,
+      "created_at": 1720299628
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 773,
+      "created_at": 1720300644,
+      "shares": [
+        "BJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 774,
+      "created_at": 1720300656
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 775,
+      "created_at": 1720301156,
+      "shares": [
+        "BJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 776,
+      "created_at": 1720301157
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 777,
+      "created_at": 1720305694,
+      "shares": [
+        "BJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 778,
+      "created_at": 1720305698
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 779,
+      "created_at": 1720306141,
+      "shares": [
+        "BJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 780,
+      "created_at": 1720306145
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 781,
+      "created_at": 1720307796,
+      "shares": [
+        "ÖSJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 782,
+      "created_at": 1720307798
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 783,
+      "created_at": 1720307884,
+      "shares": [
+        "STJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 784,
+      "created_at": 1720307900,
+      "shares": [
+        "STJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 785,
+      "created_at": 1720307927
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 786,
+      "created_at": 1720307974,
+      "shares": [
+        "ÖSJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 787,
+      "created_at": 1720308266
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 788,
+      "created_at": 1720335685,
+      "shares": [
+        "ÖSJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 789,
+      "created_at": 1720335687
+    },
+    {
+      "type": "par",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 790,
+      "created_at": 1720346483,
+      "corporation": "SNJ",
+      "share_price": "100,0,2"
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 791,
+      "created_at": 1720346497
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 792,
+      "created_at": 1720346680,
+      "shares": [
+        "UGJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 793,
+      "created_at": 1720346684
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 794,
+      "created_at": 1720347980,
+      "shares": [
+        "ÖSJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 795,
+      "created_at": 1720347998
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 796,
+      "created_at": 1720364250,
+      "shares": [
+        "ÖSJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 797,
+      "created_at": 1720364256
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 798,
+      "created_at": 1720365820,
+      "shares": [
+        "STJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 799,
+      "created_at": 1720365839
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 800,
+      "created_at": 1720372457
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 801,
+      "created_at": 1720376125,
+      "shares": [
+        "SNJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 802,
+      "created_at": 1720376132
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 804,
+      "created_at": 1720530401,
+      "shares": [
+        "STJ_1",
+        "STJ_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 805,
+      "created_at": 1720530406,
+      "shares": [
+        "TGOJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 806,
+      "created_at": 1720530410
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 807,
+      "created_at": 1720532285,
+      "shares": [
+        "STJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 808,
+      "created_at": 1720532288
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 809,
+      "created_at": 1720532577,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720532575,
+          "shares": [
+            "MÖJ_1"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720532575
+        }
+      ],
+      "corporation": "MÖJ",
+      "until_condition": 6,
+      "from_market": false,
+      "auto_pass_after": true
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "shares": [
+        "STJ_1"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 810,
+      "user": 2170,
+      "created_at": 1720533094
+    },
+    {
+      "type": "undo",
+      "entity": 2170,
+      "action_id": 809,
+      "entity_type": "player",
+      "id": 811,
+      "user": 2170,
+      "created_at": 1720533124
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 812,
+      "created_at": 1720533151,
+      "shares": [
+        "STJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 813,
+      "created_at": 1720533234,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720533234
+        }
+      ],
+      "corporation": "STJ",
+      "until_condition": 4,
+      "from_market": true,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 814,
+      "created_at": 1720533398,
+      "shares": [
+        "MÖJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 815,
+      "created_at": 1720533399
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 816,
+      "created_at": 1720546861,
+      "shares": [
+        "SNJ_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 817,
+      "created_at": 1720546863
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 818,
+      "created_at": 1720559990,
+      "shares": [
+        "TGOJ_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 819,
+      "created_at": 1720559999
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 820,
+      "created_at": 1720560184,
+      "shares": [
+        "MÖJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 821,
+      "created_at": 1720560185,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720560184,
+          "shares": [
+            "MÖJ_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720560184
+        },
+        {
+          "type": "buy_shares",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720560184,
+          "shares": [
+            "STJ_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720560184,
+          "reason": "4 share(s) bought in STJ, end condition met"
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 822,
+      "created_at": 1720560435,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720560435
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 823,
+      "created_at": 1720589283,
+      "shares": [
+        "SNJ_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 824,
+      "created_at": 1720589284
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 825,
+      "created_at": 1720598149,
+      "shares": [
+        "SNJ_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 826,
+      "created_at": 1720598163
+    },
+    {
+      "type": "sell_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 828,
+      "created_at": 1720732712,
+      "shares": [
+        "UGJ_6",
+        "UGJ_5"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 829,
+      "created_at": 1720732716,
+      "shares": [
+        "MÖJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 830,
+      "created_at": 1720732719
+    },
+    {
+      "type": "buy_shares",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 831,
+      "created_at": 1720734611,
+      "shares": [
+        "SNJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 832,
+      "created_at": 1720734613,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720734612,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "buy_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 833,
+      "created_at": 1720734691,
+      "shares": [
+        "MÖJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 834,
+      "created_at": 1720734703,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720734702,
+          "reason": "Shares were sold"
+        }
+      ]
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 3864,
+      "entity_type": "player",
+      "id": 835,
+      "created_at": 1720734775,
+      "corporation": "MÖJ",
+      "until_condition": 6,
+      "from_market": false,
+      "auto_pass_after": true
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 2170,
+      "entity_type": "player",
+      "id": 836,
+      "created_at": 1720759856,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720759857
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 837,
+      "created_at": 1720760127,
+      "shares": [
+        "SNJ_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 12106,
+      "entity_type": "player",
+      "id": 838,
+      "created_at": 1720760129,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1720760125
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 839,
+      "created_at": 1720768115,
+      "shares": [
+        "SNJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 840,
+      "created_at": 1720768118
+    },
+    {
+      "type": "buy_shares",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 841,
+      "created_at": 1720807192,
+      "shares": [
+        "MÖJ_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 842,
+      "created_at": 1720807198
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 843,
+      "created_at": 1720807758,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720807756,
+          "shares": [
+            "MÖJ_8"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720807756,
+          "reason": "6 share(s) bought in MÖJ, end condition met"
+        },
+        {
+          "type": "program_share_pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720807756,
+          "unconditional": false,
+          "indefinite": false
+        },
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720807756
+        },
+        {
+          "type": "pass",
+          "entity": 2170,
+          "entity_type": "player",
+          "created_at": 1720807756
+        },
+        {
+          "type": "pass",
+          "entity": 12106,
+          "entity_type": "player",
+          "created_at": 1720807756
+        }
+      ]
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 844,
+      "created_at": 1720852318,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 1075,
+          "entity_type": "player",
+          "created_at": 1720852317
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 17876,
+      "entity_type": "player",
+      "id": 845,
+      "created_at": 1720867675,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 17876,
+          "entity_type": "player",
+          "created_at": 1720867675
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 14510,
+      "entity_type": "player",
+      "id": 846,
+      "created_at": 1720871196,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 3864,
+          "entity_type": "player",
+          "created_at": 1720871193
+        }
+      ]
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 847,
+      "created_at": 1720875904,
+      "hex": "B5",
+      "tile": "5-2",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 848,
+      "created_at": 1720876106,
+      "hex": "B5",
+      "tile": "14-3",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 849,
+      "created_at": 1720876108,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E12"
+            ],
+            [
+              "E12",
+              "D13",
+              "C12"
+            ],
+            [
+              "C12",
+              "C10",
+              "B9",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E12",
+            "C12",
+            "A10"
+          ],
+          "revenue": 390,
+          "revenue_str": "H9-G10-E12-C12-A10 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E12-0",
+            "C12-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 850,
+      "created_at": 1720876154,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 851,
+      "created_at": 1720876189
+    },
+    {
+      "type": "undo",
+      "entity": "BJ",
+      "action_id": 846,
+      "entity_type": "corporation",
+      "id": 852,
+      "user": 3864,
+      "created_at": 1720877230
+    },
+    {
+      "type": "redo",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 853,
+      "user": 3864,
+      "created_at": 1720877363
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 854,
+      "created_at": 1720878318,
+      "hex": "E14",
+      "tile": "24-2",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 855,
+      "created_at": 1720878333
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 856,
+      "created_at": 1720878406,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "A16"
+            ],
+            [
+              "A16",
+              "B17",
+              "C16"
+            ],
+            [
+              "C16",
+              "D15"
+            ],
+            [
+              "D15",
+              "D17",
+              "D19"
+            ],
+            [
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20"
+            ],
+            [
+              "E20",
+              "E18",
+              "E16",
+              "E14",
+              "E12"
+            ],
+            [
+              "E12",
+              "F11",
+              "G10"
+            ],
+            [
+              "G10",
+              "H9"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "A16",
+            "C16",
+            "D15",
+            "D19",
+            "D21",
+            "E20",
+            "E12",
+            "G10",
+            "H9"
+          ],
+          "revenue": 650,
+          "revenue_str": "A10-A16-C16-D15-D19-D21-E20-E12-G10-H9 + Ö/V + b/B/b",
+          "nodes": [
+            "A10-0",
+            "A16-0",
+            "C16-0",
+            "D15-0",
+            "D19-0",
+            "D21-0",
+            "E20-0",
+            "E12-0",
+            "G10-0",
+            "H9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 857,
+      "created_at": 1720878408,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 858,
+      "created_at": 1720878411
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 859,
+      "created_at": 1720880971,
+      "hex": "B7",
+      "tile": "9-10",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 860,
+      "created_at": 1720880978,
+      "hex": "A4",
+      "tile": "8-12",
+      "rotation": 5
+    },
+    {
+      "type": "place_token",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 861,
+      "created_at": 1720880980,
+      "city": "X5-0-0",
+      "slot": 3,
+      "tokener": "MÖJ"
+    },
+    {
+      "type": "buy_train",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 862,
+      "created_at": 1720881261,
+      "train": "5-1",
+      "price": 903
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 863,
+      "created_at": 1720881269
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 864,
+      "created_at": 1720906074,
+      "hex": "C30",
+      "tile": "9-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 865,
+      "created_at": 1720906081
+    },
+    {
+      "type": "place_token",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 866,
+      "created_at": 1720906082,
+      "city": "611-0-0",
+      "slot": 1,
+      "tokener": "SNJ"
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 867,
+      "created_at": 1720906123,
+      "shares": [
+        "ÖSJ_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 868,
+      "created_at": 1720906130,
+      "shares": [
+        "STJ_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 1075,
+      "entity_type": "player",
+      "id": 869,
+      "created_at": 1720906141,
+      "shares": [
+        "SWB_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_train",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 870,
+      "created_at": 1720906148,
+      "train": "D-1",
+      "price": 1100,
+      "variant": "D"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 871,
+      "created_at": 1720908882,
+      "hex": "B15",
+      "tile": "8-13",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 872,
+      "created_at": 1720908885
+    },
+    {
+      "type": "place_token",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 873,
+      "created_at": 1720908888,
+      "city": "X5-0-0",
+      "slot": 3,
+      "tokener": "TGOJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 874,
+      "created_at": 1720908893,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E10",
+              "E8"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "A4",
+              "A2"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E8",
+            "B5",
+            "A2"
+          ],
+          "revenue": 360,
+          "revenue_str": "H9-G10-E8-B5-A2 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E8-0",
+            "B5-0",
+            "A2-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 875,
+      "created_at": 1720908895,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 876,
+      "created_at": 1720908912
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 877,
+      "created_at": 1720908956
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 878,
+      "created_at": 1720908961,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "F13",
+            "E12",
+            "E20",
+            "G26",
+            "D29"
+          ],
+          "revenue": 340,
+          "revenue_str": "G10-F13-E12-E20-G26-D29 + m/M",
+          "nodes": [
+            "G10-0",
+            "F13-0",
+            "E12-0",
+            "E20-0",
+            "G26-0",
+            "D29-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 879,
+      "user": 2170,
+      "created_at": 1720908975
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 880,
+      "user": 2170,
+      "created_at": 1720908983
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 881,
+      "created_at": 1720908984,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 882,
+      "created_at": 1720908985
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 883,
+      "created_at": 1720913003,
+      "hex": "B3",
+      "tile": "19-1",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 884,
+      "created_at": 1720913011
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 885,
+      "created_at": 1720913023
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 886,
+      "created_at": 1720913574,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "F13",
+            "E12",
+            "E20",
+            "G26",
+            "D29"
+          ],
+          "revenue": 340,
+          "revenue_str": "G10-F13-E12-E20-G26-D29 + m/M",
+          "nodes": [
+            "G10-0",
+            "F13-0",
+            "E12-0",
+            "E20-0",
+            "G26-0",
+            "D29-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 887,
+      "created_at": 1720913576,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 888,
+      "created_at": 1720913579
+    },
+    {
+      "hex": "B9",
+      "tile": "25-1",
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "id": 889,
+      "user": 2170,
+      "created_at": 1720935153
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 890,
+      "user": 2170,
+      "created_at": 1720935158
+    },
+    {
+      "hex": "B9",
+      "tile": "25-1",
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 891,
+      "user": 2170,
+      "created_at": 1720935162
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 892,
+      "user": 2170,
+      "created_at": 1720935163
+    },
+    {
+      "city": "63-1-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "ÖSJ",
+      "tokener": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 893,
+      "user": 2170,
+      "created_at": 1720935181
+    },
+    {
+      "type": "undo",
+      "entity": "ÖSJ",
+      "action_id": 888,
+      "entity_type": "corporation",
+      "id": 894,
+      "user": 2170,
+      "created_at": 1720935206
+    },
+    {
+      "type": "lay_tile",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 895,
+      "created_at": 1720935215,
+      "hex": "D27",
+      "tile": "23-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 896,
+      "created_at": 1720935237
+    },
+    {
+      "type": "place_token",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 897,
+      "created_at": 1720935250,
+      "city": "63-1-0",
+      "slot": 1,
+      "tokener": "ÖSJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 898,
+      "created_at": 1720935254,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "F13",
+            "E20",
+            "G26",
+            "D29"
+          ],
+          "revenue": 300,
+          "revenue_str": "G10-F13-E20-G26-D29 + m/M",
+          "nodes": [
+            "G10-0",
+            "F13-0",
+            "E20-0",
+            "G26-0",
+            "D29-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 899,
+      "created_at": 1720935255,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 900,
+      "created_at": 1720935256
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 901,
+      "user": 14510,
+      "created_at": 1720972144
+    },
+    {
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 902,
+      "user": 14510,
+      "created_at": 1720972170
+    },
+    {
+      "hex": "B9",
+      "tile": "25-1",
+      "type": "lay_tile",
+      "entity": "BJ",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 903,
+      "user": 14510,
+      "created_at": 1720972174
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 904,
+      "user": 14510,
+      "created_at": 1720972176
+    },
+    {
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 905,
+      "user": 14510,
+      "created_at": 1720972195
+    },
+    {
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 906,
+      "user": 14510,
+      "created_at": 1720972197
+    },
+    {
+      "hex": "A14",
+      "tile": "23-1",
+      "type": "lay_tile",
+      "entity": "BJ",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 907,
+      "user": 14510,
+      "created_at": 1720972222
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 908,
+      "user": 14510,
+      "created_at": 1720972223
+    },
+    {
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 909,
+      "user": 14510,
+      "created_at": 1720972229
+    },
+    {
+      "type": "undo",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 910,
+      "user": 14510,
+      "created_at": 1720972232
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 911,
+      "created_at": 1720972259,
+      "hex": "E18",
+      "tile": "46-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 912,
+      "created_at": 1720972261
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 913,
+      "created_at": 1720972265,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "A16"
+            ],
+            [
+              "A16",
+              "B17",
+              "C16"
+            ],
+            [
+              "C16",
+              "D15"
+            ],
+            [
+              "D15",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "A16",
+            "C16",
+            "D15",
+            "D19",
+            "D21",
+            "E20",
+            "G26",
+            "D29"
+          ],
+          "revenue": 420,
+          "revenue_str": "A10-A16-C16-D15-D19-D21-E20-G26-D29 + b/B + m/M",
+          "nodes": [
+            "A10-0",
+            "A16-0",
+            "C16-0",
+            "D15-0",
+            "D19-0",
+            "D21-0",
+            "E20-0",
+            "G26-0",
+            "D29-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 914,
+      "created_at": 1720972267,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 915,
+      "created_at": 1720972277
+    },
+    {
+      "hex": "B11",
+      "tile": "6-1",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 916,
+      "user": 3864,
+      "created_at": 1720976418
+    },
+    {
+      "hex": "B11",
+      "tile": "14-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 2,
+      "entity_type": "corporation",
+      "id": 917,
+      "user": 3864,
+      "created_at": 1720976434
+    },
+    {
+      "type": "buy_train",
+      "price": 1300,
+      "train": "D-2",
+      "entity": "SWB",
+      "variant": "E",
+      "entity_type": "corporation",
+      "id": 918,
+      "user": 3864,
+      "created_at": 1720976444
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 919,
+      "user": 3864,
+      "created_at": 1720976446
+    },
+    {
+      "hex": "B9",
+      "tile": "25-1",
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "id": 920,
+      "user": 3864,
+      "created_at": 1720976453
+    },
+    {
+      "type": "undo",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 921,
+      "user": 3864,
+      "created_at": 1720976459
+    },
+    {
+      "hex": "B9",
+      "tile": "25-1",
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 922,
+      "user": 3864,
+      "created_at": 1720976462
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 923,
+      "user": 3864,
+      "created_at": 1720976464
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "routes": [
+        {
+          "hexes": [
+            "A10",
+            "B5",
+            "E8",
+            "G10",
+            "H9"
+          ],
+          "nodes": [
+            "B5-0",
+            "A10-0",
+            "E8-0",
+            "G10-0",
+            "H9-0"
+          ],
+          "train": "5-1",
+          "revenue": 380,
+          "connections": [
+            [
+              "B5",
+              "B7",
+              "B9",
+              "A10"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "G10",
+              "F11",
+              "E10",
+              "E8"
+            ],
+            [
+              "H9",
+              "G10"
+            ]
+          ],
+          "revenue_str": "A10-B5-E8-G10-H9 + Ö/V"
+        }
+      ],
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 924,
+      "user": 3864,
+      "created_at": 1720976470
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 925,
+      "user": 3864,
+      "created_at": 1720976471
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 926,
+      "user": 3864,
+      "created_at": 1720976473
+    },
+    {
+      "type": "undo",
+      "entity": "SNJ",
+      "action_id": 919,
+      "entity_type": "corporation",
+      "id": 927,
+      "user": 3864,
+      "created_at": 1720976586
+    },
+    {
+      "type": "undo",
+      "entity": "MÖJ",
+      "action_id": 915,
+      "entity_type": "corporation",
+      "id": 928,
+      "user": 3864,
+      "created_at": 1720976589
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 929,
+      "created_at": 1720976711,
+      "hex": "B11",
+      "tile": "6-1",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 930,
+      "created_at": 1720976728,
+      "hex": "B11",
+      "tile": "619-2",
+      "rotation": 5
+    },
+    {
+      "type": "buy_train",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 931,
+      "created_at": 1720976733,
+      "train": "D-2",
+      "price": 1300,
+      "variant": "E"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 932,
+      "created_at": 1720976736
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 933,
+      "created_at": 1720976759,
+      "hex": "B9",
+      "tile": "25-1",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 934,
+      "created_at": 1720976781
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 935,
+      "created_at": 1720976786,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E10",
+              "E8"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "B7",
+              "B9",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E8",
+            "B5",
+            "A10"
+          ],
+          "revenue": 380,
+          "revenue_str": "H9-G10-E8-B5-A10 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E8-0",
+            "B5-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 936,
+      "created_at": 1720976787,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 937,
+      "created_at": 1720976788
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 938,
+      "created_at": 1721031553,
+      "hex": "A14",
+      "tile": "23-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 939,
+      "created_at": 1721031556
+    },
+    {
+      "type": "run_routes",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 940,
+      "created_at": 1721031560,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "G26",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "C18",
+              "B17",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "G26",
+            "E20",
+            "D21",
+            "D19",
+            "A10"
+          ],
+          "revenue": 460,
+          "revenue_str": "B31-D29-G26-E20-D21-D19-A10 + b/B + m/M/m",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "G26-0",
+            "E20-0",
+            "D21-0",
+            "D19-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 941,
+      "created_at": 1721031562,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 942,
+      "created_at": 1721033628,
+      "hex": "C20",
+      "tile": "8-9",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 943,
+      "created_at": 1721033630
+    },
+    {
+      "type": "place_token",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 944,
+      "created_at": 1721033644,
+      "city": "15-2-0",
+      "slot": 1,
+      "tokener": "TGOJ"
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 945,
+      "created_at": 1721033651,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E10",
+              "E8"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "B7",
+              "B9",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E8",
+            "B5",
+            "A10"
+          ],
+          "revenue": 380,
+          "revenue_str": "H9-G10-E8-B5-A10 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E8-0",
+            "B5-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 946,
+      "created_at": 1721033654,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 947,
+      "user": 2170,
+      "created_at": 1721033707
+    },
+    {
+      "type": "undo",
+      "entity": "UGJ",
+      "action_id": 946,
+      "entity_type": "corporation",
+      "id": 948,
+      "user": 2170,
+      "created_at": 1721033730
+    },
+    {
+      "type": "lay_tile",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 949,
+      "created_at": 1721033737,
+      "hex": "C28",
+      "tile": "8-2",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 950,
+      "created_at": 1721033747
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 951,
+      "created_at": 1721033748
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 952,
+      "created_at": 1721033752,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "C18",
+              "B17",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "F13",
+            "E20",
+            "D21",
+            "D19",
+            "A10"
+          ],
+          "revenue": 380,
+          "revenue_str": "G10-F13-E20-D21-D19-A10 + b/B",
+          "nodes": [
+            "G10-0",
+            "F13-0",
+            "E20-0",
+            "D21-0",
+            "D19-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 953,
+      "created_at": 1721033756,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 954,
+      "created_at": 1721033757
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 955,
+      "created_at": 1721041438,
+      "hex": "C30",
+      "tile": "23-2",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 956,
+      "created_at": 1721041442
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 957,
+      "created_at": 1721041464
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 958,
+      "created_at": 1721041474,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "C18",
+              "B17",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "F13",
+            "E20",
+            "D21",
+            "D19",
+            "A10"
+          ],
+          "revenue": 380,
+          "revenue_str": "G10-F13-E20-D21-D19-A10 + b/B",
+          "nodes": [
+            "G10-0",
+            "F13-0",
+            "E20-0",
+            "D21-0",
+            "D19-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 959,
+      "created_at": 1721041475,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 960,
+      "created_at": 1721041484
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 961,
+      "created_at": 1721043083
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 962,
+      "created_at": 1721043090,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D19"
+            ],
+            [
+              "D19",
+              "C18",
+              "B17",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "F13",
+            "E20",
+            "D19",
+            "A10"
+          ],
+          "revenue": 350,
+          "revenue_str": "G10-F13-E20-D19-A10 + b/B",
+          "nodes": [
+            "G10-0",
+            "F13-0",
+            "E20-0",
+            "D19-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 963,
+      "created_at": 1721043091,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 964,
+      "created_at": 1721043092
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 965,
+      "created_at": 1721043283,
+      "hex": "B9",
+      "tile": "46-1",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 966,
+      "created_at": 1721043293
+    },
+    {
+      "type": "run_routes",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 967,
+      "created_at": 1721043303,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "A10",
+              "A12",
+              "A14",
+              "A16"
+            ],
+            [
+              "A16",
+              "B17",
+              "C16"
+            ],
+            [
+              "C16",
+              "D15"
+            ],
+            [
+              "D15",
+              "E16",
+              "E18",
+              "D19"
+            ],
+            [
+              "D19",
+              "D21"
+            ],
+            [
+              "D21",
+              "E20"
+            ],
+            [
+              "E20",
+              "E22",
+              "E24",
+              "F25",
+              "G26"
+            ],
+            [
+              "G26",
+              "F27",
+              "E28",
+              "D29"
+            ]
+          ],
+          "hexes": [
+            "A10",
+            "A16",
+            "C16",
+            "D15",
+            "D19",
+            "D21",
+            "E20",
+            "G26",
+            "D29"
+          ],
+          "revenue": 420,
+          "revenue_str": "A10-A16-C16-D15-D19-D21-E20-G26-D29 + b/B + m/M",
+          "nodes": [
+            "A10-0",
+            "A16-0",
+            "C16-0",
+            "D15-0",
+            "D19-0",
+            "D21-0",
+            "E20-0",
+            "G26-0",
+            "D29-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 968,
+      "created_at": 1721043305,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "BJ",
+      "entity_type": "corporation",
+      "id": 969,
+      "created_at": 1721043307
+    },
+    {
+      "hex": "A12",
+      "tile": "26-0",
+      "type": "lay_tile",
+      "entity": "SWB",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 970,
+      "user": 3864,
+      "created_at": 1721045808
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 971,
+      "user": 3864,
+      "created_at": 1721045813
+    },
+    {
+      "type": "undo",
+      "entity": "SWB",
+      "action_id": 969,
+      "entity_type": "corporation",
+      "id": 972,
+      "user": 3864,
+      "created_at": 1721045950
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 973,
+      "created_at": 1721045953,
+      "hex": "E10",
+      "tile": "40-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 974,
+      "created_at": 1721045955
+    },
+    {
+      "type": "run_routes",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 975,
+      "created_at": 1721046006,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E10",
+              "D11"
+            ],
+            [
+              "D11",
+              "C12"
+            ],
+            [
+              "C12",
+              "D13",
+              "E12"
+            ],
+            [
+              "E12",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "C18",
+              "B17",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "D11",
+            "C12",
+            "E12",
+            "E20",
+            "D21",
+            "D19",
+            "A10"
+          ],
+          "revenue": 750,
+          "revenue_str": "H9-G10-D11-C12-E12-E20-D21-D19-A10 + Ö/V + b/B/b",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "D11-0",
+            "C12-0",
+            "E12-0",
+            "E20-0",
+            "D21-0",
+            "D19-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 976,
+      "created_at": 1721046007,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SWB",
+      "entity_type": "corporation",
+      "id": 977,
+      "created_at": 1721046011
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 978,
+      "created_at": 1721046018,
+      "hex": "A12",
+      "tile": "26-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 979,
+      "created_at": 1721046019
+    },
+    {
+      "type": "run_routes",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 980,
+      "created_at": 1721046026,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E10",
+              "E8"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "B7",
+              "B9",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E8",
+            "B5",
+            "A10"
+          ],
+          "revenue": 380,
+          "revenue_str": "H9-G10-E8-B5-A10 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E8-0",
+            "B5-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 981,
+      "created_at": 1721046027,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "MÖJ",
+      "entity_type": "corporation",
+      "id": 982,
+      "created_at": 1721046029
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 983,
+      "created_at": 1721081111,
+      "hex": "A12",
+      "tile": "42-0",
+      "rotation": 1
+    },
+    {
+      "type": "pass",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 984,
+      "created_at": 1721081117
+    },
+    {
+      "type": "run_routes",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 985,
+      "created_at": 1721081121,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "B31",
+              "C30",
+              "D29"
+            ],
+            [
+              "D29",
+              "E28",
+              "F27",
+              "G26"
+            ],
+            [
+              "G26",
+              "F25",
+              "E24",
+              "E22",
+              "E20"
+            ],
+            [
+              "E20",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "C18",
+              "B17",
+              "B15",
+              "A14",
+              "A12",
+              "B11"
+            ],
+            [
+              "B11",
+              "B9",
+              "B7",
+              "B5"
+            ],
+            [
+              "B5",
+              "B3",
+              "B1",
+              "C2"
+            ],
+            [
+              "C2",
+              "C4",
+              "D5"
+            ],
+            [
+              "D5",
+              "D7",
+              "E8"
+            ]
+          ],
+          "hexes": [
+            "B31",
+            "D29",
+            "G26",
+            "E20",
+            "D21",
+            "D19",
+            "B11",
+            "B5",
+            "C2",
+            "D5",
+            "E8"
+          ],
+          "revenue": 510,
+          "revenue_str": "B31-D29-G26-E20-D21-D19-B11-B5-C2-D5-E8 + m/M/m",
+          "nodes": [
+            "B31-0",
+            "D29-0",
+            "G26-0",
+            "E20-0",
+            "D21-0",
+            "D19-0",
+            "B11-0",
+            "B5-0",
+            "C2-0",
+            "D5-0",
+            "E8-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SNJ",
+      "entity_type": "corporation",
+      "id": 986,
+      "created_at": 1721081122,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 987,
+      "created_at": 1721081288,
+      "hex": "C22",
+      "tile": "8-4",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 988,
+      "created_at": 1721081294
+    },
+    {
+      "type": "run_routes",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 989,
+      "created_at": 1721081300,
+      "routes": [
+        {
+          "train": "5-2",
+          "connections": [
+            [
+              "H9",
+              "G10"
+            ],
+            [
+              "G10",
+              "F11",
+              "E10",
+              "E8"
+            ],
+            [
+              "E8",
+              "D7",
+              "C6",
+              "B5"
+            ],
+            [
+              "B5",
+              "B7",
+              "B9",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "H9",
+            "G10",
+            "E8",
+            "B5",
+            "A10"
+          ],
+          "revenue": 380,
+          "revenue_str": "H9-G10-E8-B5-A10 + Ö/V",
+          "nodes": [
+            "H9-0",
+            "G10-0",
+            "E8-0",
+            "B5-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "TGOJ",
+      "entity_type": "corporation",
+      "id": 990,
+      "created_at": 1721081302,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 991,
+      "created_at": 1721106176
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 992,
+      "created_at": 1721106177
+    },
+    {
+      "type": "run_routes",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 993,
+      "created_at": 1721106183,
+      "routes": [
+        {
+          "train": "6-1",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "C18",
+              "B17",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "F13",
+            "E20",
+            "D21",
+            "D19",
+            "A10"
+          ],
+          "revenue": 380,
+          "revenue_str": "G10-F13-E20-D21-D19-A10 + b/B",
+          "nodes": [
+            "G10-0",
+            "F13-0",
+            "E20-0",
+            "D21-0",
+            "D19-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 994,
+      "created_at": 1721106184,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "UGJ",
+      "entity_type": "corporation",
+      "id": 995,
+      "created_at": 1721106185
+    },
+    {
+      "hex": "D7",
+      "tile": "47-0",
+      "type": "lay_tile",
+      "entity": "STJ",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 996,
+      "user": 14510,
+      "created_at": 1721117651
+    },
+    {
+      "type": "undo",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 997,
+      "user": 14510,
+      "created_at": 1721117668
+    },
+    {
+      "type": "lay_tile",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 998,
+      "created_at": 1721117674,
+      "hex": "D7",
+      "tile": "42-1",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 999,
+      "created_at": 1721117680
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 1000,
+      "created_at": 1721117696
+    },
+    {
+      "type": "run_routes",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 1001,
+      "created_at": 1721117701,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D21"
+            ],
+            [
+              "D21",
+              "D19"
+            ],
+            [
+              "D19",
+              "C18",
+              "B17",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "F13",
+            "E20",
+            "D21",
+            "D19",
+            "A10"
+          ],
+          "revenue": 380,
+          "revenue_str": "G10-F13-E20-D21-D19-A10 + b/B",
+          "nodes": [
+            "G10-0",
+            "F13-0",
+            "E20-0",
+            "D21-0",
+            "D19-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 1002,
+      "created_at": 1721117703,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "STJ",
+      "entity_type": "corporation",
+      "id": 1003,
+      "created_at": 1721117711
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 1004,
+      "created_at": 1721121411
+    },
+    {
+      "type": "run_routes",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 1005,
+      "created_at": 1721121415,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "G10",
+              "G12",
+              "F13"
+            ],
+            [
+              "F13",
+              "E14",
+              "E16",
+              "E18",
+              "E20"
+            ],
+            [
+              "E20",
+              "D19"
+            ],
+            [
+              "D19",
+              "C18",
+              "B17",
+              "B15",
+              "A14",
+              "A12",
+              "A10"
+            ]
+          ],
+          "hexes": [
+            "G10",
+            "F13",
+            "E20",
+            "D19",
+            "A10"
+          ],
+          "revenue": 350,
+          "revenue_str": "G10-F13-E20-D19-A10 + b/B",
+          "nodes": [
+            "G10-0",
+            "F13-0",
+            "E20-0",
+            "D19-0",
+            "A10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 1006,
+      "created_at": 1721121416,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "ÖSJ",
+      "entity_type": "corporation",
+      "id": 1007,
+      "created_at": 1721121417
+    }
+  ],
+  "loaded": true,
+  "created_at": 1718275347,
+  "updated_at": 1721319962,
+  "finished_at": 1721319962
+}


### PR DESCRIPTION
- [X] Branch is derived from the latest `master`
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes
Updated Welcome text.
Added two fixtures for 18SJ. One full standard game, and one full gane for Oscarian variant. Do cover a good selection of all privates. 18SJ only had a previous fixture that tested the fix of an error case for the 2 player variant.
So it does cover a good bit of options, including incremental and full cap.

### Explanation of Change
18SJ has been stable for over a year, with only few issues. No open isses at the moment.

### Screenshots
None

### Any Assumptions / Hacks
None
