### PR TITLE
[18 India] Fix OO reservation relocate bug 

### DIFF
--- a/lib/engine/game/g_18_india/step/home_track.rb
+++ b/lib/engine/game/g_18_india/step/home_track.rb
@@ -58,12 +58,11 @@ module Engine
           # Base code doesn't handle one token and one reservation on a OO tile
           # Moves a reservation from hex to untoken city
           def replace_oo_reservations(tile)
-            return if !tile.label == 'OO'
+            return unless tile.label == 'OO'
 
             cities = tile.cities
             reservations = tile.reservations.dup
             LOGGER.debug { "replace_oo_reservations > reservations: #{reservations}" }
-            LOGGER.debug { "replace_oo_reservations > label: #{tile.label}" }
             cities.each do |city|
               next if city.tokened?
 

--- a/lib/engine/game/g_18_india/step/home_track.rb
+++ b/lib/engine/game/g_18_india/step/home_track.rb
@@ -58,19 +58,12 @@ module Engine
           # Base code doesn't handle one token and one reservation on a OO tile
           # Moves a reservation from hex to untoken city
           def replace_oo_reservations(tile)
-            return unless tile.label == 'OO'
+            return unless tile.name == '235'
 
-            cities = tile.cities
-            reservations = tile.reservations.dup
-            LOGGER.debug { "replace_oo_reservations > reservations: #{reservations}" }
-            cities.each do |city|
-              next if city.tokened?
-
-              corp = reservations.pop
-              tile.remove_reservation!(corp)
-              city.add_reservation!(corp)
-              LOGGER.debug { "replace_oo_reservations > city reservation: #{city.reservations}" }
-            end
+            corp = tile.reservations.first
+            city = tile.cities.reject(&:tokened?).first
+            city.add_reservation!(corp)
+            tile.reservations.clear
           end
 
           def hex_neighbors(_entity, hex)

--- a/lib/engine/game/g_18_india/step/home_track.rb
+++ b/lib/engine/game/g_18_india/step/home_track.rb
@@ -34,7 +34,7 @@ module Engine
           end
 
           def process_lay_tile(action)
-            LOGGER.debug 'HomeTrack > process_lay_tile'
+            LOGGER.debug { 'HomeTrack > process_lay_tile' }
             lay_tile(action)
 
             place_token(
@@ -48,29 +48,30 @@ module Engine
           end
 
           def process_place_token(action)
-            LOGGER.debug 'HomeTrack > process_place_token'
+            LOGGER.debug { 'HomeTrack > process_place_token' }
             super
             tile = action.city.tile
+            LOGGER.debug { "HomeTrack > tile: #{tile.inspect}" }
             replace_oo_reservations(tile) unless tile.reservations.empty? # move hex reservation
           end
 
           # Base code doesn't handle one token and one reservation on a OO tile
           # Moves a reservation from hex to untoken city
           def replace_oo_reservations(tile)
-            return if tile.reservations.empty?
+            return if !tile.label == 'OO'
 
             cities = tile.cities
             reservations = tile.reservations.dup
-            LOGGER.debug "replace_oo_reservations > reservations: #{reservations}"
-            tile.reservations.each do |reservation|
-              cities.each do |city|
-                if !city.tokened? || cities.count == 1
-                  city.add_reservation!(reservation)
-                  exit
-                end
-              end
+            LOGGER.debug { "replace_oo_reservations > reservations: #{reservations}" }
+            LOGGER.debug { "replace_oo_reservations > label: #{tile.label}" }
+            cities.each do |city|
+              next if city.tokened?
+
+              corp = reservations.pop
+              tile.remove_reservation!(corp)
+              city.add_reservation!(corp)
+              LOGGER.debug { "replace_oo_reservations > city reservation: #{city.reservations}" }
             end
-            tile.reservations.clear
           end
 
           def hex_neighbors(_entity, hex)


### PR DESCRIPTION
Fixes #11058 

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes
This is "unlikely" to break existing games that haven't gotten past this point or didn't have two corps in a OO tile. 

### Explanation of Change
Rewrote method that moved a reservation from a hex back to a city after it was moved by laying the first yellow OO tile. 

### Screenshots
![image](https://github.com/user-attachments/assets/27981d22-a5c3-4157-801e-f6b5f264ddc8)

### Any Assumptions / Hacks
The default code doesn't handle the case when  yellow OO tile is placed where there is a home token and a reservation to track.   This case is handled by first moving the reservation to the hex and then after the tile and token are placed, moving the reservation back to the other un-tokened city. 