### PR TITLE
[18CZ] fixes OO reservation issue with hex B9

### DIFF
--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -135,7 +135,7 @@ module Engine
           20 => 70,
         }.freeze
 
-        TILE_RESERVATION_BLOCKS_OTHERS = :always
+        TILE_RESERVATION_BLOCKS_OTHERS = :single_slot_cities
 
         TWO_PLAYER_HEXES_TO_REMOVE = %w[A22 B19 B21 B23 B25 C22 C24 C26 C28 D21 D23 D25 D27 D29 E20 E22 E24 E26
                                         E28 F21 F23 F25 F27 G20 G22 G24 G26 G28 H21 H23 H25 I20 I22 I24].freeze


### PR DESCRIPTION
Fixes #[PUT_ISSUE_NUMBER_HERE]

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

changed TILE_RESERVATION_BLOCKS_OTHERS from :always to :single_slot_cities, since this game has a OO hex with a reservation that merges into a 2-slot city in brown.

### Screenshots

### Any Assumptions / Hacks

This shouldn't need pins, since no corp would be able to token before ATE at all with the previous rule. 
