### PR TITLE
[18uruguay] various fixes

### DIFF
--- a/lib/engine/game/g_18_uruguay/companies.rb
+++ b/lib/engine/game/g_18_uruguay/companies.rb
@@ -24,7 +24,7 @@ module Engine
           revenue: 10,
           desc: 'Owner (or controlling president) moves one crop cube from a countryside'\
                 'hex to an adjacent town or city hex each OR. Closes when the last crop cube has been moved.',
-          sym: 'LA_CORN',
+          sym: 'LO_CORN',
           abilities: [
                 {
                   type: 'assign_hexes',
@@ -120,7 +120,7 @@ module Engine
 
         MINORS = [
           {
-            sym: 'LA_CORN',
+            sym: 'LO_CORN',
             name: 'Latifundio Agrícola',
             logo: '18_uruguay/corn',
             simple_logo: '18_uruguay/corn',

--- a/lib/engine/game/g_18_uruguay/corporations.rb
+++ b/lib/engine/game/g_18_uruguay/corporations.rb
@@ -22,7 +22,7 @@ module Engine
             abilities: [],
           },
           {
-            float_percent: 20,
+            float_percent: 30,
             sym: 'RPTLA',
             name: 'The River Plate Trust, Loan & Agency Company, ltd',
             logo: '1848/BOE',

--- a/lib/engine/game/g_18_uruguay/game.rb
+++ b/lib/engine/game/g_18_uruguay/game.rb
@@ -176,7 +176,7 @@ module Engine
         end
 
         def corn_farm
-          @corn_farm ||= company_by_id('LA_CORN')
+          @corn_farm ||= company_by_id('LO_CORN')
         end
 
         def sheep_farm
@@ -336,7 +336,9 @@ module Engine
           return if corporation == @rptla
           return unless @loans
 
-          amount = corporation.par_price.price * 5
+          float_capitalization = nationalized? ? 10 : 5
+
+          amount = corporation.par_price.price * float_capitalization
           @bank.spend(amount, corporation)
           @log << "#{corporation.name} receives #{format_currency(corporation.cash)}"
           take_loan(corporation, @loans[0]) if @loans.size.positive? && !nationalized?

--- a/lib/engine/game/g_18_uruguay/trains.rb
+++ b/lib/engine/game/g_18_uruguay/trains.rb
@@ -112,7 +112,7 @@ module Engine
                   },
                   {
                     'nodes' => ['town'],
-                    'pay' => 999,
+                    'pay' => 0,
                     'visit' => 999,
                   },
                 ],


### PR DESCRIPTION
Fixes #11047
Fixes #11051 
Fixes #11080

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

- Changes sym for Latifundio Agrícola to LO_CORN (and all references to it) to match the other Latifundio private syms.
- Sets float percentage for RPTLA to 30, since it has a 30% presidency.
- Corrects 4D train. It currently runs 4 cities/offboards and infinite towns, it should be max 4 stops with the ability to skip towns.

### Screenshots

### Any Assumptions / Hacks
