### PR TITLE
[1849] Forces games with Electric Dreams variant to also use Bonds and Acquiring Tokens

### DIFF
--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -829,7 +829,7 @@ module Engine
         # code below is for variant rules
 
         def acquiring_station_tokens?
-          @acquiring_station_tokens ||= @optional_rules&.include?(:acquiring_station_tokens)
+          @optional_rules&.include?(:electric_dreams) || @optional_rules&.include?(:acquiring_station_tokens)
         end
 
         def electric_dreams?
@@ -837,7 +837,7 @@ module Engine
         end
 
         def bonds?
-          @bonds ||= @optional_rules&.include?(:bonds)
+          @optional_rules&.include?(:electric_dreams) || @optional_rules&.include?(:bonds)
         end
 
         def reduced_4p_corps?

--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -829,7 +829,7 @@ module Engine
         # code below is for variant rules
 
         def acquiring_station_tokens?
-          @optional_rules&.include?(:electric_dreams) || @optional_rules&.include?(:acquiring_station_tokens)
+          @acquiring_station_tokens ||= @optional_rules&.include?(:acquiring_station_tokens)
         end
 
         def electric_dreams?
@@ -837,7 +837,7 @@ module Engine
         end
 
         def bonds?
-          @optional_rules&.include?(:electric_dreams) || @optional_rules&.include?(:bonds)
+          @bonds ||= @optional_rules&.include?(:bonds)
         end
 
         def reduced_4p_corps?

--- a/lib/engine/game/g_1849/meta.rb
+++ b/lib/engine/game/g_1849/meta.rb
@@ -42,7 +42,8 @@ module Engine
           {
             sym: :electric_dreams,
             short_name: 'Electric Dreams',
-            desc: 'Adds E-trains that run infinite distance on broad track and double select cities',
+            desc: 'Adds E-trains that run infinite distance on broad track and double select cities. Selecting this option '\
+                  'will also automatically include the Bonds and Buy Tokens variants.',
           },
         ].freeze
       end

--- a/lib/engine/game/g_1849/meta.rb
+++ b/lib/engine/game/g_1849/meta.rb
@@ -42,10 +42,20 @@ module Engine
           {
             sym: :electric_dreams,
             short_name: 'Electric Dreams',
-            desc: 'Adds E-trains that run infinite distance on broad track and double select cities. Selecting this option '\
-                  'will also automatically include the Bonds and Buy Tokens variants.',
+            desc: 'Adds E-trains that run infinite distance on broad track and double select cities',
           },
         ].freeze
+
+        def self.check_options(options, _min_players, _max_players)
+          optional_rules = (options || []).map(&:to_sym)
+
+          return if optional_rules.empty?
+
+          if optional_rules.include?(:electric_dreams) &&
+            (!optional_rules.include?(:bonds) || !optional_rules.include?(:acquiring_station_tokens))
+            { error: 'Electric Dreams variant requires the Bonds and Buy Tokens variants as well.' }
+          end
+        end
       end
     end
   end

--- a/lib/engine/game/g_1849/step/bond.rb
+++ b/lib/engine/game/g_1849/step/bond.rb
@@ -42,7 +42,6 @@ module Engine
           end
 
           def take_loan(entity, loan)
-            print 'hi!'
             raise GameError, 'Cannot issue bond' unless can_take_loan?(entity)
 
             @log << "#{entity.name} issues its bond and receives #{@game.format_currency(@game.loan_value)}"

--- a/lib/engine/game/g_1849/step/buy_token.rb
+++ b/lib/engine/game/g_1849/step/buy_token.rb
@@ -62,7 +62,6 @@ module Engine
           end
 
           def can_replace_token?(entity, token)
-            print token
             return false unless token
 
             other_corporation = token.corporation


### PR DESCRIPTION
Fixes #11116

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Rules say that games with Electric Dreams also must use the Acquiring Station Tokens and Bonds variants. This automatically includes the other two variants if Electric Dreams is chosen.

Note: This will require pins for any games that are using the Electric Dreams variant without both Bonds and Acquiring Station Tokens.

### Screenshots

### Any Assumptions / Hacks
