### PR TITLE
[22Mars] Initial Permit distribution round

### DIFF
--- a/lib/engine/game/g_22_mars/game.rb
+++ b/lib/engine/game/g_22_mars/game.rb
@@ -168,6 +168,7 @@ module Engine
           },
         ].freeze
 
+        # Game specific constants
         LAST_OR = 11
 
         @or = 0
@@ -179,7 +180,21 @@ module Engine
         def new_operating_round(round_num = 1)
           @or += 1
 
+          if @or == 9
+            @operating_rounds = 3
+            @three_or_round = true
+          end
+
           super
+        end
+
+        def or_round_finished
+          # In case we get phase change during the last OR set we ensure we have 3 ORs
+          @operating_rounds = 3 if @three_or_round
+        end
+
+        def ipo_name(_entity = nil)
+          'Treasury'
         end
 
         def timeline

--- a/lib/engine/game/g_22_mars/round/permit_purchase.rb
+++ b/lib/engine/game/g_22_mars/round/permit_purchase.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G22Mars
+      module Round
+        class PermitPurchase < Engine::Round::Draft
+          def self.short_name
+            'PPR'
+          end
+
+          def name
+            'Permit Purchase Round'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_22_mars/step/select_or_discard.rb
+++ b/lib/engine/game/g_22_mars/step/select_or_discard.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G22Mars
+      module Step
+        class SelectOrDiscard < Engine::Step::SimpleDraft
+          ACTIONS = %w[bid pass].freeze
+
+          def setup
+            @companies = @game.companies
+          end
+
+          def available
+            [@companies.first]
+          end
+
+          def finished?
+            @companies.none?
+          end
+
+          def actions(entity)
+            return [] if finished?
+
+            entity == current_entity ? ACTIONS : []
+          end
+
+          def process_pass(action)
+            company = available.first
+            player = action.entity
+
+            company.close!
+            @companies.delete(company)
+
+            @log << "#{player.name} discards #{company.name} from the game"
+
+            @round.next_entity_index!
+            action_finalized
+          end
+
+          def description
+            'Buy or Discard Permit'
+          end
+
+          def pass_description
+            'Discard Permit'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_22_mars/step/select_or_discard.rb
+++ b/lib/engine/game/g_22_mars/step/select_or_discard.rb
@@ -16,7 +16,7 @@ module Engine
           end
 
           def finished?
-            @companies.none?
+            @companies.empty?
           end
 
           def actions(entity)


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Explanation of Change
It's like ISR, but permits (privates) are randomly distributed to players (1 each) and then players can choose whether to buy the assigned permit for listed price or to remove it from the game. And you can view which permits are in player hands on Entities tab.

Also game round tracker on Info tab now has interactive Revolt markers on rounds where revolt can start.

### Screenshots
<img width="1350" alt="Screenshot 2024-08-12 at 16 17 48" src="https://github.com/user-attachments/assets/ce6051e5-a492-46b2-8d0e-b5d478dec9b0">

<img width="852" alt="Screenshot 2024-08-12 at 16 23 58" src="https://github.com/user-attachments/assets/2ae1d19c-b482-4960-83c7-da24fd1c15d2">
<img width="855" alt="Screenshot 2024-08-12 at 16 32 35" src="https://github.com/user-attachments/assets/bb991cb2-e51f-4219-9696-536a98a09d65">
<img width="871" alt="Screenshot 2024-08-12 at 16 32 45" src="https://github.com/user-attachments/assets/d159d36c-31d2-42a8-9778-1b51d7d8a763">



