### PR TITLE
[18Ardennes] Last corner case rules

### DIFF
--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -86,6 +86,7 @@ module Engine
             shares = @game.share_pool.shares_by_corporation[corporation]
             return [] if shares.empty?
             return shares if corporation.owner == minor.owner
+            return shares if corporation.receivership?
 
             @round.refusals[corporation].include?(minor) ? shares : []
           end
@@ -108,6 +109,10 @@ module Engine
           end
 
           def can_gain?(entity, bundle, exchange: false)
+            # Cannot exchange a minor for a treasury share of a public company
+            # that is in receivership.
+            return false if exchange && bundle.corporation.receivership? &&
+                            bundle.owner != @game.share_pool
             # Can go above 60% ownership if exchanging a minor for a share or
             # if buying a share from the open market.
             return true if exchange

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -90,6 +90,15 @@ module Engine
             @round.refusals[corporation].include?(minor) ? shares : []
           end
 
+          def can_buy?(entity, bundle)
+            return super unless bundle
+            # If a minor is in receivership and its share price is in the grey
+            # zone then its presidency cannot be bought.
+            return false if bundle.corporation.share_price.price.zero?
+
+            super
+          end
+
           # Exchanging a minor for a share in a floated major corporation is
           # done as a buy_share action.
           def can_buy_any?(entity)

--- a/lib/engine/game/g_18_ardennes/step/dividend.rb
+++ b/lib/engine/game/g_18_ardennes/step/dividend.rb
@@ -7,6 +7,9 @@ module Engine
     module G18Ardennes
       module Step
         class Dividend < Engine::Step::Dividend
+          # Public companies cannot enter the left-handmost space on the market.
+          MAJOR_MIN_PRICE = 50
+
           def auto_actions(entity)
             return super unless entity.receivership?
 
@@ -28,7 +31,7 @@ module Engine
             price = entity.share_price.price
             revenue *= 2 if entity.type == :minor
 
-            if revenue.zero?
+            if revenue.zero? && (price > MAJOR_MIN_PRICE || entity.type == :minor)
               { share_direction: :left, share_times: 1 }
             elsif (revenue >= price * 2) &&
                   (entity.type != :'10-share') &&

--- a/lib/engine/game/g_18_ardennes/step/exchange.rb
+++ b/lib/engine/game/g_18_ardennes/step/exchange.rb
@@ -68,7 +68,8 @@ module Engine
 
             !corporation.operating_history.empty? &&
               minor.owner != corporation.owner &&
-              treasury_share?(share)
+              treasury_share?(share) &&
+              !corporation.receivership?
           end
 
           def log_request(minor, major)


### PR DESCRIPTION
## Implementation Notes

The last few corner case rules for 18Ardennes. It is unlikely that any of these would come up in actual gameplay, but they've been coded for completeness:

- The share price of a public company (major) cannot fall below 50F.
- If a minor company is in receivership following a bankruptcy, then it cannot be bought if its share price is in the grey zone.
- If a public company is in receivership then it does not have a president who could approve a request to exchange a minor company for a treasury share. Because of this, it is not allowed to attempt to exchange for a treasury share, but a player can exchange a minor for a market share.
- A player who has won the right to start a public company is allowed to sell shares (and/or the GL minor company) before starting the public company. But they are only allowed to do so if the money raised goes towards floating the new company. Check that the par price could not have been chosen with fewer items sold, if this could have been done then make the player choose a higher par price or undo some of the sales.

Once these have been merged 18Ardennes can be moved to alpha status.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`