### PR TITLE
[1849] removes two leftover print commands from bug testing

### DIFF
--- a/lib/engine/game/g_1849/step/bond.rb
+++ b/lib/engine/game/g_1849/step/bond.rb
@@ -42,7 +42,6 @@ module Engine
           end
 
           def take_loan(entity, loan)
-            print 'hi!'
             raise GameError, 'Cannot issue bond' unless can_take_loan?(entity)
 
             @log << "#{entity.name} issues its bond and receives #{@game.format_currency(@game.loan_value)}"

--- a/lib/engine/game/g_1849/step/buy_token.rb
+++ b/lib/engine/game/g_1849/step/buy_token.rb
@@ -62,7 +62,6 @@ module Engine
           end
 
           def can_replace_token?(entity, token)
-            print token
             return false unless token
 
             other_corporation = token.corporation


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

I found two stray print commands that I used in bug testing still in the code, this removes them. 

I'm doubtful this is the source of the reported issue, but it's something!

### Screenshots

### Any Assumptions / Hacks
