### PR TITLE
[1841] new corporations: hide "last run" and exclude from liquidity

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -112,7 +112,7 @@ module View
           }
 
           subchildren = render_operating_order
-          subchildren << render_revenue_history if @corporation.operating_history.any?
+          subchildren << render_revenue_history if @game.render_revenue_history?(@corporation)
           children << h(:div, props, subchildren)
         end
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1075,7 +1075,7 @@ module Engine
 
         value = player.cash
         if emergency
-          return liquidity(player) unless @round
+          return liquidity(player, emergency: false) unless @round
 
           value += player.shares_by_corporation.sum do |corporation, shares|
             next 0 if shares.empty?
@@ -2355,6 +2355,10 @@ module Engine
 
       def show_company_owners?
         true
+      end
+
+      def render_revenue_history?(corporation)
+        !corporation.operating_history.empty?
       end
 
       private


### PR DESCRIPTION
Corporations can be restarted or reformed from mergers, but their shares cannot be sold until they have completed an operating turn.

`Game::Base` changes

* add new method `render_revenue_history?`, so that 1841 can have an override to tell when operating history belongs to a previous version of the corporation
* add explicit `emergency` keyword in `liquidity` recursive call, I found it confusing to read without it

Fixes #9502
Fixes #9525

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`