### PR TITLE
[System18] corrects price change when emr issuing

### DIFF
--- a/lib/engine/game/g_system18/step/buy_train.rb
+++ b/lib/engine/game/g_system18/step/buy_train.rb
@@ -28,7 +28,7 @@ module Engine
                                                                                                         action.bundle)
 
             @emr_issue = true
-            @game.sell_shares_and_change_price(action.bundle, movement: :left_share)
+            @game.sell_shares_and_change_price(action.bundle, movement: :left_block)
           end
 
           def process_buy_train(action)


### PR DESCRIPTION
Fixes #11161

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

According to the rules (see below), shares issued during EMR in incremental cap games should only drop the price by a single space. The code had movement: :left_share. Corrected to :left_block.

This will only affect existing incremental cap games where multiple shares were issued during EMR.

### Screenshots

![image](https://github.com/user-attachments/assets/483f34db-f119-4f33-b654-1704dfb57b98)


### Any Assumptions / Hacks
