### PR TITLE
[1861] Move Perm location name to the correct hex

### DIFF
--- a/lib/engine/game/g_1861/map.rb
+++ b/lib/engine/game/g_1861/map.rb
@@ -151,7 +151,7 @@ module Engine
           'M9' => 'Simbirsk',
           'M19' => 'Astrakhan',
           'N10' => 'Samara',
-          'P0' => 'Perm',
+          'P2' => 'Perm',
           'P8' => 'Ufa',
           'Q3' => 'Ekaterinburg (₽80 if includes M)',
           'Q11' => 'Central Asia',


### PR DESCRIPTION
## Implementation Notes

### Explanation of Change

Perm is the city in hex H2. This location name had been showing in the grey plain track hex H0.

Fixes #11175.

### Screenshots

#### The map before this change, with the Perm location name in the wrong hex
![image](https://github.com/user-attachments/assets/93ea8322-9c62-40c4-9b92-4367065cccfd)

#### The map after this change, with Perm in the correct location
![image](https://github.com/user-attachments/assets/3e5645fe-f7a3-4d54-8801-4011aa9a6c4d)


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`