### PR TITLE
Suppress profile links for dummy players

### DIFF
--- a/assets/app/lib/profile_link.rb
+++ b/assets/app/lib/profile_link.rb
@@ -3,6 +3,10 @@
 module Lib
   module ProfileLink
     def profile_link(id, name)
+      # Negative ID values are used for dummy players, these do not have
+      # profile pages.
+      return h(:span, name) if id.to_i.negative?
+
       props = {
         attrs: {
           href: "/profile/#{id}",


### PR DESCRIPTION
## Implementation Notes

### Explanation of Change

Several games have dummy players:

- The Union Bank in 1871.
- Vaclav in the two-player version of 18CZ.
- A W Edelswärd in the two-player version of 18SJ.

These are all represented by player objects with an ID of -1.

These entities are shown on the entity page (and other places) where a link to the player profile pages is included. Clicking on these links gives a 404 error, as these links are not valid.

This pull request suppresses the links to the profile pages for players with negative user IDs.

Fixes tobymao#11124.

### Any Assumptions / Hacks

The assumption here is that any negative user IDs aren't real people.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`