### PR TITLE
[18Uruguay] adds diesel discount.

### DIFF
--- a/lib/engine/game/g_18_uruguay/trains.rb
+++ b/lib/engine/game/g_18_uruguay/trains.rb
@@ -101,6 +101,7 @@ module Engine
             distance: 999,
             price: 950,
             num: 20,
+            discount: { '4' => 200, '5' => 200, '6' => 200, '7' => 200 },
             variants: [
               {
                 name: '4D',


### PR DESCRIPTION
Fixes #11173

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Adds the code for a $200 discount when trading in a 4, 5, 6, or 7 train for a diesel.

### Screenshots

### Any Assumptions / Hacks
