### PR TITLE
[1858Switzerland] Add game code for 1858 Switzerland variant

### DIFF
--- a/lib/engine/game/g_1858_switzerland/game.rb
+++ b/lib/engine/game/g_1858_switzerland/game.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'entities'
+require_relative 'graph'
 require_relative 'map'
 require_relative 'meta'
 require_relative 'tiles'
@@ -15,6 +16,7 @@ module Engine
         include Map
         include Tiles
 
+        GRAPH_CLASS = G1858Switzerland::Graph
         CURRENCY_FORMAT_STR = '%ssfr'
 
         BANK_CASH = 8_000
@@ -121,6 +123,170 @@ module Engine
         def setup
           super
           @phase4_train_trigger = PHASE4_TRAINS_RUST
+        end
+
+        def maybe_rust_wounded_trains!(grey_trains_bought, purchased_train)
+          obsolete_trains!(%w[6H 3M], purchased_train) if grey_trains_bought == PHASE4_TRAINS_OBSOLETE
+          rust_wounded_trains!(%w[4H 2M], purchased_train) if grey_trains_bought == PHASE3_TRAINS_RUST
+          rust_wounded_trains!(%w[6H 3M], purchased_train) if grey_trains_bought == PHASE4_TRAINS_RUST
+        end
+
+        def obsolete_trains!(train_names, purchased_train)
+          trains.select { |train| train_names.include?(train.name) }
+                .each { |train| train.obsolete_on = purchased_train.sym }
+          rust_trains!(purchased_train, purchased_train.owner)
+        end
+
+        def closure_round(round_num)
+          G1858Switzerland::Round::Closure.new(self, [
+            G1858::Step::ExchangeApproval,
+            G1858::Step::HomeToken,
+            G1858::Step::PrivateClosure,
+          ], round_num: round_num)
+        end
+
+        BONUS_HEXES = {
+          north: %w[C4 D3 E2 H1 I2],
+          south: %w[H15 I16],
+          east: %w[L5 L7],
+          west: %w[A14 B7],
+          revenue_ns: 'B16',
+          revenue_ew: 'L16',
+        }.freeze
+
+        def revenue_for(route, stops)
+          super + north_south_bonus(route, stops) + east_west_bonus(route, stops)
+        end
+
+        def private_colors_available(phase)
+          if phase.status.include?('yellow_privates')
+            %i[yellow]
+          elsif phase.status.include?('green_privates')
+            %i[yellow green]
+          elsif phase.status.include?('all_privates')
+            %i[yellow green lightblue]
+          elsif phase.status.include?('blue_privates')
+            %i[lightblue]
+          else
+            []
+          end
+        end
+
+        MOUNTAIN_RAILWAY_TILE = 'X28'
+        MOUNTAIN_RAILWAY_ASSIGNMENT = '+40'
+        MOUNTAIN_RAILWAY_BONUS = 40
+        ASSIGNMENT_TOKENS = {
+          MOUNTAIN_RAILWAY_ASSIGNMENT => '/icons/1858_switzerland/mountain.svg',
+        }.freeze
+
+        def submit_revenue_str(routes, _show_subsidy)
+          mountain_revenue = mountain_bonus(current_entity, routes)
+          return super if mountain_revenue.zero?
+
+          train_revenue = routes_revenue(routes)
+          "#{format_revenue_currency(train_revenue)} + " \
+            "#{format_revenue_currency(mountain_revenue)} mountain railway bonus"
+        end
+
+        def extra_revenue(entity, routes)
+          mountain_bonus(entity, routes)
+        end
+
+        def mountain_bonus(entity, routes)
+          return 0 if routes.empty?
+
+          mountain_railway_built?(entity) ? MOUNTAIN_RAILWAY_BONUS : 0
+        end
+
+        def all_potential_upgrades(tile, tile_manifest: false, selected_company: nil)
+          return super unless mountain_hex?(tile)
+
+          super + Array(@tiles.find { |t| t.name == MOUNTAIN_RAILWAY_TILE })
+        end
+
+        def upgrades_to?(from, to, special, selected_company: nil)
+          valid = super
+          return valid unless current_entity.corporation?
+          return valid if mountain_railway_built?(current_entity)
+          return valid unless mountain_hex?(from)
+
+          valid || to.name == MOUNTAIN_RAILWAY_TILE
+        end
+
+        def after_lay_tile(_hex, tile, entity)
+          return unless tile.name == MOUNTAIN_RAILWAY_TILE
+
+          entity.assign!(MOUNTAIN_RAILWAY_ASSIGNMENT)
+        end
+
+        # This method is called to remove some private railways from 1858 when
+        # there are two players. This does not happen in 18CH.
+        def setup_unbuyable_privates; end
+
+        def gotthard
+          @gotthard ||= hex_by_id('H11')
+        end
+
+        def fob_minor
+          @fob_minor ||= minor_by_id('FOB')
+        end
+
+        def gb_minor
+          @gb_minor ||= minor_by_id('GB')
+        end
+
+        def home_hex?(operator, hex, gauge = nil)
+          home_hex = super
+          return home_hex if !home_hex || hex != gotthard
+
+          # Gotthard (H11) is different from other hexes. A public company
+          # doesn't just to have to have a connection to anywhere on the hex to
+          # be able to absorb a private railway. To absorb the GB private it
+          # needs to have a connection to the broad gauge track, to absorb the
+          # FOB it needs to have a connection to the metre (narrow) gauge track.
+          (operator == fob_minor && gauge == :narrow) ||
+            (operator == gb_minor && gauge == :broad)
+        end
+
+        private
+
+        def hexes_by_id(coordinates)
+          coordinates.map { |coord| hex_by_id(coord) }
+        end
+
+        def r2r_bonus(route, stops, zone1, zone2, bonus)
+          @bonus_nodes ||= {
+            north: hexes_by_id(BONUS_HEXES[:north]).map(&:tile).flat_map(&:offboards),
+            south: hexes_by_id(BONUS_HEXES[:south]).map(&:tile).flat_map(&:offboards),
+            east: hexes_by_id(BONUS_HEXES[:east]).map(&:tile).flat_map(&:offboards),
+            west: hexes_by_id(BONUS_HEXES[:west]).map(&:tile).flat_map(&:offboards),
+          }
+          @bonus_revenue ||= {
+            north_south: hex_by_id(BONUS_HEXES[:revenue_ns]).tile.offboards.first,
+            east_west: hex_by_id(BONUS_HEXES[:revenue_ew]).tile.offboards.first,
+          }
+          return 0 unless stops.intersect?(@bonus_nodes[zone1])
+          return 0 unless stops.intersect?(@bonus_nodes[zone2])
+
+          @bonus_revenue[bonus].route_revenue(@phase, route.train)
+        end
+
+        def north_south_bonus(route, stops)
+          r2r_bonus(route, stops, :north, :south, :north_south)
+        end
+
+        def east_west_bonus(route, stops)
+          r2r_bonus(route, stops, :east, :west, :east_west)
+        end
+
+        def mountain_hex?(tile)
+          tile.color == :white && tile.upgrades.any? { |u| u.cost == 120 }
+        end
+
+        def mountain_railway_built?(entity)
+          return false unless entity.corporation?
+
+          entity.assignments.key?(MOUNTAIN_RAILWAY_ASSIGNMENT)
         end
       end
     end

--- a/lib/engine/game/g_1858_switzerland/graph.rb
+++ b/lib/engine/game/g_1858_switzerland/graph.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative '../g_1858/graph'
+
+module Engine
+  module Game
+    module G1858Switzerland
+      class Graph < G1858::Graph
+        private
+
+        def path_node(path, entity)
+          node = G1858::Part::PathNode.new(path)
+          return node unless path.hex == @game.gotthard
+
+          # The pre-printed Gotthard hex is a special case. It is a home hex
+          # for two private railways (FOB and GB) and it has two paths, one
+          # broad gauge and one metre (narrow) gauge. FOB is only allowed to
+          # trace routes from this hex using the metre gauge path, and GB can
+          # only use the broad gauge path.
+          return node if (path.track == :broad && entity == @game.gb_minor) ||
+                         (path.track == :narrow && entity == @game.fob_minor)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1858_switzerland/round/closure.rb
+++ b/lib/engine/game/g_1858_switzerland/round/closure.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1858/round/closure'
+
+module Engine
+  module Game
+    module G1858Switzerland
+      module Round
+        class Closure < G1858::Round::Closure
+          private
+
+          # Is this the final private closure round?
+          def last_pcr?
+            @game.phase.name != '5'
+          end
+
+          def companies
+            companies = @game.companies.reject(&:closed?)
+            return companies if last_pcr?
+
+            companies.reject { |company| company.color == :lightblue }
+          end
+
+          def minors
+            minors = @game.minors.reject(&:closed?)
+            return minors if last_pcr?
+
+            minors.reject { |minor| minor.color == :lightblue }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Implementation Notes

### Explanation of Change

This adds code handling the differences between the original 1858 game, and the prototype of the variant set in Switzerland.

These differences include:

- Bonuses for running north-south or east-west routes.
- Three sets of private railway companies instead of two.
- Two private closure rounds instead of one.
- Different timings for wounding and rusting mid-game trains.
- Mountain railway tiles which can be laid on hexes with a 120SF terrain cost. A public company that has laid one of these will then get a 40SF bonus to its revenue whenever it runs trains.
- Special rules for the private railway companies which have Gotthard as a home hex. Normally a public company is allowed to acquire a private railway if there is a connection to anywhere in the private's home hex; for GB you need a connection to the broad gauge track in the Gotthard hex, and for FOB you need a connection to the narrow (metre) gauge track.


### Screenshots

### Any Assumptions / Hacks


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
