### PR TITLE
[1837] Start packet auction

### DIFF
--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -13,7 +13,7 @@ module Engine
     include Passer
 
     attr_accessor :name, :desc, :min_price, :revenue, :discount, :value
-    attr_reader :sym, :min_auction_price, :treasury, :interval, :color, :text_color, :type, :auction_row
+    attr_reader :sym, :min_auction_price, :treasury, :interval, :color, :text_color, :type, :auction_row, :meta
     attr_writer :max_price
 
     def initialize(sym:, name:, value:, revenue: 0, desc: '', abilities: [], **opts)
@@ -33,6 +33,7 @@ module Engine
       @text_color = opts[:text_color] || :black
       @type = opts[:type]&.to_sym
       @auction_row = opts[:auction_row]
+      @meta = opts[:meta] || {}
 
       init_abilities(abilities)
     end

--- a/lib/engine/game/g_1837/entities.rb
+++ b/lib/engine/game/g_1837/entities.rb
@@ -6,11 +6,315 @@ module Engine
       module Entities
         COMPANIES = [
           {
+            name: 'Pilsen-Priesen Railway',
+            sym: 'EPP',
+            value: 40,
+            desc: 'Located in E11 with 100K starting capital. Coal companies cannot be sold and can only run ' \
+                  'G trains. The company can be exchanged for a 10% share of Bohemian Commercial Railway (BK) at ' \
+                  'the start of an operating round.',
+            color: :black,
+            text_color: :white,
+            meta: { start_packet: true, type: :coal },
+            abililties: [
+                type: 'exchange',
+                corporations: ['BK'],
+                owner_type: 'player',
+                when: 'exchange',
+                from: 'reserved',
+            ],
+          },
+          {
+            name: 'Reichenberg-Gablonz-Tannwalder Railway',
+            sym: 'RGTE',
+            value: 40,
+            desc: 'Located in A13 with 100K starting capital. Coal companies cannot be sold and can only run ' \
+                  'G trains. The company can be exchanged for a 10% share of Bohemian Commercial Railway (BK) at ' \
+                  'the start of an operating round.',
+            color: :black,
+            text_color: :white,
+            meta: { start_packet: true, type: :coal },
+            abililties: [
+                type: 'exchange',
+                corporations: ['BK'],
+                owner_type: 'player',
+                when: 'exchange',
+                from: 'reserved',
+            ],
+          },
+          {
+            name: 'Oderberg-Dombran Railway',
+            sym: 'EOD',
+            value: 40,
+            desc: 'Located in C19 with 100K starting capital. Coal companies cannot be sold and can only run ' \
+                  'G trains. The company can be exchanged for a 10% share of Moravian-Silesian Railway (MS) at the ' \
+                  'start of an operating round.',
+            color: :black,
+            text_color: :white,
+            meta: { start_packet: true, type: :coal },
+            abililties: [
+                type: 'exchange',
+                corporations: ['MS'],
+                owner_type: 'player',
+                when: 'exchange',
+                from: 'reserved',
+            ],
+          },
+          {
+            name: 'Karwin-Teschen Railway',
+            sym: 'EKT',
+            value: 40,
+            desc: 'Located in C21 with 100K starting capital. Coal companies cannot be sold and can only run ' \
+                  'G trains. The company can be exchanged for a 10% share of Moravian-Silesian Railway (MS) at the ' \
+                  'start of an operating round.',
+            color: :black,
+            text_color: :white,
+            meta: { start_packet: true, type: :coal },
+            abililties: [
+                type: 'exchange',
+                corporations: ['MS'],
+                owner_type: 'player',
+                when: 'exchange',
+                from: 'reserved',
+            ],
+          },
+          {
+            name: 'Mosty-Lemberg Railway',
+            sym: 'MLB',
+            value: 40,
+            desc: 'Located in B32 with 100K starting capital. Coal companies cannot be sold and can only run ' \
+                  'G trains. The company can be exchanged for a 10% share of Carl Ludwig’s Railway (CL) at the ' \
+                  'start of an operating round.',
+            color: :black,
+            text_color: :white,
+            meta: { start_packet: true, type: :coal },
+            abililties: [
+                type: 'exchange',
+                corporations: ['CL'],
+                owner_type: 'player',
+                when: 'exchange',
+                from: 'reserved',
+            ],
+          },
+          {
+            name: 'Zarnesti-Kronstadt Railway',
+            sym: 'ZKB',
+            value: 40,
+            desc: 'Located in J34 with 100K starting capital. Coal companies cannot be sold and can only run ' \
+                  'G trains. The company can be exchanged for a 10% share of Transylvanian Railway (TR) at the ' \
+                  'start of an operating round.',
+            color: :black,
+            text_color: :white,
+            meta: { start_packet: true, type: :coal },
+            abililties: [
+                type: 'exchange',
+                corporations: ['TR'],
+                owner_type: 'player',
+                when: 'exchange',
+                from: 'reserved',
+            ],
+          },
+          {
+            name: 'Simeria-Petroseni Railway',
+            sym: 'SPB',
+            value: 40,
+            desc: 'Located in K31 with 100K starting capital. Coal companies cannot be sold and can only run ' \
+                  'G trains. The company can be exchanged for a 10% share of Transylvanian Railway (TR) at the ' \
+                  'start of an operating round.',
+            color: :black,
+            text_color: :white,
+            meta: { start_packet: true, type: :coal },
+            abililties: [
+                type: 'exchange',
+                corporations: ['TR'],
+                owner_type: 'player',
+                when: 'exchange',
+                from: 'reserved',
+            ],
+          },
+          {
+            name: 'Lugoj-Resita Railway',
+            sym: 'LRB',
+            value: 40,
+            desc: 'Located in L30 with 100K starting capital. Coal companies cannot be sold and can only run ' \
+                  'G trains. The company can be exchanged for a 10% share of Tisza Railway (TI) at the start of ' \
+                  'an operating round.',
+            color: :black,
+            text_color: :white,
+            meta: { start_packet: true, type: :coal },
+            abililties: [
+                type: 'exchange',
+                corporations: ['TI'],
+                owner_type: 'player',
+                when: 'exchange',
+                from: 'reserved',
+            ],
+          },
+          {
+            name: 'Bosna-Bahn',
+            sym: 'BB',
+            value: 40,
+            desc: 'Located in P20 with 100K starting capital. Coal companies cannot be sold and can only run ' \
+                  'G trains. The company can be exchanged for a 10% share of Bosnia-Herzegovina Railway (BH) ' \
+                  'at the start of an operating round.',
+            color: :black,
+            text_color: :white,
+            meta: { start_packet: true, type: :coal },
+            abililties: [
+                type: 'exchange',
+                corporations: ['BH'],
+                owner_type: 'player',
+                when: 'exchange',
+                from: 'reserved',
+            ],
+          },
+          {
+            name: 'Hatvan-Salgotarjan Railway (EHS)',
+            sym: 'EHS',
+            value: 40,
+            desc: 'Located in F26 with 100K starting capital. Coal companies cannot be sold and can only run ' \
+                  'G trains. The company can be exchanged for a 10% share of Tisza Railway (TI) at the start of ' \
+                  'an operating round.',
+            color: :black,
+            text_color: :white,
+            meta: { start_packet: true, type: :coal },
+            abililties: [
+                type: 'exchange',
+                corporations: ['TI'],
+                owner_type: 'player',
+                when: 'exchange',
+                from: 'reserved',
+            ],
+          },
+          {
+            name: 'Kaiser Ferdinand North Railway (KK1)',
+            sym: 'KK1',
+            value: 60,
+            desc: "Director's certificate of the minor company Kaiser Ferdinand North Railway (KK1). The company " \
+                  'starts in Vienna (G17) with 90K starting capital.',
+            color: :brown,
+            meta: { start_packet: true, type: :minor },
+          },
+          {
+            name: 'Kaiserin Elisabeth-Railway (KK2)',
+            sym: 'KK2',
+            value: 60,
+            desc: "Director's certificate of the minor company Kaiserin Elisabeth-Railway (KK2). The company " \
+                  'starts in Vienna (G17) with 140K starting capital.',
+            color: :brown,
+            meta: { start_packet: true, type: :minor },
+          },
+          {
+            name: 'Kaiser Franz Joseph-Railway (KK3)',
+            sym: 'KK3',
+            value: 60,
+            desc: "Director's certificate of the minor company Kaiser Franz Joseph-Railway (KK3). The company " \
+                  'starts in Vienna (G17) with 90K starting capital.',
+            color: :brown,
+            meta: { start_packet: true, type: :minor },
+          },
+          {
+            name: 'Pest-Waitzen Railway (UG1)',
+            sym: 'UG1',
+            value: 80,
+            desc: "Director's certificate of the minor company Pest-Waitzen Railway (UG1) " \
+                  'starts in Budapest (H22) with 180K starting capital.',
+            color: :pink,
+            meta: { start_packet: true, type: :minor },
+          },
+          {
+            name: 'Mohacs-Fünfkirchener Railway (UG2)',
+            sym: 'UG2',
+            value: 80,
+            desc: "Director's certificate of the minor company Mohacs-Fünfkirchener Railway (UG2). The company " \
+                  'starts in Fün%irchen (K21) with 90K starting capital.',
+            color: :pink,
+            meta: { start_packet: true, type: :minor },
+          },
+          {
+            name: 'Pest-Czegled Railway (UG3)',
+            sym: 'UG3',
+            value: 80,
+            desc: "Director's certificate of the minor company Pest-Czegled Railway (UG3). The company " \
+                  'starts in Budapest (H22) with 180K starting capital.',
+            color: :pink,
+            meta: { start_packet: true, type: :minor },
+          },
+          {
+            name: 'Vienna-Gloggnitzer Railway (SD1)',
+            sym: 'SD1',
+            value: 100,
+            desc: "Director's certificate of the minor company Vienna-Gloggnitzer Railway (SD1). The company " \
+                  "starts in Vienna (G17) with 90K starting capital.\n\nComes with the Mountain Railway " \
+                  'Semmering Railway (H16) that has a value of 100K and a revenue of 5K.',
+            color: :orange,
+            meta: { start_packet: true, type: :minor, additional_companies: ['Semmering'] },
+          },
+          {
+            name: 'Kärntner Railway (SD2)',
+            sym: 'SD2',
+            value: 120,
+            desc: "Director's certificate of the minor company Kärntner Railway (SD2). The company " \
+                  "starts in Marburg (J16) with 90K starting capital.\n\n =Comes with the Mountain Railway " \
+                  'Karawanken Railway (J12) that has a value of 120K and a revenue of 25K.',
+            color: :orange,
+            meta: { start_packet: true, type: :minor, additional_companies: ['Karawanken'] },
+          },
+          {
+            name: 'North Tyrol Railway (SD3)',
+            sym: 'SD3',
+            value: 135,
+            desc: "Director's certificate of the minor company North Tyrol Railway (SD3). The company " \
+                  "starts in Innsbruck (I7) with 90K starting capital.\n\nComes with the Mountain Railway " \
+                  'Arlberg Railway (I5) that has a value of 135K and a revenue of 20K.',
+            color: :orange,
+            meta: { start_packet: true, type: :minor, additional_companies: ['Arlberg'] },
+          },
+          {
+            name: 'South Tyrol Railway (SD4)',
+            sym: 'SD4',
+            value: 90,
+            desc: "Director's certificate of the minor company South Tyrol Railway (SD4). The company " \
+                  "starts in Bozen (K5) with 90K starting capital.\n\nComes with the Mountain Railway " \
+                  'Brenner Railway (J6) that has a value of 90K and a revenue of 15K.',
+            color: :orange,
+            meta: { start_packet: true, type: :minor, additional_companies: ['Brenner'] },
+          },
+          {
+            name: 'Venice-Lombardy Railway (SD5)',
+            sym: 'SD5',
+            value: 70,
+            desc: "Director's certificate of the minor company Venice-Lombardy Railway (SD5). The company " \
+                  "starts in Milan (L2) or Venice (L8), the director chooses, with 90K starting capital.\n\n" \
+                  'Comes with the Mountain Railway Karst Railway (K13) that has a value of 70K and a revenue of 10K.',
+            color: :orange,
+            meta: { start_packet: true, type: :minor, additional_companies: ['Karst'] },
+          },
+          {
+            name: 'Pest-Waitzen Railway (UG1) share',
+            sym: 'UG1_share',
+            value: 90,
+            desc: 'A share of the minor company Pest-Waitzen Railway (UG1).',
+            color: :pink,
+            meta: { type: :share },
+          },
+          {
+            name: 'Pest-Czegled Railway (UG3) share',
+            sym: 'UG3_share',
+            value: 90,
+            desc: 'A share of the minor company Pest-Czegled Railway (UG3).',
+            color: :pink,
+            meta: { type: :share },
+          },
+          {
             name: 'Semmering Railway',
             sym: 'Semmering',
-            desc: 'Mountain Railway (H16)',
+            desc: "Owning player's companies do not pay the terrain cost when laying a tile on H16. " \
+                  "Other players' companies are blocked from laying track on H16 until Phase 3. " \
+                  'The company closes at the start of Phase 5.',
             value: 100,
             revenue: 5,
+            color: :gray,
+            meta: { type: :mountain_railway },
             abilities: [
               { type: 'no_buy' },
               {
@@ -35,9 +339,13 @@ module Engine
           {
             name: 'Karst Railway',
             sym: 'Karst',
-            desc: 'Mountain Railway (K13)',
+            desc: "Owning player's companies do not pay the terrain cost when laying a tile on K13. " \
+                  "Other players' companies are blocked from laying track on K13 until Phase 3. " \
+                  'The company closes at the start of Phase 5.',
             value: 70,
             revenue: 10,
+            color: :gray,
+            meta: { type: :mountain_railway },
             abilities: [
               { type: 'no_buy' },
               {
@@ -62,9 +370,13 @@ module Engine
           {
             name: 'Brenner Railway',
             sym: 'Brenner',
-            desc: 'Mountain Railway (J6)',
+            desc: "Owning player's companies do not pay the terrain cost when laying a tile on J6. " \
+                  "Other players' companies are blocked from laying track on J6 until Phase 3. " \
+                  'The company closes at the start of Phase 5.',
             value: 90,
             revenue: 15,
+            color: :gray,
+            meta: { type: :mountain_railway },
             abilities: [
               { type: 'no_buy' },
               {
@@ -89,9 +401,13 @@ module Engine
           {
             name: 'Arlberg Railway',
             sym: 'Arlberg',
-            desc: 'Mountain Railway (I5)',
+            desc: "Owning player's companies do not pay the terrain cost when laying a tile on I5. " \
+                  "Other players' companies are blocked from laying track on I5 until Phase 3. " \
+                  'The company closes at the start of Phase 5.',
             value: 135,
             revenue: 20,
+            color: :gray,
+            meta: { type: :mountain_railway },
             abilities: [
               { type: 'no_buy' },
               {
@@ -116,9 +432,13 @@ module Engine
           {
             name: 'Karawanken Railway',
             sym: 'Karawanken',
-            desc: 'Mountain Railway (J12)',
+            desc: "Owning player's companies do not pay the terrain cost when laying a tile on J12. " \
+                  "Other players' companies are blocked from laying track on J12 until Phase 3. " \
+                  'The company closes at the start of Phase 5.',
             value: 120,
             revenue: 25,
+            color: :gray,
+            meta: { type: :mountain_railway },
             abilities: [
               { type: 'no_buy' },
               {
@@ -143,9 +463,13 @@ module Engine
           {
             name: 'Wocheiner Railway',
             sym: 'Wocheiner',
-            desc: 'Mountain Railway (K11)',
+            desc: "Owning player's companies do not pay the terrain cost when laying a tile on K11. " \
+                  "Other players' companies are blocked from laying track on K11 until Phase 3. " \
+                  'The company closes at the start of Phase 5.',
             value: 50,
             revenue: 30,
+            color: :gray,
+            meta: { start_packet: true, type: :mountain_railway },
             abilities: [
               { type: 'no_buy' },
               {
@@ -170,9 +494,13 @@ module Engine
           {
             name: 'Tauern Railway',
             sym: 'Tauern',
-            desc: 'Mountain Railway (J10)',
+            desc: "Owning player's companies do not pay the terrain cost when laying a tile on J10. " \
+                  "Other players' companies are blocked from laying track on J10 until Phase 3. " \
+                  'The company closes at the start of Phase 5.',
             value: 70,
             revenue: 35,
+            color: :gray,
+            meta: { start_packet: true, type: :mountain_railway },
             abilities: [
               { type: 'no_buy' },
               {
@@ -272,7 +600,7 @@ module Engine
           {
             name: 'Hatvan-Salgotarjan Railway',
             sym: 'EHS',
-            logo: '1837/ebs',
+            logo: '1837/ehs',
             tokens: [0],
             coordinates: 'F26',
             color: :black,

--- a/lib/engine/game/g_1837/step/selection_auction.rb
+++ b/lib/engine/game/g_1837/step/selection_auction.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/selection_auction'
+
+module Engine
+  module Game
+    module G1837
+      module Step
+        class SelectionAuction < Engine::Step::SelectionAuction
+          def actions(entity)
+            return [] if @finished
+
+            super
+          end
+
+          def description
+            'Auction Start Packet items'
+          end
+
+          def may_bid?(_company)
+            true
+          end
+
+          protected
+
+          def initial_auction_entity
+            nil
+          end
+
+          private
+
+          def all_passed!
+            @finished = true
+            entities.each(&:unpass!)
+          end
+
+          def win_bid(winner, company)
+            super
+            @game.after_company_assigned(company)
+          end
+
+          def post_win_bid(winner, _company)
+            entities.each(&:unpass!)
+            @round.goto_entity!(winner.entity)
+            next_entity!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/step/selection_auction.rb
+++ b/lib/engine/step/selection_auction.rb
@@ -64,14 +64,15 @@ module Engine
       def process_bid(action)
         action.entity.unpass!
 
-        if auctioning
-          add_bid(action)
+        if !auctioning
+          selection_bid(action)
+          next_entity! if auctioning
         elsif @active_bidders.length == 1
           add_bid(action)
           resolve_bids
         else
-          selection_bid(action)
-          next_entity! if auctioning
+          auctioning
+          add_bid(action)
         end
       end
 

--- a/lib/engine/step/selection_auction.rb
+++ b/lib/engine/step/selection_auction.rb
@@ -24,13 +24,18 @@ module Engine
         super
       end
 
+      def initial_auction_entities
+        entities.rotate(@round.entity_index)
+      end
+
       def active_entities
-        if @auctioning
-          winning_bid = highest_bid(@auctioning)
-          return [@active_bidders[(@active_bidders.index(winning_bid.entity) + 1) % @active_bidders.size]] if winning_bid
+        return super unless auctioning
+
+        if (winning_bid = highest_bid(@auctioning))
+          return [@active_bidders[(@active_bidders.index(winning_bid.entity) + 1) % @active_bidders.size]]
         end
 
-        super
+        [@active_bidders[0]]
       end
 
       def process_pass(action)
@@ -84,12 +89,8 @@ module Engine
         setup_auction
         @companies = @game.initial_auction_companies.dup
         @cheapest = @companies.first
-        auction_entity(@companies.first)
+        auction_entity(initial_auction_entity) if initial_auction_entity
         @auction_triggerer = current_entity
-      end
-
-      def selection_bid(bid)
-        add_bid(bid)
       end
 
       def starting_bid(company)
@@ -113,10 +114,22 @@ module Engine
         player.cash
       end
 
+      protected
+
+      def active_auction
+        company = @auctioning
+        bids = @bids[company]
+        yield company, bids if company
+      end
+
+      def initial_auction_entity
+        @companies.first
+      end
+
       private
 
       def add_bid(bid)
-        super(bid)
+        super
         company = bid.company
         entity = bid.entity
         price = bid.price


### PR DESCRIPTION
Implementation of the start packet auction for 1837.

Also includes minor log bug fix for selection auctions where if the first player passes, the log would state "Player 1 passes" rather than "Player 1 passes on <company name>".