### PR TITLE
[Core] Add subsidies to dividend step

### DIFF
--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -35,7 +35,7 @@ module View
               @step.respond_to?(:dividend_name) ? @step.dividend_name(type) : type
             end
 
-          corp_income = option[:corporation] + option[:divs_to_corporation]
+          corp_income = option[:corporation] + option[:divs_to_corporation] + @step.total_subsidy
 
           direction =
             if (new_share_price = entity.share_price) && option[:share_direction]

--- a/lib/engine/action/run_routes.rb
+++ b/lib/engine/action/run_routes.rb
@@ -6,12 +6,13 @@ require_relative '../route'
 module Engine
   module Action
     class RunRoutes < Base
-      attr_reader :routes, :extra_revenue
+      attr_reader :routes, :extra_revenue, :subsidy
 
-      def initialize(entity, routes:, extra_revenue: 0)
+      def initialize(entity, routes:, extra_revenue: 0, subsidy: 0)
         super(entity)
         @routes = routes
         @extra_revenue = extra_revenue
+        @subsidy = subsidy
       end
 
       def self.h_to_args(h, game)
@@ -41,6 +42,7 @@ module Engine
         {
           routes: routes,
           extra_revenue: h['extra_revenue'],
+          subsidy: h['subsidy'],
         }
       end
 
@@ -62,6 +64,7 @@ module Engine
         {
           'routes' => routes,
           'extra_revenue' => extra_revenue,
+          'subsidy' => subsidy,
         }
       end
     end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -810,9 +810,9 @@ module Engine
         @last_processed_action = action.id
 
         self
-      rescue StandardError => e
-        rescue_exception(e, action)
-        self
+      #rescue StandardError => e
+      #  rescue_exception(e, action)
+      #  self
       end
 
       def process_single_action(action)
@@ -838,8 +838,8 @@ module Engine
             transition_to_next_round!
           end
         end
-      rescue Engine::GameError => e
-        rescue_exception(e, action)
+      #rescue Engine::GameError => e
+      #  rescue_exception(e, action)
       end
 
       def rescue_exception(e, action)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -810,9 +810,9 @@ module Engine
         @last_processed_action = action.id
 
         self
-      #rescue StandardError => e
-      #  rescue_exception(e, action)
-      #  self
+        # rescue StandardError => e
+        #  rescue_exception(e, action)
+        #  self
       end
 
       def process_single_action(action)
@@ -838,8 +838,8 @@ module Engine
             transition_to_next_round!
           end
         end
-      #rescue Engine::GameError => e
-      #  rescue_exception(e, action)
+        # rescue Engine::GameError => e
+        #  rescue_exception(e, action)
       end
 
       def rescue_exception(e, action)

--- a/lib/engine/game/g_1825/step/dividend.rb
+++ b/lib/engine/game/g_1825/step/dividend.rb
@@ -57,7 +57,7 @@ module Engine
             @round.receivership_loan = 0
             @round.routes = []
 
-            log_run_payout(entity, kind, revenue, action, payout)
+            log_run_payout(entity, kind, revenue, 0, action, payout)
 
             payout_corporation(payout[:corporation], entity)
 

--- a/lib/engine/game/g_1840/step/dividend.rb
+++ b/lib/engine/game/g_1840/step/dividend.rb
@@ -95,7 +95,7 @@ module Engine
             major.spend(to_pay, @game.bank)
           end
 
-          def log_run_payout(entity, kind, revenue, action, payout)
+          def log_run_payout(entity, kind, revenue, subsidy, action, payout)
             unless Dividend::DIVIDEND_TYPES.include?(kind)
               @log << "#{entity.name} runs for #{@game.format_currency(revenue)} and pays #{action.kind}"
             end

--- a/lib/engine/game/g_1840/step/dividend.rb
+++ b/lib/engine/game/g_1840/step/dividend.rb
@@ -95,7 +95,7 @@ module Engine
             major.spend(to_pay, @game.bank)
           end
 
-          def log_run_payout(entity, kind, revenue, subsidy, action, payout)
+          def log_run_payout(entity, kind, revenue, _subsidy, action, payout)
             unless Dividend::DIVIDEND_TYPES.include?(kind)
               @log << "#{entity.name} runs for #{@game.format_currency(revenue)} and pays #{action.kind}"
             end

--- a/lib/engine/game/g_1856/step/dividend.rb
+++ b/lib/engine/game/g_1856/step/dividend.rb
@@ -17,8 +17,7 @@ module Engine
           end
 
           def dividend_options(entity)
-            penalty = @round.interest_penalty[entity] || 0
-            revenue = @game.routes_revenue(routes) - penalty
+            revenue = total_revenue
 
             dividend_types.to_h do |type|
               payout = send(type, entity, revenue)
@@ -32,37 +31,8 @@ module Engine
             (revenue / entity.total_shares.to_f)
           end
 
-          def process_dividend(action)
-            entity = action.entity
-            penalty = @round.interest_penalty[entity] || 0
-            revenue = @game.routes_revenue(routes) - penalty
-            kind = action.kind.to_sym
-            payout = dividend_options(entity)[kind]
 
-            rust_obsolete_trains!(entity)
-
-            entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
-              routes,
-              action,
-              revenue,
-              @round.laid_hexes
-            )
-
-            entity.trains.each { |train| train.operated = true }
-
-            @round.routes = []
-
-            log_run_payout(entity, kind, revenue, action, payout)
-
-            @game.bank.spend(payout[:corporation], entity) if payout[:corporation].positive?
-
-            payout_shares(entity, revenue - payout[:corporation]) if payout[:per_share].positive?
-
-            change_share_price(entity, payout)
-
-            pass!
-          end
-
+          
           def share_price_change(entity, _revenue)
             # Share price of national does not change until it owns a permanent
             return {} if entity == @game.national && !@game.national_ever_owned_permanent
@@ -75,7 +45,11 @@ module Engine
             @game.share_pool
           end
 
-          def log_run_payout(entity, kind, revenue, action, payout)
+          def total_revenue
+            super - (@round.interest_penalty[@round.current_operator] || 0)
+          end
+
+          def log_run_payout(entity, kind, revenue, subsidy, action, payout)
             if (@round.interest_penalty[entity] || 0).positive?
               @log << "#{entity.name} deducts #{@game.format_currency(@round.interest_penalty[entity])}"\
                       ' for unpaid interest'

--- a/lib/engine/game/g_1856/step/dividend.rb
+++ b/lib/engine/game/g_1856/step/dividend.rb
@@ -12,8 +12,9 @@ module Engine
           def actions(entity)
             # National must withhold if it never owned a permanent
             return [] if entity.corporation? && entity == @game.national && !@game.national_ever_owned_permanent
+            return [] if entity.company? || routes.empty?
 
-            super
+            Engine::Step::Dividend::ACTIONS
           end
 
           def dividend_options(entity)

--- a/lib/engine/game/g_1856/step/dividend.rb
+++ b/lib/engine/game/g_1856/step/dividend.rb
@@ -31,8 +31,6 @@ module Engine
             (revenue / entity.total_shares.to_f)
           end
 
-
-          
           def share_price_change(entity, _revenue)
             # Share price of national does not change until it owns a permanent
             return {} if entity == @game.national && !@game.national_ever_owned_permanent
@@ -49,7 +47,7 @@ module Engine
             super - (@round.interest_penalty[@round.current_operator] || 0)
           end
 
-          def log_run_payout(entity, kind, revenue, subsidy, action, payout)
+          def log_run_payout(entity, kind, revenue, _subsidy, action, payout)
             if (@round.interest_penalty[entity] || 0).positive?
               @log << "#{entity.name} deducts #{@game.format_currency(@round.interest_penalty[entity])}"\
                       ' for unpaid interest'

--- a/lib/engine/game/g_1866/step/dividend.rb
+++ b/lib/engine/game/g_1866/step/dividend.rb
@@ -17,18 +17,16 @@ module Engine
 
           def dividend_options(entity)
             revenue = @game.routes_revenue(routes)
-            subsidy = @game.routes_subsidy(routes)
-            total_revenue = revenue + subsidy
             dividend_types.to_h do |type|
-              payout = send(type, entity, revenue, subsidy)
+              payout = send(type, entity, revenue)
               payout[:divs_to_corporation] = corporation_dividends(entity, payout[:per_share])
               [type, payout.merge(share_price_change(entity, total_revenue - payout[:corporation]))]
             end
           end
 
-          def half(entity, revenue, subsidy)
+          def half(entity, revenue)
             withheld = half_pay_withhold_amount(entity, revenue)
-            { corporation: withheld + subsidy, per_share: payout_per_share(entity, revenue - withheld) }
+            { corporation: withheld, per_share: payout_per_share(entity, revenue - withheld) }
           end
 
           def half_pay_withhold_amount(entity, revenue)
@@ -44,47 +42,8 @@ module Engine
                     "#{@game.format_currency(per_share)} per share (#{receivers})"
           end
 
-          def log_run_payout(entity, kind, revenue, subsidy, _action, payout)
-            @log << "#{entity.name} runs for #{@game.format_currency(revenue)} and pays half" if kind == 'half'
-
-            withhold = payout[:corporation] - subsidy
-            if withhold.positive? && !@game.national_corporation?(entity)
-              @log << "#{entity.name} withholds #{@game.format_currency(withhold)}"
-            elsif payout[:per_share].zero?
-              @log << "#{entity.name} does not run"
-            end
-            @log << "#{entity.name} earns subsidy of #{@game.format_currency(subsidy)}" if subsidy.positive?
-          end
-
-          def process_dividend(action)
-            entity = action.entity
-            revenue = @game.routes_revenue(routes)
-            subsidy = @game.routes_subsidy(routes)
-            kind = action.kind.to_sym
-            payout = dividend_options(entity)[kind]
-
-            rust_obsolete_trains!(entity)
-
-            entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
-              routes,
-              action,
-              revenue,
-              @round.laid_hexes
-            )
-
-            entity.trains.each { |train| train.operated = true }
-
-            @round.routes = []
-            log_run_payout(entity, kind, revenue, subsidy, action, payout)
-            payout_corporation(payout[:corporation], entity) unless @game.national_corporation?(entity)
-            payout_shares(entity, revenue + subsidy - payout[:corporation]) if payout[:per_share].positive?
-            change_share_price(entity, payout)
-
-            pass!
-          end
-
-          def payout(entity, revenue, subsidy)
-            { corporation: subsidy, per_share: payout_per_share(entity, revenue) }
+          def payout(entity, revenue)
+            { corporation: 0, per_share: payout_per_share(entity, revenue) }
           end
 
           def payout_shares(entity, revenue)
@@ -128,8 +87,8 @@ module Engine
             end
           end
 
-          def withhold(_entity, revenue, subsidy)
-            { corporation: revenue + subsidy, per_share: 0 }
+          def withhold(_entity, revenue)
+            { corporation: revenue, per_share: 0 }
           end
         end
       end

--- a/lib/engine/game/g_1868_wy/step/dividend.rb
+++ b/lib/engine/game/g_1868_wy/step/dividend.rb
@@ -21,7 +21,7 @@ module Engine
             end
           end
 
-          def log_run_payout(entity, kind, revenue, action, payout)
+          def log_run_payout(entity, kind, revenue, subsidy, action, payout)
             super unless entity.minor?
           end
 

--- a/lib/engine/game/g_1870/step/connection_dividend.rb
+++ b/lib/engine/game/g_1870/step/connection_dividend.rb
@@ -38,7 +38,7 @@ module Engine
 
             @round.routes = []
 
-            log_run_payout(entity, kind, revenue, action, payout)
+            log_run_payout(entity, kind, revenue, 0, action, payout)
 
             @game.bank.spend(payout[:corporation], entity) if payout[:corporation].positive?
 

--- a/lib/engine/game/g_1873/step/dividend.rb
+++ b/lib/engine/game/g_1873/step/dividend.rb
@@ -110,7 +110,7 @@ module Engine
             pass!
           end
 
-          def log_run_payout(entity, kind, revenue, subsidy, action, payout)
+          def log_run_payout(entity, kind, revenue, _subsidy, action, payout)
             unless Dividend::DIVIDEND_TYPES.include?(kind)
               @log << "#{entity.name} runs for #{@game.format_currency(revenue)} and pays #{action.kind}"
             end

--- a/lib/engine/game/g_1873/step/dividend.rb
+++ b/lib/engine/game/g_1873/step/dividend.rb
@@ -96,7 +96,7 @@ module Engine
             entity.trains.each { |train| train.operated = true }
             @round.routes = []
 
-            log_run_payout(entity, kind, revenue, action, payout)
+            log_run_payout(entity, kind, revenue, 0, action, payout)
 
             @game.bank.spend(payout[:corporation], entity) if payout[:corporation].positive?
 
@@ -110,7 +110,7 @@ module Engine
             pass!
           end
 
-          def log_run_payout(entity, kind, revenue, action, payout)
+          def log_run_payout(entity, kind, revenue, subsidy, action, payout)
             unless Dividend::DIVIDEND_TYPES.include?(kind)
               @log << "#{entity.name} runs for #{@game.format_currency(revenue)} and pays #{action.kind}"
             end

--- a/lib/engine/game/g_1888/step/dividend.rb
+++ b/lib/engine/game/g_1888/step/dividend.rb
@@ -9,65 +9,19 @@ module Engine
         class Dividend < Engine::Step::Dividend
           def dividend_options(entity)
             revenue = @game.routes_revenue(routes)
-            subsidy = @game.routes_subsidy(routes)
             dividend_types.to_h do |type|
-              payout = send(type, entity, revenue, subsidy)
+              payout = send(type, entity, revenue)
               payout[:divs_to_corporation] = corporation_dividends(entity, payout[:per_share])
-              [type, payout.merge(share_price_change(entity, revenue - payout[:corporation] + subsidy))]
+              [type, payout.merge(share_price_change(entity, revenue - payout[:corporation]))]
             end
           end
 
-          def process_dividend(action)
-            entity = action.entity
-            revenue = @game.routes_revenue(routes)
-            subsidy = @game.routes_subsidy(routes)
-            kind = action.kind.to_sym
-            payout = dividend_options(entity)[kind]
-
-            rust_obsolete_trains!(entity)
-
-            entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
-              routes,
-              action,
-              revenue,
-              @round.laid_hexes
-            )
-
-            entity.trains.each { |train| train.operated = true }
-
-            @round.routes = []
-
-            log_run_payout(entity, kind, revenue, subsidy, action, payout)
-
-            payout_corporation(payout[:corporation], entity)
-
-            payout_shares(entity, revenue - payout[:corporation] + subsidy) if payout[:per_share].positive?
-
-            change_share_price(entity, payout)
-
-            pass!
+          def withhold(_entity, revenue)
+            { corporation: revenue, per_share: 0 }
           end
 
-          def log_run_payout(entity, kind, revenue, subsidy, action, payout)
-            unless Dividend::DIVIDEND_TYPES.include?(kind)
-              @log << "#{entity.name} runs for #{@game.format_currency(revenue)} and pays #{action.kind}"
-            end
-
-            if (payout[:corporation] - subsidy).positive?
-              @log << "#{entity.name} withholds #{@game.format_currency(payout[:corporation])}"
-            elsif subsidy.positive?
-              @log << "#{entity.name} retains a subsidy of #{@game.format_currency(subsidy)}"
-            elsif payout[:per_share].zero?
-              @log << "#{entity.name} does not run"
-            end
-          end
-
-          def withhold(_entity, revenue, subsidy)
-            { corporation: revenue + subsidy, per_share: 0 }
-          end
-
-          def payout(entity, revenue, subsidy)
-            { corporation: subsidy, per_share: payout_per_share(entity, revenue) }
+          def payout(entity, revenue)
+            { corporation: 0, per_share: payout_per_share(entity, revenue) }
           end
         end
       end

--- a/lib/engine/game/g_18_esp/step/dividend.rb
+++ b/lib/engine/game/g_18_esp/step/dividend.rb
@@ -19,10 +19,8 @@ module Engine
 
           def dividend_options(entity)
             revenue = @game.routes_revenue(routes)
-            subsidy = @game.routes_subsidy(routes)
-            total_revenue = revenue + subsidy
             dividend_types.to_h do |type|
-              payout = send(type, entity, revenue, subsidy)
+              payout = send(type, entity, revenue)
               payout[:divs_to_corporation] = corporation_dividends(entity, payout[:per_share])
               [type, payout.merge(share_price_change(entity, total_revenue - payout[:corporation]))]
             end
@@ -44,66 +42,21 @@ module Engine
             "#{times} #{dir}"
           end
 
-          def process_dividend(action)
-            entity = action.entity
-            revenue = @game.routes_revenue(routes)
-            subsidy = @game.routes_subsidy(routes)
-            kind = action.kind.to_sym
-            payout = dividend_options(entity)[kind]
-
-            rust_obsolete_trains!(entity)
-
-            entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
-              routes,
-              action,
-              revenue,
-              @round.laid_hexes
-            )
-
-            entity.trains.each { |train| train.operated = true }
-
-            @round.routes = []
-
-            log_run_payout(entity, kind, revenue, subsidy, action, payout)
-
-            payout_corporation(payout[:corporation], entity)
-
-            payout_shares(entity, revenue - payout[:corporation] + subsidy) if payout[:per_share].positive?
-
-            change_share_price(entity, payout)
-
-            pass!
-          end
-
-          def log_run_payout(entity, kind, revenue, subsidy, action, payout)
-            unless Dividend::DIVIDEND_TYPES.include?(kind)
-              @log << "#{entity.name} runs for #{@game.format_currency(revenue)} and pays #{action.kind}"
-            end
-
-            if (payout[:corporation] - subsidy).positive?
-              @log << "#{entity.name} withholds #{@game.format_currency(payout[:corporation])}"
-            elsif subsidy.positive?
-              @log << "#{entity.name} retains a subsidy of #{@game.format_currency(subsidy)}"
-            elsif payout[:per_share].zero?
-              @log << "#{entity.name} does not run"
-            end
-          end
-
           def payout_per_share(entity, revenue)
             revenue * 1.0 / entity.total_shares
           end
 
-          def payout(entity, revenue, subsidy)
+          def payout(entity, revenue)
             if entity.corporation? && entity.type != :minor
-              { corporation: subsidy, per_share: payout_per_share(entity, revenue) }
+              { corporation: 0, per_share: payout_per_share(entity, revenue) }
             else
               amount = revenue / 2
-              { corporation: amount + subsidy, per_share: amount }
+              { corporation: amount, per_share: amount }
             end
           end
 
-          def withhold(_entity, revenue, subsidy)
-            { corporation: revenue + subsidy, per_share: 0 }
+          def withhold(_entity, revenue)
+            { corporation: revenue, per_share: 0 }
           end
         end
       end

--- a/lib/engine/game/g_18_mag/game.rb
+++ b/lib/engine/game/g_18_mag/game.rb
@@ -727,7 +727,7 @@ module Engine
         end
 
         def routes_subsidy(routes)
-          routes.sum(&:subsidy)
+          routes.first&.train&.owner&.minor? ? routes.sum(&:subsidy) : 0
         end
 
         # see if minor bought unused rail-cars

--- a/lib/engine/game/g_18_mag/step/dividend.rb
+++ b/lib/engine/game/g_18_mag/step/dividend.rb
@@ -47,14 +47,7 @@ module Engine
           end
 
           def process_dividend(action)
-            if action.entity.minor?
-              subsidy = @game.routes_subsidy(routes)
-              if subsidy.positive?
-                @game.bank.spend(subsidy, action.entity)
-                @log << "#{action.entity.name} retains a subsidy of #{@game.format_currency(subsidy)}"
-              end
-              return super
-            end
+            return super if action.entity.minor?
 
             entity = action.entity
             action_kind = action.kind

--- a/lib/engine/game/g_18_tn/step/dividend.rb
+++ b/lib/engine/game/g_18_tn/step/dividend.rb
@@ -28,7 +28,7 @@ module Engine
             { withhold: { corporation: 0, per_share: 0, divs_to_corporation: 0 } }
           end
 
-          def log_run_payout(entity, kind, revenue, action, payout)
+          def log_run_payout(entity, kind, revenue, subsidy, action, payout)
             return super unless civil_war_effect_with_single_train?(entity)
 
             @log << "#{entity.name}'s run is ignored due to Civil War"

--- a/lib/engine/game/g_18_uruguay/step/dividend.rb
+++ b/lib/engine/game/g_18_uruguay/step/dividend.rb
@@ -50,10 +50,8 @@ module Engine
             total_revenue = routes_revenue(routes, entity)
             revenue = total_revenue
 
-            subsidy = routes_subsidy(routes, entity)
-            total_revenue += subsidy
             dividend_types.to_h do |type|
-              payout = send(type, entity, revenue, subsidy)
+              payout = send(type, entity, revenue)
               payout[:divs_to_corporation] = corporation_dividends(entity, payout[:per_share])
               [type, payout.merge(share_price_change(entity, total_revenue - payout[:corporation]))]
             end
@@ -63,19 +61,19 @@ module Engine
             @game.share_pool
           end
 
-          def payout(entity, revenue, subsidy)
+          def payout(entity, revenue)
             if @game.nationalized? && entity.loans.size.positive?
               return {
-                corporation: subsidy + (payout_per_share(entity, revenue) * 10),
+                corporation: payout_per_share(entity, revenue) * 10,
                 per_share: 0,
               }
             end
 
-            { corporation: subsidy, per_share: payout_per_share(entity, revenue) }
+            { corporation: 0, per_share: payout_per_share(entity, revenue) }
           end
 
-          def withhold(_entity, revenue, subsidy)
-            { corporation: revenue + subsidy, per_share: 0 }
+          def withhold(_entity, revenue)
+            { corporation: revenue, per_share: 0 }
           end
 
           def process_dividend_rptla(action)
@@ -95,8 +93,8 @@ module Engine
 
             @round.routes = []
             log_run_payout_sub(entity, kind, revenue, subsidy, action, payout)
-            @game.bank.spend(payout[:corporation], entity) if payout[:corporation].positive?
-            payout_shares(entity, revenue + subsidy - payout[:corporation]) if payout[:per_share].positive?
+            @game.bank.spend(payout[:corporation] + subsidy, entity) if payout[:corporation].positive?
+            payout_shares(entity, revenue - payout[:corporation]) if payout[:per_share].positive?
             change_share_price(entity, payout)
 
             pass!
@@ -112,7 +110,7 @@ module Engine
             @game.payoff_loan(current_entity, loans_to_pay_off, current_entity)
           end
 
-          def log_run_payout(entity, kind, revenue, action, payout)
+          def log_run_payout(entity, kind, revenue, subisdy, action, payout)
             super unless entity.minor?
           end
 

--- a/lib/engine/game/g_18_va/step/dividend.rb
+++ b/lib/engine/game/g_18_va/step/dividend.rb
@@ -8,69 +8,12 @@ module Engine
     module G18VA
       module Step
         class Dividend < Engine::Step::Dividend
-          def withhold(_entity, revenue, subsidy)
-            { corporation: revenue + subsidy, per_share: 0 }
+          def withhold(_entity, revenue)
+            { corporation: revenue, per_share: 0 }
           end
 
-          def payout(entity, revenue, subsidy)
-            { corporation: subsidy, per_share: payout_per_share(entity, revenue) }
-          end
-
-          def dividend_options(entity)
-            revenue = @game.routes_revenue(routes)
-            subsidy = @game.routes_subsidy(routes)
-            dividend_types.to_h do |type|
-              payout = send(type, entity, revenue, subsidy)
-              payout[:divs_to_corporation] = corporation_dividends(entity, payout[:per_share])
-              [type, payout.merge(share_price_change(entity, revenue + subsidy - payout[:corporation]))]
-            end
-          end
-
-          def process_dividend(action)
-            entity = action.entity
-            revenue = @game.routes_revenue(routes)
-            subsidy = @game.routes_subsidy(routes)
-            kind = action.kind.to_sym
-            payout = dividend_options(entity)[kind]
-
-            rust_obsolete_trains!(entity)
-
-            entity.operating_history[[@game.turn, @round.round_num]] = OperatingInfo.new(
-              routes,
-              action,
-              revenue,
-              @round.laid_hexes
-            )
-
-            entity.trains.each { |train| train.operated = true }
-
-            @round.routes = []
-
-            log_run_payout(entity, kind, revenue, subsidy, action, payout)
-
-            payout_corporation(payout[:corporation], entity)
-
-            adjusted_revenue = subsidy ? revenue + subsidy : revenue
-            payout_shares(entity, adjusted_revenue - payout[:corporation]) if payout[:per_share].positive?
-
-            change_share_price(entity, payout)
-
-            pass!
-          end
-
-          def log_run_payout(entity, kind, revenue, subsidy, action, payout)
-            unless Dividend::DIVIDEND_TYPES.include?(kind)
-              @log << "#{entity.name} runs for #{@game.format_currency(revenue)} and pays #{action.kind}"
-            end
-
-            withheld_amount =  payout[:corporation] - subsidy
-            if withheld_amount.positive?
-              @log << "#{entity.name} withholds #{@game.format_currency(withheld_amount)}"
-            elsif payout[:per_share].zero?
-              @log << "#{entity.name} does not run"
-            end
-
-            @log << "#{entity.name} earns subsidy of #{@game.format_currency(subsidy)}" if subsidy.positive?
+          def payout(entity, revenue)
+            { corporation: 0, per_share: payout_per_share(entity, revenue) }
           end
 
           def share_price_change(entity, revenue = 0)

--- a/lib/engine/game/g_18_zoo/step/dividend.rb
+++ b/lib/engine/game/g_18_zoo/step/dividend.rb
@@ -11,10 +11,9 @@ module Engine
 
           def dividend_options(entity)
             revenue = @game.routes_revenue(routes)
-            subsidy = @game.routes_subsidy(routes)
 
             dividend_types.to_h do |type|
-              [type, send(type, entity, revenue, subsidy)]
+              [type, send(type, entity, revenue)]
             end
           end
 
@@ -22,9 +21,9 @@ module Engine
             :right if revenue >= @game.threshold(entity)
           end
 
-          def withhold(_entity, revenue, subsidy)
+          def withhold(_entity, revenue)
             {
-              corporation: (revenue / 25.0).ceil + subsidy,
+              corporation: (revenue / 25.0).ceil,
               per_share: 0,
               share_direction: :left,
               share_times: 1,
@@ -32,9 +31,9 @@ module Engine
             }
           end
 
-          def payout(entity, revenue, subsidy)
+          def payout(entity, revenue)
             {
-              corporation: subsidy,
+              corporation: 0,
               per_share: payout_per_share(entity, revenue),
               share_direction: revenue >= @game.threshold(entity) ? :right : nil,
               share_times: 1,
@@ -63,11 +62,8 @@ module Engine
 
           def process_dividend(action)
             @subsidy = @game.routes_subsidy(routes)
-
             super
-
             @subsidy = 0
-
             action.entity.remove_assignment!('BARREL') if @game.two_barrels_used_this_or?(action.entity)
           end
 

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -67,6 +67,7 @@ module Engine
       def process_dividend(action)
         entity = action.entity
         revenue = total_revenue
+        subsidy = total_subsidy
         kind = action.kind.to_sym
         payout = dividend_options(entity)[kind]
 
@@ -85,9 +86,9 @@ module Engine
         @round.routes = []
         @round.extra_revenue = 0
 
-        log_run_payout(entity, kind, revenue, action, payout)
+        log_run_payout(entity, kind, revenue, subsidy, action, payout)
 
-        payout_corporation(payout[:corporation], entity)
+        payout_corporation(payout[:corporation] + subsidy, entity)
 
         payout_shares(entity, revenue - payout[:corporation]) if payout[:per_share].positive?
 
@@ -100,7 +101,7 @@ module Engine
         @game.bank.spend(amount, entity) if amount.positive?
       end
 
-      def log_run_payout(entity, kind, revenue, action, payout)
+      def log_run_payout(entity, kind, revenue, subsidy, action, payout)
         unless Dividend::DIVIDEND_TYPES.include?(kind)
           @log << "#{entity.name} runs for #{@game.format_currency(revenue)} and pays #{action.kind}"
         end
@@ -110,6 +111,7 @@ module Engine
         elsif payout[:per_share].zero?
           @log << "#{entity.name} does not run"
         end
+        @log << "#{entity.name} earns subsidy of #{@game.format_currency(subsidy)}" if subsidy.positive?
       end
 
       def share_price_change(_entity, revenue)
@@ -215,6 +217,10 @@ module Engine
 
       def total_revenue
         @game.routes_revenue(routes) + extra_revenue
+      end
+
+      def total_subsidy
+        @game.routes_subsidy(routes)
       end
 
       def rust_obsolete_trains!(entity, log: true)

--- a/spec/game_state_spec.rb
+++ b/spec/game_state_spec.rb
@@ -355,7 +355,7 @@ module Engine
             },
           }
           expect(game.exception).to be_nil
-          expect(game.process_action(action).exception).to be_a(GameError)
+          expect { game.process_action(action) }.to raise_error(GameError)
         end
       end
 
@@ -391,7 +391,7 @@ module Engine
             'tokener' => 'BB',
           }
           expect(game.exception).to be_nil
-          expect(game.process_action(action).exception).to be_a(GameError)
+          expect { game.process_action(action) }.to raise_error(GameError)
         end
       end
     end

--- a/spec/lib/engine/games/g_18_zoo_spec.rb
+++ b/spec/lib/engine/games/g_18_zoo_spec.rb
@@ -457,7 +457,7 @@ module Engine
               'slot' => 1,
             }
             expect(game.exception).to be_nil
-            expect(game.process_action(action).exception).to be_a(GameError)
+            expect { game.process_action(action) }.to raise_error(GameError)
           end
         end
 
@@ -474,7 +474,7 @@ module Engine
               'slot' => 0,
             }
             expect(game.exception).to be_nil
-            expect(game.process_action(action).exception).to be_a(GameError)
+            expect { game.process_action(action) }.to raise_error(GameError)
           end
         end
 
@@ -491,7 +491,7 @@ module Engine
               'slot' => 0,
             }
             expect(game.exception).to be_nil
-            expect(game.process_action(action).exception).to be_a(GameError)
+            expect { game.process_action(action) }.to raise_error(GameError)
           end
         end
 
@@ -508,7 +508,7 @@ module Engine
               'slot' => 0,
             }
             expect(game.exception).to be_nil
-            expect(game.process_action(action).exception).to be_a(GameError)
+            expect { game.process_action(action) }.to raise_error(GameError)
           end
         end
 
@@ -525,7 +525,7 @@ module Engine
               'target_type' => 'hex',
             }
             expect(game.exception).to be_nil
-            expect(game.process_action(action).exception).to be_a(GameError)
+            expect { game.process_action(action) }.to raise_error(GameError)
           end
         end
 
@@ -543,7 +543,7 @@ module Engine
               'tokener' => 'PB',
             }
             expect(game.exception).to be_nil
-            expect(game.process_action(action).exception).to be_a(GameError)
+            expect { game.process_action(action) }.to raise_error(GameError)
           end
         end
       end

--- a/spec/lib/engine/games/g_18eu_spec.rb
+++ b/spec/lib/engine/games/g_18eu_spec.rb
@@ -75,7 +75,7 @@ module Engine
         expect(game.current_entity.shares.length).to be 6
 
         # Prevent player from attempting to purchase > 60% through normal stock buy.
-        expect(game.process_action(action).exception).to be_a(GameError)
+        expect { game.process_action(action) }.to raise_error(GameError)
         expect(game.current_entity.shares.length).to be 6
       end
     end


### PR DESCRIPTION
Add generic implementation of subsidies in the dividend step.

Previously, games that used subsidies, copy and pasted the subsidy logic into their dividend step. This PR moves that copy and pasted code into the base dividend step. If a game does not have a subsidy, the added logic has no effect.