### PR TITLE
[18Ardennes] Fix error on bankruptcy

### DIFF
--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -208,12 +208,12 @@ module Engine
           bankrupt?(player)
         end
 
-        def declare_bankrupt(player, cash_target = @bank)
+        def bankrupt!(player, cash_target)
           @log << "-- #{player.name} goes bankrupt and sells remaining shares --"
           bankrupt_sell_shares(player)
           bankrupt_sell_companies(player)
           bankrupt_transfer_cash(player, cash_target)
-          super
+          declare_bankrupt(player)
         end
 
         # If a player has gone above 60% holding in a major (by exchanging

--- a/lib/engine/game/g_18_ardennes/step/bankrupt.rb
+++ b/lib/engine/game/g_18_ardennes/step/bankrupt.rb
@@ -13,7 +13,7 @@ module Engine
           def process_bankrupt(action)
             corporation = action.entity
             player = corporation.player
-            @game.declare_bankrupt(player, corporation)
+            @game.bankrupt!(player, corporation)
             receivership_buy_train(corporation)
           end
 

--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -193,7 +193,7 @@ module Engine
           end
 
           def process_bankrupt(action)
-            @game.declare_bankrupt(action.entity)
+            @game.bankrupt!(action.entity, @game.bank)
           end
 
           def log_skip(entity)


### PR DESCRIPTION
## Implementation Notes

An extra parameter had been added to the G18Ardennes implementation of the `Game.declare_bankrupt` method, which was causing an error when the superclass method was called.

This commit renames the 18Ardennes method to `bankrupt!` which calls `declare_bankrupt` with the correct number of parameters.

Fixes tobymao#11203.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`