### PR TITLE
[18Uruguay] Company should get full cap after nationalization and no destination bonus

### DIFF
--- a/lib/engine/game/g_18_uruguay/game.rb
+++ b/lib/engine/game/g_18_uruguay/game.rb
@@ -339,6 +339,7 @@ module Engine
           float_capitalization = nationalized? ? 10 : 5
 
           amount = corporation.par_price.price * float_capitalization
+          abilities(corporation, :destination_bonus).use! if nationalized?
           @bank.spend(amount, corporation)
           @log << "#{corporation.name} receives #{format_currency(corporation.cash)}"
           take_loan(corporation, @loans[0]) if @loans.size.positive? && !nationalized?


### PR DESCRIPTION
Company should get full cap but no destination bonus after nationalization 

Fixes #11060

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
This can break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
