### PR TITLE
[18Uruguay] Company shall only retreive destination_bonus in their own turn

### DIFF
--- a/lib/engine/game/g_18_uruguay/game.rb
+++ b/lib/engine/game/g_18_uruguay/game.rb
@@ -283,6 +283,7 @@ module Engine
 
         def operating_round(round_num)
           Round::Operating.new(self, [
+            G18Uruguay::Step::DestinationBonus,
             Engine::Step::Bankrupt,
             Engine::Step::Exchange,
             G18Uruguay::Step::Farm,

--- a/lib/engine/game/g_18_uruguay/step/destination_bonus.rb
+++ b/lib/engine/game/g_18_uruguay/step/destination_bonus.rb
@@ -35,11 +35,11 @@ module Engine
           end
 
           def destination_node_check?(corporation)
-            return if corporation.closed?
-            return if corporation.destination_coordinates.nil?
+            return false if corporation.closed?
+            return false if corporation.destination_coordinates.nil?
 
             ability = @game.abilities(corporation, :destination_bonus)
-            return if ability.nil?
+            return false if ability.nil?
 
             destination_hex = @game.hex_by_id(corporation.destination_coordinates)
             home_node = corporation.tokens.first.city

--- a/lib/engine/game/g_18_uruguay/step/destination_bonus.rb
+++ b/lib/engine/game/g_18_uruguay/step/destination_bonus.rb
@@ -12,8 +12,10 @@ module Engine
           end
 
           def log_skip(entity)
-            return if entity.minor?
+            return unless entity.corporation?
             return if entity == @game.rptla
+            return if @game.abilities(entity, :destination_bonus).nil?
+            return if destination_node_check?(entity).nil?
 
             super
           end
@@ -21,15 +23,16 @@ module Engine
           def actions(entity)
             return [] if entity.minor?
             return [] if entity == @game.rptla
+            return [] if @game.abilities(entity, :destination_bonus).nil?
 
             self.class::ACTIONS
           end
 
           def auto_actions(entity)
-            corporations = @round.entities.select { |c| destination_node_check?(c) }
-            return [Engine::Action::Pass.new(entity)] if corporations.empty?
+            return [] unless entity.corporation?
+            return [Engine::Action::Pass.new(entity)] if destination_node_check?(entity).nil?
 
-            [Engine::Action::DestinationConnection.new(entity, corporations: corporations)]
+            [Engine::Action::DestinationConnection.new(entity, corporations: [entity])]
           end
 
           def destination_node_check?(corporation)

--- a/lib/engine/game/g_18_uruguay/step/destination_bonus.rb
+++ b/lib/engine/game/g_18_uruguay/step/destination_bonus.rb
@@ -29,7 +29,7 @@ module Engine
 
           def auto_actions(entity)
             return [] unless entity.corporation?
-            return [Engine::Action::Pass.new(entity)] if destination_node_check?(entity).nil?
+            return [Engine::Action::Pass.new(entity)] unless destination_node_check?(entity)
 
             [Engine::Action::DestinationConnection.new(entity, corporations: [entity])]
           end

--- a/lib/engine/game/g_18_uruguay/step/destination_bonus.rb
+++ b/lib/engine/game/g_18_uruguay/step/destination_bonus.rb
@@ -14,8 +14,7 @@ module Engine
           def log_skip(entity)
             return unless entity.corporation?
             return if entity == @game.rptla
-            return if @game.abilities(entity, :destination_bonus).nil?
-            return if destination_node_check?(entity).nil?
+            return unless destination_node_check?(entity)
 
             super
           end


### PR DESCRIPTION
[18Uruguay] Company shall only retreive destination_bonus in their own turn

Fixes #11073

Fixes #[PUT_ISSUE_NUMBER_HERE]

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
Will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
