### PR TITLE
[1822nrs] fixes spelling of shrewsbury

### DIFF
--- a/lib/engine/game/g_1822_nrs/map.rb
+++ b/lib/engine/game/g_1822_nrs/map.rb
@@ -145,7 +145,7 @@ module Engine
           'G20' => 'Blackpool',
           'G22' => 'Liverpool',
           'G24' => 'Chester',
-          'G28' => 'Shrewbury',
+          'G28' => 'Shrewsbury',
           'H1' => 'Aberdeen',
           'H3' => 'Dunfermline',
           'H5' => 'Edinburgh',


### PR DESCRIPTION
Fixes #11223

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Shrewsbury was misspelled as Shrewbury

this mistake was only on the NRS map file, spelling is correct in both 1822 and 1822MRS

### Screenshots

### Any Assumptions / Hacks
