### PR TITLE
[auto-routing] Clears previous routes before running

### DIFF
--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -264,7 +264,7 @@ module View
         end
 
         auto = lambda do
-        @routes.each(&:reset!)
+          @routes.each(&:reset!)
           router = Engine::AutoRouter.new(@game, flash)
           @routes = router.compute(
             @game.current_entity,

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -264,7 +264,7 @@ module View
         end
 
         auto = lambda do
-          @routes.each(&:reset!)
+        @routes.each(&:reset!)
           router = Engine::AutoRouter.new(@game, flash)
           @routes = router.compute(
             @game.current_entity,

--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -264,6 +264,7 @@ module View
         end
 
         auto = lambda do
+          @routes.each(&:reset!)
           router = Engine::AutoRouter.new(@game, flash)
           @routes = router.compute(
             @game.current_entity,


### PR DESCRIPTION
Fixes #10136

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Now, when a player clicks the Auto button, it doesn't update the routes. This change causes the Auto button to clear the existing routes before running its script. 

I think this makes more sense than the current application. 

In addition to saving everyone clicks, I had a new player tell me well into our second game on the site that he had just then realized that auto-routing wasn't updating his previous routes, and he'd been running under for the majority of the games we had played.

Open to feedback.

### Screenshots

### Any Assumptions / Hacks
