### PR TITLE
[1822CA] fix game end description

### DIFF
--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -48,6 +48,11 @@ module Engine
           'AF12' => 'P16',
         }.freeze
 
+        GAME_END_REASONS_TIMING_TEXT = {
+          current_or: 'Next end of an OR',
+          full_or: 'Next end of a complete OR set, with one additional OR added on',
+        }.freeze
+
         PRIVATE_MAIL_CONTRACTS = %w[P22 P23].freeze
         PRIVATE_SMALL_MAIL_CONTRACTS = %w[P24 P25].freeze
         PRIVATE_PHASE_REVENUE = %w[P8 P9].freeze


### PR DESCRIPTION
Fixes #11257

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Corrects the game end description for when the bank breaks in 1822CA

### Screenshots

### Any Assumptions / Hacks
