### PR TITLE
[Core] Allow subsidy name to be configurable in the UI

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1031,7 +1031,7 @@ module Engine
       def submit_revenue_str(routes, show_subsidy)
         revenue_str = format_revenue_currency(routes_revenue(routes))
         subsidy = routes_subsidy(routes)
-        subsidy_str = show_subsidy || subsidy.positive? ? " + #{format_currency(routes_subsidy(routes))} (subsidy)" : ''
+        subsidy_str = show_subsidy || subsidy.positive? ? " + #{format_currency(routes_subsidy(routes))} (#{subsidy_name})" : ''
         revenue_str + subsidy_str
       end
 
@@ -2359,6 +2359,10 @@ module Engine
 
       def render_revenue_history?(corporation)
         !corporation.operating_history.empty?
+      end
+
+      def subsidy_name
+        'subsidy'
       end
 
       private

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -111,7 +111,7 @@ module Engine
         elsif payout[:per_share].zero?
           @log << "#{entity.name} does not run"
         end
-        @log << "#{entity.name} earns subsidy of #{@game.format_currency(subsidy)}" if subsidy.positive?
+        @log << "#{entity.name} earns #{@game.subsidy_name} of #{@game.format_currency(subsidy)}" if subsidy.positive?
       end
 
       def share_price_change(_entity, revenue)


### PR DESCRIPTION
1837's subsidies are called `mining revenue`. This PR allows the subsidy name to be configurable to allow games to customize it to their terminology.