### PR TITLE
System18: Remove discarded trains from the game

### DIFF
--- a/lib/engine/game/g_system18/game.rb
+++ b/lib/engine/game/g_system18/game.rb
@@ -460,7 +460,7 @@ module Engine
               GSystem18::Step::Token,
               Engine::Step::Route,
               GSystem18::Step::Dividend,
-              Engine::Step::DiscardTrain,
+              GSystem18::Step::DiscardTrain,
               GSystem18::Step::BuyTrain,
             ]
           else
@@ -475,7 +475,7 @@ module Engine
               GSystem18::Step::Token,
               Engine::Step::Route,
               GSystem18::Step::Dividend,
-              Engine::Step::DiscardTrain,
+              GSystem18::Step::DiscardTrain,
               GSystem18::Step::BuyTrain,
               [Engine::Step::BuyCompany, { blocks: true }],
             ]
@@ -691,6 +691,12 @@ module Engine
           return super unless respond_to?("map_#{map_name}_place_home_token")
 
           send("map_#{map_name}_place_home_token", corporation)
+        end
+
+        def remove_discarded_train?(train)
+          return true unless respond_to?("map_#{map_name}_remove_discarded_train?")
+
+          send("map_#{map_name}_remove_discarded_train?", train)
         end
       end
     end

--- a/lib/engine/game/g_system18/step/discard_train.rb
+++ b/lib/engine/game/g_system18/step/discard_train.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/discard_train'
+
+module Engine
+  module Game
+    module GSystem18
+      module Step
+        class DiscardTrain < Engine::Step::DiscardTrain
+          def process_discard_train(action)
+            train = action.train
+
+            return super unless @game.remove_discarded_train?(train)
+
+            @game.remove_train(train)
+            @log << "#{action.entity.name} discards #{train.name}, #{train.name} is removed from the game"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #11264

## Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

