### PR TITLE
[Core] Add support for hex market movement to dividends

### DIFF
--- a/assets/app/view/game/dividend.rb
+++ b/assets/app/view/game/dividend.rb
@@ -53,7 +53,7 @@ module View
                   end
                   next if real_moves.zero?
 
-                  "#{real_moves} #{dir}"
+                  "#{real_moves} #{dir.tr('_', ' ')}"
                 end.compact.join(', ')
 
               movement_str.empty? ? 'None' : movement_str
@@ -98,7 +98,7 @@ module View
             textAlign: 'left',
           },
         }
-        share_props = { style: { width: '2.7rem' } }
+        share_props = { style: { width: '3rem' } }
 
         if corporation_interest_penalty?(entity)
           corporation_penalty = "#{entity.name} has " +

--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -201,6 +201,14 @@ module Engine
               @game.stock_market.move_up(entity)
             when :down
               @game.stock_market.move_down(entity)
+            when :diagonally_up_left
+              @game.stock_market.move_diagonally_up_left(entity)
+            when :diagonally_up_right
+              @game.stock_market.move_diagonally_up_right(entity)
+            when :diagonally_down_left
+              @game.stock_market.move_diagonally_down_left(entity)
+            when :diagonally_down_right
+              @game.stock_market.move_diagonally_down_right(entity)
             end
           end
         end

--- a/lib/engine/stock_market.rb
+++ b/lib/engine/stock_market.rb
@@ -122,36 +122,36 @@ module Engine
       @movement.left(corporation, coordinates)
     end
 
-    def move_up_left_hex(corporation)
-      move(corporation, up_left_hex(corporation, corporation.share_price.coordinates))
+    def move_diagonally_up_left(corporation)
+      move(corporation, diagonally_up_left(corporation, corporation.share_price.coordinates))
     end
 
-    def up_left_hex(corporation, coordinates)
-      @movement.up_left_hex(corporation, coordinates)
+    def diagonally_up_left(corporation, coordinates)
+      @movement.diagonally_up_left(corporation, coordinates)
     end
 
-    def move_down_left_hex(corporation)
-      move(corporation, down_left_hex(corporation, corporation.share_price.coordinates))
+    def move_diagonally_down_left(corporation)
+      move(corporation, diagonally_down_left(corporation, corporation.share_price.coordinates))
     end
 
-    def down_left_hex(corporation, coordinates)
-      @movement.down_left_hex(corporation, coordinates)
+    def diagonally_down_left(corporation, coordinates)
+      @movement.diagonally_down_left(corporation, coordinates)
     end
 
-    def move_up_right_hex(corporation)
-      move(corporation, up_right_hex(corporation, corporation.share_price.coordinates))
+    def move_diagonally_up_right(corporation)
+      move(corporation, diagonally_up_right(corporation, corporation.share_price.coordinates))
     end
 
-    def up_right_hex(corporation, coordinates)
-      @movement.up_right_hex(corporation, coordinates)
+    def diagonally_up_right(corporation, coordinates)
+      @movement.diagonally_up_right(corporation, coordinates)
     end
 
-    def move_down_right_hex(corporation)
-      move(corporation, down_right_hex(corporation, corporation.share_price.coordinates))
+    def move_diagonally_down_right(corporation)
+      move(corporation, diagonally_down_right(corporation, corporation.share_price.coordinates))
     end
 
-    def down_right_hex(corporation, coordinates)
-      @movement.down_right_hex(corporation, coordinates)
+    def diagonally_down_right(corporation, coordinates)
+      @movement.diagonally_down_right(corporation, coordinates)
     end
 
     def find_share_price(corporation, directions)
@@ -173,6 +173,14 @@ module Engine
           coordinates = down(corporation, coordinates)
         when :up
           coordinates = up(corporation, coordinates)
+        when :diagonally_up_left
+          coordinates = diagonally_up_left(corporation, coordinates)
+        when :diagonally_up_right
+          coordinates = diagonally_up_right(corporation, coordinates)
+        when :diagonally_down_left
+          coordinates = diagonally_down_left(corporation, coordinates)
+        when :diagonally_down_right
+          coordinates = diagonally_down_right(corporation, coordinates)
         end
         price = share_price(coordinates) || price
       end

--- a/lib/engine/stock_movement.rb
+++ b/lib/engine/stock_movement.rb
@@ -27,19 +27,19 @@ module Engine
       raise NotImplementedError
     end
 
-    def down_left_hex(_corporation, coordinates)
+    def diagonally_down_left(_corporation, coordinates)
       raise NotImplementedError
     end
 
-    def up_left_hex(_corporation, coordinates)
+    def diagonally_up_left(_corporation, coordinates)
       raise NotImplementedError
     end
 
-    def down_right_hex(_corporation, coordinates)
+    def diagonally_down_right(_corporation, coordinates)
       raise NotImplementedError
     end
 
-    def up_right_hex(_corporation, coordinates)
+    def diagnonally_up_right(_corporation, coordinates)
       raise NotImplementedError
     end
   end
@@ -101,30 +101,30 @@ module Engine
   class HexMovement < BaseMovement
     def left(corporation, coordinates)
       r, c = coordinates
-      new_coords = [r, c - 2]
+      new_coords = [r, c - 1]
       return new_coords if share_price(new_coords)
 
-      @market.down_left_hex(corporation, coordinates)
+      @market.diagonally_down_left(corporation, coordinates)
     end
 
     def right(corporation, coordinates)
       r, c = coordinates
-      new_coords = [r, c + 2]
+      new_coords = [r, c + 1]
       return new_coords if share_price(new_coords)
 
-      @market.up_right_hex(corporation, coordinates)
+      @market.diagonally_up_right(corporation, coordinates)
     end
 
-    def down_left_hex(_corporation, coordinates)
+    def diagonally_down_left(_corporation, coordinates)
       r, c = coordinates
-      new_coords = [r + 1, c - 1]
+      new_coords = [r + 1, c]
       x = share_price(new_coords)
       return new_coords if x
 
       coordinates
     end
 
-    def up_left_hex(_corporation, coordinates)
+    def diagonally_up_left(_corporation, coordinates)
       r, c = coordinates
       new_coords = [r - 1, c - 1]
       return new_coords if share_price(new_coords)
@@ -132,7 +132,7 @@ module Engine
       coordinates
     end
 
-    def down_right_hex(_corporation, coordinates)
+    def diagonally_down_right(_corporation, coordinates)
       r, c = coordinates
       new_coords = [r + 1, c + 1]
       return new_coords if share_price(new_coords)
@@ -140,9 +140,9 @@ module Engine
       coordinates
     end
 
-    def up_right_hex(_corporation, coordinates)
+    def diagnonally_up_right(_corporation, coordinates)
       r, c = coordinates
-      new_coords = [r - 1, c + 1]
+      new_coords = [r - 1, c]
       return new_coords if share_price(new_coords)
 
       coordinates

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -368,7 +368,7 @@ text.number {
 
 @media only screen and (min-width: 421px) {
   #left {
-    width: 20rem;
+    width: 22rem;
     margin-right: 1rem;
   }
 }


### PR DESCRIPTION
Hex markets can move diagonally up-left, up-right, down-left, and down-right. This PR adds support to the game logic and view logic to support.