### PR TITLE
[core/18RoyalGorge] add `Dividend` to `ability_blocking_step`, fix debt/company interactions

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -3227,7 +3227,7 @@ module Engine
       end
 
       def ability_blocking_step
-        supported_steps = [Step::Tracker, Step::Token, Step::Route, Step::BuyTrain]
+        supported_steps = [Step::Tracker, Step::Token, Step::Route, Step::Dividend, Step::BuyTrain]
         @round.steps.find do |step|
           supported_steps.any? { |s| step.is_a?(s) } && !step.passed? && step.active? && step.blocks?
         end

--- a/lib/engine/game/g_18_royal_gorge/step/special_choose.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/special_choose.rb
@@ -7,13 +7,22 @@ module Engine
     module G18RoyalGorge
       module Step
         class SpecialChoose < Engine::Step::SpecialChoose
+          def actions(entity)
+            if @game.indebted.include?(entity) ||
+               (entity.company? && %w[RG-D SF-D].include?(entity.sym))
+              super
+            else
+              []
+            end
+          end
+
           def process_choose_ability(action)
             return unless action.choice == 'pay_debt'
 
             debt_company = action.entity
             corporation = debt_company.owner
 
-            ability = abilities(corporation)
+            ability = Array(abilities(corporation)).find { |a| a.description == 'Pay debt' }
             ability.use!
 
             debtor, = @game.indebted[corporation]


### PR DESCRIPTION
* fixes debt pay-off and 13LB Gold Nugget bonus interacting and breaking
* possibly also affects Ghost Town Tour Co. (Y2), which is also active during the dividend step

No issue to link, issue was reported by the designer directly to me.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`