### PR TITLE
S18 full Britain map fixes; add S18 fixture

### DIFF
--- a/lib/engine/game/g_system18/map_britain_customization.rb
+++ b/lib/engine/game/g_system18/map_britain_customization.rb
@@ -91,6 +91,7 @@ module Engine
         def map_britain_game_hexes
           {
             gray: {
+              %w[a5] => 'junction;path=a:5,b:_0,terminal:1',
               %w[A4] => 'offboard=revenue:yellow_10|green_20|brown_30|gray_40',
               %w[C12] => 'path=a:0,b:1',
               %w[G2] => 'offboard=revenue:yellow_10|green_20|brown_20|gray_30',
@@ -227,7 +228,12 @@ module Engine
           corps.each_with_index do |c, idx|
             c[:float_percent] = 20
             c[:always_market_price] = true
-            c[:tokens] = [40, 100, 100, 100]
+            c[:tokens] = [[0, 0,  100, 100],      # DGN
+                          [0, 40, 100, 100],      # GFN
+                          [0, 0,  100, 100],      # PHX
+                          [0, 40, 100, 100],      # KKN
+                          [0, 40, 100, 100],      # SPX
+                          [0, 40, 100, 100]][idx] # PGS
             c[:coordinates] = [%w[F7 I8], 'J5', %w[F9 G8], 'A6', 'I12', 'A8'][idx]
             c[:city] = [1, nil, 1, nil, nil, nil][idx]
           end

--- a/public/fixtures/System18/182070.json
+++ b/public/fixtures/System18/182070.json
@@ -1,0 +1,4124 @@
+{
+  "id": 182070,
+  "description": "Retry",
+  "user": {
+    "id": 842,
+    "name": "popmart"
+  },
+  "players": [
+    {
+      "id": 213,
+      "name": "richardtempura"
+    },
+    {
+      "id": 842,
+      "name": "popmart"
+    }
+  ],
+  "min_players": 2,
+  "max_players": 3,
+  "title": "System18",
+  "settings": {
+    "seed": 2085579206,
+    "is_async": true,
+    "unlisted": true,
+    "auto_routing": true,
+    "player_order": null,
+    "optional_rules": [
+      "map_NEUS"
+    ]
+  },
+  "user_settings": null,
+  "status": "finished",
+  "turn": 5,
+  "round": "Operating Round",
+  "acting": [
+    213,
+    842
+  ],
+  "result": {
+    "213": 2303,
+    "842": 3266
+  },
+  "actions": [
+    {
+      "type": "par",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1728833834,
+      "corporation": "PHX",
+      "share_price": "90,1,3"
+    },
+    {
+      "type": "par",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1728852088,
+      "corporation": "KKN",
+      "share_price": "75,3,3"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1728853905,
+      "shares": [
+        "PHX_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1728867952,
+      "shares": [
+        "KKN_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1728868012,
+      "shares": [
+        "PHX_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1728868537,
+      "shares": [
+        "KKN_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1728874648,
+      "shares": [
+        "PHX_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1728906390,
+      "shares": [
+        "KKN_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1728916182,
+      "shares": [
+        "PHX_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1728957479,
+      "corporation": "DGN",
+      "share_price": "65,5,3"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1728958886,
+      "shares": [
+        "KKN_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1728959723,
+      "shares": [
+        "DGN_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1728992059,
+      "shares": [
+        "DGN_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1728996083,
+      "shares": [
+        "DGN_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1728997336,
+      "shares": [
+        "DGN_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1728997762,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 842,
+          "entity_type": "player",
+          "created_at": 1728997762
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1728997944,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 842,
+          "entity_type": "player",
+          "created_at": 1728997944
+        }
+      ],
+      "shares": [
+        "KKN_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 18,
+      "created_at": 1728997951,
+      "hex": "B9",
+      "tile": "57-0",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 19,
+      "created_at": 1728997975
+    },
+    {
+      "type": "buy_train",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 20,
+      "created_at": 1728997977,
+      "train": "2-0",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 21,
+      "created_at": 1728997981
+    },
+    {
+      "hex": "C8",
+      "tile": "56-0",
+      "type": "lay_tile",
+      "entity": "KKN",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "id": 22,
+      "user": 842,
+      "created_at": 1729003777
+    },
+    {
+      "type": "buy_train",
+      "price": 80,
+      "train": "2-1",
+      "entity": "KKN",
+      "variant": "2",
+      "entity_type": "corporation",
+      "id": 23,
+      "user": 842,
+      "created_at": 1729003839
+    },
+    {
+      "type": "pass",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 24,
+      "user": 842,
+      "created_at": 1729003850
+    },
+    {
+      "hex": "B11",
+      "tile": "X1-0",
+      "type": "lay_tile",
+      "entity": "DGN",
+      "rotation": 5,
+      "entity_type": "corporation",
+      "id": 25,
+      "user": 842,
+      "created_at": 1729003884
+    },
+    {
+      "type": "buy_train",
+      "price": 80,
+      "train": "2-2",
+      "entity": "DGN",
+      "variant": "2",
+      "entity_type": "corporation",
+      "id": 26,
+      "user": 842,
+      "created_at": 1729003892
+    },
+    {
+      "type": "pass",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 27,
+      "user": 842,
+      "created_at": 1729003895
+    },
+    {
+      "type": "undo",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 28,
+      "user": 842,
+      "created_at": 1729003915
+    },
+    {
+      "type": "buy_train",
+      "price": 80,
+      "train": "2-3",
+      "entity": "DGN",
+      "variant": "2",
+      "entity_type": "corporation",
+      "id": 29,
+      "user": 842,
+      "created_at": 1729003950
+    },
+    {
+      "type": "buy_train",
+      "price": 180,
+      "train": "3-0",
+      "entity": "DGN",
+      "variant": "3",
+      "entity_type": "corporation",
+      "id": 30,
+      "user": 842,
+      "created_at": 1729003954
+    },
+    {
+      "type": "undo",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 31,
+      "user": 842,
+      "created_at": 1729003984
+    },
+    {
+      "type": "undo",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 32,
+      "user": 842,
+      "created_at": 1729003985
+    },
+    {
+      "type": "undo",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 33,
+      "user": 842,
+      "created_at": 1729003988
+    },
+    {
+      "type": "undo",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 34,
+      "user": 842,
+      "created_at": 1729003990
+    },
+    {
+      "type": "undo",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 35,
+      "user": 842,
+      "created_at": 1729003991
+    },
+    {
+      "type": "buy_train",
+      "price": 80,
+      "train": "2-2",
+      "entity": "KKN",
+      "variant": "2",
+      "entity_type": "corporation",
+      "id": 36,
+      "user": 842,
+      "created_at": 1729003995
+    },
+    {
+      "type": "undo",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 37,
+      "user": 842,
+      "created_at": 1729003999
+    },
+    {
+      "type": "undo",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 38,
+      "user": 842,
+      "created_at": 1729004001
+    },
+    {
+      "type": "undo",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 39,
+      "user": 842,
+      "created_at": 1729004003
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 40,
+      "created_at": 1729004062,
+      "hex": "C8",
+      "tile": "2-0",
+      "rotation": 5
+    },
+    {
+      "type": "buy_train",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 41,
+      "created_at": 1729004074,
+      "train": "2-1",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 42,
+      "created_at": 1729004078,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 43,
+      "created_at": 1729004080
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 44,
+      "created_at": 1729004094,
+      "hex": "B11",
+      "tile": "X1-0",
+      "rotation": 4
+    },
+    {
+      "type": "buy_train",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 45,
+      "created_at": 1729004097,
+      "train": "2-3",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 46,
+      "created_at": 1729004098,
+      "train": "3-0",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 47,
+      "created_at": 1729004103
+    },
+    {
+      "type": "par",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 48,
+      "created_at": 1729004189,
+      "corporation": "SPX",
+      "share_price": "80,2,3"
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 49,
+      "created_at": 1729004197
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 50,
+      "created_at": 1729012047,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 213,
+          "entity_type": "player",
+          "created_at": 1729012046
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 51,
+      "created_at": 1729024478
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 52,
+      "created_at": 1729026623,
+      "hex": "B7",
+      "tile": "57-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 53,
+      "created_at": 1729026633
+    },
+    {
+      "type": "run_routes",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 54,
+      "created_at": 1729026635,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C10",
+              "B9"
+            ]
+          ],
+          "hexes": [
+            "C10",
+            "B9"
+          ],
+          "revenue": 60,
+          "revenue_str": "C10-B9",
+          "nodes": [
+            "C10-0",
+            "B9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 55,
+      "created_at": 1729026636,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 56,
+      "created_at": 1729026647
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 57,
+      "created_at": 1729027454,
+      "hex": "B7",
+      "tile": "14-0",
+      "rotation": 2
+    },
+    {
+      "city": "14-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "KKN",
+      "tokener": "KKN",
+      "entity_type": "corporation",
+      "id": 58,
+      "user": 842,
+      "created_at": 1729027459
+    },
+    {
+      "type": "undo",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 59,
+      "user": 842,
+      "created_at": 1729027469
+    },
+    {
+      "type": "place_token",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 60,
+      "created_at": 1729027471,
+      "city": "57-0-0",
+      "slot": 0,
+      "tokener": "KKN"
+    },
+    {
+      "type": "run_routes",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 61,
+      "created_at": 1729027481,
+      "routes": [
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "B9",
+              "A8",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "B9",
+            "B7"
+          ],
+          "revenue": 50,
+          "revenue_str": "B9-B7",
+          "nodes": [
+            "B9-0",
+            "B7-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "B9",
+              "C10"
+            ]
+          ],
+          "hexes": [
+            "B9",
+            "C10"
+          ],
+          "revenue": 60,
+          "revenue_str": "B9-C10",
+          "nodes": [
+            "B9-0",
+            "C10-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 62,
+      "created_at": 1729027483,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 63,
+      "created_at": 1729027510,
+      "train": "3-1",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 64,
+      "created_at": 1729027514
+    },
+    {
+      "hex": "C10",
+      "tile": "54-0",
+      "type": "lay_tile",
+      "entity": "DGN",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 65,
+      "user": 842,
+      "created_at": 1729027542
+    },
+    {
+      "type": "undo",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 66,
+      "user": 842,
+      "created_at": 1729027546
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 67,
+      "created_at": 1729027550,
+      "hex": "A10",
+      "tile": "8-0",
+      "rotation": 5
+    },
+    {
+      "type": "place_token",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 68,
+      "created_at": 1729027555,
+      "city": "14-0-0",
+      "slot": 1,
+      "tokener": "DGN"
+    },
+    {
+      "type": "run_routes",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 69,
+      "created_at": 1729027562,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "B7",
+              "C8"
+            ],
+            [
+              "C8",
+              "D9"
+            ]
+          ],
+          "hexes": [
+            "B7",
+            "C8",
+            "D9"
+          ],
+          "revenue": 70,
+          "revenue_str": "B7-C8-D9",
+          "nodes": [
+            "B7-0",
+            "C8-0",
+            "D9-0"
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "B7",
+              "A8",
+              "A10",
+              "B11"
+            ]
+          ],
+          "hexes": [
+            "B7",
+            "B11"
+          ],
+          "revenue": 60,
+          "revenue_str": "B7-B11",
+          "nodes": [
+            "B7-0",
+            "B11-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 70,
+      "created_at": 1729027565,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 71,
+      "created_at": 1729027588
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 72,
+      "created_at": 1729027714,
+      "hex": "C10",
+      "tile": "54-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 73,
+      "created_at": 1729027724,
+      "routes": [
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C10",
+              "B11"
+            ]
+          ],
+          "hexes": [
+            "C10",
+            "B11"
+          ],
+          "revenue": 90,
+          "revenue_str": "C10-B11",
+          "nodes": [
+            "C10-1",
+            "B11-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 74,
+      "created_at": 1729027725,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 75,
+      "created_at": 1729027727,
+      "train": "3-2",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 76,
+      "created_at": 1729027728
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 77,
+      "created_at": 1729027743,
+      "hex": "D9",
+      "tile": "59-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 78,
+      "created_at": 1729027752,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "D9",
+              "C8"
+            ],
+            [
+              "C8",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "D9",
+            "C8",
+            "B7"
+          ],
+          "revenue": 80,
+          "revenue_str": "D9-C8-B7",
+          "nodes": [
+            "D9-1",
+            "C8-0",
+            "B7-0"
+          ]
+        },
+        {
+          "train": "2-2",
+          "connections": [
+            [
+              "B9",
+              "A8",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "B9",
+            "B7"
+          ],
+          "revenue": 50,
+          "revenue_str": "B9-B7",
+          "nodes": [
+            "B9-0",
+            "B7-0"
+          ]
+        },
+        {
+          "train": "2-1",
+          "connections": [
+            [
+              "B9",
+              "C10"
+            ]
+          ],
+          "hexes": [
+            "B9",
+            "C10"
+          ],
+          "revenue": 80,
+          "revenue_str": "B9-C10",
+          "nodes": [
+            "B9-0",
+            "C10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 79,
+      "created_at": 1729027754,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 80,
+      "created_at": 1729027785
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 81,
+      "created_at": 1729027798,
+      "hex": "B11",
+      "tile": "53-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 82,
+      "created_at": 1729027809,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "B11",
+              "A10",
+              "A8",
+              "B7"
+            ],
+            [
+              "B7",
+              "C8"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "B7",
+            "C8"
+          ],
+          "revenue": 90,
+          "revenue_str": "B11-B7-C8",
+          "nodes": [
+            "B11-0",
+            "B7-0",
+            "C8-0"
+          ]
+        },
+        {
+          "train": "2-3",
+          "connections": [
+            [
+              "B11",
+              "C10"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "C10"
+          ],
+          "revenue": 110,
+          "revenue_str": "B11-C10",
+          "nodes": [
+            "B11-0",
+            "C10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 83,
+      "created_at": 1729027810,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 84,
+      "created_at": 1729027813
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 85,
+      "created_at": 1729027845,
+      "shares": [
+        "KKN_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 86,
+      "created_at": 1729027855
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 87,
+      "created_at": 1729027866,
+      "shares": [
+        "SPX_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 88,
+      "created_at": 1729027873
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 89,
+      "created_at": 1729032499,
+      "shares": [
+        "KKN_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 90,
+      "created_at": 1729032502
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 91,
+      "created_at": 1729038061,
+      "shares": [
+        "SPX_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 92,
+      "created_at": 1729038071
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 93,
+      "created_at": 1729039132,
+      "shares": [
+        "KKN_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 94,
+      "created_at": 1729039139
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 95,
+      "created_at": 1729039461,
+      "shares": [
+        "SPX_3"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 96,
+      "created_at": 1729039468
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 97,
+      "created_at": 1729040042,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 213,
+          "entity_type": "player",
+          "created_at": 1729040042
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 98,
+      "created_at": 1729040470,
+      "shares": [
+        "SPX_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 99,
+      "created_at": 1729040476,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 213,
+          "entity_type": "player",
+          "created_at": 1729040476
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 100,
+      "created_at": 1729040505
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 101,
+      "created_at": 1729048096,
+      "hex": "B9",
+      "tile": "14-1",
+      "rotation": 2
+    },
+    {
+      "type": "place_token",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 102,
+      "created_at": 1729048108,
+      "city": "14-1-0",
+      "slot": 1,
+      "tokener": "PHX"
+    },
+    {
+      "type": "run_routes",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 103,
+      "created_at": 1729048113,
+      "routes": [
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "C10",
+              "B9"
+            ],
+            [
+              "B9",
+              "A8",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "C10",
+            "B9",
+            "B7"
+          ],
+          "revenue": 120,
+          "revenue_str": "C10-B9-B7",
+          "nodes": [
+            "C10-1",
+            "B9-0",
+            "B7-0"
+          ]
+        },
+        {
+          "train": "2-0",
+          "connections": [
+            [
+              "C10",
+              "B11"
+            ]
+          ],
+          "hexes": [
+            "C10",
+            "B11"
+          ],
+          "revenue": 110,
+          "revenue_str": "C10-B11",
+          "nodes": [
+            "C10-1",
+            "B11-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 104,
+      "created_at": 1729048117,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 105,
+      "created_at": 1729048121,
+      "train": "4-0",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 106,
+      "created_at": 1729048122
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 107,
+      "created_at": 1729050169,
+      "hex": "B5",
+      "tile": "59-1",
+      "rotation": 1
+    },
+    {
+      "type": "place_token",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 108,
+      "created_at": 1729050195,
+      "city": "59-1-1",
+      "slot": 0,
+      "tokener": "KKN"
+    },
+    {
+      "type": "run_routes",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 109,
+      "created_at": 1729050202,
+      "routes": [
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "C10",
+              "B9"
+            ],
+            [
+              "B9",
+              "A8",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "C10",
+            "B9",
+            "B7"
+          ],
+          "revenue": 120,
+          "revenue_str": "C10-B9-B7",
+          "nodes": [
+            "C10-1",
+            "B9-0",
+            "B7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 110,
+      "created_at": 1729050216,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 111,
+      "created_at": 1729050219,
+      "train": "4-1",
+      "price": 300,
+      "variant": "4"
+    },
+    {
+      "type": "pass",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 112,
+      "created_at": 1729050242
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 113,
+      "created_at": 1729050272,
+      "hex": "C6",
+      "tile": "1-0",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 114,
+      "created_at": 1729050286,
+      "train": "5-0",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "pass",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 115,
+      "created_at": 1729050329
+    },
+    {
+      "hex": "D9",
+      "tile": "65-0",
+      "type": "lay_tile",
+      "entity": "DGN",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 116,
+      "user": 842,
+      "created_at": 1729050510
+    },
+    {
+      "type": "undo",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 117,
+      "user": 842,
+      "created_at": 1729050533
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 118,
+      "created_at": 1729050538,
+      "hex": "C10",
+      "tile": "62-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 119,
+      "created_at": 1729050549
+    },
+    {
+      "type": "run_routes",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 120,
+      "created_at": 1729050554,
+      "routes": [
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "B7",
+              "A8",
+              "A10",
+              "B11"
+            ],
+            [
+              "B11",
+              "C10"
+            ]
+          ],
+          "hexes": [
+            "B7",
+            "B11",
+            "C10"
+          ],
+          "revenue": 160,
+          "revenue_str": "B7-B11-C10",
+          "nodes": [
+            "B7-0",
+            "B11-0",
+            "C10-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 121,
+      "created_at": 1729050557,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 122,
+      "created_at": 1729050558,
+      "train": "5-1",
+      "price": 500,
+      "variant": "5"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 123,
+      "created_at": 1729075269,
+      "hex": "B9",
+      "tile": "63-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 124,
+      "created_at": 1729075273,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "C10",
+              "B11"
+            ]
+          ],
+          "hexes": [
+            "C10",
+            "B11"
+          ],
+          "revenue": 130,
+          "revenue_str": "C10-B11",
+          "nodes": [
+            "C10-1",
+            "B11-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "C10",
+              "B9"
+            ],
+            [
+              "B9",
+              "A8",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "C10",
+            "B9",
+            "B7"
+          ],
+          "revenue": 150,
+          "revenue_str": "C10-B9-B7",
+          "nodes": [
+            "C10-1",
+            "B9-0",
+            "B7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 125,
+      "created_at": 1729075274,
+      "kind": "payout"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 126,
+      "created_at": 1729076708,
+      "hex": "D9",
+      "tile": "65-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 127,
+      "created_at": 1729076732,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "C10",
+              "D9"
+            ],
+            [
+              "D9",
+              "C8"
+            ],
+            [
+              "C8",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "C10",
+            "D9",
+            "C8",
+            "B7"
+          ],
+          "revenue": 170,
+          "revenue_str": "C10-D9-C8-B7",
+          "nodes": [
+            "C10-0",
+            "D9-1",
+            "C8-0",
+            "B7-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "B9",
+              "C10"
+            ],
+            [
+              "C10",
+              "B11"
+            ]
+          ],
+          "hexes": [
+            "B9",
+            "C10",
+            "B11"
+          ],
+          "revenue": 170,
+          "revenue_str": "B9-C10-B11",
+          "nodes": [
+            "B9-0",
+            "C10-1",
+            "B11-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 128,
+      "created_at": 1729076750,
+      "kind": "withhold"
+    },
+    {
+      "hex": "B5",
+      "tile": "66-0",
+      "type": "lay_tile",
+      "entity": "SPX",
+      "rotation": 1,
+      "entity_type": "corporation",
+      "id": 129,
+      "user": 842,
+      "created_at": 1729076813
+    },
+    {
+      "type": "undo",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 130,
+      "user": 842,
+      "created_at": 1729076830
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 131,
+      "created_at": 1729076841,
+      "hex": "B7",
+      "tile": "63-1",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 132,
+      "created_at": 1729076850,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "B11",
+              "A10",
+              "A8",
+              "B7"
+            ],
+            [
+              "B7",
+              "C8"
+            ],
+            [
+              "C8",
+              "D9"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "B7",
+            "C8",
+            "D9"
+          ],
+          "revenue": 150,
+          "revenue_str": "B11-B7-C8-D9",
+          "nodes": [
+            "B11-0",
+            "B7-0",
+            "C8-0",
+            "D9-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 133,
+      "created_at": 1729076854,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 134,
+      "created_at": 1729076865
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 135,
+      "created_at": 1729076912,
+      "hex": "B11",
+      "tile": "61-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 136,
+      "created_at": 1729076924,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "C10",
+              "B11"
+            ],
+            [
+              "B11",
+              "A10",
+              "A8",
+              "B7"
+            ],
+            [
+              "B7",
+              "C8"
+            ],
+            [
+              "C8",
+              "D9"
+            ]
+          ],
+          "hexes": [
+            "C10",
+            "B11",
+            "B7",
+            "C8",
+            "D9"
+          ],
+          "revenue": 240,
+          "revenue_str": "C10-B11-B7-C8-D9",
+          "nodes": [
+            "C10-1",
+            "B11-0",
+            "B7-0",
+            "C8-0",
+            "D9-1"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "B5",
+              "A6",
+              "B7"
+            ],
+            [
+              "B7",
+              "B9"
+            ]
+          ],
+          "hexes": [
+            "B5",
+            "B7",
+            "B9"
+          ],
+          "revenue": 120,
+          "revenue_str": "B5-B7-B9",
+          "nodes": [
+            "B5-1",
+            "B7-0",
+            "B9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 137,
+      "created_at": 1729076927,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 138,
+      "created_at": 1729078530,
+      "shares": [
+        "PHX_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 139,
+      "created_at": 1729078534
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 140,
+      "created_at": 1729081119,
+      "shares": [
+        "PHX_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 141,
+      "created_at": 1729081132
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 142,
+      "created_at": 1729081559,
+      "shares": [
+        "DGN_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 143,
+      "created_at": 1729081562
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 144,
+      "created_at": 1729082638,
+      "shares": [
+        "DGN_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 145,
+      "created_at": 1729082649
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 146,
+      "created_at": 1729082951,
+      "shares": [
+        "DGN_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 147,
+      "created_at": 1729082956
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 148,
+      "created_at": 1729083453,
+      "shares": [
+        "DGN_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 149,
+      "created_at": 1729083496
+    },
+    {
+      "type": "sell_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 150,
+      "created_at": 1729085197,
+      "shares": [
+        "KKN_4",
+        "KKN_5",
+        "KKN_6",
+        "KKN_7",
+        "KKN_8"
+      ],
+      "percent": 50
+    },
+    {
+      "type": "sell_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 151,
+      "created_at": 1729085210,
+      "shares": [
+        "DGN_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "par",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 152,
+      "created_at": 1729085213,
+      "corporation": "GFN",
+      "share_price": "100,0,3"
+    },
+    {
+      "type": "pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 153,
+      "created_at": 1729085221
+    },
+    {
+      "type": "sell_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 154,
+      "created_at": 1729086000,
+      "shares": [
+        "PHX_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 155,
+      "created_at": 1729086020,
+      "shares": [
+        "KKN_4"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 156,
+      "created_at": 1729086035
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 157,
+      "created_at": 1729087993,
+      "auto_actions": [
+        {
+          "type": "program_disable",
+          "entity": 213,
+          "entity_type": "player",
+          "created_at": 1729087992,
+          "reason": "Cannot buy DGN from market"
+        }
+      ],
+      "corporation": "DGN",
+      "until_condition": 4,
+      "from_market": true,
+      "auto_pass_after": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 158,
+      "created_at": 1729088002,
+      "shares": [
+        "GFN_1"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 159,
+      "created_at": 1729088004
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 160,
+      "created_at": 1729088158,
+      "shares": [
+        "DGN_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 161,
+      "created_at": 1729088180
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 162,
+      "created_at": 1729088273,
+      "auto_actions": [
+        {
+          "type": "buy_shares",
+          "entity": 213,
+          "entity_type": "player",
+          "created_at": 1729088273,
+          "shares": [
+            "GFN_2"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 213,
+          "entity_type": "player",
+          "created_at": 1729088273
+        }
+      ],
+      "corporation": "GFN",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "program_buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 163,
+      "created_at": 1729088275,
+      "corporation": "GFN",
+      "until_condition": "float",
+      "from_market": false,
+      "auto_pass_after": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 164,
+      "created_at": 1729088282,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 842,
+          "entity_type": "player",
+          "created_at": 1729088282
+        },
+        {
+          "type": "buy_shares",
+          "entity": 213,
+          "entity_type": "player",
+          "created_at": 1729088282,
+          "shares": [
+            "GFN_3"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "pass",
+          "entity": 213,
+          "entity_type": "player",
+          "created_at": 1729088282
+        },
+        {
+          "type": "pass",
+          "entity": 842,
+          "entity_type": "player",
+          "created_at": 1729088282
+        },
+        {
+          "type": "buy_shares",
+          "entity": 213,
+          "entity_type": "player",
+          "created_at": 1729088282,
+          "shares": [
+            "GFN_4"
+          ],
+          "percent": 10
+        },
+        {
+          "type": "program_disable",
+          "entity": 213,
+          "entity_type": "player",
+          "created_at": 1729088282,
+          "reason": "GFN is floated"
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 165,
+      "created_at": 1729092947,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 213,
+          "entity_type": "player",
+          "created_at": 1729092947
+        },
+        {
+          "type": "pass",
+          "entity": 842,
+          "entity_type": "player",
+          "created_at": 1729092947
+        },
+        {
+          "type": "pass",
+          "entity": 213,
+          "entity_type": "player",
+          "created_at": 1729092947
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 166,
+      "created_at": 1729092966,
+      "hex": "A10",
+      "tile": "29-0",
+      "rotation": 5
+    },
+    {
+      "type": "run_routes",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 167,
+      "created_at": 1729092971,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "B11",
+              "C10"
+            ],
+            [
+              "C10",
+              "B9"
+            ],
+            [
+              "B9",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "C10",
+            "B9",
+            "B7"
+          ],
+          "revenue": 220,
+          "revenue_str": "B11-C10-B9-B7",
+          "nodes": [
+            "B11-0",
+            "C10-1",
+            "B9-0",
+            "B7-0"
+          ]
+        },
+        {
+          "train": "3-2",
+          "connections": [
+            [
+              "B11",
+              "A10",
+              "B9"
+            ],
+            [
+              "B9",
+              "A8",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "B9",
+            "B7"
+          ],
+          "revenue": 140,
+          "revenue_str": "B11-B9-B7",
+          "nodes": [
+            "B11-0",
+            "B9-0",
+            "B7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 168,
+      "created_at": 1729092973,
+      "kind": "payout"
+    },
+    {
+      "type": "place_token",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 169,
+      "created_at": 1729092979,
+      "city": "59-1-0",
+      "slot": 0,
+      "tokener": "GFN"
+    },
+    {
+      "hex": "B3",
+      "tile": "X1-0",
+      "type": "lay_tile",
+      "entity": "GFN",
+      "rotation": 0,
+      "entity_type": "corporation",
+      "id": 170,
+      "user": 213,
+      "created_at": 1729092984
+    },
+    {
+      "type": "undo",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 171,
+      "user": 213,
+      "created_at": 1729092994
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 172,
+      "created_at": 1729093005,
+      "hex": "B3",
+      "tile": "X1-0",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 173,
+      "created_at": 1729093010
+    },
+    {
+      "type": "buy_train",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 174,
+      "created_at": 1729093033,
+      "train": "3-2",
+      "price": 300
+    },
+    {
+      "type": "pass",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 175,
+      "created_at": 1729093034
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 176,
+      "created_at": 1729095331,
+      "hex": "B5",
+      "tile": "66-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 177,
+      "created_at": 1729095354,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "B11",
+              "A10",
+              "A8",
+              "B7"
+            ],
+            [
+              "B7",
+              "C8"
+            ],
+            [
+              "C8",
+              "D9"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "B7",
+            "C8",
+            "D9"
+          ],
+          "revenue": 160,
+          "revenue_str": "B11-B7-C8-D9",
+          "nodes": [
+            "B11-0",
+            "B7-0",
+            "C8-0",
+            "D9-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 178,
+      "created_at": 1729095365,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 179,
+      "created_at": 1729095472
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 180,
+      "created_at": 1729095487,
+      "hex": "A10",
+      "tile": "43-0",
+      "rotation": 4
+    },
+    {
+      "type": "run_routes",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 181,
+      "created_at": 1729095510,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "D9",
+              "C8"
+            ],
+            [
+              "C8",
+              "B7"
+            ],
+            [
+              "B7",
+              "A8",
+              "A10",
+              "B11"
+            ],
+            [
+              "B11",
+              "A12",
+              "A10",
+              "B9"
+            ]
+          ],
+          "hexes": [
+            "D9",
+            "C8",
+            "B7",
+            "B11",
+            "B9"
+          ],
+          "revenue": 200,
+          "revenue_str": "D9-C8-B7-B11-B9",
+          "nodes": [
+            "D9-1",
+            "C8-0",
+            "B7-0",
+            "B11-0",
+            "B9-0"
+          ]
+        },
+        {
+          "train": "3-0",
+          "connections": [
+            [
+              "B11",
+              "C10"
+            ],
+            [
+              "C10",
+              "B9"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "C10",
+            "B9"
+          ],
+          "revenue": 180,
+          "revenue_str": "B11-C10-B9",
+          "nodes": [
+            "B11-0",
+            "C10-1",
+            "B9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 182,
+      "created_at": 1729095538,
+      "kind": "withhold"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 183,
+      "created_at": 1729095568,
+      "hex": "C4",
+      "tile": "57-2",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 184,
+      "created_at": 1729095588,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "C10",
+              "D9"
+            ],
+            [
+              "D9",
+              "C8"
+            ],
+            [
+              "C8",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "C10",
+            "D9",
+            "C8",
+            "B7"
+          ],
+          "revenue": 180,
+          "revenue_str": "C10-D9-C8-B7",
+          "nodes": [
+            "C10-0",
+            "D9-1",
+            "C8-0",
+            "B7-0"
+          ]
+        },
+        {
+          "train": "3-1",
+          "connections": [
+            [
+              "C10",
+              "B9"
+            ],
+            [
+              "B9",
+              "A10",
+              "B11"
+            ]
+          ],
+          "hexes": [
+            "C10",
+            "B9",
+            "B11"
+          ],
+          "revenue": 180,
+          "revenue_str": "C10-B9-B11",
+          "nodes": [
+            "C10-1",
+            "B9-0",
+            "B11-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 185,
+      "created_at": 1729095592,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 186,
+      "created_at": 1729097063
+    },
+    {
+      "type": "run_routes",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 187,
+      "created_at": 1729097065,
+      "routes": [
+        {
+          "train": "4-0",
+          "connections": [
+            [
+              "B11",
+              "C10"
+            ],
+            [
+              "C10",
+              "B9"
+            ],
+            [
+              "B9",
+              "A8",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "C10",
+            "B9",
+            "B7"
+          ],
+          "revenue": 220,
+          "revenue_str": "B11-C10-B9-B7",
+          "nodes": [
+            "B11-0",
+            "C10-1",
+            "B9-0",
+            "B7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "kind": "payout",
+      "type": "dividend",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 188,
+      "user": 213,
+      "created_at": 1729097067
+    },
+    {
+      "type": "undo",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 189,
+      "user": 213,
+      "created_at": 1729097120
+    },
+    {
+      "type": "dividend",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 190,
+      "created_at": 1729097121,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 191,
+      "created_at": 1729097123,
+      "train": "6-0",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "pass",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 192,
+      "created_at": 1729098885
+    },
+    {
+      "type": "run_routes",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 193,
+      "created_at": 1729098896,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "B11",
+              "A12",
+              "A10",
+              "A8",
+              "B7"
+            ],
+            [
+              "B7",
+              "C8"
+            ],
+            [
+              "C8",
+              "D9"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "B7",
+            "C8",
+            "D9"
+          ],
+          "revenue": 160,
+          "revenue_str": "B11-B7-C8-D9",
+          "nodes": [
+            "B11-0",
+            "B7-0",
+            "C8-0",
+            "D9-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 194,
+      "created_at": 1729098898,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 195,
+      "created_at": 1729098922
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 196,
+      "created_at": 1729098969,
+      "hex": "B3",
+      "tile": "53-1",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 197,
+      "created_at": 1729098975,
+      "city": "53-1-0",
+      "slot": 0,
+      "tokener": "GFN"
+    },
+    {
+      "type": "buy_train",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 198,
+      "created_at": 1729098988,
+      "train": "4-0",
+      "price": 650
+    },
+    {
+      "type": "pass",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 199,
+      "created_at": 1729098990
+    },
+    {
+      "hex": "C4",
+      "tile": "15-0",
+      "type": "lay_tile",
+      "entity": "DGN",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 200,
+      "user": 842,
+      "created_at": 1729099080
+    },
+    {
+      "type": "undo",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 201,
+      "user": 842,
+      "created_at": 1729099095
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 202,
+      "created_at": 1729099102,
+      "hex": "C4",
+      "tile": "15-0",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 203,
+      "created_at": 1729099122
+    },
+    {
+      "type": "run_routes",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 204,
+      "created_at": 1729099130,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "B5",
+              "A6",
+              "B7"
+            ],
+            [
+              "B7",
+              "A8",
+              "A10",
+              "B11"
+            ],
+            [
+              "B11",
+              "C10"
+            ],
+            [
+              "C10",
+              "B9"
+            ]
+          ],
+          "hexes": [
+            "B5",
+            "B7",
+            "B11",
+            "C10",
+            "B9"
+          ],
+          "revenue": 270,
+          "revenue_str": "B5-B7-B11-C10-B9",
+          "nodes": [
+            "B5-0",
+            "B7-0",
+            "B11-0",
+            "C10-1",
+            "B9-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 205,
+      "created_at": 1729099137,
+      "kind": "withhold"
+    },
+    {
+      "type": "pass",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 206,
+      "created_at": 1729099164
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 207,
+      "created_at": 1729099187,
+      "hex": "D5",
+      "tile": "7-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 208,
+      "created_at": 1729099197,
+      "routes": [
+        {
+          "train": "4-1",
+          "connections": [
+            [
+              "B11",
+              "C10"
+            ],
+            [
+              "C10",
+              "B9"
+            ],
+            [
+              "B9",
+              "A8",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "C10",
+            "B9",
+            "B7"
+          ],
+          "revenue": 220,
+          "revenue_str": "B11-C10-B9-B7",
+          "nodes": [
+            "B11-0",
+            "C10-1",
+            "B9-0",
+            "B7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 209,
+      "created_at": 1729099199,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 210,
+      "created_at": 1729099201,
+      "train": "D-0",
+      "price": 900,
+      "variant": "D"
+    },
+    {
+      "type": "pass",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 211,
+      "created_at": 1729099235
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 212,
+      "created_at": 1729099256,
+      "shares": [
+        "KKN_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 213,
+      "created_at": 1729099292
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "shares": [
+        "GFN_5"
+      ],
+      "percent": 10,
+      "entity_type": "player",
+      "id": 214,
+      "user": 213,
+      "created_at": 1729099326
+    },
+    {
+      "type": "undo",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 215,
+      "user": 213,
+      "created_at": 1729099332
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 216,
+      "created_at": 1729099352,
+      "shares": [
+        "KKN_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 217,
+      "created_at": 1729099356,
+      "shares": [
+        "KKN_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 218,
+      "created_at": 1729099357,
+      "shares": [
+        "KKN_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 219,
+      "created_at": 1729099363
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 220,
+      "created_at": 1729099450,
+      "shares": [
+        "PHX_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 221,
+      "created_at": 1729099462
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 222,
+      "created_at": 1729099533,
+      "shares": [
+        "SPX_5"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "sell_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 223,
+      "created_at": 1729099539,
+      "shares": [
+        "GFN_1",
+        "GFN_2",
+        "GFN_3",
+        "GFN_4"
+      ],
+      "percent": 40
+    },
+    {
+      "type": "pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 224,
+      "created_at": 1729099545
+    },
+    {
+      "type": "buy_shares",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 225,
+      "created_at": 1729099569,
+      "shares": [
+        "SPX_6"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 226,
+      "created_at": 1729099572
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 227,
+      "created_at": 1729099611,
+      "shares": [
+        "SPX_7"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 228,
+      "created_at": 1729099612
+    },
+    {
+      "type": "program_share_pass",
+      "entity": 842,
+      "entity_type": "player",
+      "id": 229,
+      "created_at": 1729099617,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 842,
+          "entity_type": "player",
+          "created_at": 1729099617
+        }
+      ],
+      "unconditional": false,
+      "indefinite": false
+    },
+    {
+      "type": "buy_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 230,
+      "created_at": 1729099755,
+      "shares": [
+        "SPX_8"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 231,
+      "created_at": 1729099757,
+      "auto_actions": [
+        {
+          "type": "pass",
+          "entity": 842,
+          "entity_type": "player",
+          "created_at": 1729099757
+        }
+      ]
+    },
+    {
+      "type": "pass",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 232,
+      "created_at": 1729099764
+    },
+    {
+      "type": "lay_tile",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 233,
+      "created_at": 1729099772,
+      "hex": "C10",
+      "tile": "X3-0",
+      "rotation": 0
+    },
+    {
+      "type": "run_routes",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 234,
+      "created_at": 1729099776,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "B11",
+              "A12",
+              "A10",
+              "B9"
+            ],
+            [
+              "B9",
+              "C10"
+            ],
+            [
+              "C10",
+              "D9"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "B9",
+            "C10",
+            "D9"
+          ],
+          "revenue": 250,
+          "revenue_str": "B11-B9-C10-D9",
+          "nodes": [
+            "B11-0",
+            "B9-0",
+            "C10-0",
+            "D9-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 235,
+      "created_at": 1729099778,
+      "kind": "payout"
+    },
+    {
+      "type": "buy_train",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 236,
+      "created_at": 1729099790,
+      "train": "D-1",
+      "price": 700,
+      "variant": "D",
+      "exchange": "6-0"
+    },
+    {
+      "type": "pass",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 237,
+      "created_at": 1729099800
+    },
+    {
+      "hex": "D7",
+      "tile": "8-1",
+      "type": "lay_tile",
+      "entity": "SPX",
+      "rotation": 3,
+      "entity_type": "corporation",
+      "id": 238,
+      "user": 842,
+      "created_at": 1729099863
+    },
+    {
+      "type": "undo",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 239,
+      "user": 842,
+      "created_at": 1729099874
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 240,
+      "created_at": 1729099881,
+      "hex": "B11",
+      "tile": "X2-0",
+      "rotation": 0
+    },
+    {
+      "city": "X3-0-0",
+      "slot": 1,
+      "type": "place_token",
+      "entity": "SPX",
+      "tokener": "SPX",
+      "entity_type": "corporation",
+      "id": 241,
+      "user": 842,
+      "created_at": 1729099889
+    },
+    {
+      "type": "run_routes",
+      "entity": "SPX",
+      "routes": [
+        {
+          "hexes": [
+            "B5",
+            "B7",
+            "B11",
+            "C10",
+            "D9"
+          ],
+          "nodes": [
+            "B5-0",
+            "B7-0",
+            "B11-0",
+            "C10-0",
+            "D9-1"
+          ],
+          "train": "5-0",
+          "revenue": 310,
+          "connections": [
+            [
+              "B5",
+              "A6",
+              "B7"
+            ],
+            [
+              "B7",
+              "A8",
+              "A10",
+              "B11"
+            ],
+            [
+              "B11",
+              "C10"
+            ],
+            [
+              "C10",
+              "D9"
+            ]
+          ],
+          "revenue_str": "B5-B7-B11-C10-D9"
+        }
+      ],
+      "subsidy": 0,
+      "entity_type": "corporation",
+      "extra_revenue": 0,
+      "id": 242,
+      "user": 842,
+      "created_at": 1729099903
+    },
+    {
+      "type": "undo",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 243,
+      "user": 842,
+      "created_at": 1729099946
+    },
+    {
+      "type": "undo",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 244,
+      "user": 842,
+      "created_at": 1729099949
+    },
+    {
+      "type": "place_token",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 245,
+      "created_at": 1729099951,
+      "city": "X2-0-0",
+      "slot": 1,
+      "tokener": "SPX"
+    },
+    {
+      "type": "run_routes",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 246,
+      "created_at": 1729099963,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "B5",
+              "A6",
+              "B7"
+            ],
+            [
+              "B7",
+              "A8",
+              "A10",
+              "B11"
+            ],
+            [
+              "B11",
+              "C10"
+            ],
+            [
+              "C10",
+              "D9"
+            ]
+          ],
+          "hexes": [
+            "B5",
+            "B7",
+            "B11",
+            "C10",
+            "D9"
+          ],
+          "revenue": 310,
+          "revenue_str": "B5-B7-B11-C10-D9",
+          "nodes": [
+            "B5-0",
+            "B7-0",
+            "B11-0",
+            "C10-0",
+            "D9-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 247,
+      "created_at": 1729099966,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 248,
+      "created_at": 1729100006
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 249,
+      "created_at": 1729100028,
+      "hex": "D7",
+      "tile": "8-1",
+      "rotation": 3
+    },
+    {
+      "city": "15-0-0",
+      "slot": 0,
+      "type": "place_token",
+      "entity": "DGN",
+      "tokener": "DGN",
+      "entity_type": "corporation",
+      "id": 250,
+      "user": 842,
+      "created_at": 1729100042
+    },
+    {
+      "type": "undo",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 251,
+      "user": 842,
+      "created_at": 1729100054
+    },
+    {
+      "type": "pass",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 252,
+      "created_at": 1729100060
+    },
+    {
+      "type": "run_routes",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 253,
+      "created_at": 1729100067,
+      "routes": [
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "B5",
+              "A6",
+              "B7"
+            ],
+            [
+              "B7",
+              "A8",
+              "A10",
+              "B11"
+            ],
+            [
+              "B11",
+              "C10"
+            ],
+            [
+              "C10",
+              "D9"
+            ]
+          ],
+          "hexes": [
+            "B5",
+            "B7",
+            "B11",
+            "C10",
+            "D9"
+          ],
+          "revenue": 310,
+          "revenue_str": "B5-B7-B11-C10-D9",
+          "nodes": [
+            "B5-0",
+            "B7-0",
+            "B11-0",
+            "C10-0",
+            "D9-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 254,
+      "created_at": 1729100069,
+      "kind": "withhold"
+    },
+    {
+      "type": "buy_train",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 255,
+      "created_at": 1729100074,
+      "train": "D-2",
+      "price": 900,
+      "variant": "D"
+    },
+    {
+      "type": "pass",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 256,
+      "created_at": 1729100105
+    },
+    {
+      "type": "sell_shares",
+      "entity": 213,
+      "entity_type": "player",
+      "id": 257,
+      "created_at": 1729100112,
+      "shares": [
+        "DGN_4",
+        "DGN_5"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_train",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 258,
+      "created_at": 1729100117,
+      "train": "6-0",
+      "price": 630,
+      "variant": "6"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 259,
+      "created_at": 1729100175,
+      "hex": "D5",
+      "tile": "29-0",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 260,
+      "created_at": 1729100193,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "B11",
+              "A12",
+              "A10",
+              "B9"
+            ],
+            [
+              "B9",
+              "C10"
+            ],
+            [
+              "C10",
+              "D9"
+            ],
+            [
+              "D9",
+              "C8"
+            ],
+            [
+              "C8",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "B9",
+            "C10",
+            "D9",
+            "C8",
+            "B7"
+          ],
+          "revenue": 310,
+          "revenue_str": "B11-B9-C10-D9-C8-B7",
+          "nodes": [
+            "B11-0",
+            "B9-0",
+            "C10-0",
+            "D9-1",
+            "C8-0",
+            "B7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 261,
+      "created_at": 1729100204,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 262,
+      "created_at": 1729100211
+    },
+    {
+      "type": "pass",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 263,
+      "created_at": 1729100237
+    },
+    {
+      "type": "run_routes",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 264,
+      "created_at": 1729100242,
+      "routes": [
+        {
+          "train": "D-1",
+          "connections": [
+            [
+              "B11",
+              "A12",
+              "A10",
+              "B9"
+            ],
+            [
+              "B9",
+              "C10"
+            ],
+            [
+              "C10",
+              "D9"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "B9",
+            "C10",
+            "D9"
+          ],
+          "revenue": 260,
+          "revenue_str": "B11-B9-C10-D9",
+          "nodes": [
+            "B11-0",
+            "B9-0",
+            "C10-0",
+            "D9-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 265,
+      "created_at": 1729100243,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "PHX",
+      "entity_type": "corporation",
+      "id": 266,
+      "created_at": 1729100245
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 267,
+      "created_at": 1729100270,
+      "hex": "D7",
+      "tile": "25-0",
+      "rotation": 5
+    },
+    {
+      "type": "place_token",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 268,
+      "created_at": 1729100284,
+      "city": "15-0-0",
+      "slot": 1,
+      "tokener": "SPX"
+    },
+    {
+      "type": "run_routes",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 269,
+      "created_at": 1729100310,
+      "routes": [
+        {
+          "train": "5-0",
+          "connections": [
+            [
+              "B5",
+              "A6",
+              "B7"
+            ],
+            [
+              "B7",
+              "A8",
+              "A10",
+              "B11"
+            ],
+            [
+              "B11",
+              "C10"
+            ],
+            [
+              "C10",
+              "D9"
+            ]
+          ],
+          "hexes": [
+            "B5",
+            "B7",
+            "B11",
+            "C10",
+            "D9"
+          ],
+          "revenue": 310,
+          "revenue_str": "B5-B7-B11-C10-D9",
+          "nodes": [
+            "B5-0",
+            "B7-0",
+            "B11-0",
+            "C10-0",
+            "D9-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 270,
+      "created_at": 1729100340,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "SPX",
+      "entity_type": "corporation",
+      "id": 271,
+      "created_at": 1729100343
+    },
+    {
+      "type": "lay_tile",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 272,
+      "created_at": 1729100376,
+      "hex": "D7",
+      "tile": "40-0",
+      "rotation": 1
+    },
+    {
+      "type": "run_routes",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 273,
+      "created_at": 1729100411,
+      "routes": [
+        {
+          "train": "D-2",
+          "connections": [
+            [
+              "D9",
+              "E8",
+              "D7",
+              "C8"
+            ],
+            [
+              "C8",
+              "C6"
+            ],
+            [
+              "C6",
+              "D5",
+              "C4"
+            ],
+            [
+              "C4",
+              "C6"
+            ],
+            [
+              "C6",
+              "B7"
+            ],
+            [
+              "B7",
+              "C8"
+            ],
+            [
+              "C8",
+              "D9"
+            ]
+          ],
+          "hexes": [
+            "D9",
+            "C8",
+            "C6",
+            "C4",
+            "C6",
+            "B7",
+            "C8",
+            "D9"
+          ],
+          "revenue": 210,
+          "revenue_str": "D9-C8-C6-C4-C6-B7-C8-D9",
+          "nodes": [
+            "D9-0",
+            "C8-1",
+            "C6-1",
+            "C4-0",
+            "C6-0",
+            "B7-0",
+            "C8-0",
+            "D9-1"
+          ]
+        },
+        {
+          "train": "5-1",
+          "connections": [
+            [
+              "B5",
+              "A6",
+              "B7"
+            ],
+            [
+              "B7",
+              "A8",
+              "A10",
+              "B11"
+            ],
+            [
+              "B11",
+              "C10"
+            ],
+            [
+              "C10",
+              "D9"
+            ]
+          ],
+          "hexes": [
+            "B5",
+            "B7",
+            "B11",
+            "C10",
+            "D9"
+          ],
+          "revenue": 310,
+          "revenue_str": "B5-B7-B11-C10-D9",
+          "nodes": [
+            "B5-0",
+            "B7-0",
+            "B11-0",
+            "C10-0",
+            "D9-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "DGN",
+      "entity_type": "corporation",
+      "id": 274,
+      "created_at": 1729100417,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 275,
+      "created_at": 1729100434
+    },
+    {
+      "type": "run_routes",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 276,
+      "created_at": 1729100469,
+      "routes": [
+        {
+          "train": "D-0",
+          "connections": [
+            [
+              "B11",
+              "A12",
+              "A10",
+              "B9"
+            ],
+            [
+              "B9",
+              "C10"
+            ],
+            [
+              "C10",
+              "D9"
+            ],
+            [
+              "D9",
+              "C8"
+            ],
+            [
+              "C8",
+              "B7"
+            ]
+          ],
+          "hexes": [
+            "B11",
+            "B9",
+            "C10",
+            "D9",
+            "C8",
+            "B7"
+          ],
+          "revenue": 310,
+          "revenue_str": "B11-B9-C10-D9-C8-B7",
+          "nodes": [
+            "B11-0",
+            "B9-0",
+            "C10-0",
+            "D9-1",
+            "C8-0",
+            "B7-0"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 277,
+      "created_at": 1729100471,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "KKN",
+      "entity_type": "corporation",
+      "id": 278,
+      "created_at": 1729100476
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 279,
+      "created_at": 1729100491,
+      "hex": "B3",
+      "tile": "61-1",
+      "rotation": 2
+    },
+    {
+      "type": "run_routes",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 280,
+      "created_at": 1729100494,
+      "routes": [
+        {
+          "train": "6-0",
+          "connections": [
+            [
+              "B3",
+              "B5"
+            ]
+          ],
+          "hexes": [
+            "B3",
+            "B5"
+          ],
+          "revenue": 110,
+          "revenue_str": "B3-B5",
+          "nodes": [
+            "B3-0",
+            "B5-1"
+          ]
+        }
+      ],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "dividend",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 281,
+      "created_at": 1729100513,
+      "kind": "payout"
+    },
+    {
+      "type": "pass",
+      "entity": "GFN",
+      "entity_type": "corporation",
+      "id": 282,
+      "created_at": 1729100519
+    }
+  ],
+  "loaded": true,
+  "created_at": 1728679215,
+  "updated_at": 1729100545,
+  "finished_at": 1729100545
+}


### PR DESCRIPTION
Fixes #11274 
Fixes #11273 

Adds fixture for System18

Will require archiving any S18 game using the Britain map (currently only one in progress).