### PR TITLE
Update rules for 1860 and 18Ireland to deprecate my personal dropbox

### DIFF
--- a/lib/engine/game/g_1860/meta.rb
+++ b/lib/engine/game/g_1860/meta.rb
@@ -15,7 +15,7 @@ module Engine
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1860'
         GAME_LOCATION = 'Isle of Wight'
         GAME_PUBLISHER = :all_aboard_games
-        GAME_RULES_URL = 'https://www.dropbox.com/s/usfbqtdjzx6ug8f/1860-rules.pdf'
+        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/238952/third-edition-rules'
 
         PLAYER_RANGE = [2, 4].freeze
         OPTIONAL_RULES = [

--- a/lib/engine/game/g_18_ireland/meta.rb
+++ b/lib/engine/game/g_18_ireland/meta.rb
@@ -13,7 +13,7 @@ module Engine
         GAME_DESIGNER = 'Ian Scrivins'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Ireland'
         GAME_LOCATION = 'Ireland'
-        GAME_RULES_URL = 'https://www.dropbox.com/s/q19wvc8i410mr2u/18Ireland_Rules.pdf?dl=0'
+        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/219076/18ireland-rules-mass-production-version'
         GAME_TITLE = '18Ireland'
 
         PLAYER_RANGE = [3, 6].freeze


### PR DESCRIPTION

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [NA] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Update direct rules links for 1860 and 18Ireland to point to BGG instead of my personal dropbox (reduce bus factor and fragility)

### Screenshots

### Any Assumptions / Hacks
