### PR TITLE
[18MS] Fixes M&M ability to only work for owning corp

### DIFF
--- a/lib/engine/game/g_18_ms/entities.rb
+++ b/lib/engine/game/g_18_ms/entities.rb
@@ -67,6 +67,7 @@ module Engine
               {
                 type: 'token',
                 owner_type: 'corporation',
+                when: 'token',
                 hexes: [],
                 discount: 0.5,
                 count: 1,


### PR DESCRIPTION
Fixes #10025 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

The M&M private was usable by any corporation that the president of the owning corporation was running. This was corrected by adding `when: 'token'` to the company in entities.rb, limiting its use to the owning corporation's token laying step.

### Screenshots

### Any Assumptions / Hacks
