### PR TITLE
[1850] require selling down to 60% when force selling

### DIFF
--- a/lib/engine/game/g_1850/step/buy_train.rb
+++ b/lib/engine/game/g_1850/step/buy_train.rb
@@ -6,7 +6,7 @@ module Engine
   module Game
     module G1850
       module Step
-        class BuyTrain < Engine::Step::BuyTrain
+        class BuyTrain < G1870::Step::BuyTrain
           def round_state
             super.merge(
             {
@@ -33,14 +33,6 @@ module Engine
 
           def can_buy_train?(entity = nil, _shell = nil)
             super && !buyable_trains(entity).empty?
-          end
-
-          def can_sell?(entity, bundle)
-            super && bundle.corporation.holding_ok?(entity, -bundle.percent)
-          end
-
-          def selling_minimum_shares?(bundle)
-            super || !bundle.corporation.holding_ok?(bundle.owner, -bundle.percent + 1)
           end
         end
       end

--- a/lib/engine/game/g_1850/step/buy_train.rb
+++ b/lib/engine/game/g_1850/step/buy_train.rb
@@ -34,6 +34,14 @@ module Engine
           def can_buy_train?(entity = nil, _shell = nil)
             super && !buyable_trains(entity).empty?
           end
+
+          def can_sell?(entity, bundle)
+            super && bundle.corporation.holding_ok?(entity, -bundle.percent)
+          end
+
+          def selling_minimum_shares?(bundle)
+            super || !bundle.corporation.holding_ok?(bundle.owner, -bundle.percent + 1)
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #9950 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

rules say if you hold more than 60% and are selling shares of that corp, you must sell down to at least 60%. Currently this isn't enforced during EMR. 

1870 had code for this. I modified 1850 to inherit 1870's buy_train class, which I suspect was bentziaxl's intention since he had it in the require_relative at the top.

### Screenshots

### Any Assumptions / Hacks

Pins may be required if there are any games breaking this rule.