### PR TITLE
[1871] Prevents sale of more than 30% during EMR

### DIFF
--- a/lib/engine/game/g_1871/step/buy_train.rb
+++ b/lib/engine/game/g_1871/step/buy_train.rb
@@ -59,9 +59,8 @@ module Engine
             return false unless sellable_bundle?(bundle)
             return false if @game.class::MUST_SELL_IN_BLOCKS && @corporations_sold.include?(bundle.corporation)
 
-            # This is our new clause for 1871, if this is the corporation
-            # selling, we can sell all of them
-            return true if bundle.corporation == bundle.owner
+            # Corporations can sell all of their treasury shares during EMR, players may not sell more than 30% of a corporation
+            return false if bundle.corporation != bundle.owner && (bundle.percent > @game.class::TURN_SELL_LIMIT)
 
             selling_minimum_shares?(bundle)
           end

--- a/lib/engine/game/g_1871/step/buy_train.rb
+++ b/lib/engine/game/g_1871/step/buy_train.rb
@@ -59,8 +59,13 @@ module Engine
             return false unless sellable_bundle?(bundle)
             return false if @game.class::MUST_SELL_IN_BLOCKS && @corporations_sold.include?(bundle.corporation)
 
-            # Corporations can sell all of their treasury shares during EMR, players may not sell more than 30% of a corporation
-            return false if bundle.corporation != bundle.owner && (bundle.percent > @game.class::TURN_SELL_LIMIT)
+            # This is our new clause for 1871, if this is the corporation
+            # selling, we can sell all of them
+            return true if bundle.corporation == bundle.owner
+
+            # Corporations can sell all of their treasury shares during EMR,
+            # players may never sell more than 30% of a corporation at once, even during EMR
+            return false if bundle.percent > @game.class::TURN_SELL_LIMIT
 
             selling_minimum_shares?(bundle)
           end


### PR DESCRIPTION
Fixes #8260 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

This will likely require pins. 

## Implementation Notes

### Explanation of Change

Players should not be able to sell more than 30% of a corp during funding, as per rule:
![image](https://github.com/user-attachments/assets/dc978c72-cf27-436a-b1e8-1d27b7b8f17d)

Corporations may issue above 30%, so I put in an added guard clause to ensure only players are blocked. 

### Screenshots

### Any Assumptions / Hacks
