### PR TITLE
[site] Discard Trains step to display page description instead of default 'Discard Trains'

### DIFF
--- a/assets/app/view/game/discard_trains.rb
+++ b/assets/app/view/game/discard_trains.rb
@@ -39,8 +39,9 @@ module View
             &.include?('scrap_train')
         overflow << h(Map, game: @game) if @game.round.is_a?(Engine::Round::Operating)
 
+        discard_description = step.description
         h(:div, [
-          h(:h3, 'Discard Trains'),
+          h(:h3, discard_description),
           *overflow,
         ])
       end

--- a/lib/engine/game/g_18_ny/step/discard_train.rb
+++ b/lib/engine/game/g_18_ny/step/discard_train.rb
@@ -10,6 +10,10 @@ module Engine
           def process_discard_train(action)
             @game.salvage_train(action.train)
           end
+
+          def description
+            'Salvage Excess Trains'
+          end
         end
       end
     end

--- a/lib/engine/step/discard_train.rb
+++ b/lib/engine/step/discard_train.rb
@@ -23,7 +23,7 @@ module Engine
       end
 
       def description
-        'Discard Train'
+        'Discard Trains'
       end
 
       def process_discard_train(action)


### PR DESCRIPTION
Fixes #9128 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

This change, initially done for 18NY, will now allow all games to define what their Discard Trains step should display when prompting the discard of excess trains. 

I also updated the description in lib/engine/step/discard_train.rb from 'Discard Train' to 'Discard Trains', since that's what was being displayed anyway. 

### Screenshots

### Any Assumptions / Hacks

I know a previous fix (#9136) broke some things on the site. From the tests I've run on my end, these changes seem to work, but I'm happy to hear it if I'm wrong!
