### PR TITLE
[1840] Cannot pay for track cost as bonus action tobymao#11315

### DIFF
--- a/lib/engine/game/g_1840/step/special_track.rb
+++ b/lib/engine/game/g_1840/step/special_track.rb
@@ -81,7 +81,10 @@ module Engine
           end
 
           def process_lay_tile(action)
-            lay_tile(action)
+            entity = action.entity
+            spender = @game.owning_major_corporation(entity)
+
+            lay_tile(action, spender: spender)
             @round.laid_hexes << action.hex
             @round.pending_tile_lays.shift
           end


### PR DESCRIPTION
Fixes #11315 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

As per notes from @DestrinStorm in issue discussion, the call to lay_tile() from special_track.rb doesn't pass a spender.  This means it defaults to trying to spend the money from the tram line, which *never* has any money to spend, and so will always fail.

The owning major corporation should always pay the cost of a bonus track lay when there is one, the same as it does for any other actions taken by the tram line, e.g. removing / placing tokens.

Fix allows the owning major corp to correctly pay the costs for the bonus yellow tile lay in a hotseat clone of both games flagged in the issue.

### Screenshots

### Any Assumptions / Hacks
