### PR TITLE
[1822CA ERS] Winnipeg should be pass-through, not terminal

### DIFF
--- a/lib/engine/game/g_1822_ca_ers/map.rb
+++ b/lib/engine/game/g_1822_ca_ers/map.rb
@@ -17,7 +17,7 @@ module Engine
             %w[T12] => 'city=revenue:yellow_30|green_40|brown_50|gray_60,slots:2;'\
                        'path=a:4,b:_0,terminal:1;path=a:5,b:_0,terminal:1',
             %w[T14] => 'city=revenue:yellow_30|green_40|brown_50|gray_60,slots:3;'\
-                       'path=a:4,b:_0,terminal:1;path=a:5,b:_0,terminal:1',
+                       'path=a:4,b:_0;path=a:5,b:_0',
             ['Y29'] => 'city=revenue:yellow_30|green_40|brown_50|gray_60,slots:2;path=a:4,b:_0,lanes:2',
           },
         }.freeze


### PR DESCRIPTION
Fixes #11329 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Makes hex T14 on the 1822CA-ERS map a non-terminal city. Confirmed by both Scott Petersen on the issue report comments, and the designer over discord.

### Screenshots

### Any Assumptions / Hacks
