### PR TITLE
[1860] fix player value in game variant

### DIFF
--- a/lib/engine/game/g_1860/trainless_shares_half_value.rb
+++ b/lib/engine/game/g_1860/trainless_shares_half_value.rb
@@ -36,9 +36,9 @@ module Engine
           trainless_shares, train_shares = player.shares.partition { |s| s.corporation.trains.empty? }
           if @optional_rules&.include?(:non_operated_full_value)
             unoperated_corps, operated_corps = trainless_shares.partition { |s| s.corporation.operating_history.empty? }
-            player.cash + player.companies.sum(&:value) + unoperated_corps.sum(&:price) + operated_corps.sum do |s|
-                                                                                            (s.price / 2).to_i
-                                                                                          end
+            player.cash + train_shares.sum(&:price) + unoperated_corps.sum(&:price) + operated_corps.sum do |s|
+                                                                                        (s.price / 2).to_i
+                                                                                      end + player.companies.sum(&:value)
           else
             player.cash + train_shares.sum(&:price) + trainless_shares.sum do |s|
                                                         (s.price / 2).to_i


### PR DESCRIPTION
Fixes #11332

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

With the non_operated_full_value variant, when I modified the `def player_value` code, I forgot to add in the value of shares of corps with trains. Admittedly a big oversight!

I suspect we'll need to pin any finished games on that variant, since their recorded final scores will be incorrect.

### Screenshots

### Any Assumptions / Hacks
