### PR TITLE
[1822PNW] replace £ with $ in status info

### DIFF
--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -37,6 +37,13 @@ module Engine
           'NP' => 3,
         }.freeze
 
+        STATUS_TEXT = G1822PNW::Game::STATUS_TEXT.merge(
+          'can_acquire_minor_bidbox' => ['Acquire a minor from bidbox',
+                                         'Can acquire a minor from bidbox for $200, must have connection '\
+                                         'to start location'],
+          'minor_float_phase1' => ['Minors receive $100 in capital', 'Minors receive $100 capital with 50 stock value'],
+        ).freeze
+
         STARTING_COMPANIES = %w[P1 P2 P3 P4 P5 P6 P7 P8 P9 P10 P11 P12 P13 P14 P15 P16 P17 P18 P19 P20 P21
                                 M1 M2 M3 M4 M5 M6 M7 M8 M9 M10 M11 M12 M13 M14 M15 M16 M17 M18 M19 M20 M21 MA MB MC].freeze
 


### PR DESCRIPTION
Fixes #11339

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

1822PNW was using base 1822's STATUS_TEXT, which of course uses £ instead of $ as its currency symbol. This corrects that.

### Screenshots

### Any Assumptions / Hacks
