### PR TITLE
[1871] Should not be able to crossbuy after issuing shares

### DIFF
--- a/lib/engine/game/g_1871/step/buy_train.rb
+++ b/lib/engine/game/g_1871/step/buy_train.rb
@@ -20,9 +20,8 @@ module Engine
 
           def buyable_trains(entity)
             super.reject do |train|
-              entity.id == 'PEIR' &&
-              train.from_depot? &&
-                @round.bought_trains.include?(entity)
+              (entity.id == 'PEIR' && train.from_depot? && @round.bought_trains.include?(entity)) ||
+              (@last_share_issued_price && !train.from_depot?)
             end
           end
 
@@ -64,6 +63,12 @@ module Engine
             return true if bundle.corporation == bundle.owner
 
             selling_minimum_shares?(bundle)
+          end
+
+          def process_sell_shares(action)
+            super
+
+            @last_share_issued_price = action.bundle.price_per_share if action.bundle.corporation == current_entity
           end
         end
       end


### PR DESCRIPTION
Fixes #10069

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

According to the rules of the game, a company cannot cross-buy after issuing shares. This prevents that from happening. 

### Screenshots

### Any Assumptions / Hacks

Any games where a cross-buy has occurred after issuing shares would need to be pinned or archived. 
