### PR TITLE
[1849] fix for the Bonds variant

### DIFF
--- a/lib/engine/game/g_1849/step/bond.rb
+++ b/lib/engine/game/g_1849/step/bond.rb
@@ -20,8 +20,8 @@ module Engine
 
           def round_state
             {
-              issued_bond: nil,
-              redeemed_bond: nil,
+              issued_bond: false,
+              redeemed_bond: false,
             }
           end
 

--- a/lib/engine/game/g_1849/step/bond.rb
+++ b/lib/engine/game/g_1849/step/bond.rb
@@ -7,8 +7,6 @@ module Engine
     module G1849
       module Step
         class Bond < Engine::Step::Base
-          attr_reader :issued_bond, :redeemed_bond
-
           def actions(entity)
             return [] if !entity.corporation? || entity != current_entity
 
@@ -21,8 +19,10 @@ module Engine
           end
 
           def round_state
-            @issued_bond = {}
-            @redeemed_bond = {}
+            {
+              issued_bond: nil,
+              redeemed_bond: nil,
+            }
           end
 
           def description
@@ -47,7 +47,7 @@ module Engine
             @log << "#{entity.name} issues its bond and receives #{@game.format_currency(@game.loan_value)}"
             @game.bank.spend(@game.loan_value, entity)
             entity.loans << loan
-            @issued_bond[entity] = true
+            @round.issued_bond = true
 
             initial_sp = entity.share_price.price
             @game.stock_market.move_left(entity)
@@ -59,12 +59,12 @@ module Engine
             @game.bonds? &&
              @game.issue_bonds_enabled &&
              entity.corporation? &&
-             !@redeemed_bond[entity] &&
+             !@round.redeemed_bond &&
              entity.loans.size < @game.maximum_loans(entity)
           end
 
           def can_payoff_loan?(entity)
-            !@issued_bond[entity] &&
+            !@round.issued_bond &&
               !entity.loans.empty? &&
               entity.cash >= entity.loans.first.amount
           end
@@ -86,7 +86,7 @@ module Engine
 
             entity.loans.delete(loan)
 
-            @redeemed_bond[entity] = true
+            @round.redeemed_bond = true
 
             initial_sp = entity.share_price.price
             @game.stock_market.move_right(entity)


### PR DESCRIPTION
Fixes #11138

(hopefully)

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

We keep getting blocking step errors when using the Bonds variant, and it's always happening after the game enters phase 8, which is when the bonds are enabled. 

It's difficult to test this fix, as the error doesn't happen in my local test environment, but I think the fix here may help.  I changed the round_state definition, and modified the related code. 

### Screenshots

### Any Assumptions / Hacks
