### PR TITLE
[1861/1867] Restart major companies with 70% ownership limit in two-player games

### DIFF
--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -654,6 +654,14 @@ module Engine
           end
         end
 
+        def reset_corporation(corporation)
+          corp = super
+          # When a major is restarted it defaults to a 60% ownership limit.
+          # This is wrong for the two-player variants.
+          corp.max_ownership_percent = 70 if @players.size == 2
+          corp
+        end
+
         def place_639_token(tile)
           return unless @national_reservations.any?
           return if tile.cities.any? { |c| c.tokened_by?(@national) }


### PR DESCRIPTION
## Implementation Notes

If a major company is nationalised and then restarted it defaults to a 60% player ownership limit. This is wrong for the two-player variants, which allow a player to own up to 70% of a company.

Fixes tobymao#11246.

From testing, there is just one game that is broken after this patch is applied, game ID 147977 (there's an assumed pass when a player reaches 60% ownership in a merger round, which no long applies). This can be fixed by pinning or migrating.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`