### PR TITLE
[18RoyalGorge] Require graph connection for cross-buying trains

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/step/buy_train.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/buy_train.rb
@@ -16,6 +16,27 @@ module Engine
             # even when train tight, there's room for a self-rust
             return true if entity.trains.any? { |t| t.rusts_on == upcoming_train.name }
           end
+
+          def check_connected!(buyer, train)
+            return if @game.loading
+            return if train.owner == @game.depot
+
+            seller = train.corporation
+            seller_nodes = @game.graph.connected_nodes(seller).keys
+            buyer_nodes = @game.graph.connected_nodes(buyer).keys
+
+            common_nodes = seller_nodes & buyer_nodes
+            return if common_nodes.any? do |n|
+                        n.town? || n.available_slots.positive? || n.tokened_by?(seller) || n.tokened_by?(buyer)
+                      end
+
+            raise GameError, "#{buyer.name} must be connected to #{seller.name} to buy their train."
+          end
+
+          def process_buy_train(action)
+            check_connected!(action.entity, action.train)
+            super
+          end
         end
       end
     end


### PR DESCRIPTION
From page 13 of 24 in the [current rulebook PDF][0].

Check for the connection when processing the action--instead of when finding available trains to buy--to minimize the necessary graph checks.

Fixes #11364

[0]: https://boardgamegeek.com/filepage/284918/graphic-rulebook-preliminary

-----

Pins needed: any games where an illegal (unconnected) cross-buy occurred.

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`