### PR TITLE
[18RoyalGorge] export all 2+ trains at end of first OR set

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -566,7 +566,11 @@ module Engine
           @gold_shipped = 0
           update_gold_corp_cash!
 
-          depot.export! unless @depot.upcoming.empty?
+          if @depot.upcoming.first&.name == '2+'
+            depot.export_all!('2+')
+          elsif !@depot.upcoming.empty?
+            depot.export!
+          end
         end
 
         def handle_metal_payout(entity)


### PR DESCRIPTION
Fixes #11359

------

Pins needed: any games where more than one 2+ train remained at the end of the first OR set

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`