### PR TITLE
[18RoyalGorge] don't skip player if they can buy shares via private discount

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/buy_sell_par_shares.rb
@@ -105,6 +105,20 @@ module Engine
 
             super
           end
+
+          def can_buy_any?(entity)
+            super || can_buy_company_discounted_bundles?(entity)
+          end
+
+          def can_buy_company_discounted_bundles?(entity)
+            return false if bought?
+
+            cash = available_cash(entity)
+            bundles = company_discounted_bundles(@game.gold_corp) + company_discounted_bundles(@game.steel_corp)
+            bundles.any? do |_, bundle|
+              cash >= modify_purchase_price(bundle)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #11363

----

Pins: any games where a player was skipped in the SR due to no valid actions, but they could have used the discount from a private company to afford a gold or steel company share

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`