### PR TITLE
[1822/CA and core] fix 1822 tax haven bug

### DIFF
--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -164,7 +164,8 @@ module View
             h(:div, company_name_str),
             h(:div, { style: description_style }, @company.desc),
           ]
-          children << h(:div, { style: value_style }, "Value: #{@game.format_currency(@company.value)}") if @company.value
+          company_value = @game.company_value(@company)
+          children << h(:div, { style: value_style }, "Value: #{@game.format_currency(company_value)}") if company_value
           children << h(:div, { style: revenue_style }, "Revenue: #{revenue_str}") if @company.revenue
           unless @company.discount.zero?
             children << h(:div, { style: { float: 'center' } }, "Price: #{@game.format_currency(@company.min_bid)}")
@@ -251,7 +252,7 @@ module View
                       end
 
         [h(:div, name_props, [h('span.nowrap', company_name_str), h(:span, extra)]),
-         @game.show_value_of_companies?(company.owner) ? h('div.right', @game.format_currency(company.value)) : '',
+         @game.show_value_of_companies?(company.owner) ? h('div.right', @game.format_currency(@game.company_value(company))) : '',
          h('div.padded_number', revenue_str),
          @hidden_divs[company.sym]]
       end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2365,6 +2365,10 @@ module Engine
         'subsidy'
       end
 
+      def company_value(company)
+        company.value
+      end
+
       private
 
       def init_graph

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -690,10 +690,9 @@ module Engine
           end
 
           if company.id == self.class::COMPANY_OSTH && company.owner&.player? && @tax_haven.value.positive?
-            company.value = @tax_haven.value
             cash = format_currency(@tax_haven.cash)
             shares = @tax_haven.shares.map { |s| s.corporation.name }.join(',')
-            return "(#{cash}; #{shares})"
+            return "(#{cash},#{shares})"
           end
 
           nil
@@ -736,6 +735,10 @@ module Engine
           return 0 unless @tax_haven.value.positive?
 
           @tax_haven.value
+        end
+
+        def company_value(company)
+          company.id == self.class::COMPANY_OSTH ? @tax_haven.value : company.value
         end
 
         def entity_can_use_company?(entity, company)
@@ -1038,13 +1041,7 @@ module Engine
         end
 
         def player_value(player)
-          # tax_haven_company.value can sometimes be zero and sometimes the same
-          # as tax_haven_value() (issues #5200 and #11007) because it is only
-          # set in company_status_str, which is only called by some views, so
-          # substract that value and include only the correct calculation
-          tax_haven_val = tax_haven_value(player) - (tax_haven_company&.value || 0)
-
-          player.value - @player_debts[player] + tax_haven_val
+          player.value - @player_debts[player] + tax_haven_value(player)
         end
 
         def purchasable_companies(entity = nil)


### PR DESCRIPTION
1822's `company_status_str` (called by views) was mutating the value of the private company entity, and there was a substraction operation in place to try to copmensate for that, but that caused #11040 by subtracting the tax haven's value for other players.

This has been simplified with the following approach:

- when displaying the company value, call a new wrapper method in the `Game::Base` class
- in 1822, override that new method only for the Tax Haven

Now the Tax Haven private company entity will always have a value of $0/£0, but the value of the Tax Haven "player" entity is handed off to display methods.

Fixes #11040

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`
