### PR TITLE
[1888-N] corrects the Forbidden City private ability

### DIFF
--- a/lib/engine/game/g_1888/entities.rb
+++ b/lib/engine/game/g_1888/entities.rb
@@ -104,6 +104,24 @@ module Engine
           },
         ].freeze
 
+        COMPANIES_NORTH_PUBLISHED = [
+          {
+            name: 'Forbidden City',
+            value: 150,
+            revenue: 30,
+            desc: "During a stock round, a player owning this private company may close it to take one share in the IPO or the bank pool of a share company with a token in Beijing (at that time). This counts as a buy action and the player cannot sell anything the turn they're doing it. If the private is sold to a share company, this ability is lost.",
+            sym: 'FC',
+            abilities: [{
+              type: 'exchange',
+              owner_type: 'player',
+              corporations: 'any',
+              when: 'owning_player_sr_turn',
+              from: %w[ipo market],
+            }],
+            color: nil,
+          },
+        ].freeze
+
         COMPANIES_EAST = [
           {
             name: 'Kaiping Tramway',

--- a/lib/engine/game/g_1888/step/exchange.rb
+++ b/lib/engine/game/g_1888/step/exchange.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/exchange'
+require_relative '../../../step/share_buying'
+require_relative '../../../action/buy_shares'
+
+module Engine
+  module Game
+    module G1888
+      module Step
+        class Exchange < Engine::Step::Exchange
+          def can_exchange?(entity, bundle = nil)
+            # This prevents the player from exchanging for a share if they've already sold shares in the same turn
+            # This is a special rule for the published version of 1888 North
+            return false if @round.current_actions.any? { |x| x.instance_of?(Action::SellShares) } && @game.north?
+
+            super
+          end
+
+          def process_buy_shares(action)
+            super
+
+            # This makes the Forbidden City exchange count as a Buy action
+            @round.current_actions << action if @game.north?
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #11400

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

The Forbidden City private changed between the prototype phase and the final release. The final release version was never implemented. This implements it, but only when playing with the 1888-North variant, since the prototype version is still available for play on the site.

This will require pinning any games using the :north variant.

### Screenshots

### Any Assumptions / Hacks
