### PR TITLE
Removes RoyalGorge KS link from welcome page

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -16,13 +16,11 @@ module View
 
     def render_notification
       message = <<~MESSAGE
-        <p><a href='https://www.kickstarter.com/projects/18wood/18royalgorge/'>18RoyalGorge is now on Kickstarter</a>.</p>
-
         <p><a href="https://github.com/tobymao/18xx/wiki/18RoyalGorge">18RoyalGorge</a> is now in beta.</p>
 
-        <p><a href="https://github.com/tobymao/18xx/wiki/1858%20Switzerland">1858 Switzerland</a> is in alpha.</p>
+         <p><a href="https://github.com/tobymao/18xx/wiki/1858%20Switzerland">1858 Switzerland</a> is in alpha.</p>
 
-        <p>Report bugs and make feature requests <a href='https://github.com/tobymao/18xx/issues'>on GitHub</a>.</p>
+         <p>Report bugs and make feature requests <a href='https://github.com/tobymao/18xx/issues'>on GitHub</a>.</p>
       MESSAGE
 
       props = {

--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -18,9 +18,9 @@ module View
       message = <<~MESSAGE
         <p><a href="https://github.com/tobymao/18xx/wiki/18RoyalGorge">18RoyalGorge</a> is now in beta.</p>
 
-         <p><a href="https://github.com/tobymao/18xx/wiki/1858%20Switzerland">1858 Switzerland</a> is in alpha.</p>
+        <p><a href="https://github.com/tobymao/18xx/wiki/1858%20Switzerland">1858 Switzerland</a> is in alpha.</p>
 
-         <p>Report bugs and make feature requests <a href='https://github.com/tobymao/18xx/issues'>on GitHub</a>.</p>
+        <p>Report bugs and make feature requests <a href='https://github.com/tobymao/18xx/issues'>on GitHub</a>.</p>
       MESSAGE
 
       props = {


### PR DESCRIPTION
<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

The 18Royalgorge kickstarter is over. Removing the link to it from the welcome page.

### Screenshots

### Any Assumptions / Hacks
