### PR TITLE
[Core] Don't modify TRAINS definition when creating train variants

### DIFF
--- a/lib/engine/train.rb
+++ b/lib/engine/train.rb
@@ -44,8 +44,6 @@ module Engine
     end
 
     def init_variants(variants)
-      variants ||= []
-
       @variant = {
         name: @name,
         distance: @distance,
@@ -60,8 +58,9 @@ module Engine
       }
 
       # Primary variant should be at the head of the list.
-      variants.unshift(@variant)
-      @variants = variants.group_by { |h| h[:name] }.transform_values(&:first)
+      @variants = Array([@variant, *variants])
+                       .group_by { |v| v[:name] }
+                       .transform_values(&:first)
     end
 
     def variant=(new_variant)


### PR DESCRIPTION
## Implementation Notes

### Explanation of Change

The `variants` parameter passed to `Engine::Train.init_variants` is (in the default implementations) an array of train variant definitions that is part of the TRAINS constant. The code inside `init_trains` was, for each train, creating a new variant for the normal type of train and prepending it to the variant array. This was modifying the array inside the TRAINS constant, making the list of variants steadily longer.

This wasn't much of a problem in most cases as the extra items in the `variants` array were all duplicates and we only extra a single item for each variant name. But when games are loaded on the server in quick succession the TRAINS constant is shared between a game title and (potentially) any titles that inherit from that title. This was causing bug tobymao#11416, where 1858 Switzerland was attempting to modify the price of a variant, and was expecting there to only be a single item in the `variants` array for the type of train.

This commit changes the `init_variants` method to not make any changes to the array it is passed, instead copying the contents to a new array.

Fixes #11416.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
