### PR TITLE
[1837] Allow backtracking when considering token spots

### DIFF
--- a/lib/engine/game/g_1837/game.rb
+++ b/lib/engine/game/g_1837/game.rb
@@ -651,6 +651,10 @@ module Engine
           Token.new(@blocker)
         end
 
+        def token_graph_for_entity
+          @token_graph ||= Graph.new(self, backtracking: true)
+        end
+
         def legal_tile_rotation?(entity, hex, tile)
           return tile.rotation == 5 if tile.name == '436'
 

--- a/lib/engine/graph.rb
+++ b/lib/engine/graph.rb
@@ -23,6 +23,7 @@ module Engine
       @skip_track = opts[:skip_track]
       @check_tokens = opts[:check_tokens]
       @check_regions = opts[:check_regions]
+      @backtracking = opts[:backtracking] || false
     end
 
     def clear
@@ -259,7 +260,8 @@ module Engine
         local_nodes = {}
 
         node.walk(visited: visited, corporation: walk_corporation, skip_track: @skip_track,
-                  skip_paths: skip_paths, converging_path: false, walk_calls: @walk_calls[corporation]) do |path, _, _|
+                  skip_paths: skip_paths, converging_path: false, walk_calls: @walk_calls[corporation],
+                  backtracking: @backtracking) do |path, _, _|
           next if paths[path]
 
           paths[path] = true

--- a/lib/engine/part/node.rb
+++ b/lib/engine/part/node.rb
@@ -36,6 +36,8 @@ module Engine
       # counter: a hash tracking edges and junctions to avoid reuse
       # skip_track: If passed, don't walk on track of that type (ie: :broad track for 1873)
       # converging_path: When true, some predecessor path was part of a converging switch
+      # walk_calls: a hash tracking the number of walk calls
+      # backtracking: If true, allow walks to backtrack along the same edge
       #
       # This method recursively bubbles up yielded values from nested Node::Walk and Path::Walk calls
       def walk(
@@ -47,6 +49,7 @@ module Engine
         skip_track: nil,
         converging_path: true,
         walk_calls: Hash.new(0),
+        backtracking: false,
         &block
       )
         walk_calls[:all] += 1
@@ -68,6 +71,7 @@ module Engine
             counter: counter,
             converging: converging_path,
             walk_calls: walk_calls,
+            backtracking: backtracking,
           ) do |path, vp, ct, converging|
             ret = yield path, vp, visited
             next if ret == :abort
@@ -86,6 +90,7 @@ module Engine
                 skip_paths: skip_paths,
                 converging_path: converging_path || converging,
                 walk_calls: walk_calls,
+                backtracking: backtracking,
                 &block
               )
             end


### PR DESCRIPTION
1837 allows backtracking along an hex edge when determining potential token locations. This PR adds backtracking support to `walk`.