### PR TITLE
[Common] Move sold_out_stock_movement to game class

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1269,6 +1269,10 @@ module Engine
         self.class::SOLD_OUT_INCREASE
       end
 
+      def sold_out_stock_movement(corp)
+        @stock_market.move_up(corp)
+      end
+
       def log_share_price(entity, from, steps = nil, log_steps: false)
         from_price = from.price
         to = entity.share_price

--- a/lib/engine/game/g_1837/game.rb
+++ b/lib/engine/game/g_1837/game.rb
@@ -27,6 +27,7 @@ module Engine
 
         SELL_AFTER = :operate
         SELL_MOVEMENT = :down_block
+        MUST_SELL_IN_BLOCKS = true
 
         HOME_TOKEN_TIMING = :float
 

--- a/lib/engine/round/stock.rb
+++ b/lib/engine/round/stock.rb
@@ -96,7 +96,7 @@ module Engine
       end
 
       def sold_out_stock_movement(corp)
-        @game.stock_market.move_up(corp)
+        @game.sold_out_stock_movement(corp)
       end
 
       def sold_out?(corporation)


### PR DESCRIPTION
Sold out stock movement is a common difference between games. Move the functionality to the game class, to reduce the amount of games that need to override the stock round class.