### PR TITLE
Fix errors in rusts/obsoletes information in train tables on info and spreadsheet pages

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -169,7 +169,7 @@ module View
               rust_schedule[rusts_on].append(name) unless rust_schedule[rusts_on].include?(name)
             end
             Array(train_variant[:obsolete_on]).each do |obsolete_on|
-              rust_schedule[obsolete_on].append(name) unless rust_schedule[obsolete_on].include?(name)
+              obsolete_schedule[obsolete_on].append(name) unless obsolete_schedule[obsolete_on].include?(name)
             end
           end
         end
@@ -254,7 +254,7 @@ module View
 
           train_content << h(:td, obsolete_schedule[train.name]&.join(', ') || '') if show_obsolete_schedule
           train_content << if show_rusts_inline
-                             h(:td, rusts&.join(', ') || '')
+                             h(:td, rusts&.reject(&:empty?)&.join(', ') || '')
                            else
                              h(:td, rusts&.map { |value| h(:div, value) } || '')
                            end

--- a/assets/app/view/game/train_schedule.rb
+++ b/assets/app/view/game/train_schedule.rb
@@ -25,7 +25,7 @@ module View
               rust_schedule[rusts_on].append(name) unless rust_schedule[rusts_on].include?(name)
             end
             Array(train_variant[:obsolete_on]).each do |obsolete_on|
-              rust_schedule[obsolete_on].append(name) unless rust_schedule[obsolete_on].include?(name)
+              obsolete_schedule[obsolete_on].append(name) unless obsolete_schedule[obsolete_on].include?(name)
             end
           end
         end
@@ -55,8 +55,8 @@ module View
               else
                 @game.depot.upcoming.reject(&:reserved).group_by(&:name).map do |name, trains|
                   events = []
-                  events << h('div.left', "rusts #{rust_schedule[name].join(', ')}") if rust_schedule[name]
-                  events << h('div.left', "obsoletes #{obsolete_schedule[name].join(', ')}") if obsolete_schedule[name]
+                  events << h('div.left', "obsoletes #{obsolete_schedule[name].join(', ')}") unless obsolete_schedule[name].empty?
+                  events << h('div.left', "rusts #{rust_schedule[name].join(', ')}") unless rust_schedule[name].empty?
                   tds = [h(:td, @game.info_train_name(trains.first)),
                          h("td#{price_str_class}", @game.info_train_price(trains.first)),
                          h('td.right', "×#{trains.size}")]


### PR DESCRIPTION
Fix errors in rusts/obsoletes information in train tables on info and spreadsheet pages
Fixes #11305

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
