### PR TITLE
[18Uruguay] The correction of home toke timing broke RPTLA

### DIFF
--- a/lib/engine/game/g_18_uruguay/game.rb
+++ b/lib/engine/game/g_18_uruguay/game.rb
@@ -211,6 +211,7 @@ module Engine
 
           goods_setup
           @rptla = @corporations.find { |c| c.id == 'RPTLA' }
+          place_home_token(@rptla)
           @fce = @corporations.find { |c| c.id == 'FCE' }
 
           @rptla.add_ability(Engine::G18Uruguay::Ability::Ship.new(


### PR DESCRIPTION
The correction that was made to solve the problem with blocked home tokens accidently broke RTPLA so no home token were placed, this solves that issue

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
