### PR TITLE
Move to next dev stage if the dev stage has stayed the same for a year or more

### DIFF
--- a/lib/engine/game/g_1822_mx/meta.rb
+++ b/lib/engine/game/g_1822_mx/meta.rb
@@ -9,7 +9,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :beta
+        DEV_STAGE = :production
         DEPENDS_ON = '1822'
 
         GAME_SUBTITLE = 'The Railways of Mexico'

--- a/lib/engine/game/g_1822_pnw/meta.rb
+++ b/lib/engine/game/g_1822_pnw/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :beta
+        DEV_STAGE = :production
         DEPENDS_ON = '1822'
 
         GAME_SUBTITLE = nil

--- a/lib/engine/game/g_1825/meta.rb
+++ b/lib/engine/game/g_1825/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :beta
+        DEV_STAGE = :production
 
         GAME_DESIGNER = 'Francis Tresham'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1825'

--- a/lib/engine/game/g_1836_jr56/meta.rb
+++ b/lib/engine/game/g_1836_jr56/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :beta
+        DEV_STAGE = :production
         # 1856 for obvious reasons
         DEPENDS_ON = '1856'
 

--- a/lib/engine/game/g_1841/meta.rb
+++ b/lib/engine/game/g_1841/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :beta
+        DEV_STAGE = :production
 
         GAME_SUBTITLE = nil
         GAME_DESIGNER = 'Federico Vallani and Manlio Manzini'

--- a/lib/engine/game/g_1850/meta.rb
+++ b/lib/engine/game/g_1850/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :alpha
+        DEV_STAGE = :beta
         DEPENDS_ON = '1870'
         GAME_TITLE = '1850'
         GAME_SUBTITLE = 'The MidWest'

--- a/lib/engine/game/g_1858/meta.rb
+++ b/lib/engine/game/g_1858/meta.rb
@@ -7,7 +7,7 @@ module Engine
     module G1858
       module Meta
         include Game::Meta
-        DEV_STAGE = :beta
+        DEV_STAGE = :production
 
         GAME_TITLE = '1858'
         GAME_SUBTITLE = 'The Railways of Iberia'

--- a/lib/engine/game/g_18_eu/meta.rb
+++ b/lib/engine/game/g_18_eu/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :beta
+        DEV_STAGE = :production
 
         GAME_DESIGNER = 'David Hecht'
         GAME_IMPLEMENTER = 'R. Ryan Driskel'

--- a/lib/engine/game/g_18_rhl/meta.rb
+++ b/lib/engine/game/g_18_rhl/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :beta
+        DEV_STAGE = :production
 
         GAME_SUBTITLE = 'Rhineland'
         GAME_DESIGNER = 'Wolfram Janich'

--- a/lib/engine/game/g_21_moon/meta.rb
+++ b/lib/engine/game/g_21_moon/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :beta
+        DEV_STAGE = :production
         PROTOTYPE = false
 
         GAME_DESIGNER = 'Jonas Jones and Scott Petersen'


### PR DESCRIPTION
There are a number of games that haven't updated the dev stage of the game in over a year. This PR moves each of those to the next dev stage.