### PR TITLE
[Core] Check for existence of `can_finance?` method

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -300,7 +300,7 @@ module View
           children << h(:div, issue_str)
         end
 
-        if @step.can_finance?(@corporation)
+        if @step.respond_to?(:can_finance?) && @step.can_finance?(@corporation)
           text = "#{@game.bank.name} will provide financing for the amount the corporation cannot pay."
           children << h(:div, text)
         end


### PR DESCRIPTION
## Implementation Notes

### Explanation of Change

The `can_finance?` method was added for 1837 in commit d08cc8435. It's used to check whether the bank will step in to pay the cost of a train.

This has broken 1877 Venezuela. There is a default implementation of `can_finance?` added to the Step::BuyTrain class, but 1877 Venezuela allows trains to be bought in the BuySellParShares step, which did not have this method.

This commit tests for the existence of this method before calling it.

Fixes tobymao#11508.


### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`