### PR TITLE
[1871] Fix dividend payout when there are three PEIR shares

### DIFF
--- a/lib/engine/game/g_1871/step/dividend.rb
+++ b/lib/engine/game/g_1871/step/dividend.rb
@@ -31,17 +31,10 @@ module Engine
           end
 
           def payout_per_share(entity, revenue)
-            share_count =
-              if entity == @game.peir
-                # entity.total_shares doesn't always work correctly for PEIR.
-                # If there are three shares then each is a 33% share, and
-                # total_shares returns 3.030303...
-                @game.peir_shares.size
-              else
-                entity.total_shares
-              end
+            return super unless entity == @game.peir
+
             # PEIR rounds up
-            (revenue.to_f / share_count).ceil
+            (revenue.to_f / @game.peir_shares.size).ceil
           end
 
           def half_pay_withhold_amount(_entity, revenue)

--- a/lib/engine/game/g_1871/step/dividend.rb
+++ b/lib/engine/game/g_1871/step/dividend.rb
@@ -31,8 +31,17 @@ module Engine
           end
 
           def payout_per_share(entity, revenue)
+            share_count =
+              if entity == @game.peir
+                # entity.total_shares doesn't always work correctly for PEIR.
+                # If there are three shares then each is a 33% share, and
+                # total_shares returns 3.030303...
+                @game.peir_shares.size
+              else
+                entity.total_shares
+              end
             # PEIR rounds up
-            (revenue.to_f / entity.total_shares).ceil
+            (revenue.to_f / share_count).ceil
           end
 
           def half_pay_withhold_amount(_entity, revenue)


### PR DESCRIPTION
`entity.total_shares` doesn't always work correctly for PEIR.  If there are three shares then each is a 33% share, and `total_shares` returns 3.030303...

This can lead to rounding errors in dividend payout, with a revenue of 300 being calculated as 99 per share.

Fixes tobymao#11525.