### PR TITLE
[1867] Remove "medium" from corp sizes

### DIFF
--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -379,7 +379,7 @@ module Engine
                                               convert_range: 'Price range to convert minor to major',
                                               max_price: 'Maximum price for a minor').freeze
         STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(par_1: :orange, par_2: :green, convert_range: :blue).freeze
-        CORPORATION_SIZES = { 2 => :small, 5 => :medium, 10 => :large }.freeze
+        CORPORATION_SIZES = { 2 => :small, 10 => :large }.freeze
         # A token is reserved for Montreal is reserved for nationalization
         NATIONAL_RESERVATIONS = ['L12'].freeze
         GREEN_CORPORATIONS = %w[BBG LPS QLS SLA TGB THB].freeze

--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -709,7 +709,7 @@ module Engine
         end
 
         def corporation_size(entity)
-          # For display purposes is a corporation small, medium or large
+          # For displaying if a corporation is a minor or major corporation
           CORPORATION_SIZES[entity.total_shares]
         end
 


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Looks like this bit was copied over from 1817, but 1861 and 1867 don't have medium sized 5-share corps.

### Screenshots

### Any Assumptions / Hacks
