### PR TITLE
[1837] Attempt to fix transient 'hex is not available' issue

### DIFF
--- a/lib/engine/game/g_1837/game.rb
+++ b/lib/engine/game/g_1837/game.rb
@@ -670,9 +670,9 @@ module Engine
           @bank.spend(cash, minor)
           @log << "#{minor.name} receives #{format_currency(cash)}"
           if !@round.is_a?(Engine::Round::Auction) && minor.id == 'SD5'
-            coordinates = minor.coordinates
-            minor.coordinates = coordinates.shift
-            remove_reservations!(minor, coordinates)
+            coordinates = minor.coordinates.dup
+            minor.coordinates = coordinates[0]
+            remove_reservations!(minor, coordinates[1])
           end
           place_home_token(minor) unless minor.coordinates.is_a?(Array)
           if minor.corporation?


### PR DESCRIPTION
When checking for games to pin, 1837 sees the error "Cannot place token on L2 as the hex is not available" on the server only for a subset of the games. I am unable to reproduce in my development environment with the same games that cause the issue in production. This is an attempt to fix it.