### PR TITLE
[18ES] fix minor 18esp errors

### DIFF
--- a/lib/engine/game/g_18_esp/game.rb
+++ b/lib/engine/game/g_18_esp/game.rb
@@ -1128,7 +1128,7 @@ module Engine
           move_assets(corporation, minor)
 
           # handle token
-          keep_token ? swap_token(corporation, minor) : gain_token(corporation, minor)
+          swap_token(corporation, minor) if keep_token
 
           # get share
           get_reserved_share(minor.owner, corporation) if minor.ipoed
@@ -1203,12 +1203,6 @@ module Engine
           @log << "#{owner.name} gets a share of #{corporation.name}"
         end
 
-        def gain_token(corporation, minor)
-          blocked_token = corporation.tokens.find { |token| token.used == true && !token.hex && token.price == 50 }
-          blocked_token&.used = false
-          delete_token_mz(minor) if minor&.name == 'MZ'
-        end
-
         def gain_luxury_carriage_ability_from_minor(corporation, minor)
           minor_luxury_ability = luxury_ability(minor)
           return unless minor_luxury_ability
@@ -1248,14 +1242,13 @@ module Engine
         end
 
         def swap_token(survivor, nonsurvivor)
-          new_token = survivor.tokens.last
+          new_token = survivor.next_token
           old_token = nonsurvivor.tokens.first
           city = old_token.city
           if city.nil?
             city = hex_by_id(nonsurvivor.coordinates).tile.cities.find { |c| c.reserved_by?(nonsurvivor) }
             city.remove_reservation!(nonsurvivor)
           end
-          return gain_token(survivor) unless city
 
           @log << "Replaced #{nonsurvivor.name} token in #{city.hex.id} with #{survivor.name}"\
                   ' token'

--- a/lib/engine/game/g_18_esp/step/acquire.rb
+++ b/lib/engine/game/g_18_esp/step/acquire.rb
@@ -92,7 +92,7 @@ module Engine
           def can_swap?
             return merged_token_in_shared_city? unless mz?(@merging.last)
 
-            @merging.last.tokens.first&.used &&
+            @merging.first.next_token &&
             !mz?(@merging.last) &&
             merged_token_in_shared_city?
           end

--- a/lib/engine/game/g_18_esp/step/buy_train.rb
+++ b/lib/engine/game/g_18_esp/step/buy_train.rb
@@ -16,6 +16,12 @@ module Engine
             trains
           end
 
+          def buyable_train_variants(train, entity)
+            variants = super
+            variants.reject! { |t| t[:track_type] == :narrow } if entity.type == :minor
+            variants
+          end
+
           def try_take_player_loan(entity, cost)
             return unless cost.positive?
             return unless cost > entity.cash

--- a/lib/engine/game/g_18_esp/step/choose.rb
+++ b/lib/engine/game/g_18_esp/step/choose.rb
@@ -18,6 +18,12 @@ module Engine
             actions
           end
 
+          def auto_actions(entity)
+            return [Engine::Action::Choose.new(entity, choice: '2')] if entity.type == :minor
+
+            []
+          end
+
           def log_skip(_entity); end
 
           def choice_name


### PR DESCRIPTION
two minor rule changes/bug fixes:

1- when merging, corp doesn't unlock a new token. It either replaces an existing free token with one on map, or nothing (token of non survivor gets removed as usual)
2- minor companies can't own + trains (aka track_type narrow), when buying private that gets train, there's no choice, it gets a regular 2 train. Majors get the regular choice