### PR TITLE
[1867] Fix active entity for home token step

### DIFF
--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -830,7 +830,7 @@ module Engine
           G1867::Round::Stock.new(self, [
             G1867::Step::MajorTrainless,
             Engine::Step::DiscardTrain,
-            Engine::Step::HomeToken,
+            G1867::Step::HomeToken,
             G1867::Step::BuySellParShares,
           ])
         end

--- a/lib/engine/game/g_1867/step/home_token.rb
+++ b/lib/engine/game/g_1867/step/home_token.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/home_token'
+
+module Engine
+  module Game
+    module G1867
+      module Step
+        class HomeToken < Engine::Step::HomeToken
+          def override_entities
+            @round.entities
+          end
+
+          def active_entities
+            [entities[entity_index]]
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Commit d8abe5a (from pull request tobymao#11503) had changed the calculation of the active entities in a home token step. This had broken 1867, where the home token is placed by a player (the one who just started an auction), not a corporation.

This commit restores the previous behaviour.

Fixes tobymao#11565.