### PR TITLE
[1858 Switzerland] Fix train buying by robot player

### DIFF
--- a/lib/engine/game/g_1858_switzerland/step/buy_train.rb
+++ b/lib/engine/game/g_1858_switzerland/step/buy_train.rb
@@ -41,6 +41,12 @@ module Engine
             @train_exported = true if @game.robot_owner?(action.entity)
             super
           end
+
+          def spend_minmax(entity, train)
+            return super unless @game.robot_owner?(entity)
+
+            [0, 0]
+          end
         end
       end
     end


### PR DESCRIPTION
Pull request tobymao#11452 added some checks to the train buying step, to catch cases where too many shares had been issued during emergency money raising.

This was causing an error in the 1858 Switzerland two-player variant, where the robot-controlled SBB company buys a train for zero cash.

This fixes this error by declaring that zero is a valid amount for these train purchases.

Fixes tobymao#11553.