### PR TITLE
[18Uruguay] Corrected aquire fce share sequence

### DIFF
--- a/lib/engine/game/g_18_uruguay/nationalization.rb
+++ b/lib/engine/game/g_18_uruguay/nationalization.rb
@@ -31,16 +31,18 @@ module Engine
             num_shares, odd_shares = (total_percent / 10).divmod(2)
             from_secondary = @merge_data[:secondary_corps].count { |corp| corp.president?(holder) }
             num_shares += from_secondary
-            bundle =
-              if num_shares == 10
-                Engine::ShareBundle.new(@fce.shares.take(9))
-              else
-                Engine::ShareBundle.new(@fce.shares.reject(&:president).take(num_shares))
-              end
-            @share_pool.transfer_shares(bundle, holder, allow_president_change: true)
-            @log << "#{holder.name} receives  #{num_shares * 10}% in FCE in exchange to the nationalized shares"
+            if num_shares.positive?
+              bundle =
+                if num_shares == 10
+                  Engine::ShareBundle.new(@fce.shares.take(9))
+                else
+                  Engine::ShareBundle.new(@fce.shares.reject(&:president).take(num_shares))
+                end
+              @share_pool.transfer_shares(bundle, holder, allow_president_change: true)
+              @log << "#{holder.name} receives  #{num_shares * 10}% in FCE in exchange to the nationalized shares"
+            end
 
-            next unless odd_shares
+            next unless odd_shares.positive?
 
             price = @fce.share_price.price / 2
             @bank.spend(price, holder)


### PR DESCRIPTION
Fixes #11578

Also corrected half share payout so there is a small risk that games that has done the nationalization will brake 

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
