### PR TITLE
[18Norway] Corrected turn calculation

### DIFF
--- a/lib/engine/game/g_18_norway/game.rb
+++ b/lib/engine/game/g_18_norway/game.rb
@@ -335,6 +335,7 @@ module Engine
               if @round.round_num < @operating_rounds
                 new_operating_round(@round.round_num + 1)
               else
+                @turn += 1
                 or_set_finished
                 new_stock_round
               end
@@ -343,18 +344,14 @@ module Engine
               reorder_players
               new_operating_round
             when Engine::Round::Operating
-              if @round.round_num < @operating_rounds
+              if @round.round_num < @operating_rounds || @phase.tiles.include?(:green)
                 or_round_finished
                 new_nationalization_round(@round.round_num)
               else
                 @turn += 1
                 or_round_finished
-                if @phase.tiles.include?(:green)
-                  new_nationalization_round(@round.round_num)
-                else
-                  or_set_finished
-                  new_stock_round
-                end
+                or_set_finished
+                new_stock_round
               end
             when init_round.class
               init_round_finished

--- a/lib/engine/game/g_18_norway/round/nationalization.rb
+++ b/lib/engine/game/g_18_norway/round/nationalization.rb
@@ -14,6 +14,10 @@ module Engine
           def select_entities
             @game.operating_order.reverse
           end
+
+          def show_in_history?
+            false
+          end
         end
       end
     end


### PR DESCRIPTION
Updated the turn calculation in the end so that we do not end the game to early

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
