### PR TITLE
[18Norway] Companies that are floated after end game is automatically nationalized

### DIFF
--- a/lib/engine/game/g_18_norway/game.rb
+++ b/lib/engine/game/g_18_norway/game.rb
@@ -328,6 +328,16 @@ module Engine
               ], round_num: round_num)
         end
 
+        def nationalize_corporation(entity, number_of_shares)
+          value = convert(entity, number_of_shares)
+          @log << "#{entity.name} nationalized and receives #{format_currency(value)}"
+          update_cert_limit
+        end
+
+        def float_corporation(corporation)
+          nationalize_corporation(corporation, 1) if custom_end_game_reached?
+        end
+
         def next_round!
           @round =
             case @round

--- a/lib/engine/game/g_18_norway/steps/nationalize_corporation.rb
+++ b/lib/engine/game/g_18_norway/steps/nationalize_corporation.rb
@@ -42,9 +42,7 @@ module Engine
               return
             end
 
-            value = @game.convert(action.entity, action.choice.to_i)
-            @log << "#{action.entity.name} nationalized and receives #{@game.format_currency(value)}"
-            @game.update_cert_limit
+            @game.nationalize_corporation(action.entity, action.choice.to_i)
             @game.next_round!
           end
         end


### PR DESCRIPTION
Companies that are floated after end game is automatically nationalized

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
