### PR TITLE
[1844] Fix error from nil ability description

### DIFF
--- a/lib/engine/game/g_1844/game.rb
+++ b/lib/engine/game/g_1844/game.rb
@@ -397,7 +397,7 @@ module Engine
             next unless corp.destination_coordinates
 
             hex_by_id(corp.destination_coordinates).remove_assignment!(corp)
-            corp.remove_ability(corp.abilities.find { |a| a.description.start_with?('Destination') })
+            corp.remove_ability(corp.abilities.find { |a| a.description&.start_with?('Destination') })
           end
         end
 


### PR DESCRIPTION
When the first 6/6H train is bought, the destinations for pre-SBB and large historical companies are removed. This involves removing the destination abilities for these companies, but in tobymao#11591 this was causing an error.

The test for a destination ability is done for looking at the ability's description. BLS has, as well as the destination ability, an assign hexes ability. That does not have a description set, and so an `undefined method 'start_with?' for nil` was being thrown. This is fixed by using the safe navigation operator.

Fixes tobymao#11591.