### PR TITLE
[18Norway] No nationalization rounds in end game

### DIFF
--- a/lib/engine/game/g_18_norway/game.rb
+++ b/lib/engine/game/g_18_norway/game.rb
@@ -344,7 +344,14 @@ module Engine
               reorder_players
               new_operating_round
             when Engine::Round::Operating
-              if @round.round_num < @operating_rounds || @phase.tiles.include?(:green)
+              if @round.round_num < @operating_rounds
+                or_round_finished
+                if !custom_end_game_reached?
+                  new_nationalization_round(@round.round_num)
+                else
+                  new_operating_round(@round.round_num + 1)
+                end
+              elsif !custom_end_game_reached? && @phase.tiles.include?(:green)
                 or_round_finished
                 new_nationalization_round(@round.round_num)
               else


### PR DESCRIPTION
No nationalization rounds in end game
## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
