### PR TITLE
[Core] Don't assume all operating entities have trains

### DIFF
--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -25,9 +25,7 @@ module Engine
         @game.payout_companies
         @entities.each { |c| @game.place_home_token(c) } if @home_token_timing == :operating_round
         @entities.each do |entity|
-          next unless entity.respond_to?(:trains)
-
-          entity.trains.each { |train| train.operated = false }
+          entity.trains.each { |train| train.operated = false } if entity.operator?
         end
         (@game.corporations + @game.minors + @game.companies).each(&:reset_ability_count_this_or!)
         after_setup

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -24,7 +24,11 @@ module Engine
         @home_token_timing = @game.class::HOME_TOKEN_TIMING
         @game.payout_companies
         @entities.each { |c| @game.place_home_token(c) } if @home_token_timing == :operating_round
-        @entities.each { |e| e.trains.each { |t| t.operated = false } }
+        @entities.each do |entity|
+          next unless entity.respond_to?(:trains)
+
+          entity.trains.each { |train| train.operated = false }
+        end
         (@game.corporations + @game.minors + @game.companies).each(&:reset_ability_count_this_or!)
         after_setup
       end


### PR DESCRIPTION
tobymao#11586 made some changes to the setup method of operating rounds. This has caused an error in some games of 1868 Wyoming, where P6c is one of the entities in the operating round. P6c is a company and does not have a trains attribute.

This adds a guard cause, to avoid errors like this. Fixes tobymao#11594.

It is possible that the change in #11586 has exposed a bug in the 1868 Wyoming code and P6c should not be an operating entity. So there might be a fix in that code, as well as, or instead of this one.