### PR TITLE
[1837] Use backtracking graph in the token step

### DIFF
--- a/lib/engine/game/g_1837/game.rb
+++ b/lib/engine/game/g_1837/game.rb
@@ -15,6 +15,8 @@ module Engine
         include Entities
         include Map
 
+        attr_reader :token_graph
+
         CORPORATION_CLASS = G1837::Corporation
         DEPOT_CLASS = G1837::Depot
 

--- a/lib/engine/game/g_1837/game.rb
+++ b/lib/engine/game/g_1837/game.rb
@@ -15,8 +15,6 @@ module Engine
         include Entities
         include Map
 
-        attr_reader :token_graph
-
         CORPORATION_CLASS = G1837::Corporation
         DEPOT_CLASS = G1837::Depot
 

--- a/lib/engine/game/g_1837/step/token.rb
+++ b/lib/engine/game/g_1837/step/token.rb
@@ -27,7 +27,7 @@ module Engine
             # Cheaper to do the graph first, then check affordability
             current_entity == entity &&
               !(token = entity.next_token).nil? &&
-              token_graph.can_token?(entity) &&
+              @game.token_graph.can_token?(entity) &&
               can_afford_token?(token, buying_power(entity))
           end
 
@@ -40,7 +40,7 @@ module Engine
           end
 
           def can_afford_token?(token, cash)
-            token_graph.tokenable_cities(token.corporation).any? do |city|
+            @game.token_graph.tokenable_cities(token.corporation).any? do |city|
               token_price(token, city.tile.hex) <= cash
             end
           end
@@ -53,12 +53,6 @@ module Engine
           def adjust_token_price_ability!(_entity, token, hex, _city, special_ability: nil)
             token.price = token_price(token, hex)
             [token, nil]
-          end
-
-          private
-
-          def token_graph
-            @game.token_graph_for_entity
           end
         end
       end

--- a/lib/engine/game/g_1837/step/token.rb
+++ b/lib/engine/game/g_1837/step/token.rb
@@ -27,7 +27,7 @@ module Engine
             # Cheaper to do the graph first, then check affordability
             current_entity == entity &&
               !(token = entity.next_token).nil? &&
-              @game.graph.can_token?(entity) &&
+              token_graph.can_token?(entity) &&
               can_afford_token?(token, buying_power(entity))
           end
 
@@ -40,7 +40,7 @@ module Engine
           end
 
           def can_afford_token?(token, cash)
-            @game.graph.tokenable_cities(token.corporation).any? do |city|
+            token_graph.tokenable_cities(token.corporation).any? do |city|
               token_price(token, city.tile.hex) <= cash
             end
           end
@@ -53,6 +53,12 @@ module Engine
           def adjust_token_price_ability!(_entity, token, hex, _city, special_ability: nil)
             token.price = token_price(token, hex)
             [token, nil]
+          end
+
+          private
+
+          def token_graph
+            @game.token_graph_for_entity
           end
         end
       end

--- a/lib/engine/game/g_1837/step/token.rb
+++ b/lib/engine/game/g_1837/step/token.rb
@@ -27,7 +27,7 @@ module Engine
             # Cheaper to do the graph first, then check affordability
             current_entity == entity &&
               !(token = entity.next_token).nil? &&
-              @game.token_graph.can_token?(entity) &&
+              @game.token_graph_for_entity(entity).can_token?(entity) &&
               can_afford_token?(token, buying_power(entity))
           end
 
@@ -40,7 +40,7 @@ module Engine
           end
 
           def can_afford_token?(token, cash)
-            @game.token_graph.tokenable_cities(token.corporation).any? do |city|
+            @game.token_graph_for_entity(entity).tokenable_cities(token.corporation).any? do |city|
               token_price(token, city.tile.hex) <= cash
             end
           end


### PR DESCRIPTION
### Explanation of Change

1837 has two graphs: a standard one and one that allows track to backtrack at junctions. The latter is needed for placing station tokens, where this type of route is allowed.

The token step was not using this graph, it was using the standard one. This meant that not all possible token locations were being included, and an auto-pass was being generated for the token step if the only possible token locations involved backtracking.

Fixes tobymao#11600.

This shouldn't break any games. There will be games where the BH should have been able to lay a token on its first turn but wasn't allowed to, but a pass action will have been generated for those turns and that will be in the game actions.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`