### PR TITLE
[18Norway] Adding missing extra_slot attribute

### DIFF
--- a/lib/engine/game/g_18_norway/steps/token.rb
+++ b/lib/engine/game/g_18_norway/steps/token.rb
@@ -33,7 +33,7 @@ module Engine
               @game.abilities(entity, :token) do |ability|
                 place_token(entity, action.city, action.token, connected: false, special_ability: ability)
                 entity.add_ability(Ability::Token.new(type: 'token', hexes: Engine::Game::G18Norway::Game::HARBOR_HEXES,
-                                                      from_owner: true, discount: 0, connected: true))
+                                                      from_owner: true, discount: 0, connected: true, extra_slot: true))
               end
             else
               raise GameError, "Cannot place token on #{city.hex.name} city is not connected"


### PR DESCRIPTION

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
