### PR TITLE
[1858] Clear pass flag when bidding for a private

### DIFF
--- a/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
@@ -178,6 +178,11 @@ module Engine
             player.cash
           end
 
+          def add_bid(action)
+            action.entity.unpass!
+            super
+          end
+
           def win_bid(winner, _company)
             player = winner.entity
             company = winner.company


### PR DESCRIPTION
## Implementation Notes

A player's pass status was not being cleared when a bid for a private railway company was placed. This meant that it was possible for the initial stock round to end prematurely – if a player had passed on an auction earlier in the round but bid on a later one they were still marked as having passed, meaning the round could end if all other players had passed.

Fixes tobymao#11446.

This breaks a few games (seven of 1858, two of 1858 Switzerland, according to my testing) where the stock round had been ended too early. These will require pinning.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`