### PR TITLE
[1858] Disable autopass on private railway company bids

### DIFF
--- a/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
@@ -183,6 +183,31 @@ module Engine
             super
           end
 
+          def process_bid(action)
+            # Players will sometimes click the autopass button to pass during an
+            # auction, then get confused when they are not allowed to bid on
+            # future auctions in the stock round. Clear these programmed passes,
+            # unless the player can't afford to bid on any available private
+            # railway companies (this check is for later stock rounds where
+            # there are green privates available, but a player has spent all
+            # their money and doesn't want to be prompted to sell shares).
+            min_price = @game.buyable_bank_owned_companies.map(&:min_bid).min
+            @game.programmed_actions.each do |player, actions|
+              next if player.cash < min_price
+
+              actions.reject! do |act|
+                next false unless act.is_a?(Action::ProgramSharePass)
+                next false if act.unconditional
+
+                @game.player_log(player,
+                                 "Programmed action #{act} removed: private
+                                  railway company auction taking place.")
+                true
+              end
+            end
+            super
+          end
+
           def win_bid(winner, _company)
             player = winner.entity
             company = winner.company


### PR DESCRIPTION
## Implementation Notes

Players will sometimes click the autopass button to pass during an auction, then get confused when they are not allowed to bid on future auctions in the stock round.

This PR clears these programmed passes when a bid on a private railway is made, unless the player can't afford to bid on any available private railway companies. This exception is for later stock rounds where there are green privates available, but a player has spent all their money and doesn't want to be prompted to sell shares.

Fixes #11620.

This will not require any pins. There are games where players should have been given the option to participate in auctions, but these will not be broken by this change, as the pass actions have been inserted in the game action list.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`