### PR TITLE
[1852] highlights destination hex during tile laying step

### DIFF
--- a/lib/engine/game/g_18_mo/step/track_and_token.rb
+++ b/lib/engine/game/g_18_mo/step/track_and_token.rb
@@ -11,6 +11,13 @@ module Engine
             super
             @game.remove_teleport_destination(action.entity, action.city)
           end
+
+          def tokener_available_hex(entity, hex)
+            entity.all_abilities.each do |ability|
+              return true if ability.type == :token && ability.hexes.include?(hex.id)
+            end
+            super
+          end
         end
       end
     end


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Currently, the destination hexes of corps aren't highlighted during the track and token step. All corps in this game have a destination hex that they can teleport a token to (like PRR and B&O in 1846). I took the code from 1846 that serves this purpose and modified it for 1852.

### Screenshots

![image](https://github.com/user-attachments/assets/235bef12-5f1f-4b14-88c6-37479e1a1a7a)

### Any Assumptions / Hacks
