### PR TITLE
[18GB] removes clear_insolvent check from route.rb

### DIFF
--- a/lib/engine/game/g_18_gb/step/route.rb
+++ b/lib/engine/game/g_18_gb/step/route.rb
@@ -19,11 +19,10 @@ module Engine
           def check_insolvency!(entity)
             return unless entity.corporation?
 
-            if entity.receivership? && entity.trains.empty? && @game.can_run_route?(entity) && !can_afford_depot_train?(entity)
-              @game.make_insolvent(entity)
-            elsif @game.insolvent?(entity) && can_afford_depot_train?(entity)
-              @game.clear_insolvent(entity)
-            end
+            @game.make_insolvent(entity) if entity.receivership? &&
+                                            entity.trains.empty? &&
+                                            @game.can_run_route?(entity) &&
+                                            !can_afford_depot_train?(entity)
           end
 
           def can_afford_depot_train?(entity)


### PR DESCRIPTION
Fixes #11450 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

It looks like the clear_insolvency check in routes.rb was taken from this code in 1860:
https://github.com/tobymao/18xx/blob/master/lib/engine/game/g_1860/step/route.rb#L42-L51

However, 18GB has different rules for insolvency. A corp in insolvency remains in insolvency until it buys a train. (rules screenshot below).

This will likely require some pins, since some corps that should have been in insolvency would have been given the opportunity to lay track when they shouldn't have.

### Screenshots

![image](https://github.com/user-attachments/assets/0ab132fd-48d1-4528-8402-24e7b17006ed)


### Any Assumptions / Hacks
