### PR TITLE
[1848] Adds lowest bid price info to auction

### DIFF
--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -128,7 +128,7 @@ module View
             float: 'left',
           }
 
-          lowest_bid_price_style = {
+          lowest_bid_style = {
             float: 'right',
           }
 
@@ -177,7 +177,7 @@ module View
           ]
           company_value = @game.company_value(@company)
           children << h(:div, { style: current_price_style }, "Current Price: #{current_price_str}") if @company.lowest_bid_price
-          children << h(:div, { style: lowest_bid_price_style }, "Lowest Price: #{lowest_bid_price_str}") if @company.lowest_bid_price
+          children << h(:div, { style: lowest_bid_style }, "Lowest Price: #{lowest_bid_price_str}") if @company.lowest_bid_price
           children << h(:div, { style: value_style }, "Value: #{@game.format_currency(company_value)}") if company_value
           children << h(:div, { style: revenue_style }, "Revenue: #{revenue_str}") if @company.revenue
           if !@company.discount.zero? && !@company.lowest_bid_price

--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -123,6 +123,15 @@ module View
             float: 'right',
           }
 
+          current_price_style = {
+            clear: 'both',
+            float: 'left',
+          }
+
+          lowest_bid_price_style = {
+            float: 'right',
+          }
+
           bidders_style = {
             marginTop: '0.5rem',
             display: 'inline-block',
@@ -158,6 +167,8 @@ module View
 
           company_name_str = @game.respond_to?(:company_size) ? "[#{@game.company_size(@company)}] " : ''
           company_name_str += @company.name
+          lowest_bid_price_str = @game.format_currency(@company.lowest_bid_price) if @company.lowest_bid_price
+          current_price_str = @game.format_currency(@company.min_bid)
 
           children = [
             h(:div, { style: header_style }, @game.company_header(@company)),
@@ -165,10 +176,12 @@ module View
             h(:div, { style: description_style }, @company.desc),
           ]
           company_value = @game.company_value(@company)
+          children << h(:div, { style: current_price_style }, "Current Price: #{current_price_str}") if @company.lowest_bid_price
+          children << h(:div, { style: lowest_bid_price_style }, "Lowest Price: #{lowest_bid_price_str}") if @company.lowest_bid_price
           children << h(:div, { style: value_style }, "Value: #{@game.format_currency(company_value)}") if company_value
           children << h(:div, { style: revenue_style }, "Revenue: #{revenue_str}") if @company.revenue
-          unless @company.discount.zero?
-            children << h(:div, { style: { float: 'center' } }, "Price: #{@game.format_currency(@company.min_bid)}")
+          if !@company.discount.zero? && !@company.lowest_bid_price
+            children << h(:div, { style: { float: 'center' } }, "Price: #{current_price_str}")
           end
           children << render_bidders if @bids && !@bids.empty?
 

--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -12,7 +12,7 @@ module Engine
     include Ownable
     include Passer
 
-    attr_accessor :name, :desc, :min_price, :revenue, :discount, :value
+    attr_accessor :name, :desc, :min_price, :revenue, :discount, :value, :lowest_bid_price
     attr_reader :sym, :min_auction_price, :treasury, :interval, :color, :text_color, :type, :auction_row, :meta
     attr_writer :max_price
 
@@ -28,6 +28,7 @@ module Engine
       @closed = false
       @min_price = opts[:min_price] || (@value ? (@value / 2.0).ceil : nil)
       @max_price = opts[:max_price] || (@value ? (@value * 2) : nil)
+      @lowest_bid_price = opts[:lowest_bid_price] || nil
       @interval = opts[:interval] # Array of prices or nil
       @color = opts[:color] || :yellow
       @text_color = opts[:text_color] || :black

--- a/lib/engine/game/g_1848/entities.rb
+++ b/lib/engine/game/g_1848/entities.rb
@@ -10,6 +10,7 @@ module Engine
             name: "Melbourne & Hobson's Bay Railway Company",
             value: 30,
             min_price: 1,
+            lowest_bid_price: 0,
             max_price: 40,
             revenue: 5,
             desc: 'No special abilities. Can be bought for £1-£40',
@@ -19,6 +20,7 @@ module Engine
             name: 'Oodnadatta Railway',
             value: 70,
             min_price: 1,
+            lowest_bid_price: 40,
             max_price: 80,
             revenue: 10,
             desc: 'Owning Public Company or its Director may build one (1) free tile on a desert hex (marked by'\
@@ -53,6 +55,7 @@ module Engine
             name: 'Tasmanian Railways',
             value: 110,
             min_price: 1,
+            lowest_bid_price: 80,
             max_price: 140,
             revenue: 15,
             desc: 'The Tasmania tile can be placed by a Public Company on one of the two blue hexes (I8, I10). This is in'\
@@ -77,6 +80,7 @@ module Engine
             value: 170,
             discount: 0,
             min_price: 1,
+            lowest_bid_price: 140,
             max_price: 220,
             revenue: 20,
             desc: 'Owning Public Company or its Director may receive a one-time discount of £100 on the purchase'\
@@ -105,6 +109,7 @@ module Engine
             sym: 'P5',
             name: 'Trans-Australian Railway',
             value: 170,
+            lowest_bid_price: 140,
             revenue: 25,
             desc: 'The owner receives a 10% share in the QR. Cannot be bought by a corporation',
             abilities: [{ type: 'shares', shares: 'QR_1' },
@@ -114,6 +119,7 @@ module Engine
             sym: 'P6',
             name: 'North Australian Railway',
             value: 230,
+            lowest_bid_price: 220,
             revenue: 30,
             desc: "The owner receives a Director's Share share in the CAR, which must start at a par value of £100."\
                   ' Cannot be bought by a corporation. Closes when CAR purchases its first train.',

--- a/lib/engine/game/g_1848/step/dutch_auction.rb
+++ b/lib/engine/game/g_1848/step/dutch_auction.rb
@@ -21,15 +21,6 @@ module Engine
           ACTIONS = %w[bid assign].freeze
           ACTIONS_WITH_PASS = %w[bid assign pass].freeze
 
-          MIN_PRICES = {
-            'P1' => 0,
-            'P2' => 40,
-            'P3' => 80,
-            'P4' => 140,
-            'P5' => 140,
-            'P6' => 200,
-          }.freeze
-
           def description
             "Buy a Company or Reduce its Price by #{@game.format_currency(5)}"
           end
@@ -79,7 +70,7 @@ module Engine
 
           def may_reduce?(company)
             # Each private can be discounted a maximum of 6 times
-            company.min_bid > MIN_PRICES[company.sym]
+            company.min_bid > company.lowest_bid_price
           end
 
           def actions(entity)


### PR DESCRIPTION
Fixes #11041 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Currently, when you reduce the price of a private in 1848's dutch auction, it looks like the private on the right here: 

![image](https://github.com/user-attachments/assets/f0dd9591-df19-491d-8577-ed5e4eae0d0f)

I added a new property to private companies called lowest_bid_level, and then called it in the rendering page for companies in order to display more information . The result looks like this:

![image](https://github.com/user-attachments/assets/72125c0c-e929-40fd-bd79-6922deba07d6)

I toyed with just placing Value with the Current Price info, but I thought it would still be useful to know what the original price was.

I double-checked with several other games and didn't see any of them affected by this change.

Please let me know if you have better ideas for what to call each of the fields, I've never been great at naming things.

### Screenshots

### Any Assumptions / Hacks

Since the information is now stored in a property on the company, I removed a constant in the dutch_auction.rb file and called the information directly where it was needed instead. 