### PR TITLE
[System18] Changes requested by designer

### DIFF
--- a/lib/engine/game/g_system18/step/buy_train.rb
+++ b/lib/engine/game/g_system18/step/buy_train.rb
@@ -14,7 +14,7 @@ module Engine
           end
 
           def setup
-            @emr_issue = false
+            @emergency_issued = false
             super
           end
 
@@ -27,20 +27,15 @@ module Engine
             raise GameError, "Cannot sell shares of #{action.bundle.corporation.name}" unless can_sell?(action.entity,
                                                                                                         action.bundle)
 
-            @emr_issue = true
+            @round.emergency_issued = true
 
             movement_type = @game.movement_type_at_emr_share_issue_by_map
 
             @game.sell_shares_and_change_price(action.bundle, movement: movement_type)
           end
 
-          def process_buy_train(action)
-            super
-            @emr_issue = false
-          end
-
           def other_trains(entity)
-            return super unless @emr_issue
+            return super unless @emergency_issued
 
             []
           end


### PR DESCRIPTION
Fixes #10456

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Requested changes from designer: 

- For both president sales and EMR issuing shares, the price moves down one space per block of shares sold/issued.
- Also, share issuing is done automatically in one block. It should not be allowed to sell shares in multiple blocks.

I made these changes. Additionally, I noted that there were two separate variables tracking if shared had been emergency issued: @emergency_issued and @emr_issue. I consolidated these together as @emergency_issued, as they didn't appear to be tracking different information. 

I also removed this code below, since @emergency_issued is already being reset  in the `def setup` method of that same step.

https://github.com/tobymao/18xx/blob/29e21ad40ea90842d980341ffb00980629e52741/lib/engine/game/g_system18/step/buy_train.rb#L37-L40

### Screenshots

### Any Assumptions / Hacks
