### PR TITLE
[System18] no corp started game end tweak

### DIFF
--- a/lib/engine/game/g_system18/game.rb
+++ b/lib/engine/game/g_system18/game.rb
@@ -508,7 +508,7 @@ module Engine
         def reorder_players
           if corporations.none?(&:floated)
             @log << '-- Stock round ended with no floated corporations. Ending game.'
-            end_game!
+            return end_game!
           end
 
           super

--- a/lib/engine/game/g_system18/map_britain_customization.rb
+++ b/lib/engine/game/g_system18/map_britain_customization.rb
@@ -320,8 +320,8 @@ module Engine
             case @round
             when Engine::Round::Stock
               map_britain_stock_round_finished
-              @operating_rounds = @phase.operating_rounds
               reorder_players
+              @operating_rounds = @phase.operating_rounds
               new_operating_round
             when Round::Operating
               if @round.round_num < @operating_rounds

--- a/lib/engine/game/g_system18/map_northern_italy_customization.rb
+++ b/lib/engine/game/g_system18/map_northern_italy_customization.rb
@@ -291,8 +291,8 @@ module Engine
             case @round
             when Engine::Round::Stock
               map_northern_italy_stock_round_finished
-              @operating_rounds = @phase.operating_rounds
               reorder_players
+              @operating_rounds = @phase.operating_rounds
               new_operating_round
             when Round::Operating
               if @round.round_num < @operating_rounds

--- a/lib/engine/game/g_system18/map_poland_customization.rb
+++ b/lib/engine/game/g_system18/map_poland_customization.rb
@@ -267,8 +267,10 @@ module Engine
             case @round
             when Engine::Round::Stock
               map_poland_stock_round_finished
-              @operating_rounds = @phase.operating_rounds
               reorder_players
+              return if corporations.none?(&:floated)
+
+              @operating_rounds = @phase.operating_rounds
               new_operating_round
             when Round::Operating
               if @round.round_num < @operating_rounds


### PR DESCRIPTION
Fixes #11104 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
Because of the way it was implemented, if the game ended due to no one starting a corp in SR1, the game would end but the log would then indicate it was OR 1.1:

![image](https://github.com/user-attachments/assets/2ad9bb4a-78e7-4505-a7ea-c4b1c987900d)

I moved around the sequence of events to prevent this.

### Screenshots

### Any Assumptions / Hacks
