### PR TITLE
[18Norway] Reimplement that you only are allowed to have one ship per  type

### DIFF
--- a/lib/engine/game/g_18_norway/depot.rb
+++ b/lib/engine/game/g_18_norway/depot.rb
@@ -8,7 +8,7 @@ module Engine
       class Depot < Engine::Depot
         def min_depot_train
           current_entity = @game.round.current_entity
-          return super unless current_entity.trains.empty?
+          return super if current_entity.trains.any? { |train| !@game.ship?(train) }
 
           # Ships doesn't count towards needing a train, should be ignored when checking for min
           depot_trains.reject { |train| @game.ship?(train) }.min_by(&:price)

--- a/lib/engine/game/g_18_norway/depot.rb
+++ b/lib/engine/game/g_18_norway/depot.rb
@@ -7,6 +7,9 @@ module Engine
     module G18Norway
       class Depot < Engine::Depot
         def min_depot_train
+          current_entity = @game.round.current_entity
+          return super unless current_entity.trains.empty?
+
           # Ships doesn't count towards needing a train, should be ignored when checking for min
           depot_trains.reject { |train| @game.ship?(train) }.min_by(&:price)
         end

--- a/lib/engine/game/g_18_norway/steps/buy_train.rb
+++ b/lib/engine/game/g_18_norway/steps/buy_train.rb
@@ -41,11 +41,14 @@ module Engine
           end
 
           def buyable_trains(entity)
-            return super if must_buy_train?(entity) || entity.cash >= @depot.min_depot_price
+            trains = super.reject do |train|
+              next false unless @game.ship?(train)
+              next true if must_buy_train?(entity)
 
-            # We need to add the ships in the case that the company have a train but have less money then the next available train
-            super + @depot.depot_trains.select do |train|
-              @game.ship?(train) && entity.cash >= train.price
+              entity.trains.any? { |ship| ship.name == train.name }
+            end
+            trains + @depot.depot_trains.select do |train|
+              @game.ship?(train) && entity.cash >= train.price && entity.trains.none? { |ship| ship.name == train.name }
             end
           end
 

--- a/lib/engine/game/g_18_norway/steps/buy_train.rb
+++ b/lib/engine/game/g_18_norway/steps/buy_train.rb
@@ -42,17 +42,6 @@ module Engine
 
           def buyable_trains(entity)
             trains = super
-            # Due to that the min_depot only looks at trains we need to add a ship in the case where
-            # we already have a train, can afford the next ship but not the next train
-            if entity.cash < cheapest_train_price(entity)
-              trains += @depot.depot_trains.select do |train|
-                next unless @game.ship?(train)                                # Must be a ship
-                next if entity.trains.any? { |ship| ship.name == train.name } # Must not already own the ship
-                next if trains.any? { |ship| ship.name == train.name }        # Must not already be in the list
-
-                entity.cash >= train.price                                    # Can we afford it?
-              end
-            end
 
             # Remove any ships that we already have
             trains = trains.reject do |train|

--- a/lib/engine/game/g_18_norway/steps/buy_train.rb
+++ b/lib/engine/game/g_18_norway/steps/buy_train.rb
@@ -44,7 +44,7 @@ module Engine
             trains = super
 
             # Remove any ships that we already have
-            trains = trains.reject do |train|
+            trains.reject do |train|
               next unless @game.ship?(train)                            # We want to keep all trains
               next true if must_buy_train?(entity)                      # Remove all ships if we must buy a train
 

--- a/public/fixtures/18Norway/18_norway_buy_ship.json
+++ b/public/fixtures/18Norway/18_norway_buy_ship.json
@@ -1,0 +1,450 @@
+{
+  "status": "finished",
+  "actions": [
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1743923762,
+      "company": "P1",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1743923763,
+      "company": "P2",
+      "price": 30
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1743923765,
+      "company": "P3",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1743923766,
+      "company": "P4",
+      "price": 50
+    },
+    {
+      "type": "bid",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1743923767,
+      "company": "P5",
+      "price": 70
+    },
+    {
+      "type": "bid",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1743926926,
+      "company": "P7",
+      "price": 170
+    },
+    {
+      "type": "bid",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1743926928,
+      "company": "P6",
+      "price": 90
+    },
+    {
+      "type": "par",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1743927609,
+      "corporation": "D",
+      "share_price": "100,0,10"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1743927611,
+      "shares": [
+        "D_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "par",
+      "entity": 0,
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1743927615,
+      "corporation": "B",
+      "share_price": "112,0,11"
+    },
+    {
+      "type": "buy_shares",
+      "entity": 1,
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1743927623,
+      "shares": [
+        "H_1"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "buy_shares",
+      "entity": 2,
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1743927703,
+      "shares": [
+        "H_2"
+      ],
+      "percent": 20
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 13,
+      "created_at": 1743927712,
+      "hex": "D25",
+      "tile": "8-0",
+      "rotation": 5
+    },
+    {
+      "type": "pass",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 14,
+      "created_at": 1743927719
+    },
+    {
+      "type": "buy_train",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 15,
+      "created_at": 1743927729,
+      "train": "2-0",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 16,
+      "created_at": 1743927730,
+      "train": "2-1",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 17,
+      "created_at": 1743927731,
+      "train": "2-2",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 18,
+      "created_at": 1743927734,
+      "train": "2-3",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 19,
+      "created_at": 1743927745,
+      "hex": "H19",
+      "tile": "8-1",
+      "rotation": 3
+    },
+    {
+      "type": "choose",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 20,
+      "created_at": 1743927757,
+      "choice": "build"
+    },
+    {
+      "type": "pass",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 21,
+      "created_at": 1743927761
+    },
+    {
+      "type": "buy_train",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 22,
+      "created_at": 1743927781,
+      "train": "2-4",
+      "price": 72,
+      "variant": "2"
+    },
+    {
+      "type": "pass",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 23,
+      "created_at": 1743927797
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 24,
+      "created_at": 1743927810,
+      "hex": "I28",
+      "tile": "8-2",
+      "rotation": 5
+    },
+    {
+      "type": "choose",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 25,
+      "created_at": 1743927813,
+      "choice": "build"
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 26,
+      "created_at": 1743927824
+    },
+    {
+      "type": "buy_train",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 27,
+      "created_at": 1743927857,
+      "train": "2-5",
+      "price": 80,
+      "variant": "2"
+    },
+    {
+      "type": "buy_train",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 28,
+      "created_at": 1743927860,
+      "train": "3-0",
+      "price": 180,
+      "variant": "3"
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 29,
+      "created_at": 1743927862
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 30,
+      "created_at": 1743927867
+    },
+    {
+      "type": "choose",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 31,
+      "created_at": 1743927869,
+      "choice": "decline"
+    },
+    {
+      "type": "choose",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 32,
+      "created_at": 1743927871,
+      "choice": "decline"
+    },
+    {
+      "type": "choose",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 33,
+      "created_at": 1743927872,
+      "choice": "decline"
+    },
+    {
+      "type": "pass",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 34,
+      "created_at": 1743927876
+    },
+    {
+      "type": "pass",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 35,
+      "created_at": 1743927877
+    },
+    {
+      "type": "undo",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 36,
+      "created_at": 1743927883
+    },
+    {
+      "type": "undo",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 37,
+      "created_at": 1743927885
+    },
+    {
+      "type": "pass",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 38,
+      "created_at": 1743927895
+    },
+    {
+      "type": "pass",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 39,
+      "created_at": 1743927899
+    },
+    {
+      "type": "run_routes",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 40,
+      "created_at": 1743927907,
+      "routes": [],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "pass",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 41,
+      "created_at": 1743927920
+    },
+    {
+      "type": "pass",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 42,
+      "created_at": 1743927923
+    },
+    {
+      "type": "undo",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 43,
+      "created_at": 1743927930
+    },
+    {
+      "type": "lay_tile",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 44,
+      "created_at": 1743927936,
+      "hex": "I20",
+      "tile": "8-3",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 45,
+      "created_at": 1743927941
+    },
+    {
+      "type": "run_routes",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 46,
+      "created_at": 1743927944,
+      "routes": [],
+      "extra_revenue": 0,
+      "subsidy": 0
+    },
+    {
+      "type": "end_game",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 47,
+      "created_at": 1743933595
+    }
+  ],
+  "id": "hs_hnofodvu_1743923759",
+  "players": [
+    {
+      "name": "Player 1",
+      "id": 0
+    },
+    {
+      "name": "Player 2",
+      "id": 1
+    },
+    {
+      "name": "Player 3",
+      "id": 2
+    }
+  ],
+  "title": "18Norway",
+  "description": "",
+  "min_players": "3",
+  "max_players": "3",
+  "settings": {
+    "optional_rules": [],
+    "seed": ""
+  },
+  "mode": "hotseat",
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "created_at": "2025-04-06",
+  "loaded": true,
+  "result": {
+    "0": 536,
+    "1": 410,
+    "2": 410
+  },
+  "manually_ended": true,
+  "turn": 1,
+  "round": "Operating Round",
+  "acting": [
+    1
+  ],
+  "updated_at": 1743933595
+}

--- a/spec/lib/engine/games/g_18_norway/g_18_norway_buy_ship_spec.rb
+++ b/spec/lib/engine/games/g_18_norway/g_18_norway_buy_ship_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'find'
+require './spec/spec_helper'
+require 'json'
+
+module Engine
+  describe Game::G18Norway do
+    let(:players) { %w[a b c] }
+
+    let(:game_file) do
+      Find.find(FIXTURES_DIR).find { |f| File.basename(f) == "#{game_file_name}.json" }
+    end
+
+    let(:id_first_index_by_action_type) do
+      file = File.open(game_file)
+      data = JSON.parse(file.read)
+      file.close
+      data['actions'].each do |action|
+        return action['id'] - 1 if action['type'] == first_action_type
+      end
+      1
+    end
+
+    context '18Norway buy ship' do
+      let(:game_file_name) { '18_norway_buy_ship' }
+      let(:first_action_type) { 'buy_train' }
+
+      it 'Should not show ships when corporation must buy a train' do
+        game = Engine::Game.load(game_file, at_action: id_first_index_by_action_type)
+        corporation = game.current_entity
+
+        # Force corporation to have no trains
+        corporation.trains.clear
+        # Remove ignore mandatory train ability
+        corporation.remove_ability(game.abilities(corporation, :ignore_mandatory_train))
+
+        step = game.round.active_step
+        available = step.buyable_trains(corporation)
+        ships = available.select { |train| game.ship?(train) }
+        expect(ships.size).to eq(0)
+      end
+
+      it 'Should show ships when corporation must buy a train with ignore mandatory train ability' do
+        game = Engine::Game.load(game_file, at_action: id_first_index_by_action_type)
+        corporation = game.current_entity
+
+        # Force corporation to have no trains
+        corporation.trains.clear
+
+        # Add ignore mandatory train ability
+        corporation.add_ability(Engine::Ability::Base.new(
+          type: 'ignore_mandatory_train',
+          description: 'Not mandatory to own a train',
+        ))
+
+        step = game.round.active_step
+        available = step.buyable_trains(corporation)
+        ships = available.select { |train| game.ship?(train) }
+        expect(ships.size).to eq(1)
+      end
+
+      it 'Should show ships when corporation has trains but cannot afford next train' do
+        game = Engine::Game.load(game_file, at_action: id_first_index_by_action_type)
+        corporation = game.current_entity
+
+        # Give corporation a train enough money to buy next ship but not enough cash for next train
+        corporation.trains << game.depot.upcoming.first
+        corporation.cash = 150 # Less than cheapest train price but enough to buy ship
+        game.depot.export_all!('2', silent: true) # Export 2 trains so corporation can afford next train
+
+        step = game.round.active_step
+        available = step.buyable_trains(corporation)
+        ships = available.select { |train| game.ship?(train) }
+        expect(ships.size).to be > 0
+      end
+
+      it 'Should not show ships that corporation already owns' do
+        game = Engine::Game.load(game_file, at_action: id_first_index_by_action_type)
+        corporation = game.current_entity
+
+        # Give corporation a ship
+        ship = game.depot.upcoming.find { |t| game.ship?(t) }
+        corporation.trains << ship
+
+        step = game.round.active_step
+        available = step.buyable_trains(corporation)
+        duplicate_ships = available.select { |train| game.ship?(train) && train.name == ship.name }
+        expect(duplicate_ships.size).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/lib/engine/games/g_18_norway/g_18_norway_hovebanen.rb
+++ b/spec/lib/engine/games/g_18_norway/g_18_norway_hovebanen.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'find'
+require './spec/spec_helper'
+require 'json'
+
+module Engine
+  describe Game::G18Norway do
+    let(:players) { %w[a b c] }
+
+    let(:game_file) do
+      Find.find(FIXTURES_DIR).find { |f| File.basename(f) == "#{game_file_name}.json" }
+    end
+
+    context '18Norway Hovebanen' do
+      let(:game_file_name) { '18_norway_buy_ship' }
+
+      it 'Hovedbanen cash should match the auction price' do
+        game = Engine::Game.load(game_file, at_action: 7)
+        expect(game.players.map(&:cash)).to eq([300, 190, 240])
+        expect(game.hovedbanen.cash).to eq(170)
+        expect(game.hovedbanen.shares[0].price).to eq(80)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Removed a bit to much in latest commit re-adding the filter for only one ship per type

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
