### PR TITLE
[1837] Fix error in token step.

### DIFF
--- a/lib/engine/game/g_1837/step/token.rb
+++ b/lib/engine/game/g_1837/step/token.rb
@@ -40,7 +40,8 @@ module Engine
           end
 
           def can_afford_token?(token, cash)
-            @game.token_graph_for_entity(entity).tokenable_cities(token.corporation).any? do |city|
+            corp = token.corporation
+            @game.token_graph_for_entity(corp).tokenable_cities(corp).any? do |city|
               token_price(token, city.tile.hex) <= cash
             end
           end


### PR DESCRIPTION
PR tobymao#11602 has introduced an error. `G1837::Step::Token.can_place_token?` doesn't have an entity parameter, so is failing with `an Undefined method 'entity' for <Engine::Game::G1837::Step::Token>` error.

Fixes tobymao#11643.