### PR TITLE
[1841] prevent new token buy for frozen secession corps

### DIFF
--- a/lib/engine/game/g_1841/step/buy_new_tokens.rb
+++ b/lib/engine/game/g_1841/step/buy_new_tokens.rb
@@ -12,6 +12,7 @@ module Engine
 
           def actions(entity)
             return [] unless entity == pending_entity
+            return [] unless entity.corporation?
 
             %w[choose]
           end


### PR DESCRIPTION
Fixes #11310 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

I noticed in TheCat's report, their screenshot showed that while the text indicated that he was buying tokens for SFL, the entity shown below was actually his player box. 

There might be a "better" fix for this, but I added a gate to the buy_new_tokens.rb actions to return [] if entity isn't a corporation, and this resolves the issue. As far as I can tell, there's no reason why a non-corporation entity would be buying new tokens, so this seems logical.

### Screenshots

### Any Assumptions / Hacks
