### PR TITLE
[core] fixes Restart Last Turn after waterfall auction

### DIFF
--- a/lib/engine/step/waterfall_auction.rb
+++ b/lib/engine/step/waterfall_auction.rb
@@ -121,6 +121,7 @@ module Engine
           @log << "#{@auctioning.name} goes up for auction" if is_new_auction
         end
 
+        @game.next_turn!
         resolved
       end
 

--- a/lib/engine/step/waterfall_auction.rb
+++ b/lib/engine/step/waterfall_auction.rb
@@ -32,6 +32,7 @@ module Engine
           all_passed! if entities.all?(&:passed?)
           @round.next_entity_index!
         end
+        @game.next_turn!
       end
 
       def process_bid(action)
@@ -43,6 +44,7 @@ module Engine
           placement_bid(action)
           @round.next_entity_index!
         end
+        @game.next_turn!
       end
 
       def active_entities
@@ -121,7 +123,6 @@ module Engine
           @log << "#{@auctioning.name} goes up for auction" if is_new_auction
         end
 
-        @game.next_turn!
         resolved
       end
 


### PR DESCRIPTION
Fixes #6605

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

In the comments, Per pointed out that @crericha had made this comment in the Slack chat: 

![image](https://github.com/user-attachments/assets/c3dadcf6-6241-4b8c-957c-c443d963252b)

Thankfully that advice was documented, because sure enough, adding `@game.next_turn!` to the end of the `def resolve_bids_for_company(company)` method in the WaterfallAuction step resolved the issue. 

### Screenshots

### Any Assumptions / Hacks
