### PR TITLE
[1858/1858 Switzerland] Refactoring in preparation for 1858 India implementation

### DIFF
--- a/lib/engine/game/g_1858/entities.rb
+++ b/lib/engine/game/g_1858/entities.rb
@@ -116,6 +116,7 @@ module Engine
           {
             sym: 'H&G',
             name: 'Havana and Güines Railway',
+            type: 'private_batch1',
             desc: 'P1. Revenue 10, face value 30. ' \
                   'Cannot be used to start a public company or exchanged for a share.',
             value: 30,
@@ -128,6 +129,7 @@ module Engine
           {
             sym: 'B&M',
             name: 'Barcelona and Mataró Railway',
+            type: 'private_batch1',
             desc: 'P2. Revenue 23/35, face value 115. Home hex is O8. ' \
                   'Can be used to start a public company in Barcelona.',
             value: 115,
@@ -151,6 +153,7 @@ module Engine
           {
             sym: 'M&A',
             name: 'Madrid and Aranjuez Railway',
+            type: 'private_batch1',
             desc: 'P3. Revenue 25/38, face value 125. Home hexes are H11 and H13. ' \
                   'Can be used to start a public company in Madrid.',
             value: 125,
@@ -175,6 +178,7 @@ module Engine
           {
             sym: 'P&L',
             name: 'Porto and Lisbon Railway',
+            type: 'private_batch1',
             desc: 'P4. Revenue 22/33, face value 110. Home hexes are B9 and B11. ' \
                   'Can be used to start a public company in Porto.',
             value: 110,
@@ -198,6 +202,7 @@ module Engine
           {
             sym: 'V&J',
             name: 'Valencia and Jativa Railway',
+            type: 'private_batch1',
             desc: 'P5. Revenue 20/30, face value 100. Home hex is L13. ' \
                   'Can be used to start a public company in Valencia.',
             value: 100,
@@ -221,6 +226,7 @@ module Engine
           {
             sym: 'R&T',
             name: 'Reus and Tarragona Railway',
+            type: 'private_batch1',
             desc: 'P6. Revenue 12/18, face value 60. Home hex is N9. ' \
                   'Cannot be used to start a public company.',
             value: 60,
@@ -236,6 +242,7 @@ module Engine
           {
             sym: 'L&C',
             name: 'Lisbon and Carregado Railway',
+            type: 'private_batch1',
             desc: 'P7. Revenue 18/27, face value 90. Home hexes are A14 and B13. ' \
                   'Can be used to start a public company in Lisboa.',
             value: 90,
@@ -259,6 +266,7 @@ module Engine
           {
             sym: 'M&V',
             name: 'Madrid and Valladolid Railway',
+            type: 'private_batch1',
             desc: 'P8. Revenue 24/36, face value 120. Home hexes are G8, G10 and H11. ' \
                   'Can be used to start a public company in either Madrid or Valladolid.',
             value: 120,
@@ -284,6 +292,7 @@ module Engine
           {
             sym: 'M&Z',
             name: 'Madrid and Zaragoza Railway',
+            type: 'private_batch1',
             desc: 'P9. Revenue 19/29, face value 95. Home hexes are I10, J9, K8 and L7. ' \
                   'Can be used to start a public company in Zaragoza.',
             value: 95,
@@ -307,6 +316,7 @@ module Engine
           {
             sym: 'C&S',
             name: 'Córdoba and Seville Railway',
+            type: 'private_batch1',
             desc: 'P10. Revenue 21/32, face value 105. Home hexes are E18, F17 and G18. ' \
                   'Can be used to start a public company in either Sevilla or Córdoba.',
             value: 105,
@@ -331,6 +341,7 @@ module Engine
           {
             sym: 'SJ&C',
             name: 'Seville, Jerez and Cadiz Railway',
+            type: 'private_batch1',
             desc: 'P11. Revenue 14/21, face value 70. Home hexes are E18 and E20. ' \
                   'Can be used to start a public company in either Sevilla or Cádiz.',
             value: 70,
@@ -355,6 +366,7 @@ module Engine
           {
             sym: 'Z&P',
             name: 'Zaragoza and Pamplona Railway',
+            type: 'private_batch1',
             desc: 'P12. Revenue 16/24, face value 80. Home hexes are K4, K6 and L7. ' \
                   'Can be used to start a public company in Zaragoza.',
             value: 80,
@@ -378,6 +390,7 @@ module Engine
           {
             sym: 'C&B',
             name: 'Castejón and Bilbao Railway',
+            type: 'private_batch1',
             desc: 'P13. Revenue 15/23, face value 75. Home hex is I2. ' \
                   'Can be used to start a public company in Bilbao.',
             value: 75,
@@ -401,6 +414,7 @@ module Engine
           {
             sym: 'C&M',
             name: 'Córdoba and Málaga Railway',
+            type: 'private_batch1',
             desc: 'P14. Revenue 17/26, face value 85. Home hexes are G18 and G20. ' \
                   'Can be used to start a public company in either Córdoba or Málaga.',
             value: 85,
@@ -425,6 +439,7 @@ module Engine
           {
             sym: 'M&C',
             name: 'Murcia and Cartagena Railway',
+            type: 'private_batch1',
             desc: 'P15. Revenue 14/21, face value 70. Home hexes are K18 and L19. ' \
                   'Can be used to start a public company in Murcia.',
             value: 70,
@@ -448,6 +463,7 @@ module Engine
           {
             sym: 'A&S',
             name: 'Alar and Santander Railway',
+            type: 'private_batch1',
             desc: 'P16. Revenue 16/24, face value 80. Home hexes are G4 and H3. ' \
                   'Can be used to start a public company in Santander.',
             value: 80,
@@ -471,6 +487,7 @@ module Engine
           {
             sym: 'B&CR',
             name: 'Badajoz and Ciudad Real Railway',
+            type: 'private_batch1',
             desc: 'P17. Revenue 13/20, face value 65. Home hexes are D15, E14 and F15. ' \
                   'Cannot be used to start a public company.',
             value: 65,
@@ -486,6 +503,7 @@ module Engine
           {
             sym: 'S&C',
             name: 'Santiago and La Coruña Railway',
+            type: 'private_batch2',
             desc: 'P18. Revenue 30, face value 100. Home hexes are C2 and C4. ' \
                   'Can be used to start a public company in La Coruña.',
             value: 100,
@@ -508,6 +526,7 @@ module Engine
           {
             sym: 'M&S',
             name: 'Medina and Salamanca Railway',
+            type: 'private_batch2',
             desc: 'P19. Revenue 27, face value 90. Home hex is F9. ' \
                   'Cannot be used to start a public company.',
             value: 90,
@@ -520,6 +539,7 @@ module Engine
           {
             sym: 'CM&P',
             name: 'Cáceres, Madrid and Portugal Railway',
+            type: 'private_batch2',
             desc: 'P20. Revenue 40, face value 135. Home hexes are D13, E12, F13, G12 and H11. ' \
                   'Can be used to start a public company in Madrid.',
             value: 135,
@@ -543,6 +563,7 @@ module Engine
           {
             sym: 'O&V',
             name: 'Orense and Vigo Railway',
+            type: 'private_batch2',
             desc: 'P21. Revenue 33, face value 110. Home hexes are B5 and C4. ' \
                   'Can be used to start a public company in Vigo.',
             value: 110,
@@ -565,6 +586,7 @@ module Engine
           {
             sym: 'L&G',
             name: 'León and Gijón Railway',
+            type: 'private_batch2',
             desc: 'P22. Revenue 36, face value 120. Home hexes are F1, F3 and F5. ' \
                   'Can be used to start a public company in Gijón.',
             value: 120,

--- a/lib/engine/game/g_1858/game.rb
+++ b/lib/engine/game/g_1858/game.rb
@@ -339,11 +339,11 @@ module Engine
         end
 
         def hex_train?(train)
-          train.name[-1] == 'H'
+          train.distance.is_a?(Integer)
         end
 
         def metre_gauge_train?(train)
-          train.name[-1] == 'M'
+          train.track_type == :narrow
         end
 
         def hex_edge_cost(conn)

--- a/lib/engine/game/g_1858/game.rb
+++ b/lib/engine/game/g_1858/game.rb
@@ -523,17 +523,17 @@ module Engine
           @_shares[share.id] = share
         end
 
-        def private_colors_available(phase)
-          colors = [:yellow]
-          colors << :green if phase.status.include?('green_privates')
-          colors
+        def private_batches_available(phase)
+          batches = [:private_batch1]
+          batches << :private_batch2 if phase.status.include?('green_privates')
+          batches
         end
 
         def buyable_bank_owned_companies
-          available_colors = private_colors_available(@phase)
+          available_batches = private_batches_available(@phase)
           @companies.select do |company|
             !company.closed? && (company.owner == @bank) &&
-              available_colors.include?(company.color) &&
+              available_batches.include?(company.type) &&
               !@unbuyable_companies.include?(company)
           end
         end

--- a/lib/engine/game/g_1858/game.rb
+++ b/lib/engine/game/g_1858/game.rb
@@ -53,9 +53,6 @@ module Engine
 
         GRAPH_CLASS = G1858::Graph
 
-        # These are the train types that determine the rusting timing of phase 4 trains.
-        GREY_TRAINS = %w[7E 6M 5D].freeze
-
         def corporation_opts
           two_player? ? { max_ownership_percent: 70 } : {}
         end
@@ -100,7 +97,6 @@ module Engine
           # The rusting event for 6H/4M trains is triggered by the number of
           # grey trains purchased, so track the number of these sold.
           @grey_trains_bought = 0
-          @phase4_train_trigger = two_player? ? 3 : 5
 
           @unbuyable_companies = []
           setup_unbuyable_privates
@@ -481,18 +477,18 @@ module Engine
         def buy_train(operator, train, price = nil)
           bought_from_depot = (train.owner == @depot)
           super
-          return if @grey_trains_bought >= @phase4_train_trigger
+          return if @grey_trains_bought >= phase4_train_trigger
           return unless bought_from_depot
           return unless self.class::GREY_TRAINS.include?(train.name)
 
           @grey_trains_bought += 1
-          ordinal = %w[First Second Third Fourth Fifth][@grey_trains_bought - 1]
+          ordinal = %w[First Second Third Fourth Fifth Sixth Seventh][@grey_trains_bought - 1]
           @log << "#{ordinal} grey train has been bought"
           maybe_rust_wounded_trains!(@grey_trains_bought, train)
         end
 
         def maybe_rust_wounded_trains!(grey_trains_bought, purchased_train)
-          rust_wounded_trains!(%w[6H 3M], purchased_train) if grey_trains_bought == @phase4_train_trigger
+          rust_wounded_trains!(%w[6H 3M], purchased_train) if grey_trains_bought == phase4_train_trigger
         end
 
         def rust_wounded_trains!(train_names, purchased_train)

--- a/lib/engine/game/g_1858/market.rb
+++ b/lib/engine/game/g_1858/market.rb
@@ -34,7 +34,7 @@ module Engine
         end
 
         def emergency_issuable_bundles(entity)
-          return [] unless entity.trains.empty?
+          return [] unless trainless?(entity)
           return [] if entity.cash >= @depot.max_depot_price
 
           eligible, remaining = issuable_shares(entity)
@@ -46,6 +46,10 @@ module Engine
           return [] unless entity.corporation?
 
           bundles_for_corporation(share_pool, entity).reject { |bundle| entity.cash < bundle.price }
+        end
+
+        def trainless?(corporation)
+          corporation.trains.empty?
         end
       end
     end

--- a/lib/engine/game/g_1858/step/buy_train.rb
+++ b/lib/engine/game/g_1858/step/buy_train.rb
@@ -39,7 +39,7 @@ module Engine
           end
 
           def president_may_contribute?(entity, _shell = nil)
-            entity.trains.empty?
+            @game.trainless?(entity)
           end
 
           def ebuy_president_can_contribute?(corporation)
@@ -90,14 +90,14 @@ module Engine
             # market.
             closing = current_entity.share_price&.price&.zero?
 
-            if @last_share_issued_price && current_entity.trains.empty? && !closing
+            if @last_share_issued_price && @game.trainless?(current_entity) && !closing
               raise GameError, 'Must buy a train from the train depot after issuing shares'
             end
 
             super
             return if current_entity.minor?
             return if closing
-            return unless current_entity.trains.empty?
+            return unless @game.trainless?(current_entity)
 
             @log << "#{current_entity.name} does not own a train"
             old_price = current_entity.share_price

--- a/lib/engine/game/g_1858/step/route.rb
+++ b/lib/engine/game/g_1858/step/route.rb
@@ -21,6 +21,8 @@ module Engine
 
           def log_company_revenue(corporation)
             corporation.companies.each do |company|
+              next unless @game.private_railway?(company)
+
               revenue_str = @game.format_revenue_currency(company.revenue)
               @log << "#{corporation.name} receives #{revenue_str} revenue " \
                       "from private railway #{company.name}"

--- a/lib/engine/game/g_1858/step/track.rb
+++ b/lib/engine/game/g_1858/step/track.rb
@@ -65,7 +65,7 @@ module Engine
 
           def potential_tiles(entity, hex)
             tiles = super
-            return tiles unless @game.phase.name == '2'
+            return tiles unless @game.phase.status.include?('broad_gauge')
 
             # Metre gauge track is not available until phase 3.
             tiles.reject { |tile| tile.paths.map(&:track).include?(:narrow) }

--- a/lib/engine/game/g_1858/trains.rb
+++ b/lib/engine/game/g_1858/trains.rb
@@ -90,6 +90,7 @@ module Engine
             obsolete_on: '6H',
             rusts_on: '6E',
             distance: 2,
+            track_type: :broad,
             price: 100,
           },
           {
@@ -97,6 +98,7 @@ module Engine
             obsolete_on: '6E',
             rusts_on: '7E',
             distance: 4,
+            track_type: :broad,
             price: 200,
             events: [{ 'type' => 'green_privates_available' }],
             variants: [
@@ -104,6 +106,7 @@ module Engine
                 name: '2M',
                 distance: [{ 'nodes' => %w[city offboard], 'pay' => 2, 'visit' => 2 },
                            { 'nodes' => %w[town], 'pay' => 99, 'visit' => 99 }],
+                track_type: :narrow,
                 price: 100,
               },
             ],
@@ -115,12 +118,14 @@ module Engine
             # defined. They rust on the purchase of the fifth phase 7 train, so
             # the rusting is handled in the game code.
             distance: 6,
+            track_type: :broad,
             price: 300,
             variants: [
               {
                 name: '3M',
                 distance: [{ 'nodes' => %w[city offboard], 'pay' => 3, 'visit' => 3 },
                            { 'nodes' => %w[town], 'pay' => 99, 'visit' => 99 }],
+                track_type: :narrow,
                 price: 200,
               },
             ],
@@ -130,6 +135,7 @@ module Engine
             distance: [{ 'nodes' => %w[city offboard], 'pay' => 5, 'visit' => 5 },
                        { 'nodes' => %w[town], 'pay' => 0, 'visit' => 99 }],
             price: 500,
+            track_type: :broad,
             events: [{ 'type' => 'corporations_convert' },
                      { 'type' => 'privates_close' }],
             variants: [
@@ -137,6 +143,7 @@ module Engine
                 name: '4M',
                 distance: [{ 'nodes' => %w[city offboard], 'pay' => 4, 'visit' => 4 },
                            { 'nodes' => %w[town], 'pay' => 99, 'visit' => 99 }],
+                track_type: :narrow,
                 price: 400,
               },
             ],
@@ -145,12 +152,14 @@ module Engine
             name: '6E',
             distance: [{ 'nodes' => %w[city offboard], 'pay' => 6, 'visit' => 6 },
                        { 'nodes' => %w[town], 'pay' => 0, 'visit' => 99 }],
+            track_type: :broad,
             price: 650,
             variants: [
               {
                 name: '5M',
                 distance: [{ 'nodes' => %w[city offboard], 'pay' => 5, 'visit' => 5 },
                            { 'nodes' => %w[town], 'pay' => 99, 'visit' => 99 }],
+                track_type: :narrow,
                 price: 550,
               },
             ],
@@ -159,12 +168,14 @@ module Engine
             name: '7E',
             distance: [{ 'nodes' => %w[city offboard], 'pay' => 7, 'visit' => 7 },
                        { 'nodes' => %w[town], 'pay' => 0, 'visit' => 99 }],
+            track_type: :broad,
             price: 800,
             variants: [
               {
                 name: '6M',
                 distance: [{ 'nodes' => %w[city offboard], 'pay' => 6, 'visit' => 6 },
                            { 'nodes' => %w[town], 'pay' => 99, 'visit' => 99 }],
+                track_type: :narrow,
                 price: 700,
               },
             ],
@@ -173,6 +184,7 @@ module Engine
             name: '5D',
             distance: [{ 'nodes' => %w[city offboard], 'pay' => 5, 'visit' => 5 },
                        { 'nodes' => %w[town], 'pay' => 0, 'visit' => 99 }],
+            track_type: :broad,
             price: 1_100,
             multiplier: 2,
             available_on: '7',

--- a/lib/engine/game/g_1858/trains.rb
+++ b/lib/engine/game/g_1858/trains.rb
@@ -179,6 +179,11 @@ module Engine
           },
         ].freeze
 
+        # These are the train types that determine the rusting timing of phase 4 trains.
+        GREY_TRAINS = %w[7E 6M 5D].freeze
+        # The number of trains that need to be bought depends on the number of players.
+        PHASE4_TRAINS_RUST = { 2 => 3, 3 => 5, 4 => 5, 5 => 5, 6 => 5 }.freeze
+
         TRAIN_COUNTS_NORMAL = {
           '2H' => 6,
           '4H' => 5,
@@ -203,8 +208,17 @@ module Engine
           two_player? ? TRAIN_COUNTS_2P[train[:name]] : TRAIN_COUNTS_NORMAL[train[:name]]
         end
 
+        def phase4_train_trigger
+          @phase4_train_trigger ||=
+            if self.class::PHASE4_TRAINS_RUST.is_a?(Hash)
+              self.class::PHASE4_TRAINS_RUST[@players.size]
+            else
+              self.class::PHASE4_TRAINS_RUST
+            end
+        end
+
         def timeline
-          ordinal = two_player? ? 'third' : 'fifth'
+          ordinal = %w[first second third fourth fifth sixth seventh][phase4_train_trigger - 1]
           @timeline = ['5D trains are available after the first 7E/6M train has been bought',
                        "6H/3M trains rust when the #{ordinal} 7E/6M/5D train is bought"]
         end

--- a/lib/engine/game/g_1858_switzerland/entities.rb
+++ b/lib/engine/game/g_1858_switzerland/entities.rb
@@ -89,6 +89,7 @@ module Engine
           {
             sym: 'NB',
             name: 'Nordbahn',
+            type: 'private_batch1',
             desc: 'P1. Revenue 14/21, face value 70. Home hexes are G4 and H5. ' \
                   'Can be used to start a public company in Zürich.',
             value: 70,
@@ -113,6 +114,7 @@ module Engine
           {
             sym: 'NOB',
             name: 'Nordostbahn',
+            type: 'private_batch1',
             desc: 'P2. Revenue 24/36, face value 120. Home hexes are H3 and H5. ' \
                   'Can be used to start a public company in Zürich.',
             value: 120,
@@ -137,6 +139,7 @@ module Engine
           {
             sym: 'SCB',
             name: 'Centralbahn',
+            type: 'private_batch1',
             desc: 'P3. Revenue 23/35, face value 115. Home hexes are E4, F5 and G6. ' \
                   'Can be used to start a public company in Basel.',
             value: 115,
@@ -160,6 +163,7 @@ module Engine
           {
             sym: 'VSB',
             name: 'Vereingtebahn',
+            type: 'private_batch1',
             desc: 'P4. Revenue 21/32, face value 105. Home hexes are J5 and K4. ' \
                   'Can be used to start a public company in St Gallen.',
             value: 105,
@@ -183,6 +187,7 @@ module Engine
           {
             sym: 'LFB',
             name: 'Lausanne-Fribourg-Berne',
+            type: 'private_batch1',
             desc: 'P5. Revenue 22/33, face value 110. Home hexes are C10 and D9. ' \
                   'Can be used to start a public company in Lausanne.',
             value: 110,
@@ -206,6 +211,7 @@ module Engine
           {
             sym: 'OS',
             name: 'Ouest Suisse',
+            type: 'private_batch1',
             desc: 'P6. Revenue 16/24, face value 80. Home hexes are A12 and B11. ' \
                   'Can be used to start a public company in Genève.',
             value: 80,
@@ -229,6 +235,7 @@ module Engine
           {
             sym: 'BSB',
             name: 'Bernische Staatsbahn',
+            type: 'private_batch1',
             desc: 'P7. Revenue 20/30, face value 100. Home hex is E8. ' \
                   'Can be used to start a public company in Bern.',
             value: 100,
@@ -252,6 +259,7 @@ module Engine
           {
             sym: 'BB',
             name: 'Bodelibahn',
+            type: 'private_batch1',
             desc: 'P8. Revenue 12/18, face value 60. Home hex is F9. ' \
                   'Cannot be used to start a public company.',
             value: 60,
@@ -267,6 +275,7 @@ module Engine
           {
             sym: 'GB',
             name: 'Gotthardbahn',
+            type: 'private_batch1',
             desc: 'P9. Revenue 13/20, face value 65. Home hexes are H9 and H11. ' \
                   'Cannot be used to start a public company.',
             value: 65,
@@ -282,6 +291,7 @@ module Engine
           {
             sym: 'BLB',
             name: 'Bern-Luzern-Bahn',
+            type: 'private_batch1',
             desc: 'P10. Revenue 18/27, face value 90. Home hex is H7. ' \
                   'Can be used to start a public company in Luzern.',
             value: 90,
@@ -305,6 +315,7 @@ module Engine
           {
             sym: 'EB',
             name: 'Emmentalbahn',
+            type: 'private_batch1',
             desc: 'P11. Revenue 11/17, face value 55. Home hex is E6. ' \
                   'Cannot be used to start a public company.',
             value: 55,
@@ -320,6 +331,7 @@ module Engine
           {
             sym: 'AFAI',
             name: 'Alta Italia',
+            type: 'private_batch2',
             desc: 'P12. Revenue 40, face value 135. Home hex is I14. ' \
                   'Can be used to start a public company in Lugano.',
             value: 135,
@@ -342,6 +354,7 @@ module Engine
           {
             sym: 'JN',
             name: 'Jura neuchatelois',
+            type: 'private_batch2',
             desc: 'P13. Revenue 25, face value 85. Home hex is D7. ' \
                   'Cannot be used to start a public company.',
             value: 85,
@@ -354,6 +367,7 @@ module Engine
           {
             sym: 'VZ',
             name: 'Visp-Zermatt',
+            type: 'private_batch2',
             desc: 'P14. Revenue 22, face value 75. Home hexes are D13 and E12. ' \
                   'Cannot be used to start a public company.',
             value: 75,
@@ -366,6 +380,7 @@ module Engine
           {
             sym: 'S',
             name: 'Simplon',
+            type: 'private_batch3',
             desc: 'P15. Revenue 22, face value 55. Home hex is G14. ' \
                   'Cannot be used to start a public company.',
             value: 55,
@@ -378,6 +393,7 @@ module Engine
           {
             sym: 'L',
             name: 'Lötschberg',
+            type: 'private_batch3',
             desc: 'P16. Revenue 26, face value 65. Home hex is F11. ' \
                   'Cannot be used to start a public company.',
             value: 65,
@@ -390,6 +406,7 @@ module Engine
           {
             sym: 'ChA',
             name: 'Chur-Arosa',
+            type: 'private_batch3',
             desc: 'P17. Revenue 24, face value 60. Home hex is K8. ' \
                   'Cannot be used to start a public company.',
             value: 60,
@@ -402,6 +419,7 @@ module Engine
           {
             sym: 'FOB',
             name: 'Furka Oberalpbahn',
+            type: 'private_batch3',
             desc: 'P18. Revenue 28, face value 70. Home hexes are G12, H11 and I10. ' \
                   'Cannot be used to start a public company.',
             value: 70,

--- a/lib/engine/game/g_1858_switzerland/game.rb
+++ b/lib/engine/game/g_1858_switzerland/game.rb
@@ -258,15 +258,15 @@ module Engine
           super + north_south_bonus(route, stops) + east_west_bonus(route, stops)
         end
 
-        def private_colors_available(phase)
+        def private_batches_available(phase)
           if phase.status.include?('yellow_privates')
-            %i[yellow]
+            %i[private_batch1]
           elsif phase.status.include?('green_privates')
-            %i[yellow green]
+            %i[private_batch1 private_batch2]
           elsif phase.status.include?('all_privates')
-            %i[yellow green lightblue]
+            %i[private_batch1 private_batch2 private_batch3]
           elsif phase.status.include?('blue_privates')
-            %i[lightblue]
+            %i[private_batch3]
           else
             []
           end


### PR DESCRIPTION
## Implementation Notes

Ian D Wilson is working on a prototype of an 1858 based game set in India (the [rules](https://boardgamegeek.com/thread/3433590/article/45592411#45592411) and [map](https://boardgamegeek.com/thread/3433590/article/45482069#45482069) are on BGG).

This pull request refactors some of the 1858 code, to make the 1858 India implementation simpler.

- Remove the hard-coded assumption that broad gauge track is available from phase 2. Instead check the phase statuses to see when it is available.
- Adds `track_type` attributes to all the trains.
- Add a `private_railway?` method that is passed a company object and decides whether the company represents a private railway company, or some other type of private.
- Adds `type` attributes to all the company objects for the private railway companies, and uses these to determine when these are available, instead of looking at the `color` attributes.
- Add a `trainless?` method which is called to determine whether a public company can use emergency money raising.
- Add a `PHASE4_TRAINS_RUST` constant that is checked to determine when the last batch of non-permanent trains rust.
- Rewrite the `home_hex_nodes` method. This is needed for when a private railway company has a home hex with multiple cities. The 1858 code wasn't general enough, and was failing for 1858 India where the green tile had more than one possible orientation.

None of these changes affect existing games. They are mostly moving existing tests into standalone methods that can easily be overridden in the 1858 India code.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`