### PR TITLE
[Core/1868WY] Add method for checking if a hex token can be removed

### DIFF
--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -197,7 +197,8 @@ module View
           end
 
           step = @game.round.active_step
-          if @actions.include?('remove_hex_token') && @hex.tokens.find { |t| t.corporation == @entity }
+          if @actions.include?('remove_hex_token') &&
+              step.can_remove_hex_token?(@entity, @hex)
             return process_action(Engine::Action::RemoveHexToken.new(
               @entity,
               hex: @hex,

--- a/lib/engine/game/g_1868_wy/step/development_token.rb
+++ b/lib/engine/game/g_1868_wy/step/development_token.rb
@@ -80,6 +80,10 @@ module Engine
             false
           end
 
+          def can_remove_hex_token?(entity, hex)
+            hex.tokens.any? { |token| token.corporation == entity }
+          end
+
           def available_tokens(entity)
             return [] unless entity.minor?
 


### PR DESCRIPTION
## Implementation Notes

The `remove_hex_token` action is only currently used by 1868WY. I'm working on an implementation for 1858 India (a prototype from Ian D Wilson) that also wants to use this action.

There is a check built into the view class that only allows a hex token to be collected if it is owned by the currently operating entity. 1858 wants to use different checks: the tokens are neutral and can only be collected if the corporation has a route to the token, can afford to pay a fee and the game is in the correct phase.

This moves this check to a `check_hex_token?` method in the step class, and calls it from the view class. This means that 1858 India will just need to implement its own version of this method, with no logic changes to the view class.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`