### PR TITLE
[18USA] Remove asterisks from private P3's description

### DIFF
--- a/lib/engine/game/g_18_usa/entities.rb
+++ b/lib/engine/game/g_18_usa/entities.rb
@@ -68,7 +68,7 @@ module Engine
             revenue: 0,
             desc: 'Comes with one oil marker. When placing a yellow '\
                   'tile in an oilfield hex pointing to a revenue location, can place '\
-                  'token. Marked yellow hexes *can* be '\
+                  'token. Marked yellow hexes can be '\
                   'upgraded. Hexes pay $10 extra revenue and do not count as a '\
                   'stop. Hexes revenue bonus is upgraded automatically to $20 in phase 5. '\
                   'May not start or end a route at an oilfield.',


### PR DESCRIPTION
Removed unnecessary asterisks, which aren't present on similar private companies (e.g. P1 and P4)

Fixes #[PUT_ISSUE_NUMBER_HERE]

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
