### PR TITLE
21Moon: Terminal teleport fix

### DIFF
--- a/lib/engine/game/g_21_moon/entities.rb
+++ b/lib/engine/game/g_21_moon/entities.rb
@@ -81,6 +81,7 @@ module Engine
               {
                 type: 'teleport',
                 owner_type: 'corporation',
+                extra_action: true,
                 tiles: ['X29'],
                 hexes: ['F8'],
               },


### PR DESCRIPTION
Fixes #11658 

This will likely require pins for some 21Moon games.