### PR TITLE
[18Ardennes] Fix error when priority player bankrupts

### DIFF
--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -162,6 +162,20 @@ module Engine
           major_corporations.select(&:ipoed).sort
         end
 
+        # The base class version of #priority_deal_player can't cope with
+        # players going bankrupt in stock rounds. It errors if
+        # `@round.last_to_act` goes bankrupt.
+        def priority_deal_player
+          # In operating rounds the array of players will be in priority order.
+          return @players.first unless @round.current_entity&.player?
+
+          # In stock and auction rounds the first non-bankrupt player after the
+          # one who last acted has priority.
+          last_to_act = @round.last_to_act
+          idx = last_to_act ? (@players.index(last_to_act) + 1) : 0
+          @players.rotate(idx).find { |player| !player.bankrupt }
+        end
+
         def acting_for_entity(entity)
           return super unless entity == current_entity
           return super unless entity.corporation?

--- a/lib/engine/game/g_18_ardennes/step/exchange.rb
+++ b/lib/engine/game/g_18_ardennes/step/exchange.rb
@@ -52,7 +52,10 @@ module Engine
             else
               transfer = treasury_share?(share) ? :choose : :none
               exchange_minor(@round.minor, bundle, transfer)
-              @round.current_actions << action if @round.stock?
+              if @round.stock?
+                @round.current_actions << action
+                @round.last_to_act = current_entity
+              end
             end
           end
 


### PR DESCRIPTION
The implementaion of ``priority_deal_player` in Game::Base can't always cope with players going bankrupt in stock rounds. It errors if the player who was last to act goes bankupt – all players are removed from a copy of the players array, then it fails to find the last to act player in the reduced list.
https://github.com/tobymao/18xx/blob/15ccfbf74b5549cb9f11e1178006aceb97ff857a/lib/engine/game/base.rb#L2897-L2914

This adds a fixed version of this method to the 18Ardennes code.

It would *probably* be safe to add this version of the method to the base class, but I didn't want to risk missing something a breaking lots of other games. It's impossible to bankrupt in stock-type rounds in most games. It is possible to go bankrupt in merger and acquisition rounds in 1817 and derivatives, but it might not be possible for the last to act player to be bankrupt.

Fixes #11650.

This also fixes a minor cosmetic issue, the player displayed as holding priority was not being updated when someone used their stock turn to exchange a minor for a share of a public company.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`