### PR TITLE
[1862] Fix autopathing issues

### DIFF
--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -151,7 +151,9 @@ module Engine
               bitfield: bitfield_from_connection(connection, hexside_bits),
             )
             route.routes = [route]
-            route.revenue(suppress_check_other: true) # defer route-collection checks til later
+
+            # defer route combination checks til later
+            route.revenue(suppress_check_other: true, suppress_check_route_combination: true)
             train_routes[train] << route
           rescue RouteTooLong
             # ignore for this train, and abort walking this path if ignored for all trains
@@ -431,6 +433,7 @@ module Engine
         try {
           for (let rt of cb.routes) {
             rt.route['$check_other!']() // throws if bad combo
+            rt.route['$check_route_combination!']() // throws if bad combo
           }
           return true
         }

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -151,9 +151,8 @@ module Engine
               bitfield: bitfield_from_connection(connection, hexside_bits),
             )
             route.routes = [route]
-
-            # defer route combination checks til later
-            route.revenue(suppress_check_other: true, suppress_check_route_combination: true)
+            # defer route combination checks until we have the full combination of routes to check
+            route.revenue(suppress_check_route_combination: true)
             train_routes[train] << route
           rescue RouteTooLong
             # ignore for this train, and abort walking this path if ignored for all trains
@@ -419,20 +418,19 @@ module Engine
 
     %x{
       // do final combo validation using game-specific checks driven by
-      // route.check_other! that was skipped when building routes
+      // route.check_route_combination!
       function is_valid_combo(cb) {
-        // temporarily marshall back to opal since we need to call the opal route.check_other!
+        // temporarily marshall back to opal since we need to call the opal route.check_route_combination!
         let rb_rts = []
         for (let rt of cb.routes) {
-          rt.route['$routes='](rb_rts) // allows route.check_other! to process all routes
+          rt.route['$routes='](rb_rts) // allows route.check_route_combination! to process all routes
           rb_rts['$<<'](rt.route)
         }
 
-        // Run route.check_other! for the full combo, to see if game- and action-specific rules are followed.
+        // Run check_route_combination
         // Eg. 1870 destination runs should reject combos that don't have a route from home to destination city
         try {
           for (let rt of cb.routes) {
-            rt.route['$check_other!']() // throws if bad combo
             rt.route['$check_route_combination!']() // throws if bad combo
           }
           return true

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1482,7 +1482,11 @@ module Engine
         end
       end
 
+      # Intended for game specific rules that only depend on one route
       def check_other(_route); end
+
+      # Intended for game specific rules that depend on multiple routes
+      def check_route_combination(_routes); end
 
       def compute_stops(route, train = nil)
         train ||= route.train

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -996,8 +996,11 @@ module Engine
 
         def check_other(route)
           check_hex_reentry(route) unless @optional_rules&.include?(:re_enter_hexes)
-          check_home_token(current_entity, route.routes) unless route.routes.empty?
-          check_intersection(route.routes) unless route.routes.empty?
+        end
+
+        def check_route_combination(routes)
+          check_home_token(current_entity, routes) unless routes.empty?
+          check_intersection(routes) unless routes.empty?
         end
 
         # must stop at all towns on route or must maximize revenue

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -1506,19 +1506,9 @@ module Engine
         end
 
         # Can reuse track between routes, but not within a route, so this method
-        # doesn't check track reuse, but instead checks:
-        # - home token requirement
-        # - route intersection requirement
-        # - freight track end-to-end requirements
-        def check_overlap(routes)
-          return if routes.empty?
+        # doesn't check track reuse
+        def check_overlap(routes); end
 
-          check_home_token(current_entity, routes)
-          check_intersection(routes)
-          check_freight_intersections(routes)
-        end
-
-        # This checks track reuse within a route
         def check_overlap_single(route)
           tracks = []
 
@@ -1592,6 +1582,16 @@ module Engine
 
         def check_other(route)
           check_overlap_single(route)
+        end
+
+        # check for:
+        # - home token requirement
+        # - route intersection requirement
+        # - freight track end-to-end requirements
+        def check_route_combination(routes)
+          check_home_token(current_entity, routes)
+          check_intersection(routes)
+          check_freight_intersections(routes)
         end
 
         def stop_on_other_route?(this_route, stop)

--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -530,11 +530,14 @@ module Engine
           border.type == :water
         end
 
-        def check_other(route)
+        def check_route_combination(routes)
+          return if routes.empty?
+
+          route = routes.first
           return unless (destination = @round.connection_runs[route.corporation])
 
           home = home_hex(route.corporation)
-          return if route.routes.any? do |r|
+          return if routes.any? do |r|
             next if r.visited_stops.size < 2
 
             (r.visited_stops.values_at(0, -1).map(&:hex) - [home, destination]).none?

--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -756,19 +756,21 @@ module Engine
           !(route_a.visited_stops & route_b.visited_stops).empty?
         end
 
-        def check_other(route)
-          # this route must visit corresponding base, OR it must
-          # intersect with a route that does
-          this_train = route.train
-          base = @train_base[this_train]
-          return if visited_base?(this_train.owner, base, route)
+        def check_route_combination(routes)
+          routes.each do |route|
+            # this route must visit corresponding base, OR it must
+            # intersect with a route that does
+            this_train = route.train
+            base = @train_base[this_train]
+            next if visited_base?(this_train.owner, base, route)
 
-          other_route = route.routes.find { |r| r.train != this_train && @train_base[r.train] == base }
-          return if other_route && visited_base?(this_train.owner, base, other_route) && intersects?(route, other_route)
+            other_route = routes.find { |r| r.train != this_train && @train_base[r.train] == base }
+            next if other_route && visited_base?(this_train.owner, base, other_route) && intersects?(route, other_route)
 
-          raise GameError, "Must visit #{base.to_s.upcase}" unless other_route
+            raise GameError, "Must visit #{base.to_s.upcase}" unless other_route
 
-          raise GameError, "Must visit #{base.to_s.upcase} or intersect with another #{base.to_s.upcase} route that does"
+            raise GameError, "Must visit #{base.to_s.upcase} or intersect with another #{base.to_s.upcase} route that does"
+          end
         end
 
         def sp_revenue(routes)

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -315,7 +315,7 @@ module Engine
       @game.check_route_combination(@routes)
     end
 
-    def revenue(suppress_check_other: false, supress_route_token_check: false, suppress_check_route_combination: false)
+    def revenue(supress_route_token_check: false, suppress_check_route_combination: false)
       @revenue ||=
         begin
           visited = visited_stops
@@ -329,7 +329,7 @@ module Engine
           end
 
           check_terminals!
-          check_other! unless suppress_check_other
+          check_other!
           check_route_combination! unless suppress_check_route_combination
           check_cycles!
           check_distance!(visited)

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -311,7 +311,11 @@ module Engine
       @game.check_other(self)
     end
 
-    def revenue(suppress_check_other: false, supress_route_token_check: false)
+    def check_route_combination!
+      @game.check_route_combination(@routes)
+    end
+
+    def revenue(suppress_check_other: false, supress_route_token_check: false, suppress_check_route_combination: false)
       @revenue ||=
         begin
           visited = visited_stops
@@ -326,6 +330,7 @@ module Engine
 
           check_terminals!
           check_other! unless suppress_check_other
+          check_route_combination! unless suppress_check_route_combination
           check_cycles!
           check_distance!(visited)
           check_overlap!


### PR DESCRIPTION
In 1862, the autopather can't find paths which don't include the home token. This is because the check for the home token is in `check_overlap` when it should be in `check_other`. `check_overlap` is intended to be used to make sure trains don't reuse tracks whereas `check_other` is for checks that require the full set of routes to check the validity of. The key is that the autopather doesn't call `check_other` when calculating the set of all possible routes per train.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Explanation of Change

The main key is the autorouter suppresses `check_other` when looking for valid routes. If we move this code from `check_overlap` into `check_other`, then the autorouter can find routes that don't include the home token. I also moved the other two over because there isn't a reason to check them for single routes so we get a little bit of autorouter performance to skip the work.

This is part of a stack of changes with more information here:
https://github.com/PistonPercy/18xx/pull/1