### PR TITLE
[Scripts] Include optional rules in validation script output

### DIFF
--- a/scripts/validate.rb
+++ b/scripts/validate.rb
@@ -61,7 +61,12 @@ $total_time = 0
 
 def run_game(game, actions = nil, strict: false, silent: false)
   actions ||= game.actions.map(&:to_h)
-  data={'id':game.id, 'title': game.title, 'status':game.status}
+  data = {
+    'id' => game.id,
+    'title' => game.title,
+    'optional_rules' => game.settings['optional_rules'],
+    'status' => game.status
+  }
 
   puts "running game #{game.id}" unless silent
 


### PR DESCRIPTION
This is a small tweak to the output of the validation scripts. It includes the list of variants/optional rules  selected for a game in the `validate.json` output file.

Fixes #[PUT_ISSUE_NUMBER_HERE]

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`