### PR TITLE
[1849] fixes blocking step error in variants

### DIFF
--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -111,9 +111,9 @@ module Engine
             distance: 6,
             price: 200,
             rusts_on: '10H',
-            events: [{ 'type' => 'green_par' }, { 'type' => 'buy_tokens' }],
+            events: [{ 'type' => 'green_par' }],
           },
-          { name: '8H', distance: 8, price: 350, rusts_on: '16H', events: [{ 'type' => 'bonds' }] },
+          { name: '8H', distance: 8, price: 350, rusts_on: '16H' },
           {
             name: '10H',
             num: 2,
@@ -126,7 +126,7 @@ module Engine
             num: 1,
             distance: 12,
             price: 800,
-            events: [{ 'type' => 'close_companies' }, { 'type' => 'earthquake' }, { 'type' => 'e_tokens' }],
+            events: [{ 'type' => 'close_companies' }, { 'type' => 'earthquake' }],
           },
           { name: '16H', distance: 16, price: 1100 },
           { name: 'E', num: 6, available_on: '12H', distance: 99, price: 550 },
@@ -134,20 +134,18 @@ module Engine
         ].freeze
 
         def game_trains
-          train_list = super.dup
-          train_list.reject! { |t| t[:name] == 'E' } unless electric_dreams?
-
-          conditions = [
-            { name: '6H', type: 'buy_tokens', condition: !acquiring_station_tokens? },
-            { name: '8H', type: 'bonds', condition: !bonds? },
-            { name: '12H', type: 'e_tokens', condition: !electric_dreams? },
-          ]
-
-          conditions.each do |cond|
-            train_list.find { |t| t[:name] == cond[:name] }[:events].reject! { |e| e['type'] == cond[:type] } if cond[:condition]
+          unless @game_trains
+            @game_trains = super.map(&:dup)
+            _train_4h, train_6h, train_8h, _train_10h, train_12h, _train_16h, train_e, _train_r6h = @game_trains
+            train_6h[:events] = [{ 'type' => 'green_par' }, { 'type' => 'buy_tokens' }] if acquiring_station_tokens?
+            train_8h[:events] = [{ 'type' => 'bonds' }] if bonds?
+            if electric_dreams?
+              train_12h[:events] =
+                [{ 'type' => 'close_companies' }, { 'type' => 'earthquake' }, { 'type' => 'e_tokens' }]
+            end
+            @game_trains.delete(train_e) unless electric_dreams?
           end
-
-          train_list
+          @game_trains
         end
 
         CAPITALIZATION = :incremental

--- a/lib/engine/game/g_1849/step/buy_train.rb
+++ b/lib/engine/game/g_1849/step/buy_train.rb
@@ -38,7 +38,7 @@ module Engine
 
           def buyable_trains(entity)
             # Cannot buy E-train without E-token
-            trains_to_buy = super.dup
+            trains_to_buy = super
 
             trains_to_buy = trains_to_buy.reject { |t| t.name == 'E' } unless @game.e_token?(entity)
 

--- a/lib/engine/game/g_1849/step/buy_train.rb
+++ b/lib/engine/game/g_1849/step/buy_train.rb
@@ -38,7 +38,7 @@ module Engine
 
           def buyable_trains(entity)
             # Cannot buy E-train without E-token
-            trains_to_buy = super
+            trains_to_buy = super.dup
 
             trains_to_buy = trains_to_buy.reject { |t| t.name == 'E' } unless @game.e_token?(entity)
 


### PR DESCRIPTION
Fixes #[11138]

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

@ollybh ran into a similar issue with 1858 Switzerland, which he resolved with this pull request: #11411. After discussion with him, I took the same approach here, and this passes validate_all on a mix of games experiencing the blocking step error and base game files that aren't facing the issue.

I also took the opportunity to improve a method in the game's buy_train step, adding a `.dup` to another method.

I don't believe this will require any pins.

### Screenshots

### Any Assumptions / Hacks
