### PR TITLE
[1877 Stockholm Tramways] clear graph after merger

### DIFF
--- a/lib/engine/game/g_1877_stockholm_tramways/step/acquire.rb
+++ b/lib/engine/game/g_1877_stockholm_tramways/step/acquire.rb
@@ -95,6 +95,7 @@ module Engine
             else
               @merge_finished = true
             end
+            @game.graph.clear_graph_for(action.corporation)
           end
 
           def can_buy?(entity, bundle)


### PR DESCRIPTION
Fixes #10155


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Newly available track after merger wasn't showing as available. clearing the graph after mergers resolves this. 

### Screenshots

Before: 
![image](https://github.com/user-attachments/assets/6a6c1796-0b6f-49ea-94c3-f04c49059b36)

After: 

![image](https://github.com/user-attachments/assets/d00d2eed-4955-4015-b7d0-0a03c888638d)


### Any Assumptions / Hacks
