### PR TITLE
[1880] Add log message after SR when corp can't buy train

### DIFF
--- a/lib/engine/game/g_1880/step/buy_train.rb
+++ b/lib/engine/game/g_1880/step/buy_train.rb
@@ -33,6 +33,10 @@ module Engine
 
           def log_skip(entity)
             return if entity.minor?
+            return @log << "#{entity.name} is at train limit and cannot buy a train" if !room?(entity) &&
+                                                                  @game.saved_or_round&.round_num == @round.round_num
+            return @log << "#{entity.name} cannot afford a train" if !can_buy_train?(entity) &&
+                                                                      @game.saved_or_round&.round_num == @round.round_num
 
             super
           end

--- a/lib/engine/game/g_1880/step/buy_train.rb
+++ b/lib/engine/game/g_1880/step/buy_train.rb
@@ -33,8 +33,21 @@ module Engine
 
           def log_skip(entity)
             return if entity.minor?
+
             return @log << "#{entity.name} is at train limit and cannot buy a train" unless room?(entity)
             return @log << "#{entity.name} cannot afford a train" unless can_buy_train?(entity)
+
+            super
+          end
+
+          def log_pass(entity)
+            # this captures the ID of the current train available for purchase from the depot
+            train_id = @game.depot.depot_trains.first.id
+
+            # these log messages are returned when a corp comes out of the stock round unable to buy a train after having bought
+            # the last train of the previous rank
+            return @log << "#{entity.name} is at train limit and cannot buy a train" if !room?(entity) && train_id.end_with?('-0')
+            return @log << "#{entity.name} cannot afford a train" if !can_buy_train?(entity) && train_id.end_with?('-0')
 
             super
           end

--- a/lib/engine/game/g_1880/step/buy_train.rb
+++ b/lib/engine/game/g_1880/step/buy_train.rb
@@ -33,10 +33,8 @@ module Engine
 
           def log_skip(entity)
             return if entity.minor?
-            return @log << "#{entity.name} is at train limit and cannot buy a train" if !room?(entity) &&
-                                                                  @game.saved_or_round&.round_num == @round.round_num
-            return @log << "#{entity.name} cannot afford a train" if !can_buy_train?(entity) &&
-                                                                      @game.saved_or_round&.round_num == @round.round_num
+            return @log << "#{entity.name} is at train limit and cannot buy a train" unless room?(entity)
+            return @log << "#{entity.name} cannot afford a train" unless can_buy_train?(entity)
 
             super
           end


### PR DESCRIPTION
Fixes #8808

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Initially I was going to add this log message only if the corp was coming out of an SR, but I wasn't sure that I was really limiting it to that scenario. I realised though, these added log messages works fine even if the corp isn't coming out of an SR, so I simplified the code. 

I don't even think `super` is needed at this point, but I figured I'd leave it as a catch-all

### Screenshots

### Any Assumptions / Hacks
