### PR TITLE
[1807] Auction ferry and underground railway private companies

### DIFF
--- a/lib/engine/game/g_1807/game.rb
+++ b/lib/engine/game/g_1807/game.rb
@@ -133,11 +133,6 @@ module Engine
           @companies.select { |company| !company.closed? && !company.owner }
         end
 
-        def purchasable_companies(_entity)
-          # Private companies cannot be bought, they must be auctioned.
-          []
-        end
-
         def unowned_purchasable_companies(_entity)
           (@companies + @future_companies).select do |company|
             !company.closed? && !company.owner

--- a/lib/engine/game/g_1807/game.rb
+++ b/lib/engine/game/g_1807/game.rb
@@ -77,6 +77,15 @@ module Engine
           super
         end
 
+        def stock_round
+          G1867::Round::Stock.new(self, [
+            G1867::Step::MajorTrainless,
+            Engine::Step::DiscardTrain,
+            Engine::Step::HomeToken,
+            G1807::Step::BuySellParShares,
+          ])
+        end
+
         def operating_round(round_num)
           calculate_interest
           G1867::Round::Operating.new(self, [
@@ -122,6 +131,11 @@ module Engine
 
         def buyable_bank_owned_companies
           @companies.select { |company| !company.closed? && !company.owner }
+        end
+
+        def purchasable_companies(_entity)
+          # Private companies cannot be bought, they must be auctioned.
+          []
         end
 
         def unowned_purchasable_companies(_entity)

--- a/lib/engine/game/g_1807/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1807/step/buy_sell_par_shares.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1867/step/buy_sell_par_shares'
+
+module Engine
+  module Game
+    module G1807
+      module Step
+        class BuySellParShares < G1867::Step::BuySellParShares
+          def bank_first?
+            # Show the private companies before minors/public companies/systems.
+            true
+          end
+
+          def can_bid_any?(player)
+            super || auctionable_companies.any? { |c| can_bid_company?(player, c) }
+          end
+
+          def can_bid_company?(player, company)
+            (!@auctioning || @auctioning == company) &&
+              auctionable_companies.include?(company) &&
+              (min_bid(company) <= player.cash)
+          end
+
+          def can_buy_company?(_player, _company)
+            false
+          end
+
+          def max_bid(player, _entity)
+            return 0 unless @game.num_certs(player) < @game.cert_limit
+
+            player.cash
+          end
+
+          def min_bid(entity)
+            return highest_bid(entity).price + min_increment if @auctioning
+
+            entity.company? ? entity.min_bid : MIN_BID
+          end
+
+          def win_bid(bid, _company)
+            return super if bid.corporation
+
+            player = bid.entity
+            company = bid.company
+            price = bid.price
+
+            @log << "#{player.name} wins the auction for #{company.name} "\
+                    "with a bid of #{@game.format_currency(price)}"
+
+            player.spend(price, @game.bank)
+            company.owner = player
+            player.companies << company
+          end
+
+          private
+
+          def auctionable_companies
+            @game.buyable_bank_owned_companies
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1807/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1807/step/buy_sell_par_shares.rb
@@ -51,6 +51,11 @@ module Engine
             player.spend(price, @game.bank)
             company.owner = player
             player.companies << company
+            @auctioning = nil
+
+            # Player to the right of the winner is the new player
+            @round.goto_entity!(player)
+            @round.next_entity!
           end
 
           private


### PR DESCRIPTION
One of the ways that 1807 differs from 1861 and 1867 is that is has more private companies. The game starts in exactly the same way as 1861/1867 with an auction of private railway companies. But later in the game other privates become available: ferry companies and then underground railways. Once these are available they can be put up for auction in a stock round, with the auction proceeding in the same way as auctions for minor companies.

This pull request adds the code for auctioning private companies in stock rounds.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`