### PR TITLE
[1858 India] Map updates

### DIFF
--- a/lib/engine/game/g_1858_india/entities.rb
+++ b/lib/engine/game/g_1858_india/entities.rb
@@ -151,7 +151,7 @@ module Engine
             abilities: [
               { type: 'no_buy' },
               { type: 'revenue_change', revenue: 36, on_phase: '3' },
-              { type: 'reservation', hex: 'K6', icon: '1858_india/BS+BT' },
+              { type: 'reservation', hex: 'K6' },
               {
                 type: 'exchange',
                 owner_type: 'player',
@@ -221,7 +221,7 @@ module Engine
             abilities: [
               { type: 'no_buy' },
               { type: 'revenue_change', revenue: 35, on_phase: '3' },
-              { type: 'reservation', hex: 'K6', icon: '1858_india/BS+BT' },
+              { type: 'reservation', hex: 'K6' },
               {
                 type: 'exchange',
                 owner_type: 'player',

--- a/lib/engine/game/g_1858_india/map.rb
+++ b/lib/engine/game/g_1858_india/map.rb
@@ -563,14 +563,6 @@ module Engine
                     'path=track:future,a:3,b:_0;' \
                     'upgrade=cost:40,terrain:river;' \
                     'icon=image:1858_india/CPC,sticky:1;',
-            %w[K6] =>
-                    'city=revenue:0;' \
-                    'label=Y;' \
-                    'future_label=label:B,color:gray;' \
-                    'path=track:future,a:3,b:_0;' \
-                    'path=track:future,a:4,b:_0;' \
-                    'icon=image:1858_india/BT,sticky:1;' \
-                    'icon=image:1858_india/BS,sticky:1;',
             %w[K8] =>
                     'town=revenue:0;' \
                     'path=track:future,a:1,b:_0;' \
@@ -737,6 +729,12 @@ module Engine
                     'path=a:4,b:_2;' \
                     'border=type:province,edge:3;' \
                     'border=type:province,edge:4;',
+            %w[K6] =>
+                    'city=revenue:30,slots:2;' \
+                    'label=Y;' \
+                    'future_label=label:B,color:gray;' \
+                    'path=a:3,b:_0;' \
+                    'path=a:4,b:_0;' \
           },
 
           red: {

--- a/lib/engine/game/g_1858_india/map.rb
+++ b/lib/engine/game/g_1858_india/map.rb
@@ -416,7 +416,7 @@ module Engine
                     'upgrade=cost:40,terrain:swamp;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:3;' \
-                    'border=type:impassible,edge:5;',
+                    'border=type:impassable,edge:5;',
             %w[H5] =>
                     'upgrade=cost:40,terrain:swamp;' \
                     'border=type:province,edge:2;' \
@@ -480,7 +480,7 @@ module Engine
                     'icon=image:1858_india/DC,sticky:1;',
             %w[I4] =>
                     'town=revenue:0;' \
-                    'border=type:impassible,edge:2;',
+                    'border=type:impassable,edge:2;',
             %w[I6] =>
                     'town=revenue:0;' \
                     'path=track:future,a:3,b:_0;' \
@@ -647,7 +647,7 @@ module Engine
                     'border=type:province,edge:3;',
             %w[N7] =>
                     'border=type:province,edge:4;' \
-                    'border=type:impassible,edge:5;',
+                    'border=type:impassable,edge:5;',
             %w[N9] =>
                     'upgrade=cost:40,terrain:mountain;' \
                     'border=type:province,edge:0;' \
@@ -665,7 +665,7 @@ module Engine
                     'border=type:province,edge:3;',
             %w[O8] =>
                     'town=revenue:0;' \
-                    'border=type:impassible,edge:2;' \
+                    'border=type:impassable,edge:2;' \
                     'border=type:province,edge:3;' \
                     'border=type:province,edge:4;',
             %w[O10] =>

--- a/lib/engine/game/g_1858_india/map.rb
+++ b/lib/engine/game/g_1858_india/map.rb
@@ -268,6 +268,7 @@ module Engine
                     'upgrade=cost:40,terrain:river;' \
                     'icon=image:1858_india/KK,sticky:1;',
             %w[F5] =>
+                    'upgrade=cost:20,terrain:desert;' \
                     'border=type:province,edge:3;' \
                     'border=type:province,edge:4;' \
                     'border=type:province,edge:5;',
@@ -347,6 +348,7 @@ module Engine
                     'border=type:province,edge:5;' \
                     'icon=image:1858_india/KK,sticky:1;',
             %w[G4] =>
+                    'upgrade=cost:20,terrain:desert;' \
                     'border=type:province,edge:0;' \
                     'border=type:province,edge:4;' \
                     'border=type:province,edge:5;',
@@ -411,12 +413,12 @@ module Engine
             %w[G26] =>
                     'upgrade=cost:40,terrain:mountain;',
             %w[H3] =>
-                    'upgrade=cost:40,terrain:river;' \
+                    'upgrade=cost:40,terrain:swamp;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:3;' \
                     'border=type:impassible,edge:5;',
             %w[H5] =>
-                    'upgrade=cost:40,terrain:river;' \
+                    'upgrade=cost:40,terrain:swamp;' \
                     'border=type:province,edge:2;' \
                     'border=type:province,edge:3;',
             %w[H7] =>
@@ -746,11 +748,8 @@ module Engine
                     'path=track:dual,a:0,b:_0;' \
                     'border=type:province,edge:0;' \
                     'border=type:province,edge:5;',
-          },
-
-          gray: {
             %w[I26] =>
-                    'town=revenue:20;' \
+                    'offboard=revenue:yellow_20|green_30|brown_40|gray_40;' \
                     'path=a:2,b:_0;' \
                     'icon=image:1858_india/DC,sticky:1;',
           },

--- a/lib/engine/game/g_1858_india/map.rb
+++ b/lib/engine/game/g_1858_india/map.rb
@@ -734,7 +734,7 @@ module Engine
                     'label=Y;' \
                     'future_label=label:B,color:gray;' \
                     'path=a:3,b:_0;' \
-                    'path=a:4,b:_0;' \
+                    'path=a:4,b:_0;',
           },
 
           red: {

--- a/public/icons/1858_india/BS+BT.svg
+++ b/public/icons/1858_india/BS+BT.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8">
-  <text x="4" y="3.7" text-anchor="middle" dominant-baseline="auto" font-weight="700" font-size="3" font-family="Lato" letter-spacing="-0.2px" fill="#000000">BS</text>
-  <text x="4" y="4.3" text-anchor="middle" dominant-baseline="hanging" font-weight="700" font-size="3" font-family="Lato" letter-spacing="-0.1px" fill="#000000">BT</text>
-</svg>


### PR DESCRIPTION
A few map updates from playtesting:

- Bombay [K6] starts as a yellow tile.
- Chittagong [I26] is an off-board area.
- Some tweaks to terrain costs and terrain icons.

Also fix a typo in border types.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`