### PR TITLE
[1848] reverts change #11630 - unexpected bugs

### DIFF
--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -123,15 +123,6 @@ module View
             float: 'right',
           }
 
-          current_price_style = {
-            clear: 'both',
-            float: 'left',
-          }
-
-          lowest_bid_style = {
-            float: 'right',
-          }
-
           bidders_style = {
             marginTop: '0.5rem',
             display: 'inline-block',
@@ -167,8 +158,6 @@ module View
 
           company_name_str = @game.respond_to?(:company_size) ? "[#{@game.company_size(@company)}] " : ''
           company_name_str += @company.name
-          lowest_bid_price_str = @game.format_currency(@company.lowest_bid_price) if @company.lowest_bid_price
-          current_price_str = @game.format_currency(@company.min_bid)
 
           children = [
             h(:div, { style: header_style }, @game.company_header(@company)),
@@ -176,12 +165,10 @@ module View
             h(:div, { style: description_style }, @company.desc),
           ]
           company_value = @game.company_value(@company)
-          children << h(:div, { style: current_price_style }, "Current Price: #{current_price_str}") if @company.lowest_bid_price
-          children << h(:div, { style: lowest_bid_style }, "Lowest Price: #{lowest_bid_price_str}") if @company.lowest_bid_price
           children << h(:div, { style: value_style }, "Value: #{@game.format_currency(company_value)}") if company_value
           children << h(:div, { style: revenue_style }, "Revenue: #{revenue_str}") if @company.revenue
-          if !@company.discount.zero? && !@company.lowest_bid_price
-            children << h(:div, { style: { float: 'center' } }, "Price: #{current_price_str}")
+          unless @company.discount.zero?
+            children << h(:div, { style: { float: 'center' } }, "Price: #{@game.format_currency(@company.min_bid)}")
           end
           children << render_bidders if @bids && !@bids.empty?
 

--- a/lib/engine/company.rb
+++ b/lib/engine/company.rb
@@ -12,7 +12,7 @@ module Engine
     include Ownable
     include Passer
 
-    attr_accessor :name, :desc, :min_price, :revenue, :discount, :value, :lowest_bid_price
+    attr_accessor :name, :desc, :min_price, :revenue, :discount, :value
     attr_reader :sym, :min_auction_price, :treasury, :interval, :color, :text_color, :type, :auction_row, :meta
     attr_writer :max_price
 
@@ -28,7 +28,6 @@ module Engine
       @closed = false
       @min_price = opts[:min_price] || (@value ? (@value / 2.0).ceil : nil)
       @max_price = opts[:max_price] || (@value ? (@value * 2) : nil)
-      @lowest_bid_price = opts[:lowest_bid_price] || nil
       @interval = opts[:interval] # Array of prices or nil
       @color = opts[:color] || :yellow
       @text_color = opts[:text_color] || :black

--- a/lib/engine/game/g_1848/entities.rb
+++ b/lib/engine/game/g_1848/entities.rb
@@ -10,7 +10,6 @@ module Engine
             name: "Melbourne & Hobson's Bay Railway Company",
             value: 30,
             min_price: 1,
-            lowest_bid_price: 0,
             max_price: 40,
             revenue: 5,
             desc: 'No special abilities. Can be bought for £1-£40',
@@ -20,7 +19,6 @@ module Engine
             name: 'Oodnadatta Railway',
             value: 70,
             min_price: 1,
-            lowest_bid_price: 40,
             max_price: 80,
             revenue: 10,
             desc: 'Owning Public Company or its Director may build one (1) free tile on a desert hex (marked by'\
@@ -55,7 +53,6 @@ module Engine
             name: 'Tasmanian Railways',
             value: 110,
             min_price: 1,
-            lowest_bid_price: 80,
             max_price: 140,
             revenue: 15,
             desc: 'The Tasmania tile can be placed by a Public Company on one of the two blue hexes (I8, I10). This is in'\
@@ -80,7 +77,6 @@ module Engine
             value: 170,
             discount: 0,
             min_price: 1,
-            lowest_bid_price: 140,
             max_price: 220,
             revenue: 20,
             desc: 'Owning Public Company or its Director may receive a one-time discount of £100 on the purchase'\
@@ -109,7 +105,6 @@ module Engine
             sym: 'P5',
             name: 'Trans-Australian Railway',
             value: 170,
-            lowest_bid_price: 140,
             revenue: 25,
             desc: 'The owner receives a 10% share in the QR. Cannot be bought by a corporation',
             abilities: [{ type: 'shares', shares: 'QR_1' },
@@ -119,7 +114,6 @@ module Engine
             sym: 'P6',
             name: 'North Australian Railway',
             value: 230,
-            lowest_bid_price: 220,
             revenue: 30,
             desc: "The owner receives a Director's Share share in the CAR, which must start at a par value of £100."\
                   ' Cannot be bought by a corporation. Closes when CAR purchases its first train.',

--- a/lib/engine/game/g_1848/step/dutch_auction.rb
+++ b/lib/engine/game/g_1848/step/dutch_auction.rb
@@ -21,6 +21,15 @@ module Engine
           ACTIONS = %w[bid assign].freeze
           ACTIONS_WITH_PASS = %w[bid assign pass].freeze
 
+          MIN_PRICES = {
+            'P1' => 0,
+            'P2' => 40,
+            'P3' => 80,
+            'P4' => 140,
+            'P5' => 140,
+            'P6' => 200,
+          }.freeze
+
           def description
             "Buy a Company or Reduce its Price by #{@game.format_currency(5)}"
           end
@@ -70,7 +79,7 @@ module Engine
 
           def may_reduce?(company)
             # Each private can be discounted a maximum of 6 times
-            company.min_bid > company.lowest_bid_price
+            company.min_bid > MIN_PRICES[company.sym]
           end
 
           def actions(entity)


### PR DESCRIPTION
Fixes #11703 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

unfortunately the changes for 1848 causes an unforeseen issue with the Volatility expansion in 1817, causing this console error during the auction: 
![image](https://github.com/user-attachments/assets/f4384d47-a826-484a-96d3-d5ea48b26535)

I've tinkered around with it, but can't seem to identify how to fix the issue, so I'd rather just revert my change for now. If anyone has ideas on how to fix this without reverting, let me know!



### Screenshots

### Any Assumptions / Hacks
