### PR TITLE
1837: fix for multiple train discards #11705

### DIFF
--- a/lib/engine/game/g_1837/step/discard_train.rb
+++ b/lib/engine/game/g_1837/step/discard_train.rb
@@ -9,6 +9,7 @@ module Engine
         class DiscardTrain < Engine::Step::DiscardTrain
           def process_discard_train(action)
             super
+            @round.merged_trains[action.entity].delete(action.train)
             return if crowded_corps.include?(action.entity)
 
             @round.merged_trains[action.entity].clear


### PR DESCRIPTION
Fixes #11705 

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

`@round.merged_trains[action.entity].delete(action.train)` is a silent no-op (returns `nil`, but we're not using the return value) if either:
- `action.train` (the discarded train) is not a member of `@round.merged_trains[action.entity]` (the list of merged trains)
-  The list is empty.
 
It can be safely called every time we discard a train.

### Explanation of Change

Phase change which both lowers the train limit and merges coal companies can leave a corporation needing to discard multiple trains to meet the new train limit.  This could be trains from both the merged coal companies, which must be discarded first, and also from the corporation's trains that were already owned before the merge.

The existing code chooses either the list of 'merged' trains, if non-empty, or the list of already-owned trains, and tries to satisfy ALL of the required discards from that list.  If more trains must be discarded than are in the 'merged' list, the game stalls.  It does not empty the list of 'merged' trains until after the corporation is back down to the train limit.

By removing each train from the list of 'merged' trains as it is discarded, we can get to an empty list of 'merged' trains during the discard step, which triggers the logic to show the list of already-owned trains to complete the discard process.

### Screenshots

### Any Assumptions / Hacks
