### PR TITLE
[1848] Fix lowest bid price for P6

### DIFF
--- a/lib/engine/game/g_1848/entities.rb
+++ b/lib/engine/game/g_1848/entities.rb
@@ -119,7 +119,7 @@ module Engine
             sym: 'P6',
             name: 'North Australian Railway',
             value: 230,
-            lowest_bid_price: 220,
+            lowest_bid_price: 200,
             revenue: 30,
             desc: "The owner receives a Director's Share share in the CAR, which must start at a par value of £100."\
                   ' Cannot be bought by a corporation. Closes when CAR purchases its first train.',


### PR DESCRIPTION
All privates should have a lowest bid price that is £30 less than their face value.

There's a very small chance this might require pinning or migrating some games.

Fixes #11712.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`