### PR TITLE
[1858 India] Add mail trains

### DIFF
--- a/lib/engine/game/g_1858_india/game.rb
+++ b/lib/engine/game/g_1858_india/game.rb
@@ -86,6 +86,11 @@ module Engine
           corporation.trains.any? { |train| mail_train?(train) }
         end
 
+        def must_buy_train?(corporation)
+          # A mail train doesn't fulfil the requirement to own a train.
+          corporation.trains.none? { |train| !mail_train?(train) }
+        end
+
         def num_corp_trains(corporation)
           # Mail trains don't count towards train limit.
           corporation.trains.count { |train| !mail_train?(train) }

--- a/lib/engine/game/g_1858_india/game.rb
+++ b/lib/engine/game/g_1858_india/game.rb
@@ -153,7 +153,7 @@ module Engine
           train = route.train
           return 0 unless @round.mail_trains[train.owner] == train
 
-          10 * stops.count(&:city?)
+          10 * stops.count { |stop| stop.city? || stop.offboard? }
         end
       end
     end

--- a/lib/engine/game/g_1858_india/game.rb
+++ b/lib/engine/game/g_1858_india/game.rb
@@ -41,7 +41,7 @@ module Engine
             G1858India::Step::Route,
             G1858::Step::Dividend,
             G1858::Step::DiscardTrain,
-            G1858::Step::BuyTrain,
+            G1858India::Step::BuyTrain,
             G1858::Step::IssueShares,
           ], round_num: round_num)
         end
@@ -80,6 +80,15 @@ module Engine
 
         def mail_train?(train)
           train.name == 'Mail'
+        end
+
+        def owns_mail_train?(corporation)
+          corporation.trains.any? { |train| mail_train?(train) }
+        end
+
+        def num_corp_trains(corporation)
+          # Mail trains don't count towards train limit.
+          corporation.trains.count { |train| !mail_train?(train) }
         end
 
         def route_trains(entity)

--- a/lib/engine/game/g_1858_india/game.rb
+++ b/lib/engine/game/g_1858_india/game.rb
@@ -86,8 +86,9 @@ module Engine
           corporation.trains.any? { |train| mail_train?(train) }
         end
 
-        def must_buy_train?(corporation)
-          # A mail train doesn't fulfil the requirement to own a train.
+        def trainless?(corporation)
+          # For emergency money raising, a mail train on its own doesn't stop
+          # a public company from issuing shares.
           corporation.trains.none? { |train| !mail_train?(train) }
         end
 

--- a/lib/engine/game/g_1858_india/game.rb
+++ b/lib/engine/game/g_1858_india/game.rb
@@ -154,7 +154,8 @@ module Engine
           train = route.train
           return 0 unless @round.mail_trains[train.owner] == train
 
-          10 * stops.count { |stop| stop.city? || stop.offboard? }
+          stop_bonus = (train.multiplier || 1) * (train.obsolete ? 5 : 10)
+          stop_bonus * stops.count { |stop| stop.city? || stop.offboard? }
         end
       end
     end

--- a/lib/engine/game/g_1858_india/step/buy_train.rb
+++ b/lib/engine/game/g_1858_india/step/buy_train.rb
@@ -18,7 +18,7 @@ module Engine
           private
 
           def can_buy_mail_train?(entity)
-            !@game.owns_mail_train?(entity) && !@game.must_buy_train?(entity)
+            !@game.owns_mail_train?(entity)
           end
 
           def room?(entity, _shell = nil)

--- a/lib/engine/game/g_1858_india/step/buy_train.rb
+++ b/lib/engine/game/g_1858_india/step/buy_train.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1858/step/buy_train'
+
+module Engine
+  module Game
+    module G1858India
+      module Step
+        class BuyTrain < G1858::Step::BuyTrain
+          def buyable_trains(entity)
+            return super unless @game.owns_mail_train?(entity)
+
+            super.reject { |train| @game.mail_train?(train) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1858_india/step/buy_train.rb
+++ b/lib/engine/game/g_1858_india/step/buy_train.rb
@@ -8,9 +8,25 @@ module Engine
       module Step
         class BuyTrain < G1858::Step::BuyTrain
           def buyable_trains(entity)
-            return super unless @game.owns_mail_train?(entity)
+            trains = super
+            trains.reject! { |t| @game.mail_train?(t) } unless can_buy_mail_train?(entity)
+            return trains unless at_train_limit?(entity)
 
-            super.reject { |train| @game.mail_train?(train) }
+            trains.select { |train| @game.mail_train?(train) }
+          end
+
+          private
+
+          def can_buy_mail_train?(entity)
+            !@game.owns_mail_train?(entity) && !@game.must_buy_train?(entity)
+          end
+
+          def room?(entity, _shell = nil)
+            super || !@game.owns_mail_train?(entity)
+          end
+
+          def at_train_limit?(entity)
+            @game.num_corp_trains(entity) == @game.train_limit(entity)
           end
         end
       end

--- a/lib/engine/game/g_1858_india/step/route.rb
+++ b/lib/engine/game/g_1858_india/step/route.rb
@@ -40,11 +40,7 @@ module Engine
           private
 
           def choosing?(corporation)
-            owns_mail_train?(corporation) && !mail_train_attached?(corporation)
-          end
-
-          def owns_mail_train?(corporation)
-            corporation.trains.any? { |train| @game.mail_train?(train) }
+            @game.owns_mail_train?(corporation) && !mail_train_attached?(corporation)
           end
 
           # The trains that a mail train can be attached to.

--- a/lib/engine/game/g_1858_india/step/route.rb
+++ b/lib/engine/game/g_1858_india/step/route.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1858/step/route'
+
+module Engine
+  module Game
+    module G1858India
+      module Step
+        class Route < G1858::Step::Route
+          def actions(entity)
+            actions = super.dup
+            actions << 'choose' if !actions.empty? && choosing?(entity)
+            actions
+          end
+
+          def choice_name
+            'Attach mail train to another train'
+          end
+
+          def choices
+            attachable_trains(current_entity).to_h do |train|
+              [train.id, "#{train.name} train"]
+            end
+          end
+
+          def round_state
+            super.merge({ mail_trains: {} })
+          end
+
+          def process_choose(action)
+            @round.mail_trains[action.entity] = @game.train_by_id(action.choice)
+          end
+
+          def train_name(corporation, train)
+            return train.name unless @round.mail_trains[corporation] == train
+
+            "#{train.name} + Mail"
+          end
+
+          private
+
+          def choosing?(corporation)
+            owns_mail_train?(corporation) && !mail_train_attached?(corporation)
+          end
+
+          def owns_mail_train?(corporation)
+            corporation.trains.any? { |train| @game.mail_train?(train) }
+          end
+
+          # The trains that a mail train can be attached to.
+          def attachable_trains(corporation)
+            corporation.trains.select do |train|
+              train.track_type == :broad && !@game.mail_train?(train)
+            end
+          end
+
+          def mail_train_attached?(corporation)
+            !@round.mail_trains[corporation].nil?
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
1858 India has mail trains. These are similar to 1822's Pullman trains, in that they are attached to another train and affect its run. They give a £10 revenue bonus for each large city or off-board area they visit.

Mail trains do not count towards the train limit, and a company that only owns a mail train can still use emergency money raising to buy another train.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`