### PR TITLE
[18Ardennes] Fix error after bankruptcy in stock round

### DIFF
--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -167,13 +167,21 @@ module Engine
         # `@round.last_to_act` goes bankrupt.
         def priority_deal_player
           # In operating rounds the array of players will be in priority order.
-          return @players.first unless @round.current_entity&.player?
+          return @players.first if @round.operating?
 
           # In stock and auction rounds the first non-bankrupt player after the
           # one who last acted has priority.
           last_to_act = @round.last_to_act
           idx = last_to_act ? (@players.index(last_to_act) + 1) : 0
           @players.rotate(idx).find { |player| !player.bankrupt }
+        end
+
+        # The base class version of #reorder_players also can't cope with
+        # players going bankrupt in a stock round. It can give an error after
+        # an out-of-bounds array access returns nil.
+        def reorder_players(order = nil, log_player_order: false, silent: false)
+          @players.rotate!(@players.index(priority_deal_player))
+          @log << "#{@players.first.name} has priority deal" unless silent
         end
 
         def acting_for_entity(entity)

--- a/lib/engine/game/g_18_ardennes/game.rb
+++ b/lib/engine/game/g_18_ardennes/game.rb
@@ -179,7 +179,7 @@ module Engine
         # The base class version of #reorder_players also can't cope with
         # players going bankrupt in a stock round. It can give an error after
         # an out-of-bounds array access returns nil.
-        def reorder_players(order = nil, log_player_order: false, silent: false)
+        def reorder_players(_order = nil, log_player_order: false, silent: false)
           @players.rotate!(@players.index(priority_deal_player))
           @log << "#{@players.first.name} has priority deal" unless silent
         end

--- a/lib/engine/game/g_18_ardennes/step/minor_auction.rb
+++ b/lib/engine/game/g_18_ardennes/step/minor_auction.rb
@@ -137,6 +137,7 @@ module Engine
 
           def process_bid(action)
             action.entity.unpass!
+            @round.last_to_act = action.entity
 
             if discount_mode?
               # GL has been purchased
@@ -155,6 +156,7 @@ module Engine
           end
 
           def process_par(action)
+            @round.last_to_act = action.entity
             process_purchase(action)
           end
 


### PR DESCRIPTION
The base implementation of `Game.reorder_players` can give an error after bankruptcies in a stock round. An out-of-bounds array access returns nil.

Fixes tobymao#11710.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`