### PR TITLE
[18esp] fix mz mza cheater token

### DIFF
--- a/lib/engine/game/g_18_esp/step/home_token.rb
+++ b/lib/engine/game/g_18_esp/step/home_token.rb
@@ -11,8 +11,13 @@ module Engine
             return super unless entity.name == 'MZ'
 
             [Engine::Action::PlaceToken.new(entity,
-                                            city: @game.city_by_id('F24-0-2'),
+                                            city: get_mz_city(entity),
                                             slot: 0)]
+          end
+
+          def get_mz_city(entity)
+            cities = @game.hex_by_id(entity.coordinates).tile.cities
+            entity.city < cities.length ? cities[entity.city] : cities.first
           end
 
           def process_place_token(action)


### PR DESCRIPTION
MZA and MZ share a single slot city in madrid (f24).
When mz is taken over, and MZA was placed as a cheater token, the closing of MZ doesn't remove the extra slot.
added minor code to fix this behaviour.