### PR TITLE
[1822NRS] removes erroneous hex from map

### DIFF
--- a/lib/engine/game/g_1822_nrs/map.rb
+++ b/lib/engine/game/g_1822_nrs/map.rb
@@ -266,7 +266,7 @@ module Engine
               'city=revenue:yellow_40|green_60|brown_80|gray_100,slots:1,loc:4,groups:London;path=a:3,b:_1',
           },
           blue: {
-            %w[L11 R31] =>
+            ['L11'] =>
               'junction;path=a:2,b:_0,terminal:1',
             ['F17'] =>
               'junction;path=a:4,b:_0,terminal:1',


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

There was a random hex duplicated in R31 completely outside of the map. This has been there since the game was first implemented 4 years ago, but definitely serves no purpose.

### Screenshots

![image](https://github.com/user-attachments/assets/a0e74f5e-f74d-4e05-aeb0-2a6e71d77a2e)


### Any Assumptions / Hacks
