### PR TITLE
[18ESP] Updated rules URLs

### DIFF
--- a/lib/engine/game/g_18_esp/meta.rb
+++ b/lib/engine/game/g_18_esp/meta.rb
@@ -14,7 +14,10 @@ module Engine
         GAME_DESIGNER = 'Lonny Orgler and Enrique Trigueros'
         GAME_LOCATION = 'Spain'
         GAME_PUBLISHER = :lonny_games
-        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/273359/18espana-18esp-english-draft-rules'
+        GAME_RULES_URL = {
+          '18ESP Rules' => 'https://boardgamegeek.com/filepage/299403/18esp-english-rules',
+          '18ESP Playbook' => 'https://boardgamegeek.com/filepage/299500/english-playbook',
+        }.freeze
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18ESP'
 
         PLAYER_RANGE = [3, 6].freeze


### PR DESCRIPTION
The link for the game rules had broken. It looks like the BGG file page for the draft rules has been deleted now that a final version of the rules is available.

This updates the rules link to point to a BGG page for the final version of the Lonny Games rules. It also adds a link to the Playbook file page.