### PR TITLE
[1849] Variants - remove bonds block

### DIFF
--- a/lib/engine/game/g_1849/step/bond_interest_payment.rb
+++ b/lib/engine/game/g_1849/step/bond_interest_payment.rb
@@ -20,10 +20,6 @@ module Engine
             super if @game.bonds?
           end
 
-          def blocks?
-            false
-          end
-
           def skip!
             pass!
             entity = current_entity


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Removes the `def blocks?` method from bonds, which was done when I was testing ideas to fix the previous bonds issue. I have come to realize that removing this caused the bonds interest to not be charged.

### Screenshots

### Any Assumptions / Hacks
