### PR TITLE
[18Norway] fixes coordinates for P1 from I23 to J23

### DIFF
--- a/lib/engine/game/g_18_norway/companies.rb
+++ b/lib/engine/game/g_18_norway/companies.rb
@@ -10,9 +10,9 @@ module Engine
             sym: 'P1',
             value: 20,
             revenue: 5,
-            desc: 'Blocks hex (I23) until bought by a public company, or when the first 5 train is bought, ' \
+            desc: 'Blocks hex (J23) until bought by a public company, or when the first 5 train is bought, ' \
                   'which also closes the P1.',
-            abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['I23'] }],
+            abilities: [{ type: 'blocks_hexes', owner_type: 'player', hexes: ['J23'] }],
             color: nil,
           },
           {


### PR DESCRIPTION
Fixes #11739

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

P1 was configured for hex I23 but should be J23. I23 doesn't even exist.
corrected ability and description.

### Screenshots

### Any Assumptions / Hacks
