### PR TITLE
[1847AE] should LFK only pay on on first new train

### DIFF
--- a/lib/engine/game/g_1847_ae/step/buy_single_train_of_type.rb
+++ b/lib/engine/game/g_1847_ae/step/buy_single_train_of_type.rb
@@ -17,11 +17,9 @@ module Engine
 
           def process_buy_train(action)
             new_train = @depot.upcoming.include?(action.train)
-            print "new train: #{new_train} "
             super
 
             lfk = @game.lfk
-            print "train bought this round: #{@game.train_bought_this_round} "
             return if @game.train_bought_this_round || !lfk.floated? || !new_train
 
             lfk_owner = lfk.owner

--- a/lib/engine/game/g_1847_ae/step/buy_single_train_of_type.rb
+++ b/lib/engine/game/g_1847_ae/step/buy_single_train_of_type.rb
@@ -16,11 +16,13 @@ module Engine
           end
 
           def process_buy_train(action)
-            from_discard = @depot.discarded.include?(action.train)
+            new_train = @depot.upcoming.include?(action.train)
+            print "new train: #{new_train} "
             super
 
             lfk = @game.lfk
-            return if @game.train_bought_this_round || !lfk.floated? || from_discard
+            print "train bought this round: #{@game.train_bought_this_round} "
+            return if @game.train_bought_this_round || !lfk.floated? || !new_train
 
             lfk_owner = lfk.owner
             if lfk_owner.player?


### PR DESCRIPTION
Fixes #11735

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

The rules say that a dividend is paid to the owner of LFK every time the first train has been bought from the Bank, but as implemented, the code was giving the dividend every time the first train was bought from anywhere other than the discards, which means it was also paying out if the first train was a cross buy.

This will require pins. 

### Screenshots

![image](https://github.com/user-attachments/assets/b7d8e980-0d6c-4d98-9a02-038c71633557)


### Any Assumptions / Hacks
