### PR TITLE
[1858 Switzerland] Fix spelling of VSB private railway company

### DIFF
--- a/lib/engine/game/g_1858_switzerland/entities.rb
+++ b/lib/engine/game/g_1858_switzerland/entities.rb
@@ -162,7 +162,7 @@ module Engine
           },
           {
             sym: 'VSB',
-            name: 'Vereingtebahn',
+            name: 'Vereinigtebahn',
             type: 'private_batch1',
             desc: 'P4. Revenue 21/32, face value 105. Home hexes are J5 and K4. ' \
                   'Can be used to start a public company in St Gallen.',


### PR DESCRIPTION
The VSB private railway company should be spelled "Vereinigtebahn", not "Vereingtebahn".

Fixes tobymao#11737.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`