### PR TITLE
[1858] Fix error in hotseat games

### DIFF
--- a/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1858/step/buy_sell_par_shares.rb
@@ -193,6 +193,7 @@ module Engine
             # their money and doesn't want to be prompted to sell shares).
             min_price = @game.buyable_bank_owned_companies.map(&:min_bid).min
             @game.programmed_actions.each do |player, actions|
+              next unless player
               next if player.cash < min_price
 
               actions.reject! do |act|


### PR DESCRIPTION
I wasn't able to reproduce this myself, but someone else was getting errors when starting 1858 and 1858 India games in hotseat mode. The error was occuring when trying to place the first bid on a private railway company: `undefined method 'cash' for nil`.

This was occurring in the loop iterating over `@game.programmed_actions`. It was returning an element where `player` (the key) was nil and the `actions` (values) were an empty array.
This prevents the error by testing for the nil key.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`