### PR TITLE
[1861/1867] Don't transfer zero-cost tokens from minors to majors

### DIFF
--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -818,6 +818,14 @@ module Engine
           @game_end_check = super || @game_end_check
         end
 
+        # The merger process can result in the new major having just two
+        # tokens. This gives them their third token if that has happened.
+        def fix_token_count!(corporation)
+          return if corporation.tokens.size == 3
+
+          corporation.tokens << Engine::Token.new(corporation, price: 40)
+        end
+
         private
 
         def new_auction_round

--- a/lib/engine/game/g_1867/step/merge.rb
+++ b/lib/engine/game/g_1867/step/merge.rb
@@ -213,10 +213,7 @@ module Engine
               @round.corporations_removing_tokens = [target] + @merging
             else
               # Add the $40 token back
-              if target.tokens.size < 3
-                new_token = Engine::Token.new(target, price: 40)
-                target.tokens << new_token
-              end
+              @game.fix_token_count!(target)
 
               tokens = target.tokens.map { |t| t.city&.hex&.id }
               charter_tokens = tokens.size - tokens.compact.size

--- a/lib/engine/game/g_1867/step/reduce_tokens.rb
+++ b/lib/engine/game/g_1867/step/reduce_tokens.rb
@@ -25,6 +25,8 @@ module Engine
           end
 
           def move_tokens_to_surviving(surviving, others)
+            # Stop zero-cost tokens from being moved from a minor to a major.
+            others.each { |corp| corp.tokens.select!(&:city) }
             super
             # Add the $40 token back if the major only has two tokens
             @game.fix_token_count!(surviving)

--- a/lib/engine/game/g_1867/step/reduce_tokens.rb
+++ b/lib/engine/game/g_1867/step/reduce_tokens.rb
@@ -26,12 +26,8 @@ module Engine
 
           def move_tokens_to_surviving(surviving, others)
             super
-
-            return unless surviving.tokens.size < 3
-
-            # Add the $40 token back
-            new_token = Engine::Token.new(surviving, price: 40)
-            surviving.tokens << new_token
+            # Add the $40 token back if the major only has two tokens
+            @game.fix_token_count!(surviving)
           end
 
           def help


### PR DESCRIPTION
The fix for tobymao#8589 in PR tobymao#8689 was incomplete. It prevented public companies (majors) being given free tokens when three or more minors merged to form a major, but it did not handle the case of two minor companies with tokens in the same city being merged to form a new major. When this type of merger was being done, one of the two minor companies' tokens was being removed by the player and was returned to the minor's charter. The call  to `move_tokens_to_surviving` from `Step::ReduceTokens.process_reduce_tokens` was then moving this token from the minor to the major, where it was keeping the zero cost it had in the minor company.

This prevents this from happening by clearing all unplaced tokens from minor companies at the start of `move_tokens_to_surviving`. 1861/1867 does not need to move unplaced tokens around, the major companies already have as many tokens as they are allowed.

Fixes tobymao#11750.

This change will require some games to be pinned. My testing has identified sixteen games (IDs 166657, 167133, 169529, 170303, 174514, 179054, 179561, 184963, 186342, 192864, 194061, 194226, 198029, 198627, 199860, 208635) which are broken by this. I've looked at all these games and they all have a two-way merger where the minors had tokens in the same city. Pin `ccbfcd9a8` should be used for these games.

This pull request also includes some refactoring of the 1867 code that was sitting in my 1807 branch. It extracts a `fix_token_count!` method that is called from `G1867::Step::ReduceTokens.move_tokens_to_surviving`, and also from `G1867::Step::Merge.finish_merge_to_major`. This method is being extracted to make it easier to override the behaviour in the 1807 code, where public companies have four tokens not three, and systems can have eight or twelve, and all these tokens cost £20 per hex, not the 40₽/$40 per hex for the last token you have in 1861/1867.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`