### PR TITLE
Ensure that opal runtime is loaded

### DIFF
--- a/lib/js_context.rb
+++ b/lib/js_context.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 require 'mini_racer'
+require 'opal'
 
 class JsContext
   def initialize(file)
     @file = file
-    @snapshot = MiniRacer::Snapshot.new(File.read(@file, encoding: 'UTF-8'))
+    # Create a snapshot that includes both Opal runtime and the target file
+    opal_runtime = Opal::Builder.build('opal').to_s
+    file_contents = File.read(@file, encoding: 'UTF-8')
+    @snapshot = MiniRacer::Snapshot.new("#{opal_runtime}\n#{file_contents}")
   end
 
   def eval(script)


### PR DESCRIPTION
An attempt to stabilize the test environment.
Try to ensures that the Opal runtime is available in the JavaScript context before any Opal-compiled code is executed.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
