### PR TITLE
[1848] must sell in blocks -> confirmed by designer

### DIFF
--- a/lib/engine/game/g_1848/game.rb
+++ b/lib/engine/game/g_1848/game.rb
@@ -46,7 +46,7 @@ module Engine
 
         CAPITALIZATION = :full
 
-        MUST_SELL_IN_BLOCKS = false
+        MUST_SELL_IN_BLOCKS = true
 
         EBUY_PRES_SWAP = false
 


### PR DESCRIPTION
Fixes #11764

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Currently, players can sell one share of a corp, then another, then another, etc to cause multiple price drops in a single turn.  While the rules as written don't have a specific ruling against this, I know we encountered the same issue with 1844 and Helmut's ruling was that [you must sell all shares as a single block.](https://boardgamegeek.com/thread/3308703/can-players-sell-multiple-shares-in-a-company-one) Given that he's also the designer here, I would assume that holds true. 

I can try reaching out to him if we think a confirmation would be helpful.

### Screenshots

### Any Assumptions / Hacks
