### PR TITLE
assets: Require the source map to exist if it is enabled

### DIFF
--- a/lib/assets.rb
+++ b/lib/assets.rb
@@ -245,7 +245,9 @@ class Assets
     compilers = metadata.map do |file, opts|
       FileUtils.mkdir_p(opts[:build_path])
       js_path = opts[:js_path]
-      next if @cache && File.exist?(js_path) && File.mtime(js_path) >= opts[:mtime]
+      if @cache && File.exist?(js_path) && File.mtime(js_path) >= opts[:mtime] && (!@source_maps || File.exist?(js_path + '.map'))
+        next
+      end
 
       Opal::Compiler.new(File.read(opts[:path]), file: file, requirable: true)
     end.compact


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Explanation of Change

The way to repro this bug is pretty simple:
- Load up a 1822 game (or substitute the instructions appropriately)
- `rm public/assets/g_1822.js.map`
- Touch a ruby file to cause rake to restart
- Refresh the 1822 game page and see an exception like:
```
  "/18xx/lib/assets.rb:34:in `read'",
  "/18xx/lib/assets.rb:34:in `extend'",
  "/18xx/lib/assets.rb:204:in `block (2 levels) in combine'",
  "/18xx/lib/assets.rb:202:in `map'",
  "/18xx/lib/assets.rb:202:in `block in combine'",
  "/18xx/lib/assets.rb:196:in `each'",
  "/18xx/lib/assets.rb:196:in `combine'",
  "/18xx/api.rb:74:in `block in <class:Api>'",
  "/usr/local/bundle/gems/roda-3.55.0/lib/roda/pl
```
- If you refresh again it works because presumably somewhere the 18xx server is caching that it has built the files, but I don't know where.

This just makes it so that we consider the game file dirty if the source map is enabled and does not exist, so that it will be rebuilt. I don't know if this has been a long standing issue for others since my source maps introduction (if so sorry), but I noticed it was happening to me suddenly (maybe switching between running tests and running the UI?). 