### PR TITLE
Some minor autorouter bugfixes

### DIFF
--- a/assets/app/view/game/route_selector.rb
+++ b/assets/app/view/game/route_selector.rb
@@ -274,6 +274,8 @@ module View
           router.compute(
             @game.current_entity,
             routes: @routes.reject { |r| r.paths.empty? },
+            path_timeout: setting_for(:path_timeout).to_i,
+            route_timeout: setting_for(:route_timeout).to_i,
             callback: lambda do |routes|
               @routes = routes
               @selected_route = @routes.first

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -11,6 +11,7 @@ module Engine
 
     def initialize(game, flash = nil)
       @game = game
+      @train_autoroute_group = @game.class::TRAIN_AUTOROUTE_GROUPS
       @next_hexside_bit = 0
       @flash = flash
     end
@@ -364,7 +365,7 @@ module Engine
               : 0;
             r += routes[0].estimate_revenue;
             let train_group = 0;
-            const game_group_rules = this.router.game.$class().TRAIN_AUTOROUTE_GROUPS;
+            const game_group_rules = this.router.train_autoroute_group;
             if (game_group_rules == "each_train_separate") {
               train_group = number_train_groups;
               ++number_train_groups;

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -18,6 +18,7 @@ module Engine
 
     def compute(corporation, **opts)
       @running = true
+      @route_timeout = opts[:route_timeout] || 10
       trains = @game.route_trains(corporation).sort_by(&:price)
       train_routes, path_walk_timed_out = path(trains, corporation, **opts)
       @flash&.call('Auto route path walk failed to complete (PATH TIMEOUT)') if path_walk_timed_out
@@ -460,6 +461,9 @@ module Engine
                 this.router.$real_revenue(this.best_routes)
                 this.update_callback(this.best_routes)
                 this.render = false;
+            }
+            if (performance.now() - this.start_of_all > this.router.route_timeout * 1000) {
+                throw 'ROUTE_TIMEOUT';
             }
             await next_frame();
             if (!this.router.running) {

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -351,6 +351,12 @@ module Engine
             ([train, routes]) => [...routes, null], // add a null route to the end for the "no route for this train" case
           );
 
+          if (trains_to_routes.length === 0) {
+            this.router.running = false;
+            this.update_callback([]);
+            return;
+          }
+
           for (let i = 0; i < trains_to_routes.length; ++i) {
             // the last route is the null route so skip it
             for (let j = 0; j < trains_to_routes[i].length - 1; ++j) {

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -644,7 +644,6 @@ module Engine
           end
 
           local_cities.group_by(&:itself).each do |k, v|
-            puts "Local train can only use each token on #{k.hex.id} once"
             raise GameError, "Local train can only use each token on #{k.hex.id} once" if v.size > 1
           end
         end


### PR DESCRIPTION
- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

This was caught while rebasing my mass game replay tool and re-running them and while debugging https://github.com/tobymao/18xx/issues/11784. None are particularly fatal, but the inheritance on train_autoroute_group means that all the 1822 games will have subpar auto-routing when they have an E trains until it is merged.

### Explanation of Change

I can split these into separate pull requests if desired, but they are all simple changes.
- Get the autogroup constant in ruby so the inheritance lookup rules are respected
- Delete a log statement that made debugging https://github.com/tobymao/18xx/issues/11784 annoying
- A pedantic detail on not errorring when no valid paths are available. This is caught by the testing harness, but the UI is the same
- Restore reading the settings for route + path timeout and then add in route timeout support. I don't tweak the path setting so I didn't catch that and then the route timeout is less necessary since we don't lock the UI anymore, but restoring it to as it was.
