### PR TITLE
[1858 family] Enforce correct track types in route selector

### DIFF
--- a/lib/engine/game/g_1858/game.rb
+++ b/lib/engine/game/g_1858/game.rb
@@ -394,6 +394,10 @@ module Engine
           end
         end
 
+        def skip_route_track_type(train)
+          metre_gauge_train?(train) ? :broad : :narrow
+        end
+
         def routes_revenue(routes)
           super + @round.current_operator
                         .companies.select { |c| private_railway?(c) }


### PR DESCRIPTION
It was possible, when manually setting routes for trains in 1858, to route narrow gauge trains over broad gauge track, and to route broad gauge trains over narrow gauge tracks. These routes can never be legal, so it is better to make it impossible to select these routes.

This adds a `skip_route_track_type` method which makes it impossible to select a route with the wrong track type. Both narrow and broad gauge trains can still be routed over dual gauge track.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`