### PR TITLE
autorouter: Fix invalid array check

### DIFF
--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -376,7 +376,7 @@ module Engine
             if (game_group_rules == "each_train_separate") {
               train_group = number_train_groups;
               ++number_train_groups;
-            } else if (game_group_rules && routes.length > 0) {
+            } else if (Array.isArray(game_group_rules) && routes.length > 0) {
               const train_name = routes[0].$train().$name();
               train_group = game_group_rules.findIndex(group => group.includes(train_name)) + 1;
               number_train_groups = game_group_rules.length + 1;


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

This was intended to be an array/non-nil check but unfortunately https://github.com/tobymao/18xx/commit/75be0ddd65e101037ac5f1d62b529a67fbbeec5d changed the behavior of how ruby's nil appeared in this code path (before it used to be undefined and now it is NilClass.. which seems to also have an length property :/ ). Switch from a truthy check to an explicit array check.

I tested 1858 (this has no train autogroup, so falls into the else),  1822 with a combo with no E train and a combo with both an E train and no Etrain (this falls into the code path for this if statement) as well as 1862 and ~dozen other games for good measure. Hopefully, this finally fixes this finicky codepath. 