### PR TITLE
Create a git tag when deploying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,11 @@ prod_deploy : clean
 	$(CONTAINER_COMPOSE) run rack rake precompile && \
 		rsync --verbose --checksum public/pinned/*.js.gz deploy@18xx:~/18xx/public/pinned/ && \
 		rsync --verbose --checksum public/assets/*.js public/assets/*.js.gz public/assets/version.json deploy@18xx:~/18xx/public/assets/ && \
-		ssh -l deploy 18xx "source ~/.profile && cd ~/18xx/ && git pull && make prod_rack_up_b_d"
+		ssh -l deploy 18xx "source ~/.profile && cd ~/18xx/ && git pull && make prod_rack_up_b_d && make tag"
+
+# tag currently checked out commit with date in public/assets/version.json
+tag:
+	./scripts/tag_deployment.sh $(CONTAINER_COMPOSE)
 
 style:
 	$(CONTAINER_COMPOSE) exec rack rubocop -A

--- a/scripts/tag_deployment.sh
+++ b/scripts/tag_deployment.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Creates a git tag with the timestamp from version.json
+
+# the container engine, e.g., 'podman' or 'docker compose'
+CONTAINER_COMPOSE="${@}"
+
+TAG=$($CONTAINER_COMPOSE exec rack bundle exec ruby scripts/tag_name.rb)
+
+git tag $TAG
+git push origin refs/tags/$TAG

--- a/scripts/tag_name.rb
+++ b/scripts/tag_name.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'json'
+
+# Prints to STDOUT the timestamp found in version.json in a compact format
+# suitable for creating a git tag
+
+file = File.join(File.dirname(__FILE__), '../public/assets/version.json')
+version = JSON.parse(File.read(file))
+timestamp = version['version_epochtime'].to_i
+version_localtime = Time.at(timestamp)
+
+puts version_localtime.strftime('%Y-%m-%d_%H.%M.%S')


### PR DESCRIPTION
This adds `make tag` and executes it during `make prod_deploy`. It creates a git tag on the deployed commit. The tag name is a human-readable UTC timestamp that uses the same source as the timestamp shown on the `/about` page.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`