### PR TITLE
[18Norway] Include discount when calculating cheapest train price

### DIFF
--- a/lib/engine/game/g_18_norway/game.rb
+++ b/lib/engine/game/g_18_norway/game.rb
@@ -319,12 +319,13 @@ module Engine
           depot_trains.min_by(&:price)
         end
 
-        def cheapest_train_price(_corporation)
-          cheapest_train.price
+        def cheapest_train_price(corporation)
+          ability = abilities(corporation, :train_discount, time: 'buying_train')
+          cheapest_train.min_price(ability: ability)
         end
 
         def can_go_bankrupt?(player, corporation)
-          total_emr_buying_power(player, corporation) < cheapest_train_price
+          total_emr_buying_power(player, corporation) < cheapest_train_price(corporation)
         end
 
         def new_nationalization_round(round_num)
@@ -616,7 +617,7 @@ module Engine
 
           available = @depot.available_upcoming_trains.reject { |train| ship?(train) }
           return [] unless (train = available.min_by(&:price))
-          return [] if corp.cash >= train.price
+          return [] if corp.cash >= cheapest_train_price(corp)
 
           bundles = bundles_for_corporation(corp, corp)
 

--- a/lib/engine/game/g_18_norway/steps/buy_train.rb
+++ b/lib/engine/game/g_18_norway/steps/buy_train.rb
@@ -88,8 +88,8 @@ module Engine
             [1, entity.cash]
           end
 
-          def needed_cash(entity)
-            cheapest_train_price(entity)
+          def needed_cash(_entity)
+            cheapest_train_price(current_entity)
           end
 
           def process_buy_train(action)


### PR DESCRIPTION
Fixes #11799

Can break existing games

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
