### PR TITLE
[core] deployment/validation/getting started DB script fixes and enhancements

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,7 +29,7 @@ If that pop-up doesn't appear, open the `Ports` tab in the Codespace, hover the 
 If configuring the droplet from scratch, these are the requirements:
 
 - `docker`
-- `docker-compose`
+- `docker compose`
 - `make`
 - this repo (via `git clone`)
 
@@ -42,7 +42,7 @@ make
 ```
 
 To ensure a rebuild of one or more of the containers, this make task will add
-`--build` to the `docker-compose up` command that is run by the default task:
+`--build` to the `docker compose up` command that is run by the default task:
 
 ```
 make dev_up_b
@@ -58,7 +58,7 @@ As with dev, `make prod_up_b` will add `--build` to the compose command ran by
 `make prod_up`.
 
 To update the code on the server with the latest master and rerun
-`docker-compose up --build`:
+`docker compose up --build`:
 
 ```
 make prod_deploy
@@ -88,11 +88,11 @@ To restore the local database from a `db.backup.gz`:
 2. copy backup to db container
 
 ```
-CONTAINER_ID=$(docker ps | grep 18xx_db | awk '{print $1}')
+CONTAINER_ID=$(docker ps --filter name="db.?1" --format '{{.ID}}')
 docker cp db.backup.gz $CONTAINER_ID:/home/db
 ```
 
-3. go to the container with `docker-compose exec db bash`, then run these
+3. go to the container with `docker compose exec db bash`, then run these
    commands:
 
 ```
@@ -105,7 +105,7 @@ pg_restore -U root -d 18xx_development db.backup
 
 https://docs.docker.com/get-started/
 
-If `docker-compose up` requires login, you probably need to create an access
+If `docker compose up` requires login, you probably need to create an access
 token and login with the Docker CLI:
 
 - https://docs.docker.com/docker-hub/access-tokens/
@@ -146,17 +146,17 @@ Failures:
 
 #### Running test fixtures
 
-Run `docker-compose exec rack rake` while a docker instance is running to run rubocop and test games. This ensures your changes don't break existing games, and that the code matches the project's style guide.
+Run `docker compose exec rack rake` while a docker instance is running to run rubocop and test games. This ensures your changes don't break existing games, and that the code matches the project's style guide.
 
 Run a specific set of test fixtures using the `-e` flag to `rspec`. This is useful when testing a specific bug or reproducing an issue.
 
-`docker-compose exec rack rspec spec/lib/engine/games/game_spec.rb -e '<folder_name> <fixture_name>' [...]`
+`docker compose exec rack rspec spec/lib/engine/games/game_spec.rb -e '<folder_name> <fixture_name>' [...]`
 
-e.g. `docker-compose exec rack rspec spec/lib/engine/games/game_spec.rb -e '1860 19354'`
+e.g. `docker compose exec rack rspec spec/lib/engine/games/game_spec.rb -e '1860 19354'`
 
 #### Profiling the code
 
-Run `docker-compose exec rack rake stackprof[spec/fixtures/18_chesapeake/1277.json]` (or other file) to load and process the json file 1000 times. This will generate a stackprof.dump which can be further analyzed
+Run `docker compose exec rack rake stackprof[spec/fixtures/18_chesapeake/1277.json]` (or other file) to load and process the json file 1000 times. This will generate a stackprof.dump which can be further analyzed
 
 ```
 stackprof --d3-flamegraph stackprof.dump >stackprof.html
@@ -168,7 +168,7 @@ stackprof stackprof.dump
 Once a game has been made available on the website, bugs may be found where the solutions requires breaking active gamestates due to missing or added required actions. If the action is known to always need removal, or the additional action needed able to be determined computationally, we can automate this fix. This assumes you have a fixture/json file locally you want to fix.
 
 1. Update `repair` within `scripts/migrate_game.rb` with the logic required to add/delete a step
-2. Run `docker-compose exec rack irb`
+2. Run `docker compose exec rack irb`
 3. Execute `load "scripts/migrate_game.rb"`
 4. Execute `migrate_json('your_json_file.json')`
 
@@ -178,24 +178,24 @@ This will apply the migrations to the game file you specified, allowing you to v
 
 You may want example games in your development environment to test. One way to do this is to import games directly from the production website.
 
-1. Run `docker-compose exec rack irb`
+1. Run `docker compose exec rack irb`
 2. Execute `load "scripts/import_game.rb"`
 3. Execute `import_game(<product_game_id>)`
 
-A copy of that game is now available locally. All accounts in the imported games will have their passwords scrubbed and will be assigned "password" as their new default one. You can use this to login as any active user in the game. 
+A copy of that game is now available locally. All accounts in the imported games will have their passwords scrubbed and will be assigned "password" as their new default one. You can use this to login as any active user in the game.
 
 #### Pinning a game in your local test enviornment
 
 You may want to pin a specific game in your local development environment. Pinning a game allows for breaking changes to be introduced while 'freezing' the existing game to a previous code commit version. Pinning is designed to work in production environments only, the following workaround can be applied to pin games in your local development environment.
 
-1. Run `docker-compose exec rack irb`
+1. Run `docker compose exec rack irb`
 2. Import all the dependcies that will allow you to run `Game` class. Alternativly you can run `load "scripts/import_game.rb"`
 3. Run `game = Game[id: <id of game you want to pin>]`
 4. Run `game.settings['pin'] ='<sha of commit>'` . The sha should be of length 9 of the commit you want to pin to.
 5. Run `game.save` to save the changes.
 
 For the pin to work you need to generate the pin.js file. Doing so will break your development environment. Perform the following steps to generate the pin file and fix your development environment
-1. Run `docker-compose exec rack rake precompile`
+1. Run `docker compose exec rack rake precompile`
 2. Delete the contents of build folder
 3. Restart your  development environment server
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := dev_up_b
-CONTAINER_COMPOSE ?= $(CONTAINER_ENGINE)-compose
+CONTAINER_COMPOSE ?= $(CONTAINER_ENGINE) compose
 CONTAINER_ENGINE ?= docker
 
 clean:
@@ -52,7 +52,7 @@ prod_deploy : clean
 	$(CONTAINER_COMPOSE) run rack rake precompile && \
 		rsync --verbose --checksum public/pinned/*.js.gz deploy@18xx:~/18xx/public/pinned/ && \
 		rsync --verbose --checksum public/assets/*.js public/assets/*.js.gz public/assets/version.json deploy@18xx:~/18xx/public/assets/ && \
-		ssh -l deploy 18xx "source ~/.profile && cd ~/18xx/ && git pull && make prod_rack_up_b_d && make tag"
+		ssh -t -l deploy 18xx "source ~/.profile && cd ~/18xx/ && git pull && make prod_rack_up_b_d && make tag"
 
 # tag currently checked out commit with date in public/assets/version.json
 tag:

--- a/scripts/data_dir.sh
+++ b/scripts/data_dir.sh
@@ -2,10 +2,10 @@
 
 # ensure that ./db/data exists and is not owned by root
 #
-# - ./db/data/ is need for the postgres container
+# - ./db/data/ is needed for the postgres container
 #
-# - if it does not exist when docker-compose tries to create the container,
-#   docker-compose will create the dir, and it will be owned by root, preventing
+# - if it does not exist when docker compose tries to create the container,
+#   docker compose will create the dir, and it will be owned by root, preventing
 #   the postgres container from working
 #
 # - postgres requires the data dir to be empty when it initializes, so if a file
@@ -14,6 +14,7 @@
 
 umask 0077
 mkdir -p db/data
+chmod 700 db/data
 
 if [[ $1 == 'podman' ]]; then
   db_uid=1000

--- a/scripts/db/dump.sh
+++ b/scripts/db/dump.sh
@@ -12,11 +12,13 @@ else
     DB_FILE="${1}"
 fi
 
+DB_CONTAINER_NAME=$(docker ps --filter name="db.?1" --format '{{.Names}}')
+
 # create gzipped backup file in docker container
-docker exec -i 18xx-db-1 bash -c "pg_dump --host localhost --port ${DB_PORT} --user ${DB_USER} --no-password --exclude-table schema_info --exclude-table message_bus --data-only --format t ${DB_NAME} | gzip > /home/db/${DB_FILE}"
+docker exec -i ${DB_CONTAINER_NAME} bash -c "pg_dump --host localhost --port ${DB_PORT} --user ${DB_USER} --no-password --exclude-table schema_info --exclude-table message_bus --data-only --format t ${DB_NAME} | gzip > /home/db/${DB_FILE}"
 
 # copy backup to host
-docker cp 18xx-db-1:/home/db/${DB_FILE} .
+docker cp ${DB_CONTAINER_NAME}:/home/db/${DB_FILE} .
 
 # remove backup from docker container
-docker exec -i 18xx-db-1 rm -v /home/db/${DB_FILE}
+docker exec -i ${DB_CONTAINER_NAME} rm -v /home/db/${DB_FILE}

--- a/scripts/db/load_from_backup.sh
+++ b/scripts/db/load_from_backup.sh
@@ -24,8 +24,9 @@ gunzip --keep --force ${DB_FILE}
 TMP_DB_FILE=${DB_FILE/.gz/}
 
 # restore
-docker-compose exec rack rake dev_bounce
-docker exec -i 18xx_db_1 pg_restore --clean --username ${DB_USER} --dbname ${DB_NAME} --format tar < ${TMP_DB_FILE}
+docker compose exec rack rake dev_bounce
+DB_CONTAINER_NAME=$(docker ps --filter name="db.?1" --format '{{.Names}}')
+docker exec -i ${DB_CONTAINER_NAME} pg_restore --clean --username ${DB_USER} --dbname ${DB_NAME} --format tar < ${TMP_DB_FILE}
 
 # remove uncompressed backup
 rm --verbose ${TMP_DB_FILE}

--- a/scripts/generate_logos.README
+++ b/scripts/generate_logos.README
@@ -6,7 +6,7 @@ To use the script, first add paths to the logos in the entities. Review another 
 
 Run the development docker container. In a terminal window, enter the following to get a Ruby prompt:
 
-docker-compose exec rack rake dev_irb
+docker compose exec rack rake dev_irb
 
 Then in Ruby, enter (for 1849, for example):
 

--- a/scripts/tag_deployment.sh
+++ b/scripts/tag_deployment.sh
@@ -5,7 +5,16 @@
 # the container engine, e.g., 'podman' or 'docker compose'
 CONTAINER_COMPOSE="${@}"
 
-TAG=$($CONTAINER_COMPOSE exec rack bundle exec ruby scripts/tag_name.rb)
+TAG=$(${CONTAINER_COMPOSE} exec rack bundle exec ruby scripts/tag_name.rb)
+if [ -z "${TAG}" ]; then
+    echo "Failed to get tag name. CONTAINER_COMPOSE=\"${CONTAINER_COMPOSE}\""
+    exit 1
+fi
 
-git tag $TAG
-git push origin refs/tags/$TAG
+git tag "${TAG}"
+
+if git push origin "refs/tags/${TAG}"; then
+   echo "Created and pushed release tag \"${TAG}\""
+else
+   echo "Failed to push release tag \"${TAG}\""
+fi

--- a/scripts/tag_name.rb
+++ b/scripts/tag_name.rb
@@ -10,4 +10,4 @@ version = JSON.parse(File.read(file))
 timestamp = version['version_epochtime'].to_i
 version_localtime = Time.at(timestamp)
 
-puts version_localtime.strftime('%Y-%m-%d_%H.%M.%S')
+print version_localtime.strftime('%Y-%m-%d_%H.%M.%S')

--- a/scripts/validate.rb
+++ b/scripts/validate.rb
@@ -53,6 +53,40 @@ class Validate
         _errors
       end
   end
+
+  def error_counts_by_title
+    error_ids_by_title.transform_values(&:size)
+  end
+
+  def ids_to_act_on
+    @ids_to_act_on ||=
+      begin
+        _ids_to_act_on = {'archive' => [], 'pin' => []}
+        error_ids_by_title.each do |title, ids|
+          key = {
+            prealpha: 'archive',
+            alpha: 'archive',
+            beta: 'pin',
+            production: 'pin',
+          }[Engine.meta_by_title(title)::DEV_STAGE]
+          _ids_to_act_on[key].concat(ids)
+        end
+        _ids_to_act_on.transform_values!(&:sort!)
+      end
+  end
+
+  def ids_to_pin
+    ids_to_act_on['pin']
+  end
+
+  def ids_to_archive
+    ids_to_act_on['archive']
+  end
+
+  def pin_and_archive!(pin_version)
+    pin_games(pin_version, ids_to_pin)
+    archive_games(ids_to_archive)
+  end
 end
 
 $count = 0
@@ -208,5 +242,11 @@ def pin_games(pin_version, game_ids)
       data.settings['pin'] = pin_version
     end
     data.save
+  end
+end
+
+def archive_games(game_ids)
+  game_ids.each do |id|
+    Game[id].archive!
   end
 end


### PR DESCRIPTION
* DB scripts: get name of db container from `docker ps` output instead of using underscores (switched from underscores to dashes in a few places 63e2b22, but I missed some spots in my haste, and more importantly this new approach is not dependent on Docker version)

* add `-t` to `ssh` command in `make prod_deploy` so that the git tag creation script works during deployment

* use `print` instead of `puts` in `scripts/tag_name.rb` so that the newline does not get added to `$TAG` in `scripts/tag_deployment.sh`

* add more methods to `Validate` class in `scripts/validate.rb` for convenience when inspecting results and pinning/archiving

* explicitly set mode for `db/data/`

    * `umask` should have covered this but apparently it did not work for @MatthewDeKoning when he was getting set up for #11810

* prefer 'docker compose' over 'docker-compose'

    * Docker Compose v2 uses `docker compose`, and now the compose plugin has been installed on the server, so local dev environments don't need to use `docker-compose` just to be compatible with the server

    * if a dev is still using the older version, `CONTAINER_COMPOSE=docker-compose` should still work for most uses

    * when merging I will also update the commands on these wiki pages:

      - [ ] https://github.com/tobymao/18xx/wiki/Developing-for-18xx.games
      - [ ] https://github.com/tobymao/18xx/wiki/Developing-FAQ