### PR TITLE
[infra] remove 'version' from compose files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 x-rack: &rack
   image: 18xx_rack:dev
   environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 x-rack: &rack
   command: bash -c "bundle exec rake prod_up && bundle exec unicorn -c config/unicorn.rb"
   image: 18xx_rack:prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   rack:
     build:


### PR DESCRIPTION
gets rid of this warning:

```
WARN[0000] /home/michael/projects/18xx/docker-compose.yml: the attribute
`version` is obsolete, it will be ignored, please remove it to avoid potential
confusion
```