### PR TITLE
[1858 India/Core] Add option to show private companies on the left in the buy trains step

### DIFF
--- a/assets/app/view/game/round/operating.rb
+++ b/assets/app/view/game/round/operating.rb
@@ -137,7 +137,10 @@ module View
 
           left << h(MapLegend, game: @game) if @game.show_map_legend? && @game.show_map_legend_on_left?
           right << h(Map, game: @game) unless hide_map
-          right << h(:div, div_props, [h(BuyCompanies, limit_width: true)]) if @current_actions.include?('buy_company')
+          if @current_actions.include?('buy_company')
+            on_left = @step.respond_to?(:show_companies_on_left?) && @step.show_companies_on_left?
+            (on_left ? left : right) << h(:div, div_props, [h(BuyCompanies, limit_width: true)])
+          end
           right << h(:div, div_props, [h(AcquireCompanies)]) if aquire_company_action
           right << h(:div, div_props, [h(CorporateSellCompanies)]) if @current_actions.include?('corporate_sell_company')
           right << h(:div, div_props, [h(CorporateBuyCompanies)]) if @current_actions.include?('corporate_buy_company')

--- a/lib/engine/game/g_1858_india/game.rb
+++ b/lib/engine/game/g_1858_india/game.rb
@@ -63,7 +63,7 @@ module Engine
             G1858::Step::Token,
             G1858India::Step::Route,
             G1858::Step::Dividend,
-            G1858::Step::DiscardTrain,
+            G1858India::Step::DiscardTrain,
             G1858India::Step::BuyTrain,
             G1858::Step::IssueShares,
           ], round_num: round_num)

--- a/lib/engine/game/g_1858_india/step/buy_train.rb
+++ b/lib/engine/game/g_1858_india/step/buy_train.rb
@@ -38,6 +38,10 @@ module Engine
                     "#{@game.format_currency(price)}"
           end
 
+          def show_companies_on_left?
+            true
+          end
+
           private
 
           def can_buy_mail_train?(entity)

--- a/lib/engine/game/g_1858_india/step/discard_train.rb
+++ b/lib/engine/game/g_1858_india/step/discard_train.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1858/step/discard_train'
+
+module Engine
+  module Game
+    module G1858India
+      module Step
+        class DiscardTrain < G1858::Step::DiscardTrain
+          def trains(corporation)
+            super.reject { |train| @game.mail_train?(train) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1858_india/step/route.rb
+++ b/lib/engine/game/g_1858_india/step/route.rb
@@ -17,6 +17,14 @@ module Engine
             'Attach mail train to another train'
           end
 
+          def help
+            return unless @game.owns_mail_train?(current_entity)
+            return unless attachable_trains(current_entity).empty?
+
+            "#{current_entity.id} owns a mail train but does not own any " \
+              'broad gauge trains that it can be attached to.'
+          end
+
           def choices
             attachable_trains(current_entity).to_h do |train|
               [train.id, "#{train.name} train"]
@@ -48,7 +56,9 @@ module Engine
           private
 
           def choosing?(corporation)
-            @game.owns_mail_train?(corporation) && !mail_train_attached?(corporation)
+            @game.owns_mail_train?(corporation) &&
+              !mail_train_attached?(corporation) &&
+              !attachable_trains(corporation).empty?
           end
 
           # The trains that a mail train can be attached to.


### PR DESCRIPTION
## Implementation Notes

1858 India is almost ready to be moved to alpha status. All features have now been implemented, it is currently undergoing private alpha testing before it is moved to alpha on the main site.

This contains a few changes, mostly cosmetic.


### Private companies in the buy trains step

1858 India has a couple of locomotive works private companies. These can be purchased by public companies from the bank during the buy trains step. The current rendering puts the private companies underneath the map in this step – this is reasonable because they usually won't be bought during the step. But 1858 India has a big map, so the privates are likely to be off the bottom of the screen and so forgotten about.

This adds a check for a `show_companies_on_left?` method in the step object, if this method exists and returns true then the buyable privates are instead rendered on the left-hand side, with the train list and the corporation card.

#### Before change: private companies underneath the map
![image](https://github.com/user-attachments/assets/42df4b07-39d5-4f1c-a020-d3d996de30a0)

#### After change: private companies on the left side
![image](https://github.com/user-attachments/assets/8e90037b-9c2f-4b49-9b3a-e07cd91acde3)


### Mail trains cannot be discarded

Mail trains do not count towards the train limit. If a company has to discard trains because it is over the limit, it isn't allowed to (and wouldn't want to) discard mail trains, so don't show these as an option.


### Better message if mail trains cannot be attached to any train

Mail trains are attached to another broad gauge train to give increased revenue for large cities and off-board areas visited. The interface for this is the same as Pullmans in 1822. If a company owns a mail train but only has narrow gauge trains then show a better message describing the situation.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`