### PR TITLE
[1849 variants] fixes Round_state in bonds step

### DIFF
--- a/lib/engine/game/g_1849/step/bond.rb
+++ b/lib/engine/game/g_1849/step/bond.rb
@@ -20,8 +20,8 @@ module Engine
 
           def round_state
             {
-              issued_bond: false,
-              redeemed_bond: false,
+              issued_bond: [],
+              redeemed_bond: [],
             }
           end
 
@@ -51,7 +51,7 @@ module Engine
             @log << "#{entity.name} issues its bond and receives #{@game.format_currency(@game.loan_value)}"
             @game.bank.spend(@game.loan_value, entity)
             entity.loans << loan
-            @round.issued_bond = true
+            @round.issued_bond << entity
 
             initial_sp = entity.share_price.price
             @game.stock_market.move_left(entity)
@@ -63,12 +63,12 @@ module Engine
             @game.bonds? &&
              @game.issue_bonds_enabled &&
              entity.corporation? &&
-             !@round.redeemed_bond &&
+             !@round.redeemed_bond.include?(entity) &&
              entity.loans.size < @game.maximum_loans(entity)
           end
 
           def can_payoff_loan?(entity)
-            !@round.issued_bond &&
+            !@round.issued_bond.include?(entity) &&
               !entity.loans.empty? &&
               entity.cash >= entity.loans.first.amount
           end
@@ -90,7 +90,7 @@ module Engine
 
             entity.loans.delete(loan)
 
-            @round.redeemed_bond = true
+            @round.redeemed_bond << entity
 
             initial_sp = entity.share_price.price
             @game.stock_market.move_right(entity)


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Somehow, I goofed and used boolean round_state elements instead of creating an array, which of course didn't have the intended effect of tracking each corporation's issuing and redeeming.

This corrects the round_state and the methods that relate to it. 

No pins seem to be required. I opened all 5 active games using bonds and loaded them into my test environment. they all loaded fine. 

### Screenshots

### Any Assumptions / Hacks
