### PR TITLE
[18Norway] fix price change after SR

### DIFF
--- a/lib/engine/game/g_18_norway/game.rb
+++ b/lib/engine/game/g_18_norway/game.rb
@@ -297,7 +297,7 @@ module Engine
         end
 
         def stock_round
-          Engine::Round::Stock.new(self, [
+          G18Norway::Round::Stock.new(self, [
             Engine::Step::DiscardTrain,
             Engine::Step::Exchange,
             Engine::Step::SpecialTrack,

--- a/lib/engine/game/g_18_norway/round/stock.rb
+++ b/lib/engine/game/g_18_norway/round/stock.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/stock'
+
+module Engine
+  module Game
+    module G18Norway
+      module Round
+        class Stock < Engine::Round::Stock
+          def corporations_to_move_price
+            @game.corporations.select(&:floated?)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #11823

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Market adjustments for minors at the end of a stock round which were sold out or that had shares in the market weren't happening. This is because, by default, that operation excludes minors. I added a stock.rb file to 18_Norway that modifies the `corporations_to_move_price` method to include them, and then pointed the game.rb file to G18Norway::Round::Stock.

### Screenshots

![image](https://github.com/user-attachments/assets/ffad9229-fae6-45c9-b550-c4ae7c8bdd6a)


### Any Assumptions / Hacks

Likely all active games will need to be pinned or nuked.