### PR TITLE
[base] - updates log to include player name when corp takes SR action

### DIFF
--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -47,13 +47,15 @@ module Engine
       corporation = bundle.corporation
       ipoed = corporation.ipoed
       floated = corporation.floated?
+      name = entity.name
+      name += " (#{entity.owner.name})" if @game.round.is_a?(Engine::Round::Stock) && entity != entity.owner
 
       corporation.ipoed = true if bundle.presidents_share
       price = bundle.price
       par_price = corporation.par_price&.price
 
       if ipoed != corporation.ipoed && par_price && !silent
-        @log << "#{entity.name} #{@game.ipo_verb(corporation)} #{corporation.name} at "\
+        @log << "#{name} #{@game.ipo_verb(corporation)} #{corporation.name} at "\
                 "#{@game.format_currency(par_price)}"
       end
 
@@ -74,14 +76,14 @@ module Engine
         price = exchange_price || 0
         case exchange
         when :free
-          @log << "#{entity.name} receives #{share_str}" unless silent
+          @log << "#{name} receives #{share_str}" unless silent
         when Company
           unless silent
             @log << if exchange_price
-                      "#{entity.name} exchanges #{exchange.name} and #{@game.format_currency(price)}"\
+                      "#{name} exchanges #{exchange.name} and #{@game.format_currency(price)}"\
                         " from #{from} for #{share_str}"
                     else
-                      "#{entity.name} exchanges #{exchange.name} from #{from} for #{share_str}"
+                      "#{name} exchanges #{exchange.name} from #{from} for #{share_str}"
                     end
           end
         end
@@ -93,7 +95,7 @@ module Engine
         verb = entity == corporation ? 'redeems' : 'buys'
         unless silent
           discounter_str = discounter ? "(#{discounter.name}) " : ''
-          @log << "#{entity.name} #{discounter_str}#{verb} #{share_str} "\
+          @log << "#{name} #{discounter_str}#{verb} #{share_str} "\
                   "from #{from} "\
                   "for #{@game.format_currency(price)}#{swap_text}#{borrowed_text}"
         end
@@ -152,7 +154,10 @@ module Engine
     end
 
     def log_sell_shares(entity, verb, bundle, price, swap_text)
-      @log << "#{entity.name} #{verb} #{num_presentation(bundle)} " \
+      name = entity.name
+      name += " (#{entity.owner.name})" if @game.round.is_a?(Engine::Round::Stock) && entity != entity.owner
+
+      @log << "#{name} #{verb} #{num_presentation(bundle)} " \
               "of #{bundle.corporation.name} and receives #{@game.format_currency(price)}#{swap_text}"
     end
 


### PR DESCRIPTION
Fixes #11790

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

A user noted that 18USA lists the name of the corp and the player when taking loans in 18USA, but not when the corp issues or redeems shares. 

![Image](https://github.com/user-attachments/assets/ecece462-6283-4176-a194-195a3e5f52d7)

These later elements appear in the share_pool.rb file. It could be clearer if this information was included in all games where corps can take stock actions, so I made some edits to share_pool.rb to apply this site-wide. 

I borrowed the basic idea from 1817 here:

https://github.com/tobymao/18xx/blob/6c5692516add29893e8e07b95ed9c6eabc1c579e/lib/engine/game/g_1817/game.rb#L694-L695

Please let me know if I've overlooked anything!

### Screenshots

### Any Assumptions / Hacks
