### PR TITLE
[1822NRS] adds London stub for LNWR

### DIFF
--- a/lib/engine/game/g_1822_nrs/map.rb
+++ b/lib/engine/game/g_1822_nrs/map.rb
@@ -185,10 +185,12 @@ module Engine
               '',
             ['G10'] =>
               'border=edge:0,type:water,cost:40',
-            %w[L21 M28] =>
+            ['L21'] =>
               'upgrade=cost:20,terrain:swamp',
             %w[M22] =>
               'upgrade=cost:40,terrain:swamp',
+            ['M28'] =>
+              'upgrade=cost:20,terrain:swamp;stub=edge:5',
             %w[G14 I12 I24] =>
               'upgrade=cost:40,terrain:hill',
             %w[E10 F9 G8 H7 H9 H15 I8 I10 J7 J23 J25] =>


### PR DESCRIPTION
Fixes #11791

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Scott Petersen confirms on [BGG here](https://boardgamegeek.com/thread/3524561/article/46189461#46189461) that there should be stub track in hex M28 to prevent LNWR from being locked into its home.

### Screenshots

### Any Assumptions / Hacks
