### PR TITLE
[Core] Set corporation as ipoed one first share purchase

### DIFF
--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -48,7 +48,7 @@ module Engine
       ipoed = corporation.ipoed
       floated = corporation.floated?
 
-      corporation.ipoed = true if bundle.presidents_share
+      corporation.ipoed = true if bundle.presidents_share || (!ipoed && corporation.presidents_share.owner != corporation)
       price = bundle.price
       par_price = corporation.par_price&.price
 


### PR DESCRIPTION
In games where multiple shares can be exchanged prior to parring the corporation, its possible that the presidents share is already acquired before the corporation is parred. Add additional logic to check for this case and properly mark the corporation as ipoed.