### PR TITLE
[1822, 1822MX] add 2p variants, 1822MRS starter variant

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -36,11 +36,11 @@ module Engine
 
         BANK_CASH = 12_000
 
-        CERT_LIMIT = { 2 => 40, 3 => 26, 4 => 20, 5 => 16, 6 => 13, 7 => 11 }.freeze
+        CERT_LIMIT = { 2 => 33, 3 => 26, 4 => 20, 5 => 16, 6 => 13, 7 => 11 }.freeze
 
         EBUY_FROM_OTHERS = :never
 
-        STARTING_CASH = { 2 => 1000, 3 => 700, 4 => 525, 5 => 420, 6 => 350, 7 => 300 }.freeze
+        STARTING_CASH = { 2 => 900, 3 => 700, 4 => 525, 5 => 420, 6 => 350, 7 => 300 }.freeze
 
         CAPITALIZATION = :incremental
 
@@ -348,7 +348,7 @@ module Engine
         TWO_HOME_CORPORATION = 'LNWR'
 
         BIDDING_TOKENS = {
-          '2': 7,
+          '2': 8,
           '3': 6,
           '4': 5,
           '5': 4,

--- a/lib/engine/game/g_1822/meta.rb
+++ b/lib/engine/game/g_1822/meta.rb
@@ -29,9 +29,12 @@ module Engine
             desc: 'shorter game on the southern part of the map',
           },
         ].freeze
-        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/219065/1822-railways-great-britain-rules'
+        GAME_RULES_URL = {
+          'Rules' => 'https://boardgamegeek.com/filepage/219065/1822-railways-great-britain-rules',
+          '2-player rules (BGG thread)' => 'https://boardgamegeek.com/thread/2429917/article/34848979#34848979',
+        }.freeze
 
-        PLAYER_RANGE = [3, 7].freeze
+        PLAYER_RANGE = [2, 7].freeze
 
         OPTIONAL_RULES = [
           {

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -15,6 +15,17 @@ module Engine
         include G1822CA::Map
         include G1822CA::Trains
 
+        CERT_LIMIT = { 2 => 40, 3 => 26, 4 => 20, 5 => 16, 6 => 13, 7 => 11 }.freeze
+        STARTING_CASH = { 2 => 1000, 3 => 700, 4 => 525, 5 => 420, 6 => 350, 7 => 300 }.freeze
+        BIDDING_TOKENS = {
+          '2': 7,
+          '3': 6,
+          '4': 5,
+          '5': 4,
+          '6': 3,
+          '7': 3,
+        }.freeze
+
         DOUBLE_HEX = %w[G13 I15 AB22 AG13 AH10].freeze
 
         BIDDING_BOX_START_MINOR = 'M6'

--- a/lib/engine/game/g_1822_ca/meta.rb
+++ b/lib/engine/game/g_1822_ca/meta.rb
@@ -19,7 +19,7 @@ module Engine
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = {
           'Rules' => 'https://boardgamegeek.com/filepage/238950/1822ca-rules',
-          '2-player Scenarios' => 'https://boardgamegeek.com/thread/2591186/1822ca-2-player-scenarios',
+          '2-player rules (BGG thread)' => 'https://boardgamegeek.com/thread/2591186/1822ca-2-player-scenarios',
         }.freeze
         GAME_TITLE = '1822CA'
         GAME_ISSUE_LABEL = '1822CA'

--- a/lib/engine/game/g_1822_mrs/entities.rb
+++ b/lib/engine/game/g_1822_mrs/entities.rb
@@ -4,20 +4,40 @@ module Engine
   module Game
     module G1822MRS
       module Entities
-        STARTING_COMPANIES = %w[P1 P2 P5 P6 P7 P8 P9 P10 P11 P12 P13 P14 P15 P16 P18
-                                C1 C2 C3 C4 C6 C7 C9 M7 M8 M9 M10 M11 M12 M13 M14 M15
-                                M16 16 M17 M18 M19 M20 M21 M24].freeze
+        CONCESSIONS = %w[C1 C2 C3 C4 C6 C7 C9].freeze
 
-        STARTING_COMPANIES_ADVANCED = %w[P1 P2 P3 P4 P5 P6 P7 P8 P9 P10 P11 P12
-                                         C1 C2 C3 C4 C6 C7 C9 M7 M8 M9 M10 M11 M12 M13 M14 M15
-                                         M16 16 M17 M18 M19 M20 M21 M24].freeze
+        MINORS_CORPORATIONS = %w[7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 24].freeze
+        MINORS_COMPANIES = MINORS_CORPORATIONS.map { |m| "M#{m}" }.freeze
 
-        STARTING_COMPANIES_TWOPLAYER = %w[P1 P2 P3 P4 P5 P6 P7 P8 P9 P10 P11 P12
-                                          C1 C2 C3 C4 C6 C7 C9 M7 M8 M9 M10 M11 M12 M13 M14 M15
-                                          M16 16 M17 M18 M19 M20 M21 M24].freeze
+        STARTING_COMPANIES = [
+          # P1, P2, P5-P16, P17
+          'P1', 'P2', 'P5', 'P6', 'P7', 'P8', 'P9', 'P10', 'P11', 'P12', 'P13', 'P14', 'P15', 'P16', 'P18',
+          *CONCESSIONS,
+          *MINORS_COMPANIES
+        ].freeze
 
-        STARTING_CORPORATIONS = %w[7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 24
-                                   LNWR GWR LBSCR SECR MR LYR SWR].freeze
+        STARTING_COMPANIES_STARTER = [
+          # P1, P2, P5-P14
+          'P1', 'P2', 'P5', 'P6', 'P7', 'P8', 'P9', 'P10', 'P11', 'P12', 'P13', 'P14',
+          *CONCESSIONS,
+          *MINORS_COMPANIES
+        ].freeze
+
+        STARTING_COMPANIES_ADVANCED = [
+          # P1-P12
+          'P1', 'P2', 'P3', 'P4', 'P5', 'P6', 'P7', 'P8', 'P9', 'P10', 'P11', 'P12',
+          *CONCESSIONS,
+          *MINORS_COMPANIES
+        ].freeze
+
+        STARTING_COMPANIES_TWOPLAYER = [
+          # P1-P12
+          'P1', 'P2', 'P3', 'P4', 'P5', 'P6', 'P7', 'P8', 'P9', 'P10', 'P11', 'P12',
+          *CONCESSIONS,
+          *MINORS_COMPANIES
+        ].freeze
+
+        STARTING_CORPORATIONS = (MINORS_CORPORATIONS + %w[LNWR GWR LBSCR SECR MR LYR SWR]).freeze
       end
     end
   end

--- a/lib/engine/game/g_1822_mrs/game.rb
+++ b/lib/engine/game/g_1822_mrs/game.rb
@@ -32,6 +32,15 @@ module Engine
 
         STARTING_CASH = { 2 => 750, 3 => 500, 4 => 375, 5 => 300, 6 => 250, 7 => 215 }.freeze
 
+        BIDDING_TOKENS = {
+          '2': 7,
+          '3': 6,
+          '4': 5,
+          '5': 4,
+          '6': 3,
+          '7': 3,
+        }.freeze
+
         MARKET = [
           ['', '', '', '', '', '', '', '', '', '', '', '', '',
            '330', '360', '400', '450', '500e', '550e', '600e'],
@@ -206,6 +215,7 @@ module Engine
 
         def starting_companies
           return self.class::STARTING_COMPANIES_ADVANCED if optional_advanced?
+          return self.class::STARTING_COMPANIES_STARTER if optional_starter?
           return self.class::STARTING_COMPANIES_TWOPLAYER if @players.size == 2
 
           self.class::STARTING_COMPANIES
@@ -213,6 +223,10 @@ module Engine
 
         def optional_advanced?
           @optional_rules&.include?(:advanced)
+        end
+
+        def optional_starter?
+          @optional_rules&.include?(:starter)
         end
       end
     end

--- a/lib/engine/game/g_1822_mrs/meta.rb
+++ b/lib/engine/game/g_1822_mrs/meta.rb
@@ -26,10 +26,27 @@ module Engine
 
         OPTIONAL_RULES = [
           {
+            sym: :starter,
+            short_name: 'Starter',
+            desc: 'Play with P1, P2, and P5-P14. Intended for those with no experience with 1822.',
+          },
+          {
             sym: :advanced,
             short_name: 'Advanced',
-            desc: 'Play with P1-12 and M14 will start in minor bid box 1.',
+            desc: 'Play with P1-12. M14 starts in minor bid box 1.',
           },
+          {
+            sym: :sw_peninsula,
+            short_name: 'Southwest Peninsula',
+            desc: 'Replace two random minor companies with M22 and M23, whose '\
+                  'home tokens will be placed in Southwest England (D39).',
+            players: [2],
+          },
+
+        ].freeze
+
+        MUTEX_RULES = [
+          %i[starter advanced],
         ].freeze
       end
     end

--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -15,10 +15,11 @@ module Engine
 
         attr_accessor :ndem_acting_player, :number_ndem_shares, :ndem_state
 
-        CERT_LIMIT = { 3 => 16, 4 => 13, 5 => 10 }.freeze
+        CERT_LIMIT = { 2 => 27, 3 => 16, 4 => 13, 5 => 10 }.freeze
         CERT_LIMIT_INCREASED = { 3 => 18, 4 => 14, 5 => 11 }.freeze
 
         BIDDING_TOKENS = {
+          '2': 7,
           '3': 6,
           '4': 5,
           '5': 4,
@@ -34,7 +35,7 @@ module Engine
           'IRM' => 3,
         }.freeze
 
-        STARTING_CASH = { 3 => 500, 4 => 375, 5 => 300 }.freeze
+        STARTING_CASH = { 2 => 750, 3 => 500, 4 => 375, 5 => 300 }.freeze
 
         STARTING_COMPANIES = %w[P1 P2 P3 P4 P5 P6 P7 P8 P9 P10 P11 P12 P13 P14 P15 P16 P17 P18
                                 C1 C2 C3 C4 C5 C6 C7 M1 M2 M3 M4 M5 M6 M7 M8 M9 M10 M11 M12 M13 M14 M15
@@ -51,7 +52,6 @@ module Engine
         ].freeze
 
         MUST_SELL_IN_BLOCKS = true
-        SELL_MOVEMENT = :left_per_10_if_pres_else_left_one
         PRIVATE_TRAINS = %w[P1 P2 P3 P4 P5 P6].freeze
         EXTRA_TRAINS = %w[2P P+ LP 3/2P].freeze
         EXTRA_TRAIN_PERMANENTS = %w[2P LP 3/2P].freeze
@@ -508,6 +508,10 @@ module Engine
 
           ndem = @round.entities.pop
           @round.entities.insert(@round.entity_index + 1, ndem)
+        end
+
+        def sell_movement(_corporation)
+          @sell_movement ||= @players.size == 2 ? :left_share_pres : :left_per_10_if_pres_else_left_one
         end
 
         def sell_shares_and_change_price(bundle, allow_president_change: true, swap: nil, movement: nil)

--- a/lib/engine/game/g_1822_mx/meta.rb
+++ b/lib/engine/game/g_1822_mx/meta.rb
@@ -17,7 +17,11 @@ module Engine
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1822MX'
         GAME_LOCATION = 'Mexico'
         GAME_PUBLISHER = :all_aboard_games
-        GAME_RULES_URL = 'https://boardgamegeek.com/filepage/206630/1822mx-rules'
+        GAME_RULES_URL = {
+          'Rules' => 'https://boardgamegeek.com/filepage/206630/1822mx-rules',
+          '2-player rules (BGG thread)' => 'https://boardgamegeek.com/thread/2594249/article/36912132#36912132',
+        }.freeze
+
         GAME_TITLE = '1822MX'
 
         OPTIONAL_RULES = [
@@ -25,10 +29,11 @@ module Engine
             sym: :higher_cert_limit,
             short_name: 'Higher Certificate Counts (Prototype Variant)',
             desc: 'Increase certificate limit to 18/14/11 for 3/4/5 player games',
+            players: [3, 4, 5],
           },
         ].freeze
 
-        PLAYER_RANGE = [3, 5].freeze
+        PLAYER_RANGE = [2, 5].freeze
       end
     end
   end

--- a/lib/engine/game/g_1822_nrs/entities.rb
+++ b/lib/engine/game/g_1822_nrs/entities.rb
@@ -4,12 +4,27 @@ module Engine
   module Game
     module G1822NRS
       module Entities
-        STARTING_COMPANIES = %w[P1 P2 P3 P4 P6 P7 P8 P9 P11 P12 P13 P14 P15 P16 P18 P19 P20 P21
-                                C1 C5 C6 C7 C8 C10 M1 M2 M3 M4 M5 M6 M7 M8 M9 M10 M15
-                                M16 M26 M27 M28 M29].freeze
+        CONCESSIONS = %w[C1 C5 C6 C7 C8 C10].freeze
 
-        STARTING_CORPORATIONS = %w[1 2 3 4 5 6 7 8 9 10 15 16 26 27 28 29
-                                   LNWR CR MR LYR NBR NER].freeze
+        # 1-10, 15, 16, 26-29
+        MINORS_CORPORATIONS = %w[1 2 3 4 5 6 7 8 9 10 15 16 26 27 28 29].freeze
+        MINORS_COMPANIES = MINORS_CORPORATIONS.map { |m| "M#{m}" }.freeze
+
+        STARTING_COMPANIES = [
+          # P1-P21, except P5, P10, P17
+          'P1', 'P2', 'P3', 'P4', 'P6', 'P7', 'P8', 'P9', 'P11', 'P12', 'P13', 'P14', 'P15', 'P16', 'P18', 'P19', 'P20', 'P21',
+          *CONCESSIONS,
+          *MINORS_COMPANIES
+        ].freeze
+
+        STARTING_COMPANIES_TWOPLAYER = [
+          # P1-P12
+          'P1', 'P2', 'P3', 'P4', 'P5', 'P6', 'P7', 'P8', 'P9', 'P10', 'P11', 'P12',
+          *CONCESSIONS,
+          *MINORS_COMPANIES
+        ].freeze
+
+        STARTING_CORPORATIONS = (MINORS_CORPORATIONS + %w[LNWR CR MR LYR NBR NER]).freeze
 
         STARTING_COMPANIES_OVERRIDE = {
           'M15' => { desc: 'A 50% director’s certificate in the associated minor company. Starting location is N29.' },

--- a/lib/engine/game/g_1822_nrs/game.rb
+++ b/lib/engine/game/g_1822_nrs/game.rb
@@ -17,7 +17,7 @@ module Engine
 
         BIDDING_BOX_START_MINOR = nil
 
-        CERT_LIMIT = { 3 => 16, 4 => 13, 5 => 10, 6 => 9, 7 => 8 }.freeze
+        CERT_LIMIT = { 2 => 27, 3 => 16, 4 => 13, 5 => 10, 6 => 9, 7 => 8 }.freeze
 
         EXCHANGE_TOKENS = {
           'LNWR' => 4,
@@ -28,7 +28,16 @@ module Engine
           'NER' => 3,
         }.freeze
 
-        STARTING_CASH = { 3 => 500, 4 => 375, 5 => 300, 6 => 250, 7 => 215 }.freeze
+        STARTING_CASH = { 2 => 750, 3 => 500, 4 => 375, 5 => 300, 6 => 250, 7 => 215 }.freeze
+
+        BIDDING_TOKENS = {
+          '2': 7,
+          '3': 6,
+          '4': 5,
+          '5': 4,
+          '6': 3,
+          '7': 3,
+        }.freeze
 
         MARKET = [
           ['', '', '', '', '', '', '', '', '', '', '', '', '',
@@ -218,6 +227,12 @@ module Engine
               **corporation.merge(opts),
             )
           end.compact
+        end
+
+        def starting_companies
+          return self.class::STARTING_COMPANIES_TWOPLAYER if @players.size == 2
+
+          self.class::STARTING_COMPANIES
         end
       end
     end

--- a/lib/engine/game/g_1822_nrs/meta.rb
+++ b/lib/engine/game/g_1822_nrs/meta.rb
@@ -22,7 +22,7 @@ module Engine
         GAME_ISSUE_LABEL = '1822'
         GAME_IS_VARIANT_OF = G1822::Meta
 
-        PLAYER_RANGE = [3, 7].freeze
+        PLAYER_RANGE = [2, 7].freeze
       end
     end
   end


### PR DESCRIPTION
Variants taken from 1822 rulebook and BGG posts by Scott Petersen (BGG links are in the relevant `meta.rb` files).

* 1822MX 2p
* 1822 2p
* 1822MRS - starter variant
* 1822MRS 2p - southwest peninsula
* 1822NRS - 2p, with P1-P12 (even P5 and P10, which are normally excluded from NRS, as I got crickets in [this thread](https://boardgamegeek.com/thread/3530881/1822nrs-2-player-which-privates-to-use))

Fixes #11229

I have validation running locally now against all 1822-family games.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`