### PR TITLE
[dev] allow all Logger values for DB_LOG_LEVEL in dev, default to fatal

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,6 +5,8 @@ x-rack: &rack
     RACK_ENV: development
     RUBYOPTS: --yjit
     OPAL_PREFORK_DISABLE: "true"
+    # debug/info/warn/error/fatal
+    DB_LOG_LEVEL: fatal
   build:
     args:
       RACK_ENV: development

--- a/models.rb
+++ b/models.rb
@@ -19,7 +19,11 @@ DB.register_advisory_lock(:action_lock)
 if ENV['RACK_ENV'] == 'development' || ENV['RACK_ENV'] == 'test'
   require 'logger'
   logger = Logger.new($stdout)
-  logger.level = Logger::FATAL if ENV['RACK_ENV'] == 'test' || ENV['DB_LOG_LEVEL'] == 'fatal'
+  if ENV['RACK_ENV'] == 'test'
+    logger.level = Logger::FATAL
+  elsif ENV['DB_LOG_LEVEL']
+    logger.level = Logger.const_get(ENV['DB_LOG_LEVEL'].upcase)
+  end
   DB.loggers << logger
 end
 


### PR DESCRIPTION
replace previous default which spews a ton of output when connecting to the DB

if you still want that verbose db output, now you can set DB_LOG_LEVEL in the Docker Compose configuration
