### PR TITLE
[dev] update PR template with suggestions for PR title tags

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,18 @@ Fixes #[PUT_ISSUE_NUMBER_HERE]
 
 <!--
 
-Please minimize the amount of changes to shared `lib/engine` code, if possible
+Your PR title should start with a tag showing the affected 18xx title or titles,
+e.g., "[1889] use fancy logos".
 
-If you are implementing a new game, please break up the changes into multiple PRs for ease of review.
+Please minimize the amount of changes to shared `lib/engine` code, if
+possible. If you are changing any shared code there, please include "[core]" at
+the start of your PR title.
+
+If your changes affect the developer/maintainer experience but are not end-user
+facing, please inclue a "[dev]" tag.
+
+If you are implementing a new game, please break up the changes into multiple
+PRs for ease of review.
 
 -->
 


### PR DESCRIPTION
I used `[infra]` for "infrastructure" on some of my recent PRs that affect the dev/deployment experience, and by the time I got around to updating this template I decided `[dev]` was probably better, even for changes that will only affect maintainers and not all developers.