### PR TITLE
[18 India] fixed sr1 buy issues and cleaned up ferry tile fix #11487and #11810

### DIFF
--- a/lib/engine/game/g_18_india/step/sell_once_then_buy_certs.rb
+++ b/lib/engine/game/g_18_india/step/sell_once_then_buy_certs.rb
@@ -193,6 +193,7 @@ module Engine
           end
 
           def can_buy_from_ipo?(entity, company)
+            return false if @game.round_counter == 1
             return false if @round.bought_from_market
             return false if @round.bought_from_hand
             return false if @round.bought_from_ipo && @round.current_actions.count > 1

--- a/lib/engine/game/g_18_india/step/track.rb
+++ b/lib/engine/game/g_18_india/step/track.rb
@@ -104,10 +104,6 @@ module Engine
           # Added multple yellow tile check and Yellow OO reservation check
           def process_lay_tile(action)
             if action.tile.color == :yellow
-              # check for invalid ferry placement
-              if action.tile.id == 'IF2-0' && (action.tile.rotation == 1 && action.hex.id == 'J37')
-                raise GameError, 'Invalid Ferry Tile Placement'
-              end
               raise GameError, 'New yellow tiles must extend path from railhead and previously laid tiles' \
                unless connected_to_track_laying_path?(action.hex)
 
@@ -131,6 +127,8 @@ module Engine
 
           # Bypass some Step::Tracker tests for Town to City upgrade: maintain exits, and check new exits are valid
           def legal_tile_rotation?(entity, hex, tile)
+            return false if tile.name == 'IF2' && tile.rotation == 1
+
             old_tile = hex.tile
             if @game.yellow_town_to_city_upgrade?(old_tile, tile)
               all_new_exits_valid = tile.exits.all? { |edge| hex.neighbors[edge] }


### PR DESCRIPTION
Fixes #11483.

adds simple check to ensure ipo not purchased SR1, fixes ferry tile placement to only show legit placements vs throwing error on incorrect placement. 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

^ the above tests have been run - i am sadly ignorant of how to add the tag "archive_alpha_games" which this needs. 

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
