### PR TITLE
Autorouter: Allow overlapping routes with pre-filled trains and don't search for routes for pre-filled trains

### DIFF
--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -77,7 +77,7 @@ module Engine
                    end
 
       # if only routing for subset of trains, omit the trains we won't assemble routes for
-      skip_trains = static.flat_map(:train).to_a
+      skip_trains = static.flat_map(&:train).to_a
       trains -= skip_trains
 
       train_routes = Hash.new { |h, k| h[k] = [] }    # map of train to route list

--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -64,7 +64,18 @@ module Engine
       path_walk_timed_out = false
       now = Time.now
 
-      skip_paths = static.flat_map(&:paths).to_h { |path| [path, true] }
+      skip_paths = if @train_autoroute_group.nil?
+                     static.flat_map(&:paths).to_h { |path| [path, true] }
+                   elsif @train_autoroute_group == :each_train_separate
+                     # all trains have their own autoroute group so it's not possible to fill skip_paths
+                     {}
+                   else # rubocop:disable Lint/DuplicateBranch
+                     # NOTE: there is room for an optimization here. In the case of TRAIN_AUTOROUTE_GROUP being an array,
+                     # we need to compare the train types that are prefilled and the train types that will be searched and
+                     # if there is overlap and all the trains that are being searched can't visit the path it can be in skip_path
+                     {}
+                   end
+
       # if only routing for subset of trains, omit the trains we won't assemble routes for
       skip_trains = static.flat_map(:train).to_a
       trains -= skip_trains


### PR DESCRIPTION
Fixes https://github.com/tobymao/18xx/issues/7982 as well as a bug I found while testing the fix.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

I left a note on a possible optimization for skip_paths for games that use TRAIN_AUTOROUTE_GROUP (1822 family is the prime example). But I avoided doing it because it's complicated and didn't want to mess it up. So I focused on the bug fix (allow re-using paths with routes that are prefilled) .

### Explanation of Change

The two bugs fixed:
- We still calculated all paths for trains that were prefilled. This is completely wasted work. I can't figure out how this happened, but it's been in the repo for 6+ months and scrolling through history I don't see an obvious spot that caused the bug. I'm not good enough at ruby + our frameworks to know if this is something that used to/should work.
- If the game rules allow routes to overlap, we don't fill in skip_paths for pre-filled routes. This allows the other routes to find routes containing the paths of the pre-filled routes. 