### PR TITLE
[18MEX] Correct bug for upgrading F5 for non-470 tile #11462

### DIFF
--- a/lib/engine/game/g_18_mex/game.rb
+++ b/lib/engine/game/g_18_mex/game.rb
@@ -724,8 +724,13 @@ module Engine
             return unless action.hex.id == 'F5'
             return if p2_company.closed? || action.entity == p2_company
 
-            p2_company.remove_ability(p2_company.all_abilities.first)
-            @log << "#{p2_company.name} loses the ability to lay F5"
+            # Remove p2 ability to lay F5, but if someone else already
+            # have built there the ability has already been lost
+            p2_ability = p2_company.all_abilities.first
+            return if p2_ability.nil?
+
+            p2_company.remove_ability(p2_ability)
+            @log << "#{p2_company.name} loses the ability to lay tile 470 in F5"
           end
         end
 


### PR DESCRIPTION

Fixes #11462

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games: N/A
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Simple bug fix.

### Explanation of Change

Bug was caused by an attempt to remove the P2 ability when upgrading F5 to green. This had already been done when yellow non-470 tile was put there, so the ability did not remain.

Fix was just to not remove if ability already lost.

### Screenshots

None. Tested manually to do the upgrade of F5, and after bug fix it works.

### Any Assumptions / Hacks

None
