### PR TITLE
[Shikoku 1889] Fix - remove terrain icon on hex F9

### DIFF
--- a/lib/engine/game/g_1889/map.rb
+++ b/lib/engine/game/g_1889/map.rb
@@ -133,7 +133,7 @@ module Engine
           },
           green: {
             ['F9'] => 'city=revenue:30,slots:2;path=a:2,b:_0;path=a:3,b:_0;'\
-                      'path=a:4,b:_0;path=a:5,b:_0;label=K;upgrade=cost:80,terrain:water',
+                      'path=a:4,b:_0;path=a:5,b:_0;label=K;upgrade=cost:80',
           },
         }.freeze
 


### PR DESCRIPTION
Made it the same as hex I4. In the physical game both use a symbol for "urban dense area" but 18xx.games does not yet support that symbol. Only a graphical correction; upgrade cost is still 80.

Fixes #11849

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Just removed terrain symbol from hex F9. Just presentation change - no functional change.

### Explanation of Change

See Issue. 18xx.games does not support symbol for "urban dense area".

### Screenshots
![Screenshot from 2025-07-06 12-45-35](https://github.com/user-attachments/assets/5812c571-b609-4518-a35d-f36b76923049)

### Any Assumptions / Hacks
None