### PR TITLE
Add more tiles optional rule to 18 ireland

### DIFF
--- a/lib/engine/game/g_18_ireland/game.rb
+++ b/lib/engine/game/g_18_ireland/game.rb
@@ -48,6 +48,20 @@ module Engine
 
           Bank.new(cash, log: @log)
         end
+#
+#        def init_tile(name, val)
+#          if more_tiles?
+#            modified_val = if val.is_a?(Integer)
+#                             (1.5 * val).ceil
+#                           elsif val != 'unlimited' && val.is_a?(Hash) && val.key?('count') && val['count'].is_a?(Integer)
+#                               val.merge('count' => (1.5 * val['count']).floor)
+#                           else
+#                             val # Fallback for unexpected 'val' types
+#                           end
+#            super(name, modified_val)
+#          else
+#            super(name, val)
+#        end
 
         CERT_LIMIT = { 3 => 16, 4 => 12, 5 => 10, 6 => 8 }.freeze
 
@@ -746,6 +760,10 @@ module Engine
 
         def larger_bank?
           @larger_bank ||= @optional_rules&.include?(:larger_bank)
+        end
+
+        def more_tiles?
+          @more_tiles ||= @optional_rules&.include?(:more_tiles)
         end
       end
     end

--- a/lib/engine/game/g_18_ireland/game.rb
+++ b/lib/engine/game/g_18_ireland/game.rb
@@ -48,20 +48,21 @@ module Engine
 
           Bank.new(cash, log: @log)
         end
-#
-#        def init_tile(name, val)
-#          if more_tiles?
-#            modified_val = if val.is_a?(Integer)
-#                             (1.5 * val).ceil
-#                           elsif val != 'unlimited' && val.is_a?(Hash) && val.key?('count') && val['count'].is_a?(Integer)
-#                               val.merge('count' => (1.5 * val['count']).floor)
-#                           else
-#                             val # Fallback for unexpected 'val' types
-#                           end
-#            super(name, modified_val)
-#          else
-#            super(name, val)
-#        end
+
+        def init_tile(name, val)
+          if more_tiles?
+            modified_val = if val.is_a?(Integer)
+                             (1.5 * val).ceil
+                           elsif val != 'unlimited' && val.is_a?(Hash) && val.key?('count') && val['count'].is_a?(Integer)
+                               val.merge('count' => (1.5 * val['count']).ceil)
+                           else
+                             val # Fallback for unexpected 'val' types
+                           end
+            super(name, modified_val)
+          else
+            super(name, val)
+          end
+        end
 
         CERT_LIMIT = { 3 => 16, 4 => 12, 5 => 10, 6 => 8 }.freeze
 

--- a/lib/engine/game/g_18_ireland/meta.rb
+++ b/lib/engine/game/g_18_ireland/meta.rb
@@ -24,6 +24,11 @@ module Engine
             short_name: 'Larger £5,000 bank',
             desc: 'Larger bank variant, instead of £4,000',
           },
+          {
+            sym: :more_tiles,
+            short_name: 'More of each tile',
+            desc: 'Adds 50% more of each tile type'
+          }
         ].freeze
       end
     end


### PR DESCRIPTION
Fixes N/A

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes
Added 1.5x multiplier option to 18 ireland tiles 

### Explanation of Change
18 ireland often has too few of each tile by a large margin (3-4x), this creates an option to allow for more of such tiles
