### PR TITLE
[1822] Don't remove corporations' home tokens

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2014,6 +2014,9 @@ module Engine
               end
 
             corp_tokens_with_count.each do |corp, (tokens_to_remove, token_count)|
+              # Sort the tokens to make sure that a corporation's home token
+              # does not get removed.
+              tokens_to_remove.sort_by! { |t| corp.tokens.index(t) }
               (token_count - 1).times do
                 @log << "Extra token for #{corp.name} is returned to their available tokens"
                 token = tokens_to_remove.pop


### PR DESCRIPTION
## Implementation Notes

When multiple cities on a tile merge, a corporation which had tokens in the different cities will have all but one returned to its charter.

Which token was returned depended on the order of the cities on the tile, with the tokens in the higher index cities removed. It was possible for a corporation's initial token to be removed by this algorithm. This was breaking the calculation of destination bonuses, as the check for a run between a coporation's home and destination is made by looking at its first and destination tokens.

This sorts the duplicated tokens by their index in the corporation's `tokens` array. This ensures that the home token, the first token in this array, will not be removed.

Fixes tobymao#11845.

This won't need any pins. There will be some games where the destination bonuses have been calculated incorrectly, but the calculated value is stored in the action log and so won't be affected.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`