### PR TITLE
autorouter: Fix timeout/early exit code

### DIFF
--- a/lib/engine/auto_router.rb
+++ b/lib/engine/auto_router.rb
@@ -401,11 +401,13 @@ module Engine
             Opal.LOGGER.$info("routing phase took " + (performance.now() - this.start_of_all) + "ms")
             this.update_callback(best_routes);
           }).catch((e) => {
+            let best_routes = this.best_routes;
             this.router.flash("Auto route selection failed to complete (" + e + ")");
             Opal.LOGGER.$error("routing phase failed with: " + e);
-            Opal.LOGGER.$error(e.stack);
+            Opal.LOGGER.$error("routing exception backtrace:\n" + e.stack);
             this.router.running = false;
-            this.update_callback([]);
+            this.router.$real_revenue(best_routes)
+            this.update_callback(best_routes);
           });
         }
 
@@ -422,7 +424,9 @@ module Engine
           current_train_data,
         ) {
           for (let route of current_train_data.routes) {
-            await this.check_if_we_should_break();
+            if (await this.check_if_we_should_break()) {
+              return;
+            }
 
             let current_routes_metadata = starting_combo_metadata;
             if (route) { // route is null for the "empty route"
@@ -465,13 +469,14 @@ module Engine
                 this.render = false;
             }
             if (performance.now() - this.start_of_all > this.router.route_timeout * 1000) {
-                throw 'ROUTE_TIMEOUT';
+                throw new Error('ROUTE_TIMEOUT');
             }
             await next_frame();
             if (!this.router.running) {
-              return;
+              return true;
             }
             this.start_of_execution_tick = performance.now();
+            return false;
           }
         }
       }


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Explanation of Change

Fixes the early exit code to actually exit and clean up the error messages. This was noticeable when navigating away from the turn while autorouting.  Now when we early exit we also set the routes to the best known routes rather than reverting back to the default routes that show when you open the route selection UI.

I used https://18xx.games/game/215779?action=620 which was able to hit the default 10 second routing timeout on my machine to test this code. I also tested that normal pathing still works.
