### PR TITLE
[1837] Exchanges shouldn't allow presidency change before corporation parred

### DIFF
--- a/lib/engine/game/g_1837/game.rb
+++ b/lib/engine/game/g_1837/game.rb
@@ -471,7 +471,7 @@ module Engine
         def exchange_coal_minor(minor)
           target = exchange_target(minor)
           @log << "#{minor.id} exchanged for a share of #{target.id}"
-          merge_minor!(minor, target)
+          merge_minor!(minor, target, allow_president_change: target.ipoed)
         end
 
         def event_close_mountain_railways!

--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -254,7 +254,8 @@ module Engine
 
       return if majority_share_holders.any? { |player| player == previous_president }
 
-      president = majority_share_holders
+      president = majority_share_holders.find { |player| player == corporation.presidents_share.owner } unless previous_president
+      president ||= majority_share_holders
         .select { |p| p.percent_of(corporation) >= corporation.presidents_percent }
         .min_by do |p|
         if previous_president == self


### PR DESCRIPTION
Also update presidency logic for the situation where multiple shares have already exchanged before the corporation has parred. The parring player should maintain presidency if a majority share holder.