### PR TITLE
[18Norway] include shares held by NSB when checking sold out status

### DIFF
--- a/lib/engine/game/g_18_norway/round/stock.rb
+++ b/lib/engine/game/g_18_norway/round/stock.rb
@@ -10,6 +10,10 @@ module Engine
           def corporations_to_move_price
             @game.corporations.select(&:floated?)
           end
+
+          def sold_out?(corporation)
+            corporation.share_holders.select { |s_h, _| s_h.player? || s_h == @game.nsb }.values.sum == 100
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #11863

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

By default, the `sold_out?` method checks if all shares are held by players. In this case, the NSB entity is also able to own shares of corporations. I added a custom `sold_out?` method that includes shares held by the NSB in the check.

### Screenshots

### Any Assumptions / Hacks
