### PR TITLE
[1825] Unit 2 should support 4 players

### DIFF
--- a/lib/engine/game/g_1825/meta.rb
+++ b/lib/engine/game/g_1825/meta.rb
@@ -25,7 +25,7 @@ module Engine
           {
             sym: :unit_2,
             short_name: 'Unit 2',
-            players: [2, 3],
+            players: [2, 3, 4],
           },
           {
             sym: :unit_3,


### PR DESCRIPTION
Fixes #11855

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Unit 2 should support 2-4 players. It looks like the cert limit and starting cash were all configured to support 4 players, but then the meta page only listed 2-3.

Tiny little fix!

Confirmed here: http://www.fwtwr.com/18xx/info/inv-1825-unit2.asp

### Screenshots

### Any Assumptions / Hacks
