### PR TITLE
[User/Create game pages] Add user settings for default game options

### DIFF
--- a/assets/app/lib/settings.rb
+++ b/assets/app/lib/settings.rb
@@ -40,6 +40,9 @@ module Lib
       path_timeout: 30,
       route_timeout: 10,
       show_stats: false,
+      is_async: true,
+      invite_only: false,
+      auto_routing: false,
     }.freeze
 
     def self.included(base)
@@ -56,14 +59,13 @@ module Lib
        Lib::Storage[option],
        SETTINGS[option]].compact.first
     end
+    alias color_for setting_for
 
     def toggle_setting(option, game = nil)
       value = !setting_for(option, game)
       Lib::Storage[option] = value
       Lib::Storage["#{option}_#{game.class.title}"] = value if game
     end
-
-    alias color_for setting_for
 
     def route_prop(index, prop)
       setting_for(route_prop_string(index, prop))

--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -5,6 +5,7 @@
 require 'game_manager'
 require 'user_manager'
 require 'lib/settings'
+require 'lib/whats_this'
 require 'view/game_row'
 require 'view/logo'
 require 'view/form'
@@ -12,6 +13,7 @@ require 'view/form'
 module View
   class User < Form
     include Lib::Settings
+    include Lib::WhatsThis::AutoRoute
     include GameManager
     include UserManager
 
@@ -87,6 +89,7 @@ module View
         render_email,
         h('div#settings__options', [
           render_notifications,
+          render_default_game_options,
           h(:h3, 'Statistics'),
           render_checkbox('Show Individual Statistics on Profile Page', :show_stats),
           h(:h3, 'Display'),
@@ -424,6 +427,49 @@ module View
         edit_user(params)
         `setTimeout(function() { location.reload() }, 1000)`
       end
+    end
+
+    def render_default_game_options
+      is_async = setting_for(:is_async)
+
+      children = [
+        h(:h3, 'Default Game Options'),
+        h(:p, 'Your settings here will be used as the default selection whenever you create a new multiplayer game.'),
+        h(:div, { style: { padding: '0.5rem' } }, [
+            render_input(
+              'Async',
+              id: 'async',
+              type: 'radio',
+              attrs: { name: 'is_async', checked: is_async == true || is_async.nil? },
+              container_style: { display: 'inline-block' },
+            ),
+            render_input(
+              'Live',
+              id: 'live',
+              type: 'radio',
+              attrs: { name: 'is_async', checked: is_async == false },
+              container_style: { display: 'inline-block' },
+            ),
+          ]),
+
+        render_input(
+          'Invite only game',
+          id: 'invite_only',
+          type: :checkbox,
+          container_style: { paddingLeft: '0.5rem' },
+          attrs: { checked: setting_for(:invite_only) == true },
+        ),
+        render_input(
+          'Auto Routing',
+          id: 'auto_routing',
+          type: :checkbox,
+          container_style: { paddingLeft: '0.5rem' },
+          siblings: [auto_route_whats_this],
+          attrs: { checked: setting_for(:auto_routing) == true },
+        ),
+
+      ]
+      h(:div, children)
     end
   end
 end

--- a/models/user.rb
+++ b/models/user.rb
@@ -20,6 +20,7 @@ class User < Base
     consent notifications webhook webhook_url webhook_user_id red_logo bg font bg2 font2 your_turn hotseat_game
     white yellow green brown gray red blue purple
     path_timeout route_timeout show_stats
+    is_async invite_only auto_routing
   ]).freeze
 
   def update_settings(params)
@@ -28,6 +29,14 @@ class User < Base
     params.each do |key, value|
       settings[key] = value if SETTINGS.include?(key)
     end
+    settings['is_async'] =
+      if params['live'] == true
+        false
+      elsif params['async'].nil?
+        true
+      else
+        params['async']
+      end
 
     settings.delete('webhook_url') if settings['webhook'] != 'custom'
   end


### PR DESCRIPTION
* now players that want auto-routing to always be on won't need to remember to check the box when they create a new game (see https://github.com/tobymao/18xx/issues/6598#issuecomment-1009393255); and of course the same applies for the "Live" label and invite-only games

* also fix error in console on create game page when clicking on async/live; `is_async` was undefined, so an error was thrown instead of of the `is_async` param getting updated

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

### Screenshots

<img width="743" height="483" alt="Screenshot 2025-08-03 165055" src="https://github.com/user-attachments/assets/f934d2b0-b527-4b78-b717-91797960eabb" />
