### PR TITLE
S18: MS fixes - start tokens, end of game

### DIFF
--- a/lib/engine/game/g_system18/game.rb
+++ b/lib/engine/game/g_system18/game.rb
@@ -767,6 +767,12 @@ module Engine
           ability = corporation.abilities.first
           hexes.find { |h| h.name == ability.hexes.first } if ability
         end
+
+        def game_end_check_values(name)
+          return super unless respond_to?("map_#{cmap_name}_game_end_check_values")
+
+          send("map_#{cmap_name}_game_end_check_values", name)
+        end
       end
     end
   end

--- a/lib/engine/game/g_system18/map_ms_customization.rb
+++ b/lib/engine/game/g_system18/map_ms_customization.rb
@@ -231,7 +231,7 @@ module Engine
         end
 
         def map_ms_constants
-          redef_const(:GAME_END_CHECK, { bankrupt: :immediate, bank: :full_or, final_phase: :one_more_full_or_set })
+          redef_const(:GAME_END_CHECK, { bankrupt: :immediate, final_phase: :one_more_full_or_set, bank: :full_or })
           redef_const(:EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST, false)
         end
 
@@ -283,6 +283,10 @@ module Engine
 
         def map_ms_setup
           @corporations.each do |corporation|
+            # place all home tokens
+            place_home_token(corporation)
+
+            # assign destination
             ability = abilities(corporation, :assign_hexes)
             hex = hex_by_id(ability.hexes.first)
 
@@ -335,6 +339,12 @@ module Engine
           return '' if extra.zero?
 
           "+ #{format_revenue_currency(extra)} destination bonus"
+        end
+
+        def map_ms_game_end_check_values
+          return self.class::GAME_END_CHECK unless @phase.name == 'D'
+
+          { bankrupt: :immediate, final_phase: :one_more_full_or_set }
         end
       end
     end


### PR DESCRIPTION
Fixes #11897 

Fixes the end game criteria to actually match the RAW: buying a D will cancel the game ending due to the bank breaking.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
