### PR TITLE
[18RoyalGorge] add note that Y4 cannot be sold to a corporation

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/entities.rb
+++ b/lib/engine/game/g_18_royal_gorge/entities.rb
@@ -58,7 +58,7 @@ module Engine
             sym: 'Y4',
             name: 'William Palmer (Y4)',
             desc: 'Owning player will start the game with a 10% of Rio Grande and a 10% share of CF&I. '\
-                  'Closes when the first 5+ train is purchased.',
+                  'Closes when the first 5+ train is purchased. May never be sold to a corporation.',
             value: 75,
             revenue: 5,
             abilities: [


### PR DESCRIPTION
https://boardgamegeek.com/thread/3416338/william-palmer-cash-for-share

Because this is such a small change, I originally was including this on an endgame fix PR, but that was delayed so I'm just doing this separately now.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`