### PR TITLE
[System 18] Fix China map price movement

### DIFF
--- a/lib/engine/game/g_system18/step/china_track.rb
+++ b/lib/engine/game/g_system18/step/china_track.rb
@@ -7,15 +7,6 @@ module Engine
     module GSystem18
       module Step
         class ChinaTrack < Track
-          def round_state
-            super.merge({ citytown_track: 0 })
-          end
-
-          def setup
-            super
-            @round.citytown_track = 0
-          end
-
           def process_lay_tile(action)
             lay_tile_action(action)
             tile = action.tile
@@ -25,7 +16,6 @@ module Engine
               old_price = entity.share_price
               @game.stock_market.move_right(action.entity)
               @game.log_share_price(entity, old_price)
-              @round.citytown_track += 1
             end
 
             pass! unless can_lay_tile?(action.entity)
@@ -38,7 +28,7 @@ module Engine
           end
 
           def pass!
-            if @round.citytown_track.zero?
+            if @round.num_laid_track.zero?
               old_price = current_entity.share_price
               @game.stock_market.move_left(current_entity)
               @game.log_share_price(current_entity, old_price)


### PR DESCRIPTION
Fixes #11910 

This may require archiving some finished S18 games.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
