### PR TITLE
[System18] reduce train limit in phase 2 and 3

### DIFF
--- a/lib/engine/game/g_system18/game.rb
+++ b/lib/engine/game/g_system18/game.rb
@@ -188,11 +188,11 @@ module Engine
         ].freeze
 
         S18_FULLCAP_PHASES = [
-          { name: '2', train_limit: 4, tiles: [:yellow], operating_rounds: 1 },
+          { name: '2', train_limit: 3, tiles: [:yellow], operating_rounds: 1 },
           {
             name: '3',
             on: '3',
-            train_limit: 4,
+            train_limit: 3,
             tiles: %i[yellow green],
             operating_rounds: 2,
           },
@@ -227,11 +227,11 @@ module Engine
         ].freeze
 
         S18_INCCAP_PHASES = [
-          { name: '2', train_limit: 4, tiles: [:yellow], operating_rounds: 2 },
+          { name: '2', train_limit: 3, tiles: [:yellow], operating_rounds: 2 },
           {
             name: '3',
             on: '3',
-            train_limit: 4,
+            train_limit: 3,
             tiles: %i[yellow green],
             operating_rounds: 2,
           },

--- a/lib/engine/game/g_system18/map_ms_customization.rb
+++ b/lib/engine/game/g_system18/map_ms_customization.rb
@@ -180,11 +180,11 @@ module Engine
 
         def map_ms_game_phases
           [
-            { name: '2', train_limit: 4, tiles: [:yellow], operating_rounds: 1 },
+            { name: '2', train_limit: 3, tiles: [:yellow], operating_rounds: 1 },
             {
               name: '3',
               on: '3',
-              train_limit: 4,
+              train_limit: 3,
               tiles: %i[yellow green],
               operating_rounds: 2,
             },

--- a/lib/engine/game/g_system18/map_twisting_tracks_customization.rb
+++ b/lib/engine/game/g_system18/map_twisting_tracks_customization.rb
@@ -227,11 +227,11 @@ module Engine
 
         def map_twisting_tracks_game_phases
           [
-            { name: '2', train_limit: 4, tiles: [:yellow], operating_rounds: 1 },
+            { name: '2', train_limit: 3, tiles: [:yellow], operating_rounds: 1 },
             {
               name: '3',
               on: '3',
-              train_limit: 4,
+              train_limit: 3,
               tiles: %i[yellow green],
               operating_rounds: 2,
             },


### PR DESCRIPTION
Fixes #11905 

Will require pins and archives.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
