### PR TITLE
[1873] Fix check_intersection with empty trains

### DIFF
--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -1773,6 +1773,8 @@ module Engine
 
         def check_route_combination(routes)
           routes.each do |route|
+            next if route.chains.empty?
+
             # make sure routes from same supertrain intersect
             super_routes = routes.reject do |r|
               r.chains.empty? ||


### PR DESCRIPTION
Fixes #11786 

No pins needed

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
