### PR TITLE
Make it possible to disable par_chart in derived games

### DIFF
--- a/assets/app/view/game/par.rb
+++ b/assets/app/view/game/par.rb
@@ -87,7 +87,7 @@ module View
       def render_par(target = nil)
         return [h(:div, 'Cannot Par')] unless @game.can_par?(@corporation, @current_entity)
 
-        if @game.respond_to?(:par_chart)
+        if @game.respond_to?(:par_chart) && @game.par_chart
           render_par_from_par_chart
         else
           render_inline_selection(target)

--- a/assets/app/view/game/round/auction.rb
+++ b/assets/app/view/game/round/auction.rb
@@ -75,7 +75,7 @@ module View
             next unless share.president
 
             children << h(Corporation, corporation: share.corporation)
-            children << if @game.respond_to?(:par_chart)
+            children << if @game.respond_to?(:par_chart) && @game.par_chart
                           h(ParChart, corporation_to_par: share.corporation)
                         else
                           h(Par, corporation: share.corporation)

--- a/assets/app/view/game/round/stock.rb
+++ b/assets/app/view/game/round/stock.rb
@@ -114,7 +114,7 @@ module View
             next unless share.president
 
             children << h(Corporation, corporation: share.corporation)
-            children << if @game.respond_to?(:par_chart)
+            children << if @game.respond_to?(:par_chart) && @game.par_chart
                           h(ParChart, corporation_to_par: share.corporation)
                         else
                           h(Par, corporation: share.corporation)

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -553,7 +553,7 @@ module View
           ])
         end
 
-        children << h(ParChart) if @game.respond_to?(:par_chart)
+        children << h(ParChart) if @game.respond_to?(:par_chart) && @game.par_chart
         children << h(LoanChart) if @game.respond_to?(:loan_chart)
 
         h(:div, children)


### PR DESCRIPTION
This does not fix any issue, but is a preparation for 1824 mainly.
It should not affect any existing games.

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

For games not imp,ementing par_chart this change will have no effect at all.

In case a game does implement par_chart by creating information this will cause a slight degradation. But if the game does cache its par chart the effect will be minimal.

### Explanation of Change

The idea is that it should be possible to remove a par chart from a game that inherits from a game that uses it.
By adding the check for non nil, the affected game can implement par_chart and let it return nil.

### Screenshots

None. But I have created hotseat games of 1837 and 1880, and checked Market view, and it worked as it should.

### Any Assumptions / Hacks

N/A