### PR TITLE
[18Ardennes] Prevent players from bidding in a public comany auction using a zero-priced minor company

### DIFF
--- a/lib/engine/game/g_18_ardennes/step/major_auction.rb
+++ b/lib/engine/game/g_18_ardennes/step/major_auction.rb
@@ -304,6 +304,7 @@ module Engine
           # company concession.
           def qualifying_minor?(minor, concession)
             return false if minor.closed?
+            return false if minor.share_price.price.zero?
             return true unless restricted?
 
             coords = Entities::PUBLIC_COMPANY_HEXES[concession.id]


### PR DESCRIPTION
If a minor company is in the left-handmost space on the stock market (zero price) then it is not elegible to be used to start a public company.

Fixes #11918.

In theory this could break some games, if a zero-prices minor had been used to bid in a public company auction. I tested this change against a database copy from a few weeks ago and didn't find any affected games, but it's possible there are more recent ones that would be affected and need pinning.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`