### PR TITLE
[dev] Apple Silicon setup for local dev via env vars

### DIFF
--- a/.rerun.amd64
+++ b/.rerun.amd64
@@ -1,0 +1,1 @@
+--force-polling

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,7 +24,7 @@ If that pop-up doesn't appear, open the `Ports` tab in the Codespace, hover the 
 ![image](https://user-images.githubusercontent.com/1711810/201538007-a5b4bf8a-9214-4ca3-a6a5-6304601c34c2.png)
 
 
-### Droplet configuration
+## Droplet configuration
 
 If configuring the droplet from scratch, these are the requirements:
 
@@ -33,7 +33,7 @@ If configuring the droplet from scratch, these are the requirements:
 - `make`
 - this repo (via `git clone`)
 
-### Docker
+## Docker
 
 Start the Docker stack for this project:
 
@@ -68,6 +68,13 @@ make prod_deploy
 
 Make code changes, and within a few seconds the app should restart. Manually
 refresh your browser to load the new app.
+
+> **_NOTE:_** for local development on Apple Silicon, use the
+> `/Dockerfile.amd64` and `/db/Dockerfile.amd64` files by setting
+> `DEV_DOCKERFILE=Dockerfile.amd64` whenever running `make` or `docker compose`
+> commands, e.g., `DEV_DOCKERFILE=Dockerfile.amd64 make dev_up_b`. If you use
+> Docker Desktop, enable `Use Rosetta for x86_64/amd64 emulation on Apple
+> Silicon` in `Docker Desktop / Settings / General / Virtual Machine Options`.
 
 #### Database
 

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,0 +1,24 @@
+FROM --platform=linux/amd64 ruby:3.2
+
+ARG RACK_ENV
+RUN mkdir /18xx
+WORKDIR /18xx
+RUN git config --global --add safe.directory /18xx
+
+RUN if [ "$RACK_ENV" = "development" ]; \
+    then \
+      curl -s https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.36.tgz | tar xz; \
+      mv package/bin/esbuild /usr/local/bin && rm -rf package; \
+    fi;
+
+COPY Gemfile Gemfile.lock ./
+RUN if [ "$RACK_ENV" = "production" ]; \
+    then bundle config set without 'test development'; \
+    fi; \
+    bundle install;
+COPY . .
+
+COPY .rerun.amd64 .rerun
+
+CMD bundle exec rake dev_up && \
+    bundle exec rerun --background -i 'build/*' -i 'public/*' 'unicorn -c config/unicorn.rb'

--- a/db/Dockerfile.amd64
+++ b/db/Dockerfile.amd64
@@ -1,0 +1,5 @@
+FROM postgres:14.1
+
+COPY ./postgresql.conf /etc/postgresql/postgresql.conf
+
+CMD ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,6 +10,7 @@ x-rack: &rack
   build:
     args:
       RACK_ENV: development
+    dockerfile: ${DEV_DOCKERFILE:-Dockerfile}
   volumes:
     - .:/18xx:z
     - /18xx/vendor
@@ -29,3 +30,5 @@ services:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: password
       POSTGRES_DB: 18xx_development
+    build:
+      dockerfile: ${DEV_DOCKERFILE:-Dockerfile}


### PR DESCRIPTION
As of this writing, these are the instructions for Apple Silicon currently on the wiki:

> ### Developing on Macbooks with Apple M1/M2 chip
>
> Some modules don't fully support Apple Silicon chips yet so you need preparations:
>
> 1. If you use Docker Desktop, enable `Use Rosetta for x86/amd64 emulation on Apple Silicon` in Docker Desktop / Preferences / Features in development
> 2. Edit `Dockerfile`, replacing `FROM` in line 1 with `FROM --platform=linux/amd64`
> 3. Edit `db/Dockerfile`, removing [lines 3 to 9](https://github.com/tobymao/18xx/blob/943f42ef2afc23342fa62b2c5e2be94073dde23f/db/Dockerfile#L3-L9)
> 4. Create a file named `.rerun` with following line in it `--force-polling`
> 5. Follow usual steps on starting the app

With this commit, instead of steps 2-4, the env var `DEV_DOCKERFILE` can be set to `Dockerfile.amd64` before starting the stack and everything is taken care of; no more uncommitted git changes needed.

<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`