### PR TITLE
[Core] Tweak to algorithm for restoring previous routes

### DIFF
--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -466,14 +466,12 @@ module Engine
 
       # If we're reconstructing a route with multiple ways to satisfy
       # the connection data (e.g., 457--464, IR7--8), prefer ones that
-      # pass through the nodes associated with it.
-      if @node_signatures
-        candidates.each do |a, b, left, right, middle|
-          return [a, b, left, right, middle] if [left, right, middle].all? { |n| @node_signatures.include?(n.signature) }
-        end
-      end
+      # pass through the most nodes associated with it.
+      return candidates[0] unless @node_signatures
 
-      candidates[0]
+      candidates.max_by do |_a, _b, left, right, middle|
+        [left, right, middle].count { |n| @node_signatures.include?(n.signature) }
+      end
     end
 
     def find_matching_chains(hex_ids)


### PR DESCRIPTION
When an old route is being loaded, either for route history or to populate the route selector, we attempt to map the route onto upgraded tiles.

Part of this process is done in `Route.find_matching_chains`. If there are multiple candidate routes between tiles A1→B2→C3 it will look for nodes that were on the previous route. If the previous route visited nodes A1-0, B2-1 and C3-1 it will prefer a candidate route that includes all three of those nodes. But if no candidates include all three nodes then the first candidate route is returned.

This algorithm was failing in [game 211985](https://18xx.games/game/211985), resulting in a broken route being loaded.

At [action 541](https://18xx.games/game/211985?action=541) in OR8.3, N runs its 5+5 train through the town on hex F16.

<img width="327" height="297" alt="Image" src="https://github.com/user-attachments/assets/3b5aa336-9779-4527-a7eb-2770e500a479" />

On its next operating round, at [action 609](https://18xx.games/game/211985?action=609), the route is regenerated, but is broken in hex F16. It enters from hex G15 and goes to the town in F16 then jumps across to the city in F16 and exits to hex E17.

<img width="572" height="481" alt="Image" src="https://github.com/user-attachments/assets/bb046de5-9c57-4318-a372-ca1e4ea51a54" />

This mistake is caused by hex E17 being upgraded from yellow to green, which has removed the second town on the tile. The previous route had visited the town with signature E17-1 but this no longer exists, and `find_matching_chains` gives up when it cannot find a chain that matches three nodes.

This pull request changes the algorithm to return the candidate route which matches the most nodes. So if there are two candidate routes where the first visits nodes [A1-0, B2-0, C3-0] and the second visits [A1-0, B2-1, C3-0] it will prefer the second candidate as it matches two nodes whereas the first matches just one.

Fixes tobymao#11872.


### Any Assumptions / Hacks

This fix is enough for the case that was reported. There might be situations where there are similar problems and there are multiple candidate routes which match the same number of nodes, and this could give a similarly broken route.

A possible further enhancement would be to check that the route is contiguous with no breaks. But rewriting the algorithm to ensure only contiguous routes are created would require larger changes to the code.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
