### PR TITLE
[1822PNW] Port tiles must connect to large track spikes

### DIFF
--- a/lib/engine/game/g_1822_pnw/step/special_track.rb
+++ b/lib/engine/game/g_1822_pnw/step/special_track.rb
@@ -71,7 +71,7 @@ module Engine
             entities = Array(entity_or_entities)
             entity, *_combo_entities = entities
 
-            return hex.tile.paths.any? { |p| p.exits == tile.exits } if @game.port_company?(entity)
+            return legal_tile_rotation_port_company?(entity, hex, tile) if @game.port_company?(entity)
             return true if tile == @game.cube_tile
             return true if @game.legal_city_and_town_tile(hex, tile)
             return legal_tile_rotation_portage_company?(entity, hex, tile) if @game.portage_company?(entity)
@@ -79,6 +79,13 @@ module Engine
             return legal_tile_rotation_coal_company?(entity, hex, tile) if @game.coal_company?(entity)
 
             super
+          end
+
+          def legal_tile_rotation_port_company?(_entity, hex, tile)
+            # The water hexes can have both short and long track spikes. The short ones are to allow
+            # tiles adjacent to the water to be upgraded. The long track spikes show the legal orientations
+            # of the port tiles.
+            hex.tile.paths.any? { |p| (p.terminal == '1') && (p.exits == tile.exits) }
           end
 
           def available_hex_portage_company(entity, hex)


### PR DESCRIPTION
Water hexes can have both short and long track spikes. The short ones (a path with a terminal attibute of value '2') are to allow tiles adjacent to the water to be upgraded. The long track spikes (a path with a terminal attribute of value '1') show the legal orientations of the port tiles.

The existing code for checking the port tile orientation is only checking whether the track on the port tile replaces one of the track connections on the water tile. It does not check the type of track, so it is possible to lay the tile in an illegal orientation, replacing a short track spike instead of a long one.

Fixes tobymao#11927.

Some games might require pinning, if a port tile has been laid in an incorrect orientation. Pin cf50d53ee can be used for these games.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`