### PR TITLE
[System18] Implement changed rules for NEUS and Northern Italy

### DIFF
--- a/lib/engine/game/g_system18/map_neus_customization.rb
+++ b/lib/engine/game/g_system18/map_neus_customization.rb
@@ -98,7 +98,25 @@ module Engine
         end
 
         def map_neus_game_companies
-          []
+          [
+            {
+              name: 'Locomotive Works',
+              value: 150,
+              revenue: 30,
+              desc: 'Does not close while owned by a player. If owned by a player '\
+                    'when the first 5-train is purchased it may no longer be sold '\
+                    'to a public company and the revenue is increased to 50.',
+              sym: 'LW',
+              abilities: [{ type: 'close', on_phase: 'never', owner_type: 'player' },
+                          {
+                            type: 'revenue_change',
+                            revenue: 50,
+                            on_phase: '5',
+                            owner_type: 'player',
+                          }],
+              color: nil,
+            },
+          ]
         end
 
         # DGN GFN PHX KKN SPX
@@ -113,11 +131,11 @@ module Engine
         end
 
         def map_neus_game_cash
-          { 2 => 850, 3 => 575 }
+          { 2 => 850, 3 => 575, 4 => 430 }
         end
 
         def map_neus_game_cert_limit
-          { 2 => 20, 3 => 13 }
+          { 2 => 20, 3 => 13, 4 => 8 }
         end
 
         def map_neus_game_capitalization
@@ -137,16 +155,31 @@ module Engine
           find_train(trains, '3')[:num] = 3
           find_train(trains, '4')[:num] = 2
           find_train(trains, '5')[:num] = 2
+          find_train(trains, '5')[:events] = [{ 'type' => 'close_companies' }]
           find_train(trains, '6')[:num] = 1
           find_train(trains, 'D')[:num] = 10
           trains
         end
 
         def map_neus_game_phases
-          self.class::S18_FULLCAP_PHASES
+          phases = self.class::S18_FULLCAP_PHASES
+          phases[1][:status] = %w[can_buy_companies]
+          phases[2][:status] = %w[can_buy_companies]
+          phases
         end
 
-        def map_neus_constants; end
+        def map_neus_constants
+          redef_const(:STATUS_TEXT, {
+                        'can_buy_companies' =>
+                        ['Can Buy Companies', 'All corporations can buy companies from players'],
+                      })
+        end
+
+        def map_neus_init_round
+          Engine::Round::Auction.new(self, [
+            GSystem18::Step::UpwardsAuction,
+          ])
+        end
       end
     end
   end

--- a/lib/engine/game/g_system18/map_northern_italy_customization.rb
+++ b/lib/engine/game/g_system18/map_northern_italy_customization.rb
@@ -250,7 +250,9 @@ module Engine
         def map_northern_italy_game_phases
           phases = Array.new(self.class::S18_INCCAP_PHASES)
           phases[0][:status] = ['local_tokens'] # 2
+          phases[0][:train_limit] = 4           # 2
           phases[1][:status] = ['local_tokens'] # 3
+          phases[1][:train_limit] = 4           # 3
           phases[2][:status] = ['local_tokens'] # 4
 
           phases << {

--- a/lib/engine/game/g_system18/meta.rb
+++ b/lib/engine/game/g_system18/meta.rb
@@ -22,7 +22,7 @@ module Engine
           {
             sym: :map_NEUS,
             short_name: 'Map: Northeast US',
-            players: [2, 3],
+            players: [2, 3, 4],
             designer: 'Scott Petersen',
           },
           {

--- a/lib/engine/game/g_system18/step/charter_auction.rb
+++ b/lib/engine/game/g_system18/step/charter_auction.rb
@@ -8,6 +8,11 @@ module Engine
     module GSystem18
       module Step
         class CharterAuction < GSystem18::Step::UpwardsAuction
+          def all_passed!
+            # Need to move entity round once more to be back to the priority deal player
+            @round.next_entity_index!
+            pass!
+          end
         end
       end
     end

--- a/lib/engine/game/g_system18/step/order_auction.rb
+++ b/lib/engine/game/g_system18/step/order_auction.rb
@@ -8,13 +8,6 @@ module Engine
     module GSystem18
       module Step
         class OrderAuction < GSystem18::Step::UpwardsAuction
-          def actions(entity)
-            acts = super.dup
-
-            acts.delete('pass') unless auctioning
-            acts
-          end
-
           def description
             'Bid on Initial Player Order'
           end
@@ -39,6 +32,15 @@ module Engine
 
             start_player = @auction_triggerer
             @round.goto_entity!(start_player)
+            next_entity!
+          end
+
+          def post_price_reduction(company)
+            super
+            return unless company.min_bid <= 0
+
+            @round.goto_entity!(company.owner)
+            company.owner.pass!
             next_entity!
           end
         end


### PR DESCRIPTION
Fixes #11922 and #11932 

No pins needed.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Added new private and auction round to S18: Northeastern US
Increased train limit in phases 2 and 3 for S18: Northern Italy

I revamped UpwardAuction to handle dropping prices when all privates aren't sold when every player passes. I modified CharterAuction to not do this and modifed OrderAuction to take advantage of the new UpwardAuction. As a result, the Mississippi map no longer requires a player to start an auction.

### Screenshots

### Any Assumptions / Hacks
