### PR TITLE
[1837] Correct method call, adding missing ?

### DIFF
--- a/lib/engine/game/g_1837/game.rb
+++ b/lib/engine/game/g_1837/game.rb
@@ -800,7 +800,7 @@ module Engine
 
         def sold_out_stock_movement(corporation)
           # Needed for 1824, which use base behavior for sold out (and do not use diagonal stock movements)
-          return super unless @stock_market.hex_market
+          return super unless @stock_market.hex_market?
 
           if corporation.owner.percent_of(corporation) <= 40
             @stock_market.move_up(corporation)


### PR DESCRIPTION
No issues reported yet, but it probably causes problems in 1837 games

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

stock_market does not have a hex_market method, it should be hex_market?

### Explanation of Change

Change was done in 1837 to cater for 1824, but a mistake was made. This commit fixes that.

### Screenshots

N/A

### Any Assumptions / Hacks

N/A