### PR TITLE
[1844] Fix error on SBB formation

### DIFF
--- a/lib/engine/game/g_1844/game.rb
+++ b/lib/engine/game/g_1844/game.rb
@@ -528,8 +528,9 @@ module Engine
           if (president_shares = president.shares_of(sbb)).none? { |share| share.percent == 10 }
             ten_percent_share = @share_pool.shares_of(sbb).find { |share| share.percent == 10 } ||
                                   president_priority_order[-1].shares_of(sbb).find { |share| share.percent == 10 }
+            share_owner = ten_percent_share.owner
             @share_pool.transfer_shares(ShareBundle.new([ten_percent_share]), president, allow_president_change: false)
-            @share_pool.transfer_shares(ShareBundle.new(president_shares.take(2)), share.owner, allow_president_change: false)
+            @share_pool.transfer_shares(ShareBundle.new(president_shares.take(2)), share_owner, allow_president_change: false)
           end
 
           # Make sure president has the presidents cert


### PR DESCRIPTION
When the SBB forms, if the new president was not president of any of the pre-SBB companies, then they must be given a 10% share certificate. The code to swap two 5% shares for a 10% share was failing, as the variable `share` is never defined.

Fixes tobymao#11887.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`