### PR TITLE
[18 Christmas Eve] fix endgame reason not appearing above game log

### DIFF
--- a/lib/engine/game/g_18_christmas_eve/game.rb
+++ b/lib/engine/game/g_18_christmas_eve/game.rb
@@ -27,7 +27,11 @@ module Engine
 
         GAME_END_REASONS_TEXT = Base::GAME_END_REASONS_TEXT.merge(
           custom: 'First D Purchased'
-        )
+        ).freeze
+
+        GAME_END_DESCRIPTION_REASON_MAP_TEXT = Base::GAME_END_DESCRIPTION_REASON_MAP_TEXT.merge(
+          custom: 'First D Purchased'
+        ).freeze
 
         def cornelius
           # cornelius, as inheriting behaviour from the chessie cornelius private


### PR DESCRIPTION
Fixes #11875

<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Screenshots

Before:
<img width="585" height="113" alt="Screenshot 2025-08-27 at 20 14 30" src="https://github.com/user-attachments/assets/8644396b-4fad-42c4-93de-c42ecf031722" />

After:
<img width="715" height="88" alt="Screenshot 2025-08-27 at 20 17 29" src="https://github.com/user-attachments/assets/714154c1-e271-4721-a76c-e390639a7b90" />