### PR TITLE
[dev] add script to create a GitHub Release for latest tag when deploying

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 See [`TILES.md`](/TILES.md) for some details and useful routes for tile
 development.
 
-See [Developing on Windows](https://github.com/tobymao/18xx/wiki/Developing-For-18xx.games#developing-on-windows) to get setup on Windows
+See [Developing on Windows](https://github.com/tobymao/18xx/wiki/Developing-For-18xx.games#developing-on-windows) to get setup on Windows Subsystem for Linux
 
 ## Use a Github Codespace
 
@@ -24,14 +24,18 @@ If that pop-up doesn't appear, open the `Ports` tab in the Codespace, hover the 
 ![image](https://user-images.githubusercontent.com/1711810/201538007-a5b4bf8a-9214-4ca3-a6a5-6304601c34c2.png)
 
 
-## Droplet configuration
+## Droplet/local configuration
 
-If configuring the droplet from scratch, these are the requirements:
+If configuring your local environment or the droplet from scratch, these are the requirements:
 
-- `docker`
-- `docker compose`
-- `make`
+- [Docker](https://docs.docker.com/desktop/)
+- `make` (can be installed via [Homebrew](https://formulae.brew.sh/formula/make))
 - this repo (via `git clone`)
+
+### For Maintainers
+
+- [GitHub CLI](https://cli.github.com/) is required to create new
+  [Releases](https://github.com/tobymao/18xx/releases) when deploying
 
 ## Docker
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ prod_deploy : clean
 	$(CONTAINER_COMPOSE) run rack rake precompile && \
 		rsync --verbose --checksum public/pinned/*.js.gz deploy@18xx:~/18xx/public/pinned/ && \
 		rsync --verbose --checksum public/assets/*.js public/assets/*.js.gz public/assets/version.json deploy@18xx:~/18xx/public/assets/ && \
-		ssh -t -l deploy 18xx "source ~/.profile && cd ~/18xx/ && git pull && make prod_rack_up_b_d && make tag"
+		ssh -t -l deploy 18xx "source ~/.profile && cd ~/18xx/ && git pull && make prod_rack_up_b_d && make tag" && \
+		./scripts/gh_release_from_tag.sh
 
 # tag currently checked out commit with date in public/assets/version.json
 tag:

--- a/Rakefile
+++ b/Rakefile
@@ -105,16 +105,24 @@ task :precompile do
   assets.combine(:all)
 
   # Copy to the pin directory
-  git_rev = `git rev-parse --short HEAD`.strip
   version_epochtime = Time.now.strftime('%s')
+  timestamp_tag = Time.at(version_epochtime.to_i).strftime('%Y-%m-%d_%H.%M.%S')
   pin_dir = Assets::OUTPUT_BASE + Assets::PIN_DIR
+  FileUtils.mkdir_p(pin_dir)
+  assets.pin("#{pin_dir}/#{timestamp_tag}.js.gz")
+
+  git_rev = `git rev-parse --short HEAD`.strip
+  repo = 'tobymao/18xx'
   File.write(Assets::OUTPUT_BASE + '/assets/version.json', JSON.dump(
+    timestamp_tag: timestamp_tag,
+    release_url: "https://github.com/#{repo}/releases/tag/#{timestamp_tag}",
+    unreleased_url: "https://github.com/#{repo}/compare/#{timestamp_tag}...master",
+
+    # keep old keys for backwards compatibility
     hash: git_rev,
     url: "https://github.com/tobymao/18xx/commit/#{git_rev}",
     version_epochtime: version_epochtime,
   ))
-  FileUtils.mkdir_p(pin_dir)
-  assets.pin("#{pin_dir}#{git_rev}.js.gz")
 
   assets.clean_intermediate_output_files
 end

--- a/assets/app/view/about.rb
+++ b/assets/app/view/about.rb
@@ -17,6 +17,21 @@ module View
         link = node_to_s(h(:a, { attrs: { href: version['url'] } }, version['hash']))
         `document.getElementById('version').innerHTML = #{link}`
         `document.getElementById('version_localtime').innerHTML = #{version_localtime}`
+
+        if version['release_url']
+          release_link = node_to_s(
+            h(:a, { attrs: { href: version['release_url'], target: '_blank' } }, version['timestamp_tag'])
+          )
+          `document.getElementById('release').innerHTML = #{release_link}`
+
+          unreleased_link = node_to_s(
+            h(:a, { attrs: { href: version['unreleased_url'], target: '_blank' } }, 'View all unreleased commits.')
+          )
+          `document.getElementById('unreleased').innerHTML = #{unreleased_link}`
+
+          `document.getElementById('release_info').classList.remove('hidden')`
+          `document.getElementById('release_info_legacy').classList.add('hidden')`
+        end
       end
 
       message = <<~MESSAGE
@@ -27,7 +42,10 @@ module View
         code on <a href='https://github.com/tobymao/18xx/issues'>GitHub</a>. All games are used with express written consent from their respective rights holders. You can find more information about the games on the <a href='https://github.com/tobymao/18xx/wiki'>wiki</a>.
         </p>
 
+        <p id='release_info' class='hidden'>Current version: <span id='release'>unknown</span>. <span id='unreleased'></span></p>
+        <span id='release_info_legacy'>
         <p>Current version: <span id='version'>unknown</span> deployed at <span id='version_localtime'>unknown</span> (<a href="https://github.com/tobymao/18xx/commits/master">View all recent commits</a>)</p>
+        </span>
 
         <h2>Conduct Expectations</h2>
 

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -428,3 +428,7 @@ div#game:focus {
     float: left;
   }
 }
+
+.hidden {
+  display: none;
+}

--- a/scripts/gh_release_from_tag.sh
+++ b/scripts/gh_release_from_tag.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -e
+
+# Creates a GitHub Release from the latest tag. This is automatically run during
+# `make prod_deploy`.
+#
+# Alternatively, a release can be created for a pre-existing $OLD_TAG by running
+# this script manually. To do this, run these commands:
+#
+#     git checkout $OLD_TAG
+#
+#     # run this to include `version.json` and pin tarball assets
+#     docker compose exec rack bundle exec rake precompile
+#
+#     # after running precompile, in `version.json` you'll need to replace the values for
+#     # `timestamp_tag`, `release_url`, and `unreleased_url` to match the actual
+#     # tag instead of the using the time you run this command. If you would
+#     # like to also replace `version_epochtime` to match the tag's timestamp,
+#     # you can use `scripts/tag_name_to_timestamp.rb` to get the timestamp.
+#
+#     # manually find the tag for the release prior to the tag you're releasing
+#     PREVIOUS_TAG=<prior_release_tag>
+#
+#     ./scripts/gh_release_from_tag.sh $OLD_TAG $PREVIOUS_TAG
+
+TAG=${1}
+PREVIOUS_TAG=${2}
+
+if [ -z "${TAG}" ]; then
+    LATEST_FLAG='--latest'
+
+    TAGS=$(git show-ref --tags | \
+               grep -E '\brefs/tags/\d{4}-\d{2}-\d{2}_\d{2}\.\d{2}\.\d{2}' | \
+               cut -d ' ' -f 2 | \
+               cut -d '/' -f 3)
+    TAG=$(echo "${TAGS}" | tail -1)
+    PREVIOUS_TAG=$(echo "${TAGS}" | tail -2 | head -1)
+else
+    LATEST_FLAG='--latest=false'
+fi
+
+if [ -z "${PREVIOUS_TAG}" ]; then
+    echo 'No PREVIOUS_TAG found for `gh release create ${TAG} --notes-start-tag=${PREVIOUS_TAG}`'
+    exit 1
+fi
+
+TARBALL="${TARBALL:-public/pinned/${TAG}.js.gz}"
+if [ ! -f ${TARBALL} ]; then
+    TARBALL=''
+fi
+
+VERSION_JSON="${VERSION_JSON:-public/assets/version.json}"
+if [ ! -f ${VERSION_JSON} ]; then
+    VERSION_JSON=''
+fi
+
+REPO="${REPO:-tobymao/18xx}"
+
+git checkout ${TAG}
+gh release create ${TAG} ${TARBALL} ${VERSION_JSON} \
+   ${LATEST_FLAG} \
+   --repo ${REPO} \
+   --verify-tag \
+   --generate-notes \
+   --notes-start-tag "${PREVIOUS_TAG}"

--- a/scripts/tag_name_to_timestamp.rb
+++ b/scripts/tag_name_to_timestamp.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'time'
+
+print DateTime.strptime(ARGV[0], '%Y-%m-%d_%H.%M.%S').strftime('%s')


### PR DESCRIPTION
### Explanation of Change

The next step in improving the deployment process after https://github.com/tobymao/18xx/pull/11806. With the new script `./scripts/gh_release_from_tag.sh`, a [Release page](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#about-releases) is created, providing better documentation about what is currently deployed.

* add script to create a GitHub Release, run it at the end of `make prod_deploy`
    * the Release includes an auto-generated "changelog" link, using GitHub's
      `/compare` route to list all commits and show the net code changes from
      the previous release to the current one
    * the pin tarball and `version.json` are uploaded to the Release Assets
* pin tarballs now are named with the release tag name (formatted timestamp)
  instead of the short commit SHA
* the `/about` page now links to the Release (instead of latest commit) and
  provides a link to all unreleased commits
    * if `version.json` does not contain the keys for this new release process,
      the information will be shown in the old style (i.e., short commit SHA and
      link to "recent commits" on master)

**Maintainers should install the [GitHub CLI](https://cli.github.com/) and authenticate with `gh auth login` before running `make prod_deploy`**

### Screenshots

#### main repo page, "Releases" visible on the right:

<img width="1249" height="505" alt="Screenshot 2025-08-26 at 22 54 24" src="https://github.com/user-attachments/assets/d0dd09e1-2716-40e8-8661-b91c2d94da6c" />

#### Release page, with downloadable pin tarball and auto-generated link to "Changelog":


<img width="1241" height="562" alt="Screenshot 2025-08-28 at 16 00 25" src="https://github.com/user-attachments/assets/280b5049-8f35-4fda-9f9e-b96a29180a23" />



#### "Changelog" showing commits (oldest to newest) added in this release:

<img width="1246" height="778" alt="Screenshot 2025-08-26 at 22 54 54" src="https://github.com/user-attachments/assets/ad5a79ca-ae00-4e6a-9533-e2af97a51c46" />


#### new `/about` page:

<img width="506" height="153" alt="Screenshot 2025-08-29 at 08 42 56" src="https://github.com/user-attachments/assets/3c23ce9b-eb95-4c07-a70b-d6e39cabbe47" />


### Any Assumptions / Hacks

* a maintainer running `make prod_deploy` has installed and logged in with the [GitHub CLI](https://cli.github.com/)
* existing tags will not be converted to Releases; but if any deployment error causes a Release page to not be created, it will be possible to use `gh_release_from_tag.sh` to retroactively create a Release
* the env var `REPO` can be overridden, but outside of testing the script on my fork this likely will not be needed/useful
* pins to *this release and later* will use `pin='<timestamp_tag>'`, but pins to previous releases will still need `pin='<commit_sha>'`
