### PR TITLE
[dev] set `"loaded": true` when importing fixtures; require for all fixtures

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -208,6 +208,9 @@ task 'fixture_import', [:id] do |_task, args|
   game_data = db_game.to_h
   game_data[:actions] = game.raw_actions.map(&:to_h)
 
+  # this is required for opening fixtures in the browser at /fixture/<title>/<id>
+  game_data[:loaded] = true
+
   user = 1000
   group = 1000
 

--- a/spec/lib/engine/games/game_spec.rb
+++ b/spec/lib/engine/games/game_spec.rb
@@ -26,6 +26,9 @@ module Engine
           expect(rungame.finished).to eq(true)
           expect(data['status']).to eq('finished')
 
+          # this is required for opening fixtures in the browser at /fixture/<title>/<id>
+          expect(data['loaded']).to eq(true)
+
           # some fixtures want to test that the last N actions of the game replayed the same as in the fixture
           test_last_actions = data['test_last_actions']
           next unless test_last_actions


### PR DESCRIPTION
without this, `/fixture/<title>/<id>` ends up redirecting to `/game/<id>` and loading the game from the local DB instead of the fixture file

when copying/downloading hotseat data, `loaded` is already `true` so I only encountered this when trying `rake fixture_import`

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

