### PR TITLE
[dev] for macOS: ignore `.rerun`, add recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ validate*.json
 .idea
 
 .vscode
+
+.rerun

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -75,6 +75,10 @@ refresh your browser to load the new app.
 > commands, e.g., `DEV_DOCKERFILE=Dockerfile.amd64 make dev_up_b`. If you use
 > Docker Desktop, enable `Use Rosetta for x86_64/amd64 emulation on Apple
 > Silicon` in `Docker Desktop / Settings / General / Virtual Machine Options`.
+> A tool like [direnv](https://direnv.net/) can be used so you can set up a
+> `.envrc` file instead of manually setting `DEV_DOCKERFILE` every time you
+> start work on the project.  You should also run `ln -s .rerun.amd64 .rerun`
+> once.
 
 #### Database
 

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -18,7 +18,5 @@ RUN if [ "$RACK_ENV" = "production" ]; \
     bundle install;
 COPY . .
 
-COPY .rerun.amd64 .rerun
-
 CMD bundle exec rake dev_up && \
     bundle exec rerun --background -i 'build/*' -i 'public/*' 'unicorn -c config/unicorn.rb'


### PR DESCRIPTION
followup to [#11930](https://github.com/tobymao/18xx/pull/11930)

copying the file in the Docker image doesn't really work due to mounting the
whole directory; macOS users can set up a symlink for `.rerun`

[`direnv`](https://direnv.net/) is a tool that reads `.envrc` files when you enter that directory; now
I have `export DEV_DOCKERFILE=Dockerfile.amd64` saved in my `.envrc` so that it
will always be set correctly in my terminals, and with it gitignored it won't
break anything for non-mac contributors


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`