### PR TITLE
[18GB] Restrict buying president's certificate from the pool

### DIFF
--- a/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_gb/step/buy_sell_par_shares.rb
@@ -109,6 +109,12 @@ module Engine
               can_gain?(entity, bundle)
           end
 
+          def can_gain?(entity, bundle, exchange: false)
+            return super if bundle.owner != @game.share_pool || !bundle.presidents_share
+
+            entity.shares_of(bundle.corporation).one?
+          end
+
           def already_president?(corporation)
             @round.presidencies&.include?(corporation)
           end


### PR DESCRIPTION
In 18GB the president's certificate can be sold to the share pool, and the corporation is placed in receivership. Once this has happened, a player is not allowed to directly buy the president's certificate. They must either buy two single shares (from either the IPO or the pool) or buy a single share and then buy the president's certificate from the pool and place the single share back in the pool.

This check was not in place and a player who did not own any shares in a company was being given the option to buy the president's share from the pool.

Fixes tobymao#11886.

There is at least one game broken by this (at [action 295 of game 208720](https://18xx.games/game/208720?action=295)).

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`