### PR TITLE
[18Norway] Allow BB to buy a ship when they have the ignore_mandatory_train ability

### DIFF
--- a/lib/engine/game/g_18_norway/steps/buy_train.rb
+++ b/lib/engine/game/g_18_norway/steps/buy_train.rb
@@ -52,6 +52,12 @@ module Engine
             end
           end
 
+          def ebuy_offer_only_cheapest_depot_train?
+            return false if @game.abilities(current_entity, :ignore_mandatory_train) && !@game.phase.tiles.include?(:brown)
+
+            @game.class::EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST
+          end
+
           def process_sell_shares(action)
             raise GameError, "Cannot sell shares of #{action.bundle.corporation.name}" unless can_sell?(action.entity,
                                                                                                         action.bundle)


### PR DESCRIPTION
BB shall be allowed to buy a ship even if it does not have a train
Fixes #11870

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
