### PR TITLE
[core] prevent placing token on an unavailable hex

### DIFF
--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -149,6 +149,9 @@ module View
 
           step = @game.round.active_step(@selected_company)
           entity = @selected_company || step.current_entity
+
+          return unless step.available_hex(entity, @tile.hex)
+
           remove_token_step = @game.round.step_for(entity, 'remove_token')
           place_token_step = @game.round.step_for(entity, 'place_token')
           buy_token_step = @game.round.step_for(entity, 'buy_token')

--- a/lib/engine/step/token.rb
+++ b/lib/engine/step/token.rb
@@ -31,6 +31,11 @@ module Engine
       def process_place_token(action)
         entity = action.entity
 
+        if !@game.loading && !available_hex(entity, action.city.hex)
+          raise GameError, "#{entity.name} cannot place token in City "\
+                           "#{action.city.id} on hex #{action.city.hex.id}"
+        end
+
         place_token(entity, action.city, action.token)
         pass!
       end


### PR DESCRIPTION
Discovered this while working on #11301, when it was DPR's turn clicking on a city slot
in an un-highlighted hex still managed to place a token.

With the `assets/` change, clicking now is a no-op as expected, and without that change
but with the `lib/engine/` change, clicking leads to an error banner and the action is
prevented.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`