### PR TITLE
[1824] Set game (and Cisleithania) in Alpha

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -16,7 +16,8 @@ module View
 
     def render_notification
       message = <<~MESSAGE
-        <p><a href="https://github.com/tobymao/18xx/wiki/1804">1804</a> is now in alpha.</p>
+        <p><a href="https://github.com/tobymao/18xx/wiki/1824">1824</a> is now in alpha, together with the
+           <a href="https://github.com/tobymao/18xx/wiki/1824-Cisleithania-map">1824 Cisleithania map variants</a>.</p>
 
         <p>Report bugs and make feature requests <a href='https://github.com/tobymao/18xx/issues'>on GitHub</a>.</p>
       MESSAGE

--- a/lib/engine/game/g_1824/meta.rb
+++ b/lib/engine/game/g_1824/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :prealpha
+        DEV_STAGE = :alpha
         DEPENDS_ON = '1837'
 
         GAME_SUBTITLE = 'Austrian-Hungarian Railway'.freeze

--- a/lib/engine/game/g_1824_cisleithania/meta.rb
+++ b/lib/engine/game/g_1824_cisleithania/meta.rb
@@ -12,9 +12,8 @@ module Engine
 
         DEPENDS_ON = '1824'
 
-        DEV_STAGE = :prealpha
+        DEV_STAGE = :alpha
 
-        GAME_IS_VARIANT_OF = G1824::Meta
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1824-Cisleithania-map'.freeze
         GAME_TITLE = '1824 Cisleithania'.freeze
 


### PR DESCRIPTION
This PR is depending on #11968

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Depending on #11968 

Removed 1804 alpha notice. Or should this just add 1824 and let 1804 remain?

### Explanation of Change

With #11968 the 1824 implementation is good enough to play as Alpha.

### Screenshots

### Any Assumptions / Hacks

I removed GAME:_IS_VARIANT_OF meta info, as that ment 1824 Cisleithania did not appear in the create game part. As it does not appear as a variant when creating 1824 I thought it was best. Or should it remains and something be changed in 1824 to make it work?