### PR TITLE
[1822PNW] fix share prices for starting minors in Starting Packet Variant

### DIFF
--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -646,7 +646,7 @@ module Engine
             %w[P10 P11],
           ]
 
-          par_price = stock_market.par_prices[0]
+          par_price = stock_market.par_prices[-1]
 
           @players.each.with_index do |player, index|
             player.cash = 0


### PR DESCRIPTION
Starting price should be $50, which is apparently the "last" par price, while $100 is the "first".

Fixes #11959

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
