### PR TITLE
[1822MRS/1822NRS] Tax Haven variant, fix NRS 2p

### DIFF
--- a/lib/engine/game/g_1822_mrs/meta.rb
+++ b/lib/engine/game/g_1822_mrs/meta.rb
@@ -42,7 +42,12 @@ module Engine
                   'home tokens will be placed in Southwest England (D39).',
             players: [2],
           },
-
+          {
+            sym: :tax_haven_multiple,
+            short_name: 'Tax Haven Variant',
+            desc: 'P16 (Tax Haven) can use the cash it accumulates to buy 1 share per SR. Cannot '\
+                  'own multiple shares of one corporation.',
+          },
         ].freeze
 
         MUTEX_RULES = [

--- a/lib/engine/game/g_1822_nrs/entities.rb
+++ b/lib/engine/game/g_1822_nrs/entities.rb
@@ -19,7 +19,7 @@ module Engine
 
         STARTING_COMPANIES_TWOPLAYER = [
           # P1-P12
-          'P1', 'P2', 'P3', 'P4', 'P5', 'P6', 'P7', 'P8', 'P9', 'P10', 'P11', 'P12',
+          'P1', 'P2', 'P3', 'P4', 'P6', 'P7', 'P8', 'P9', 'P11', 'P12',
           *CONCESSIONS,
           *MINORS_COMPANIES
         ].freeze

--- a/lib/engine/game/g_1822_nrs/meta.rb
+++ b/lib/engine/game/g_1822_nrs/meta.rb
@@ -23,6 +23,15 @@ module Engine
         GAME_IS_VARIANT_OF = G1822::Meta
 
         PLAYER_RANGE = [2, 7].freeze
+
+        OPTIONAL_RULES = [
+          {
+            sym: :tax_haven_multiple,
+            short_name: 'Tax Haven Variant',
+            desc: 'P16 (Tax Haven) can use the cash it accumulates to buy 1 share per SR. Cannot '\
+                  'own multiple shares of one corporation.',
+          },
+        ].freeze
       end
     end
   end


### PR DESCRIPTION
Fix setup for 1822NRS 2p; just remove P5 and P10. Fixes #11874

Add Tax Haven variant to both scenarios. Fixes #11877

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`