### PR TITLE
[1822 family] add help text to acquire_company step about cert limit

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -981,7 +981,7 @@ module Engine
           Engine::Round::Operating.new(self, [
             G1822::Step::PendingToken,
             G1822::Step::FirstTurnHousekeeping,
-            Engine::Step::AcquireCompany,
+            G1822::Step::AcquireCompany,
             G1822::Step::DiscardTrain,
             G1822::Step::SpecialChoose,
             G1822::Step::SpecialTrack,

--- a/lib/engine/game/g_1822/step/acquire_company.rb
+++ b/lib/engine/game/g_1822/step/acquire_company.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/route'
+
+module Engine
+  module Game
+    module G1822
+      module Step
+        class AcquireCompany < Engine::Step::AcquireCompany
+          def help
+            return if current_entity.owner.companies.count { |c| @game.company_header(c) == 'PRIVATE COMPANY' }.zero?
+
+            'Reminder: unacquired private companies count against your certificate limit.'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -522,7 +522,7 @@ module Engine
           Engine::Round::Operating.new(self, [
             G1822::Step::PendingToken,
             G1822::Step::FirstTurnHousekeeping,
-            Engine::Step::AcquireCompany,
+            G1822::Step::AcquireCompany,
             G1822::Step::DiscardTrain,
             G1822::Step::SpecialChoose,
             G1822Africa::Step::LayGameReserve,

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -352,7 +352,7 @@ module Engine
           Engine::Round::Operating.new(self, [
             G1822CA::Step::PendingToken,
             G1822::Step::FirstTurnHousekeeping,
-            Engine::Step::AcquireCompany,
+            G1822::Step::AcquireCompany,
             G1822CA::Step::DiscardTrain,
             G1822CA::Step::AssignSawmill,
             G1822::Step::SpecialChoose,

--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -308,7 +308,7 @@ module Engine
           Engine::Round::Operating.new(self, [
             G1822::Step::PendingToken,
             G1822::Step::FirstTurnHousekeeping,
-            Engine::Step::AcquireCompany,
+            G1822::Step::AcquireCompany,
             G1822::Step::DiscardTrain,
             G1822MX::Step::SpecialChoose,
             G1822MX::Step::SpecialTrack,

--- a/lib/engine/game/g_1822_pnw/step/acquire_company.rb
+++ b/lib/engine/game/g_1822_pnw/step/acquire_company.rb
@@ -6,7 +6,7 @@ module Engine
   module Game
     module G1822PNW
       module Step
-        class AcquireCompany < Engine::Step::AcquireCompany
+        class AcquireCompany < G1822::Step::AcquireCompany
           attr_reader :choices
 
           def actions(entity)


### PR DESCRIPTION
As a player, I may have been burned a couple times by forgetting to acquire private companies in the last OR before a SR where cert limit was going to matter.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`