### PR TITLE
[1824] Avoid showing multi exchange buttons #11988

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -467,7 +467,10 @@ module Engine
         end
 
         def exchange_entities
-          @companies.reject(&:closed?)
+          # Only one MR to exchange at a time - if we show all here they appear as multiple buttons in GUI
+          # under selected corporation. See #11988.
+          unclosed = @companies.reject(&:closed?)
+          unclosed.empty? ? [] : [unclosed.first]
         end
 
         def mountain_railway?(entity)


### PR DESCRIPTION
Fixes 11988

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

This should not break any game. And it wont fix the game broken in #11988 - that game can be archived.

## Implementation Notes

Just ensure exchange_entities returns 0 or 1 companies.

### Explanation of Change

If a player owned multiple MRs, when doing forced MR exchange, when player clicked on an exchangeable corporation one button with "Exchange X for 10% share" appeared. If the player does not click on the top one, but one of the ones below, this caused the game to break.

By only showing one button in this situation the user cannot trigger this bug.

### Screenshots

N/A

### Any Assumptions / Hacks

N/A
