### PR TITLE
[1824] Disallow upgrade of yellow one town to yellow two town #11993

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -196,10 +196,11 @@ module Engine
           :corporation
         end
 
-        # 1824 differ from 1837 as it allows any legal single town upgrade to green (duble towns have no green tiles)
+        # 1824 differ from 1837 as it allows any legal single town upgrade to green (double towns have no green tiles)
+        # TODO: Add a unit test for upgrade yellow single town to green, and no upgrade for double town
         def yellow_town_tile_upgrades_to?(from, to)
           # honors pre-existing track?
-          from.paths_are_subset_of?(to.paths)
+          from.paths_are_subset_of?(to.paths) && to.color == :green && from.towns.one? && to.towns.one?
         end
 
         # 1824 version differ from 1837 as a national can become in receivership, and tie breaker is different


### PR DESCRIPTION
Corrected this bug by adding a check that upgrade of yellow town tile is only allowed it is a single town (both from and to) and to a green tile.

Fixes #11993 
Fixes #12002 

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

**Note! The bug led to an illegal upgrade in one game. That game will break and can be archived. Games without illegal upgrades will not be affected.**

## Implementation Notes

Code is a change from 1837 as they have different rules. But the check in 1824 did not check that
it was a single town upgrade to green. Have now added that to ensure only single towns can be upgraded.

### Explanation of Change

The bug made it possible to upgrade yellow single town to yellow double town, which is illegal.

### Screenshots

Double towns has now disappeared from chices

### Any Assumptions / Hacks

None
