### PR TITLE
[System18] Add Russia map; move to beta; change SELL_AFTER

### DIFF
--- a/lib/engine/game/g_system18/entities.rb
+++ b/lib/engine/game/g_system18/entities.rb
@@ -5,7 +5,15 @@ module Engine
     module GSystem18
       module Entities
         def game_companies
+          return [] unless respond_to?("map_#{map_name}_game_companies")
+
           send("map_#{map_name}_game_companies")
+        end
+
+        def game_minors
+          return [] unless respond_to?("map_#{map_name}_game_minors")
+
+          send("map_#{map_name}_game_minors")
         end
 
         S18_CORPORATIONS = [

--- a/lib/engine/game/g_system18/map_britain_customization.rb
+++ b/lib/engine/game/g_system18/map_britain_customization.rb
@@ -509,6 +509,7 @@ module Engine
           redef_const(:CURRENCY_FORMAT_STR, '£%s')
           redef_const(:TILE_UPGRADES_MUST_USE_MAX_EXITS, %i[unlabeled_cities])
           redef_const(:TILE_LAYS, [{ lay: true, upgrade: true, cost: 0 }, { lay_replaced: :if_green_upgraded }])
+          redef_const(:REMOVE_UNUSED_RESERVATIONS, true)
         end
 
         def map_britain_setup

--- a/lib/engine/game/g_system18/map_china_rapid_development_customization.rb
+++ b/lib/engine/game/g_system18/map_china_rapid_development_customization.rb
@@ -109,10 +109,6 @@ module Engine
           }
         end
 
-        def map_china_rapid_development_game_companies
-          []
-        end
-
         # DGN GFN PHX KKN SPX
         def map_china_rapid_development_game_corporations(corps)
           corps.each_with_index do |c, idx|

--- a/lib/engine/game/g_system18/map_france_customization.rb
+++ b/lib/engine/game/g_system18/map_france_customization.rb
@@ -105,10 +105,6 @@ module Engine
           }
         end
 
-        def map_france_game_companies
-          []
-        end
-
         def map_france_game_corporations(corps)
           corps.each_with_index do |c, idx|
             c[:float_percent] = 20

--- a/lib/engine/game/g_system18/map_russia_customization.rb
+++ b/lib/engine/game/g_system18/map_russia_customization.rb
@@ -1,0 +1,491 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module GSystem18
+      module MapRussiaCustomization
+        MOSCOW_HEX = 'C8'
+        ST_PETERSBERG_HEX = 'A6'
+        KIEV_HEX = 'E4'
+        MY_HEX = 'B9'
+        MR_HEX = 'D9'
+        NATIONAL_CORP = 'SPX'
+
+        def map_russia_game_tiles(tiles)
+          tiles.merge!({
+                         '637' =>
+                         {
+                           'count' => 1,
+                           'color' => 'green',
+                           'code' => 'city=revenue:50,loc:0.5;city=revenue:50,loc:2.5;city=revenue:50,loc:4.5;'\
+                                     'path=a:0,b:_0;path=a:_0,b:1;path=a:4,b:_2;path=a:_2,b:5;'\
+                                     'path=a:2,b:_1;path=a:_1,b:3;label=M',
+                         },
+                         '638' =>
+            {
+              'count' => 1,
+              'color' => 'brown',
+              'code' => 'city=revenue:70,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;'\
+                        'path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=M',
+            },
+                         '641' =>
+            {
+              'count' => 1,
+              'color' => 'brown',
+              'code' => 'city=revenue:50,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:5,b:_0;label=S',
+            },
+                       })
+        end
+
+        def map_russia_layout
+          :pointy
+        end
+
+        def map_russia_game_location_names
+          {
+            'A6' => 'St Petersberg',
+            'B3' => 'Riga',
+            'C2' => 'Kaunas & Vilnius',
+            'C4' => 'Vitebsk & Daugavpils',
+            'C6' => 'Smolensk',
+            'C8' => 'Moscow',
+            'C10' => 'Nizhny Novgorod',
+            'C12' => 'Siberia',
+            'D1' => 'Poland',
+            'D3' => 'Minsk & Pinsk',
+            'D7' => 'Tula & Orel',
+            'D11' => 'Simbirsk & Penza',
+            'E4' => 'Kiev',
+            'E8' => 'Voronezh',
+            'E12' => 'Saratov',
+            'F7' => 'Kharkov',
+            'F11' => 'Tsaritsyn',
+          }
+        end
+
+        def map_russia_game_hexes
+          {
+            gray: {
+              %w[A2 B1] => 'path=a:4,b:5',
+              %w[C4] => 'town=revenue:10;town=revenue:10;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_1;path=a:2,b:_1',
+              %w[F3] => 'path=a:2,b:3;path=a:4,b:3',
+              %w[F13] => 'path=a:1,b:2',
+            },
+
+            red: {
+              %w[C12] => 'offboard=revenue:yellow_20|green_40|brown_60;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0',
+              %w[D1] => 'offboard=revenue:yellow_30|green_40|brown_50;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
+            },
+            green: {
+              %w[A6] => 'city=revenue:30;city=revenue:30;path=a:0,b:_0;path=a:5,b:_1;label=S',
+            },
+            white: {
+              %w[A4 B11 D5 D9 E2 E6 E10 F9] => '',
+              %w[B9] => 'upgrade=cost:20,terrain:river',
+              %w[F5] => 'upgrade=cost:40,terrain:river',
+              %w[B3 C6 E8 E12 F7 F11] => 'city',
+              %w[C10] => 'city=revenue:0;upgrade=cost:20,terrain:river',
+              %w[C2 D3 D7 D11] => 'town=revenue:0;town=revenue:0',
+            },
+            yellow: {
+              %w[B5] => 'path=a:0,b:3',
+              %w[B7] => 'path=a:2,b:5',
+              %w[C8] => 'city=revenue:40;city=revenue:40;city=revenue:40;path=a:0,b:_0;path=a:2,b:_1;path=a:4,b:_2;label=M',
+              %w[E4] => 'city=revenue:30;city=revenue:30;path=a:2,b:_0;path=a:4,b:_1;label=OO',
+            },
+          }
+        end
+
+        def map_russia_game_companies
+          [
+            {
+              name: 'Tsarskoye Selo Railway',
+              sym: 'TS',
+              value: 20,
+              revenue: 10,
+              max_price: 30,
+              desc: 'No special abilities.',
+              color: nil,
+            },
+            {
+              name: 'Moscow - Yaroslavl Railway',
+              sym: 'MY',
+              value: 40,
+              revenue: 20,
+              max_price: 60,
+              desc: 'When owned by a corporation, they gain 10₽ extra revenue for '\
+                    'each of their routes that include Moscow',
+              abilities: [
+                {
+                  type: 'hex_bonus',
+                  owner_type: 'corporation',
+                  hexes: [MOSCOW_HEX],
+                  amount: 10,
+                },
+                {
+                  type: 'blocks_hexes',
+                  owner_type: 'player',
+                  hexes: [MY_HEX],
+                },
+              ],
+              color: nil,
+            },
+            {
+              name: 'Moscow - Ryazan Railway',
+              sym: 'MR',
+              value: 50,
+              revenue: 25,
+              max_price: 75,
+              desc: 'When owned by a corporation, they gain 10₽ extra revenue for '\
+                    'each of their routes that include Moscow',
+              abilities: [
+                {
+                  type: 'hex_bonus',
+                  owner_type: 'corporation',
+                  hexes: [MOSCOW_HEX],
+                  amount: 10,
+                },
+                {
+                  type: 'blocks_hexes',
+                  owner_type: 'player',
+                  hexes: [MR_HEX],
+                },
+              ],
+              color: nil,
+            },
+          ]
+        end
+
+        def map_russia_minor_corporations
+          [
+            {
+              sym: 'RO',
+              name: 'Riga-Orel Railway',
+              logo: '1861/RO',
+              simple_logo: '1861/RO.alt',
+              float_percent: 100,
+              always_market_price: true,
+              tokens: [0],
+              type: 'minor',
+              coordinates: 'B3',
+              shares: [100],
+              max_ownership_percent: 100,
+              color: '#009595',
+            },
+            {
+              sym: 'KB',
+              name: 'Kiev-Brest Railway',
+              logo: '1861/KB',
+              simple_logo: '1861/KB.alt',
+              float_percent: 100,
+              always_market_price: true,
+              tokens: [0],
+              shares: [100],
+              max_ownership_percent: 100,
+              type: 'minor',
+              coordinates: 'E4',
+              city: 0,
+              color: '#4cb5d2',
+            },
+            {
+              sym: 'KK',
+              name: 'Kiev-Kursk Railway',
+              logo: '1861/KK',
+              simple_logo: '1861/KK.alt',
+              float_percent: 100,
+              always_market_price: true,
+              tokens: [0],
+              shares: [100],
+              max_ownership_percent: 100,
+              type: 'minor',
+              coordinates: 'E4',
+              city: 1,
+              color: '#0097df',
+            },
+            {
+              sym: 'SPW',
+              name: 'St. Petersburg Warsaw',
+              logo: '1861/SPW',
+              simple_logo: '1861/SPW.alt',
+              float_percent: 100,
+              always_market_price: true,
+              tokens: [0],
+              shares: [100],
+              max_ownership_percent: 100,
+              type: 'minor',
+              coordinates: 'A6',
+              city: 0,
+              color: '#0189d1',
+            },
+            {
+              sym: 'KR',
+              name: 'Kharkiv-Rostov Railway',
+              logo: '1861/KR',
+              simple_logo: '1861/KR.alt',
+              float_percent: 100,
+              always_market_price: true,
+              tokens: [0],
+              shares: [100],
+              max_ownership_percent: 100,
+              type: 'minor',
+              coordinates: 'F7',
+              color: '#772282',
+            },
+            {
+              sym: 'N',
+              name: 'Nikolaev Railway',
+              logo: '1861/N',
+              simple_logo: '1861/N.alt',
+              float_percent: 100,
+              always_market_price: true,
+              tokens: [0],
+              shares: [100],
+              max_ownership_percent: 100,
+              type: 'minor',
+              coordinates: MOSCOW_HEX,
+              city: 1,
+              color: '#d30869',
+            },
+            {
+              sym: 'MK',
+              name: 'Moscow-Kursk Railway',
+              logo: '1861/M-K',
+              simple_logo: '1861/M-K.alt',
+              float_percent: 100,
+              always_market_price: true,
+              tokens: [0],
+              shares: [100],
+              max_ownership_percent: 100,
+              type: 'minor',
+              coordinates: MOSCOW_HEX,
+              city: 0,
+              color: '#d75500',
+            },
+            {
+              sym: 'MNN',
+              name: 'Moscow-Nizhnii Novgorod',
+              logo: '1861/MNN',
+              simple_logo: '1861/MNN.alt',
+              float_percent: 100,
+              always_market_price: true,
+              tokens: [0],
+              shares: [100],
+              max_ownership_percent: 100,
+              type: 'minor',
+              coordinates: MOSCOW_HEX,
+              city: 2,
+              color: '#ef4223',
+            },
+          ]
+        end
+
+        # DGN GFN PHX KKN SPX
+        def map_russia_game_corporations(corps)
+          corps.each_with_index do |c, idx|
+            c[:float_percent] = 20
+            c[:always_market_price] = true
+            c[:type] = 'major'
+            c[:coordinates] = [nil, nil, nil, nil, 'A6'][idx]
+            c[:city] = [nil, nil, nil, nil, 1][idx]
+            c[:type] = %w[major major major major national][idx]
+          end
+          find_corp(corps, 'SPX')[:tokens] = [0, 0, 0, 0, 0]
+          minors = map_russia_minor_corporations
+          minors.concat(corps)
+        end
+
+        def map_russia_game_cash
+          { 2 => 315, 3 => 210 }
+        end
+
+        def map_russia_game_cert_limit
+          { 2 => 16, 3 => 11 }
+        end
+
+        def map_russia_game_capitalization
+          :incremental
+        end
+
+        def map_russia_game_market
+          self.class::MARKET_1D
+        end
+
+        def map_russia_game_trains(trains)
+          # don't use D trains
+          trains.delete(find_train(trains, 'D'))
+          find_train(trains, '4')[:rusts_on] = '8'
+          # udpate
+          find_train(trains, '2')[:num] = 6
+          find_train(trains, '2')[:distance] = [{ 'nodes' => %w[city offboard town], 'pay' => 2, 'visit' => 2 },
+                                                { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }]
+          find_train(trains, '3')[:num] = 5
+          find_train(trains, '3')[:distance] = [{ 'nodes' => %w[city offboard town], 'pay' => 3, 'visit' => 3 },
+                                                { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }]
+          find_train(trains, '4')[:num] = 2
+          find_train(trains, '4')[:distance] = [{ 'nodes' => %w[city offboard town], 'pay' => 4, 'visit' => 4 },
+                                                { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }]
+          find_train(trains, '5')[:num] = 2
+          find_train(trains, '5')[:distance] = [{ 'nodes' => %w[city offboard town], 'pay' => 5, 'visit' => 5 },
+                                                { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }]
+          find_train(trains, '6')[:num] = 2
+          find_train(trains, '6')[:distance] = [{ 'nodes' => %w[city offboard town], 'pay' => 6, 'visit' => 6 },
+                                                { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }]
+          find_train(trains, '8')[:num] = 10
+          find_train(trains, '8')[:events] = [{ 'type' => 'close_companies' }]
+          find_train(trains, '8')[:distance] = [{ 'nodes' => %w[city offboard town], 'pay' => 8, 'visit' => 8 },
+                                                { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }]
+          trains
+        end
+
+        def map_russia_game_phases
+          [
+            {
+              name: '2',
+              train_limit: { minor: 2 },
+              tiles: [:yellow],
+              operating_rounds: 2,
+            },
+            {
+              name: '3',
+              on: '3',
+              train_limit: { minor: 2, major: 4 },
+              tiles: %i[yellow green],
+              operating_rounds: 2,
+              status: %w[can_buy_companies can_merge],
+            },
+            {
+              name: '4',
+              on: '4',
+              train_limit: { minor: 1, major: 3 },
+              tiles: %i[yellow green],
+              operating_rounds: 2,
+              status: %w[can_buy_companies can_merge can_start_major],
+            },
+            {
+              name: '5',
+              on: '5',
+              train_limit: { minor: 1, major: 3 },
+              tiles: %i[yellow green brown],
+              operating_rounds: 2,
+              status: %w[can_buy_companies can_merge can_start_major],
+            },
+            {
+              name: '6',
+              on: '6',
+              train_limit: { minor: 1, major: 2 },
+              tiles: %i[yellow green brown],
+              operating_rounds: 2,
+              status: %w[can_buy_companies can_merge can_start_major],
+            },
+            {
+              name: '8',
+              on: '8',
+              train_limit: { minor: 0, major: 2 },
+              tiles: %i[yellow green brown gray],
+              status: %w[can_merge can_start_major],
+              operating_rounds: 2,
+            },
+          ]
+        end
+
+        def map_russia_constants
+          redef_const(:CURRENCY_FORMAT_STR, '%s₽')
+          redef_const(:HOME_TOKEN_TIMING, :par)
+          redef_const(:HOME_TOKEN_TIMING, :par)
+          redef_const(:STATUS_TEXT,
+                      {
+                        'can_buy_companies' =>
+                        ['Can Buy Companies', 'All corporations can buy companies from players'],
+                        'can_merge' =>
+                        ['Can Merge/Convert Minors',
+                         'May form a major corporation by converting a minor or merging two connected minors'],
+                        'can_start_major' =>
+                        ['Can Start a Major', 'May start a major corporation directly'],
+                      })
+          redef_const(:GAME_END_CHECK, { final_phase: :one_more_full_or_set })
+        end
+
+        def map_russia_init_round
+          Engine::Round::Auction.new(self, [
+            GSystem18::Step::ConsecutiveAuction,
+          ])
+        end
+
+        def map_russia_stock_steps
+          [
+            Engine::Step::DiscardTrain,
+            Engine::Step::Exchange,
+            Engine::Step::SpecialTrack,
+            GSystem18::Step::HomeToken,
+            GSystem18::Step::BuySellParBidMerge,
+          ]
+        end
+
+        def map_russia_setup
+          # place sphinx home token
+          spx = corporation_by_id('SPX')
+          hex = hex_by_id(spx.coordinates)
+          tile = hex.tile
+          cities = tile.cities
+          city = cities.find { |c| c.reserved_by?(spx) } || cities.first
+          token = spx.find_token_by_type
+          @log << "#{spx.name} places a token on #{hex.name}"
+          city.place_token(spx, token)
+        end
+
+        def map_russia_home_token_locations(corporation)
+          return [] unless corporation.type == :major
+
+          # find hexes with open slots
+          hexes.select do |hex|
+            hex.tile.cities.any? { |c| c.tokenable?(corporation, free: true) }
+          end
+        end
+
+        def map_russia_check_other(route)
+          if route.visited_stops.count { |s| s.hex.id == MOSCOW_HEX } > 1
+            raise GameError, 'Cannot visit Moscow more than once with the same train'
+          end
+          if route.visited_stops.count { |s| s.hex.id == KIEV_HEX } > 1
+            raise GameError, 'Cannot visit Moscow more than once with the same train'
+          end
+          return unless route.visited_stops.count { |s| s.hex.id == ST_PETERSBERG_HEX } > 1
+
+          raise GameError, 'Cannot visit St Petersberg more than once with the same train'
+        end
+
+        def map_russia_bonuses(route, stops)
+          extra = 0
+          route.corporation.companies.each do |company|
+            abilities(company, :hex_bonus) do |ability|
+              extra += stops.map { |s| s.hex.id }.uniq&.sum { |id| ability.hexes.include?(id) ? ability.amount : 0 }
+            end
+          end
+
+          extra
+        end
+
+        def map_russia_extra_revenue_for(route, stops)
+          map_russia_bonuses(route, stops)
+        end
+
+        def map_russia_extra_revenue_str(route)
+          bonus = map_russia_bonuses(route, route.stops)
+          bonus.zero? ? '' : ' + Moscow'
+        end
+
+        def map_russia_must_buy_train?(_entity)
+          false
+        end
+
+        def map_russia_no_trains(entity)
+          nationalize(entity, corporation_by_id(NATIONAL_CORP))
+        end
+
+        def map_russia_or_round_finished
+          depot.export! if phase.name.to_i < 8
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_system18/map_twisting_tracks_customization.rb
+++ b/lib/engine/game/g_system18/map_twisting_tracks_customization.rb
@@ -150,10 +150,6 @@ module Engine
           }
         end
 
-        def map_twisting_tracks_game_companies
-          []
-        end
-
         # DGN GFN PHX KKN SPX
         def map_twisting_tracks_game_corporations(corps)
           corps.each_with_index do |c, idx|

--- a/lib/engine/game/g_system18/map_uk_limited_customization.rb
+++ b/lib/engine/game/g_system18/map_uk_limited_customization.rb
@@ -72,10 +72,6 @@ module Engine
         end
         # rubocop:enable Layout/LineLength
 
-        def map_uk_limited_game_companies
-          []
-        end
-
         # DGN GFN PHX KKN SPX
         def map_uk_limited_game_corporations(corps)
           corps.each_with_index do |c, idx|

--- a/lib/engine/game/g_system18/meta.rb
+++ b/lib/engine/game/g_system18/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :alpha
+        DEV_STAGE = :beta
         PROTOTYPE = true
 
         GAME_DESIGNER = 'Scott Petersen'
@@ -92,11 +92,17 @@ module Engine
             players: [2, 3, 4],
             designer: 'Ian Wilson',
           },
+          {
+            sym: :map_Russia,
+            short_name: 'Map: Russia',
+            players: [2, 3],
+            designer: 'Ian Wilson',
+          },
         ].freeze
 
         MUTEX_RULES = [
           %i[map_NEUS map_France map_Twisting_Tracks map_UK_Limited map_China_Rapid_Development map_Poland map_Britain
-             map_Britain_N map_Britain_S map_Northern_Italy map_MS map_Scotland],
+             map_Britain_N map_Britain_S map_Northern_Italy map_MS map_Scotland map_Russia],
         ].freeze
       end
     end

--- a/lib/engine/game/g_system18/step/buy_sell_par_bid_merge.rb
+++ b/lib/engine/game/g_system18/step/buy_sell_par_bid_merge.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares_via_bid'
+
+module Engine
+  module Game
+    module GSystem18
+      module Step
+        class BuySellParBidMerge < Engine::Step::BuySellParSharesViaBid
+          # currently this is very specific to the Russia map (and cohorts)
+          MIN_BID = 100
+          MERGE_PHASE = 3
+          MAJOR_PHASE = 4
+          PURCHASE_ACTIONS = [Action::BuyCompany, Action::BuyShares, Action::Par, Action::Choose].freeze
+
+          def actions(entity)
+            return corporation_actions(entity) if entity.corporation?
+            return [] unless entity == current_entity
+            return %w[bid pass] if @auctioning
+
+            actions = []
+            actions << 'choose' if can_convert_any?(entity) || can_merge_any?(entity)
+            actions.concat(super)
+            actions << 'pass' if !actions.empty? && !actions.include?('pass')
+
+            actions
+          end
+
+          def setup
+            super
+            @chosen_corporation = nil
+          end
+
+          def win_bid(winner, _company)
+            entity = winner.entity
+            corporation = winner.corporation
+            price = winner.price
+
+            @log << "#{entity.name} wins bid on #{corporation.name} for #{@game.format_currency(price)}"
+            par_price = price / 2
+
+            share_price = get_all_par_prices(corporation).find { |sp| sp.price <= par_price }
+
+            # Temporarily give the entity cash to buy the corporation PAR shares
+            @game.bank.spend(share_price.price * 2, entity)
+
+            action = Action::Par.new(entity, corporation: corporation, share_price: share_price)
+            process_par(action)
+
+            # Clear the corporation of 'share' cash grabbed earlier.
+            corporation.spend(corporation.cash, @game.bank)
+
+            # Then move the full amount.
+            entity.spend(price, corporation)
+
+            @auctioning = nil
+
+            # Player to the right of the winner is the new player
+            @round.goto_entity!(winner.entity)
+            pass!
+          end
+
+          def can_bid_any?(entity)
+            max_bid(entity) >= MIN_BID && !bought? &&
+            @game.corporations.any? do |c|
+              @game.can_par?(c, entity) && c.type == :minor && can_buy?(entity, c.shares.first&.to_bundle)
+            end
+          end
+
+          def can_ipo_any?(entity)
+            @game.phase.name.to_i >= MAJOR_PHASE && !bought? &&
+            @game.corporations.any? do |c|
+              @game.can_par?(c, entity) && c.type == :major && can_buy?(entity, c.shares.first&.to_bundle)
+            end
+          end
+
+          def get_all_par_prices(_corp)
+            # minors and majors can start at the same values
+            @game.stock_market.share_prices_with_types(%i[par])
+          end
+
+          def ipo_type(entity)
+            # Major's are par, minors are bid
+            phase = @game.phase.name.to_i
+            case entity.type
+            when :major
+              if phase >= MAJOR_PHASE
+                if @game.home_token_locations(entity).empty?
+                  'No home token locations are available'
+                else
+                  :par
+                end
+              else
+                "Cannot start till phase #{MAJOR_PHASE}"
+              end
+            when :national
+              'Cannot start'
+            else
+              :bid
+            end
+          end
+
+          def can_convert?(minor)
+            (minor.owner == current_entity) && (minor.type == :minor) &&
+              minor.floated? && !bought?
+          end
+
+          def can_convert_any?(_entity)
+            return false if @game.phase.name.to_i < MERGE_PHASE
+            return false if bought?
+
+            @game.corporations.any? { |corporation| can_convert?(corporation) }
+          end
+
+          def connected?(minor_a, minor_b)
+            # Mergeable candidates must be connected by track, minors only have one token which simplifies it
+            # (partially borrowed from 1867)
+            # FIXME: avoid graph by using destination_connection
+            parts = @game.graph.connected_nodes(minor_a).keys
+            parts.select(&:city?).any? { |c| c.tokens.compact.any? { |t| t.corporation == minor_b } }
+          end
+
+          def possible_mergers(owner)
+            possible = []
+            @game.corporations.select { |c| c.type == :minor && c.owner == owner }.combination(2) do |pair|
+              possible << pair if connected?(pair[0], pair[1])
+            end
+            possible
+          end
+
+          def can_merge_any?(_entity)
+            return false if @game.phase.name.to_i < MERGE_PHASE
+            return false if bought?
+
+            !possible_mergers(current_entity).empty?
+          end
+
+          def corporation_actions(corporation)
+            return [] unless choice_available?(corporation)
+
+            %w[choose pass]
+          end
+
+          def choice_available?(entity)
+            entity.corporation? && entity.type == :major &&
+              !entity.floated? &&
+              (can_convert_any?(entity) || can_merge_any?(entity))
+          end
+
+          def entity_choices(entity)
+            vals = @game.corporations.select { |c| c.owner == current_entity && c.type == :minor }.to_h do |minor|
+              ["#{entity.id}:#{minor.id}", "Convert #{minor.id}"]
+            end
+            possible_mergers(current_entity).each do |pair|
+              vals["#{entity.id}:#{pair[0].id}+#{pair[1].id}"] = "Merge #{pair[0].id} and #{pair[1].id}"
+            end
+            vals
+          end
+
+          def choice_name; end
+
+          def process_choose(action)
+            choice = action.choice
+            colon_index = choice.index(':')
+            plus_index = choice.index('+')
+            corp = @game.corporation_by_id(choice[0..colon_index - 1])
+
+            if plus_index
+              minor_a = @game.corporation_by_id(choice[colon_index + 1..plus_index - 1])
+              minor_b = @game.corporation_by_id(choice[plus_index + 1..-1])
+              @game.merge(current_entity, corp, minor_a, minor_b)
+            else
+              minor = @game.corporation_by_id(choice[colon_index + 1..-1])
+              @game.convert(current_entity, corp, minor)
+            end
+
+            track_action(action, corp)
+
+            @chosen_corporation = corp
+          end
+
+          def can_buy_multiple?(_entity, corporation, _owner)
+            return false unless @round.current_actions.any? { |x| x.is_a?(Action::Choose) }
+
+            corporation == @chosen_corporation &&
+            @round.current_actions.none? { |x| x.is_a?(Action::Par) } &&
+              @round.current_actions.none? { |x| x.is_a?(Action::BuyShares) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_system18/step/buy_train.rb
+++ b/lib/engine/game/g_system18/step/buy_train.rb
@@ -20,6 +20,13 @@ module Engine
 
           def skip!
             @round.receivership_train_buy(self, :process_buy_train)
+            @game.no_trains(current_entity) if current_entity.trains.empty? && !current_entity.receivership?
+            super
+          end
+
+          def process_pass(action)
+            @game.no_trains(action.entity) if action.entity.trains.empty?
+            super
           end
 
           def process_sell_shares(action)

--- a/lib/engine/game/g_system18/step/consecutive_auction.rb
+++ b/lib/engine/game/g_system18/step/consecutive_auction.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+require_relative 'upwards_auction'
+
+module Engine
+  module Game
+    module GSystem18
+      module Step
+        class ConsecutiveAuction < GSystem18::Step::UpwardsAuction
+          def available
+            [@companies.first]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_system18/step/dividend.rb
+++ b/lib/engine/game/g_system18/step/dividend.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../../step/dividend'
+require_relative 'minor_half_pay'
 
 module Engine
   module Game
@@ -10,6 +11,7 @@ module Engine
           DIVIDEND_TYPES = %i[payout half withhold].freeze
           SIMPLE_DIVIDEND_TYPES = %i[payout withhold].freeze
           include Engine::Step::HalfPay
+          include GSystem18::Step::MinorHalfPay
 
           def share_price_change(entity, revenue = 0)
             return super if @game.share_price_change_for_dividend_as_full_cap_by_map?

--- a/lib/engine/game/g_system18/step/home_token.rb
+++ b/lib/engine/game/g_system18/step/home_token.rb
@@ -7,19 +7,34 @@ module Engine
     module GSystem18
       module Step
         class HomeToken < Engine::Step::HomeToken
+          def description
+            super unless @game.merging
+
+            'Place Token'
+          end
+
           def process_place_token(action)
             corporation = action.entity
+
+            if @game.merging && action.city != @game.merge_a_city && action.city != @game.merge_b_city
+              raise GameError, 'Must select one of two cities originally tokened'
+            end
+
             super
 
             # after placing token in chosen hex, must remove reservation in other hex
-            @game.hexes.each do |hex|
-              hex.tile.cities.each do |city|
-                if city.reserved_by?(corporation)
-                  city.reservations.delete(corporation)
-                  @log << "Removing unused reservation for #{corporation.name} in #{hex.id}"
+            if @game.class::REMOVE_UNUSED_RESERVATIONS
+              @game.hexes.each do |hex|
+                hex.tile.cities.each do |city|
+                  if city.reserved_by?(corporation)
+                    city.reservations.delete(corporation)
+                    @log << "Removing unused reservation for #{corporation.name} in #{hex.id}"
+                  end
                 end
               end
             end
+
+            @game.finish_merge if @round.pending_tokens.empty? && @game.merging
           end
         end
       end

--- a/lib/engine/game/g_system18/step/minor_half_pay.rb
+++ b/lib/engine/game/g_system18/step/minor_half_pay.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module GSystem18
+      module Step
+        module MinorHalfPay
+          def actions(entity)
+            return [] if entity.minor?
+            return [] if entity.corporation? && entity.type == :minor
+
+            super
+          end
+
+          def skip!
+            return super if current_entity.corporation? && current_entity.type != :minor
+
+            revenue = @game.routes_revenue(routes)
+            process_dividend(Action::Dividend.new(
+              current_entity,
+              kind: revenue.positive? ? 'payout' : 'withhold',
+            ))
+          end
+
+          def share_price_change(entity, revenue = 0)
+            return super if current_entity.corporation? && current_entity.type != :minor
+
+            price = entity.share_price.price
+            LOGGER.debug { "minor - price: #{price}, revenue: #{revenue}" }
+
+            # minors are limited to one jump to the right
+            if revenue.zero?
+              { share_direction: :left, share_times: 1 }
+            elsif revenue >= price
+              { share_direction: :right, share_times: 1 }
+            else
+              {}
+            end
+          end
+
+          def payout(entity, revenue)
+            return super if entity.corporation? && entity.type != :minor
+
+            amount = revenue / 2
+            { corporation: amount, per_share: amount }
+          end
+
+          def payout_shares(entity, revenue)
+            return super if entity.corporation? && entity.type != :minor
+
+            @log << "#{entity.owner.name} receives #{@game.format_currency(revenue)}"
+            @game.bank.spend(revenue, entity.owner)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_system18/step/order_auction.rb
+++ b/lib/engine/game/g_system18/step/order_auction.rb
@@ -7,13 +7,9 @@ module Engine
   module Game
     module GSystem18
       module Step
-        class OrderAuction < GSystem18::Step::UpwardsAuction
+        class OrderAuction < GSystem18::Step::ConsecutiveAuction
           def description
             'Bid on Initial Player Order'
-          end
-
-          def available
-            [@companies.first]
           end
 
           def initial_auction_entities

--- a/lib/engine/game/g_system18/step/upwards_auction.rb
+++ b/lib/engine/game/g_system18/step/upwards_auction.rb
@@ -77,7 +77,6 @@ module Engine
           def setup
             setup_auction
             @companies = @game.companies.reject(&:closed?).sort_by(&:value)
-            # setup_tiered_auction
           end
 
           def starting_bid(company)
@@ -137,6 +136,14 @@ module Engine
 
             all_pass_next_entity
 
+            discount_company
+          end
+
+          def all_pass_next_entity
+            @round.next_entity_index!
+          end
+
+          def discount_company
             # if any privates still left, reduce price and start over
             company = @companies.first
             company.discount += PRICE_DROP
@@ -153,10 +160,6 @@ module Engine
               @log << "#{company.name} price reduced to #{@game.format_currency(company.min_bid)}"
               post_price_reduction(company)
             end
-          end
-
-          def all_pass_next_entity
-            @round.next_entity_index!
           end
 
           def post_price_reduction(_company)


### PR DESCRIPTION
I don't think this will require additional pinning

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Add Russia map and rules to System18
Move System18 to Beta
Move incremental cap games to `SELL_AFTER = :first`
Add more general support for game-specific stock rounds and/or steps
Add support for minors
Simplify maps w/o privates


### Screenshots

### Any Assumptions / Hacks
