### PR TITLE
[1862] Initial commit to add solo variant to 1862 (EA)

### DIFF
--- a/lib/engine/game/g_1862/meta.rb
+++ b/lib/engine/game/g_1862/meta.rb
@@ -35,6 +35,15 @@ module Engine
             desc: 'Use increased train numbers in train roster',
           },
         ].freeze
+
+        GAME_VARIANTS = [
+          {
+            sym: :solo,
+            name: 'Solo',
+            title: '1862 Solo',
+            desc: 'Solo variant',
+          },
+        ].freeze
       end
     end
   end

--- a/lib/engine/game/g_1862_solo.rb
+++ b/lib/engine/game/g_1862_solo.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1862Solo
+    end
+  end
+end

--- a/lib/engine/game/g_1862_solo/corporation.rb
+++ b/lib/engine/game/g_1862_solo/corporation.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../../corporation'
+
+module Engine
+  module Game
+    module G1862Solo
+      class Corporation < Engine::Corporation
+        def total_shares
+          7
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_solo/game.rb
+++ b/lib/engine/game/g_1862_solo/game.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../g_1862/game'
+require_relative 'meta'
+
+module Engine
+  module Game
+    module G1862Solo
+      class Game < G1862::Game
+        include_meta(G1862Solo::Meta)
+        CERT_LIMIT = {
+          1 => 25,
+        }.freeze
+
+        STARTING_CASH = {
+          1 => 1200,
+        }.freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_solo/game.rb
+++ b/lib/engine/game/g_1862_solo/game.rb
@@ -64,7 +64,7 @@ module Engine
           Company.new(
             sym: share.id,
             name: share.corporation.name,
-            value: 0, #share.price,
+            value: 0,
             desc: description,
             type: :share,
             color: share.corporation.color,
@@ -77,19 +77,19 @@ module Engine
 
         def deal_deck_to_ipo(deck)
           all_rows_indexes.each do |row|
-            @ipo_rows[row] = deck.pop(6)  # 6 shares per row
+            @ipo_rows[row] = deck.pop(6) # 6 shares per row
           end
         end
 
         def game_tiles
           TILES.dup.merge!({
-                            'X' =>
-                                {
-                                  'count' => 4,
-                                  'color' => 'brown',
-                                  'code' => '',
-                                },
-                          })
+                             'X' =>
+                                 {
+                                   'count' => 4,
+                                   'color' => 'brown',
+                                   'code' => '',
+                                 },
+                           })
         end
 
         # 1862 solo does not have any parliament rounds
@@ -125,7 +125,7 @@ module Engine
           @round_counter += 1
           stock_round
         end
-        
+
         def stock_round
           G1862::Round::Stock.new(self, [
             G1862::Step::BuyTokens,
@@ -158,7 +158,7 @@ module Engine
           []
         end
 
-        def init_corporations(stock_market)
+        def init_corporations(_stock_market)
           self.class::CORPORATIONS.map do |corporation|
             corporation[:float_percent] = 30
             corporation[:shares] = [10, 10, 10, 10, 10, 10, 10]
@@ -181,7 +181,7 @@ module Engine
           true
         end
 
-        def company_revenue_str(company)
+        def company_revenue_str(_company)
           '0'
         end
 
@@ -200,7 +200,7 @@ module Engine
         def ipo_timeline(index)
           row = @ipo_rows[index]
           row.map do |company|
-            "#{company.name}"
+            company.name.to_s
           end
         end
 

--- a/lib/engine/game/g_1862_solo/game.rb
+++ b/lib/engine/game/g_1862_solo/game.rb
@@ -8,13 +8,80 @@ module Engine
     module G1862Solo
       class Game < G1862::Game
         include_meta(G1862Solo::Meta)
+
+        # No cert limit
         CERT_LIMIT = {
-          1 => 25,
+          1 => 999,
         }.freeze
 
         STARTING_CASH = {
-          1 => 1200,
+          1 => 600,
         }.freeze
+
+        # No cert limit
+        def show_game_cert_limit?
+          false
+        end
+
+        def setup_preround
+          @original_corporations = @corporations.dup
+
+          super
+
+          @original_corporations.reject { |c| @corporations.include?(c) }.each do |c|
+            hex = @hexes.find { |h| h.id == c.coordinates } # hex_by_id doesn't work here
+            old_tile = hex.tile
+            tile_string = ''
+            hex.tile = Tile.from_code(old_tile.name, 'brown', tile_string)
+          end
+        end
+
+        def game_tiles
+          TILES.dup.merge!({
+                            'X' =>
+                                {
+                                  'count' => 4,
+                                  'color' => 'brown',
+                                  'code' => '',
+                                },
+                          })
+        end
+
+        def next_round!
+          @skip_round.clear
+          @round =
+            case @round
+            when Engine::Round::Stock
+              @operating_rounds = @phase.operating_rounds
+              reorder_players
+              new_operating_round
+            when Engine::Round::Operating
+              if @round.round_num < @operating_rounds
+                or_round_finished
+                new_operating_round(@round.round_num + 1)
+              else
+                @turn += 1
+                or_round_finished
+                or_set_finished
+                if @lner_triggered
+                  @lner_triggered = false
+                  form_lner
+                  new_stock_round
+                else
+                  new_parliament_round
+                end
+              end
+            else
+              raise "round class #{@round.class} not handled"
+            end
+        end
+
+        def init_round
+          @log << "-- #{round_description('Stock', 1)} --"
+          @round_counter += 1
+          stock_round
+        end
+        
       end
     end
   end

--- a/lib/engine/game/g_1862_solo/game.rb
+++ b/lib/engine/game/g_1862_solo/game.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../g_1862/game'
+require_relative 'corporation'
 require_relative 'meta'
 
 module Engine
@@ -8,6 +9,8 @@ module Engine
     module G1862Solo
       class Game < G1862::Game
         include_meta(G1862Solo::Meta)
+
+        attr_reader :ipo_rows
 
         # No cert limit
         CERT_LIMIT = {
@@ -33,6 +36,46 @@ module Engine
             old_tile = hex.tile
             tile_string = ''
             hex.tile = Tile.from_code(old_tile.name, 'brown', tile_string)
+          end
+
+          # Build draw and draft decks for player hand and IPO rows
+          @ipo_rows = [[], [], [], [], [], [], [], [], []]
+          create_decks(@corporations)
+        end
+
+        def create_decks(corporations)
+          draw_deck = []
+
+          corporations.each do |corporation|
+            corporation.ipo_shares.each do |share|
+              draw_deck << convert_share_to_company(share)
+            end
+          end
+
+          draw_deck.sort_by! { rand }
+          deal_deck_to_ipo(draw_deck)
+        end
+
+        # create a placeholder 'company' for shares in IPO
+        def convert_share_to_company(share)
+          description = "Certificate for #{share.percent}\% of #{share.corporation.full_name}."
+          Company.new(
+            sym: share.id,
+            name: share.corporation.name,
+            value: 0, #share.price,
+            desc: description,
+            type: :share,
+            color: share.corporation.color,
+            text_color: share.corporation.text_color,
+            # reference to share in treasury
+            treasury: share,
+            revenue: nil,
+          )
+        end
+
+        def deal_deck_to_ipo(deck)
+          all_rows_indexes.each do |row|
+            @ipo_rows[row] = deck.pop(6)  # 6 shares per row
           end
         end
 
@@ -82,6 +125,77 @@ module Engine
           stock_round
         end
         
+        def show_ipo_rows?
+          true
+        end
+
+        def in_ipo?(company)
+          @ipo_rows.flatten.include?(company)
+        end
+
+        def ipo_row_and_index(company)
+          all_rows_indexes.each do |row|
+            index = @ipo_rows[row].index(company)
+            return [row, index] if index
+          end
+          nil
+        end
+
+        def ipo_remove(row, company)
+          @ipo_rows[row].delete(company)
+        end
+
+        def init_corporations(stock_market)
+          self.class::CORPORATIONS.map do |corporation|
+            corporation[:float_percent] = 30
+            corporation[:shares] = [10, 10, 10, 10, 10, 10, 10]
+            corporation[:max_ownership_percent] = 70
+            corporation[:min_price] = 1
+            initiated_corp = G1862Solo::Corporation.new(
+              **corporation.merge(corporation_opts),
+            )
+            initiated_corp.forced_share_percent = 10
+            initiated_corp
+          end
+        end
+
+        # So that value is not shown on company cards representing shares
+        def company_value(_company)
+          0
+        end
+
+        def show_value_of_companies?(_owner)
+          true
+        end
+
+        def company_revenue_str(company)
+          '0'
+        end
+
+        # Timeline information for INFO tab
+        def timeline
+          timeline = []
+
+          all_rows_indexes.each do |i|
+            ipo_row_i = ipo_timeline(i)
+            timeline << "IPO ROW #{i + 1}: #{ipo_row_i.join(', ')}" unless ipo_row_i.empty?
+          end
+
+          timeline
+        end
+
+        def ipo_timeline(index)
+          row = @ipo_rows[index]
+          row.map do |company|
+            "#{company.name}"
+          end
+        end
+
+        private
+
+        def all_rows_indexes
+          (0..8)
+        end
       end
     end
   end

--- a/lib/engine/game/g_1862_solo/meta.rb
+++ b/lib/engine/game/g_1862_solo/meta.rb
@@ -14,6 +14,7 @@ module Engine
 
         DEV_STAGE = :prealpha
 
+        GAME_IS_VARIANT_OF = G1862::Meta
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1862'.freeze
         GAME_TITLE = '1862 Solo'.freeze
 

--- a/lib/engine/game/g_1862_solo/meta.rb
+++ b/lib/engine/game/g_1862_solo/meta.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../meta'
+require_relative '../g_1862/meta'
+
+module Engine
+  module Game
+    module G1862Solo
+      module Meta
+        include Game::Meta
+        include G1862::Meta
+
+        DEPENDS_ON = '1862'
+
+        DEV_STAGE = :prealpha
+
+        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1862'.freeze
+        GAME_TITLE = '1862 Solo'.freeze
+
+        PLAYER_RANGE = [1, 1].freeze
+        OPTIONAL_RULES = [].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_solo/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1862_solo/step/buy_sell_par_shares.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares'
+
+module Engine
+  module Game
+    module G1862Solo
+      module Step
+        class BuySellParShares < Engine::Step::BuySellParShares
+          ACTIONS = %w[buy_company pass].freeze
+          UNCHARTERED_TOKEN_COST = 40
+
+          def actions(entity)
+            return [] unless entity == current_entity
+
+            actions = ACTIONS.dup
+            actions << 'sell_shares' if can_sell_any?(entity)
+            actions
+          end
+
+          # Shares only bought as companies
+          def visible_corporations
+            []
+          end
+
+          # Shares should not appear in market
+          def can_buy?(entity, bundle)
+            true
+          end
+
+          # Shares only bought as companies
+          def can_buy_any?(entity)
+            true
+          end
+
+          # Shares only bought as companies
+          def can_ipo_any?(entity)
+            false
+          end
+
+          def pool_shares(_)
+            []
+          end
+
+          def purchasable_companies(_)
+            []
+          end
+
+          def can_buy_company?(player, company)
+            result = @game.ipo_rows.flatten.include?(company) && available_cash(player) >= company.value
+            puts "Can #{player.name} buy #{company.name}? #{result}, included? #{@game.buyable_bank_owned_companies.include?(company)}, available cash? #{available_cash(player) >= company.value}, company value? #{company.value}"
+            result
+          end
+
+          def process_par(action)
+            corporation = action.corporation
+            @game.convert_to_incremental!(corporation)
+            corporation.tokens.pop # 3 -> 2
+            raise GameError, 'Wrong number of tokens for Unchartered Company' if corporation.tokens.size != 2
+
+            super
+          end
+
+          def get_par_prices(entity, _corp)
+            @game.repar_prices.select { |p| p.price * 3 <= entity.cash }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_solo/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1862_solo/step/buy_sell_par_shares.rb
@@ -8,7 +8,6 @@ module Engine
       module Step
         class BuySellParShares < Engine::Step::BuySellParShares
           ACTIONS = %w[buy_company pass].freeze
-          UNCHARTERED_TOKEN_COST = 40
 
           def actions(entity)
             return [] unless entity == current_entity
@@ -23,42 +22,8 @@ module Engine
             []
           end
 
-          # Shares should not appear in market
-          def can_buy?(entity, bundle)
-            true
-          end
-
-          # Shares only bought as companies
-          def can_buy_any?(entity)
-            true
-          end
-
-          # Shares only bought as companies
-          def can_ipo_any?(entity)
-            false
-          end
-
-          def pool_shares(_)
-            []
-          end
-
-          def purchasable_companies(_)
-            []
-          end
-
           def can_buy_company?(player, company)
-            result = @game.ipo_rows.flatten.include?(company) && available_cash(player) >= company.value
-            puts "Can #{player.name} buy #{company.name}? #{result}, included? #{@game.buyable_bank_owned_companies.include?(company)}, available cash? #{available_cash(player) >= company.value}, company value? #{company.value}"
-            result
-          end
-
-          def process_par(action)
-            corporation = action.corporation
-            @game.convert_to_incremental!(corporation)
-            corporation.tokens.pop # 3 -> 2
-            raise GameError, 'Wrong number of tokens for Unchartered Company' if corporation.tokens.size != 2
-
-            super
+            @game.ipo_rows.flatten.include?(company) && available_cash(player) >= company.value
           end
 
           def get_par_prices(entity, _corp)

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -310,7 +310,9 @@ module Engine
       end
 
       def can_buy_company?(player, company)
-        @game.buyable_bank_owned_companies.include?(company) && available_cash(player) >= company.value
+        result = @game.buyable_bank_owned_companies.include?(company) && available_cash(player) >= company.value
+        puts "Can #{player.name} buy #{company.name}? #{result}, included? #{@game.buyable_bank_owned_companies.include?(company)}, available cash? #{available_cash(player) >= company.value}, company value? #{company.value}"
+        result
       end
 
       def get_par_prices(entity, _corp)

--- a/lib/engine/step/buy_sell_par_shares.rb
+++ b/lib/engine/step/buy_sell_par_shares.rb
@@ -310,9 +310,7 @@ module Engine
       end
 
       def can_buy_company?(player, company)
-        result = @game.buyable_bank_owned_companies.include?(company) && available_cash(player) >= company.value
-        puts "Can #{player.name} buy #{company.name}? #{result}, included? #{@game.buyable_bank_owned_companies.include?(company)}, available cash? #{available_cash(player) >= company.value}, company value? #{company.value}"
-        result
+        @game.buyable_bank_owned_companies.include?(company) && available_cash(player) >= company.value
       end
 
       def get_par_prices(entity, _corp)


### PR DESCRIPTION
This is a commit that adds the solo variant to 1862 as prealpha. It should not affect existing implementation of 1862.

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

This is an initial commit that just do some setup, and display IPO rows in SR. It is based on 1862 base game.

It is far from playable, so it is in prealpha.

Have not added permits a la 1862 solo yet (6 permits - 2 of each - are used, and corporation gets the first one when it is parred). Instead the base 1862 mechanism is used.

My idea is to continue with SR work to get that to work, before I make the next PR. But it requires some architectural decisions how to handle the SR actions specific to 1862 Solo before I can continue.

### Explanation of Change

Initial commit.

### Screenshots

Stock Market:
<img width="2550" height="1864" alt="image" src="https://github.com/user-attachments/assets/76affd84-af2e-4b92-93dc-4c751afc2e5f" />

Timeline about IPO rows:
<img width="663" height="475" alt="image" src="https://github.com/user-attachments/assets/632977ae-f875-476b-9286-a88c6b667a60" />

Entities view:
<img width="2886" height="1784" alt="image" src="https://github.com/user-attachments/assets/f032fe9c-f5a0-4f4d-b9ca-b79eade38880" />

### Any Assumptions / Hacks

None