### PR TITLE
[1824] Add missing HomeToken step, fixes #12007

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -272,8 +272,8 @@ module Engine
 
         def stock_round
           Engine::Round::Stock.new(self, [
-            G1824::Step::DiscardTrain,
             G1824::Step::KkTokenChoice, # In case train export triggers KK formation
+            G1824::Step::DiscardTrain,
             G1824::Step::ForcedMountainRailwayExchange, # In case train export after OR set triggers exchage
             G1824::Step::BuySellParExchangeShares,
           ])
@@ -281,8 +281,9 @@ module Engine
 
         def operating_round(round_num)
           Engine::Round::Operating.new(self, [
-            G1837::Step::Bankrupt,
             G1824::Step::KkTokenChoice,
+            Engine::Step::HomeToken,
+            G1837::Step::Bankrupt,
             G1824::Step::DiscardTrain,
             Engine::Step::SpecialTrack,
             G1824::Step::Track,

--- a/lib/engine/game/g_1824_cisleithania/game.rb
+++ b/lib/engine/game/g_1824_cisleithania/game.rb
@@ -188,8 +188,8 @@ module Engine
 
         def stock_round
           Engine::Round::Stock.new(self, [
-            G1824::Step::DiscardTrain,
             G1824::Step::KkTokenChoice, # In case train export triggers KK formation
+            G1824::Step::DiscardTrain,
             G1824::Step::ForcedMountainRailwayExchange, # In case train export after OR set triggers exchage
             G1824Cisleithania::Step::BuySellParExchangeShares,
           ])
@@ -199,6 +199,7 @@ module Engine
           Engine::Round::Operating.new(self, [
             G1837::Step::Bankrupt,
             G1824::Step::KkTokenChoice,
+            Engine::Step::HomeToken,
             G1824::Step::DiscardTrain,
             G1824Cisleithania::Step::BondToken,
             Engine::Step::SpecialTrack,


### PR DESCRIPTION
Could cause initial operating to fail for Staatsbahn that form between ORs.

Fixes #12007

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

I think this should not cause any game to fail, rather it will fix games that has gotten stuck on the error.

## Implementation Notes

HomeToken step was missing, which ment that pending_tokens was not defined.
Unclear why this works sometimes?

### Explanation of Change
See Implementation notes.

### Screenshots
N/A

### Any Assumptions / Hacks
N/A