### PR TITLE
[core] don't render prealpha game variants in production

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -257,6 +257,8 @@ module View
         update_player_range(variant[:meta])
 
         stage = variant[:meta]::DEV_STAGE
+        next if stage == :prealpha && @production
+
         stage_str = stage == :production ? '' : "(#{stage}) "
 
         desc_text = variant[:desc] ? ": #{variant[:desc]}" : ''
@@ -269,7 +271,7 @@ module View
           attrs: { value: sym, checked: @selected_variant == variant },
           on: { input: toggle_game_variant(sym) },
         )])
-      end
+      end.compact
 
       optional_rules = selected_game_or_variant::OPTIONAL_RULES.map do |o_r|
         next if o_r[:hidden]


### PR DESCRIPTION
This will hide the 1862 "Solo" checkbox until it is alpha

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`