### PR TITLE
[1822] allow acquiring for two shares if major is in yellow

### DIFF
--- a/lib/engine/game/g_1822/step/minor_acquisition.rb
+++ b/lib/engine/game/g_1822/step/minor_acquisition.rb
@@ -294,7 +294,9 @@ module Engine
             end
 
             # The corporation have atleast two share, calculate if corp or player should receive/pay difference
-            if ipo_shares > 1 && @game.num_certs(minor.owner) < @game.cert_limit
+            if ipo_shares > 1 &&
+              (!entity.counts_for_limit ||
+               @game.num_certs(minor.owner) < @game.cert_limit)
               choice = pay_choice_str(entity, minor, 2)
               choices['two_shares'] = choice if choice
             end


### PR DESCRIPTION
Fixes #12018

Pins are theoretically possible, but I think unlikely to be needed.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`