### PR TITLE
[1822PNW scenarios] fix `TRAINS` and `PHASES`

### DIFF
--- a/lib/engine/game/g_1822_pnw/scenario.rb
+++ b/lib/engine/game/g_1822_pnw/scenario.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1822PNW
+      module Scenario
+        PHASES = [
+          {
+            name: '1',
+            on: '',
+            train_limit: { minor: 2, major: 4 },
+            tiles: [:yellow],
+            status: ['minor_float_phase1'],
+            operating_rounds: 1,
+          },
+          {
+            name: '2',
+            on: %w[2 3],
+            train_limit: { minor: 2, major: 4 },
+            tiles: [:yellow],
+            status: %w[minor_float_phase2 l_upgrade],
+            operating_rounds: 2,
+          },
+          {
+            name: '3',
+            on: '3',
+            train_limit: { minor: 2, major: 4 },
+            tiles: %i[yellow green],
+            status: %w[can_buy_trains minor_float_phase3on],
+            operating_rounds: 2,
+          },
+          {
+            name: '4',
+            on: '4',
+            train_limit: { minor: 1, major: 3 },
+            tiles: %i[yellow green],
+            status: %w[can_buy_trains minor_float_phase3on],
+            operating_rounds: 2,
+          },
+          {
+            name: '5',
+            on: '5',
+            train_limit: { minor: 1, major: 2 },
+            tiles: %i[yellow green brown],
+            status: %w[can_buy_trains
+                       can_acquire_minor_bidbox
+                       can_par
+                       minors_green_upgrade
+                       minor_float_phase3on],
+            operating_rounds: 2,
+          },
+          {
+            name: '6',
+            on: '6',
+            train_limit: { minor: 1, major: 2 },
+            tiles: %i[yellow green brown],
+            status: %w[can_buy_trains
+                       can_acquire_minor_bidbox
+                       can_par
+                       full_capitalisation
+                       minors_green_upgrade
+                       minor_float_phase3on],
+            operating_rounds: 2,
+          },
+          {
+            name: '7',
+            on: '7',
+            train_limit: { minor: 1, major: 2 },
+            tiles: %i[yellow green brown gray],
+            status: %w[can_buy_trains
+                       can_acquire_minor_bidbox
+                       can_par
+                       full_capitalisation
+                       minors_green_upgrade
+                       minor_float_phase3on],
+            operating_rounds: 2,
+          },
+        ].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1822_pnw_short/game.rb
+++ b/lib/engine/game/g_1822_pnw_short/game.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../g_1822_pnw/game'
-require_relative '../g_1822/scenario'
+require_relative '../g_1822_pnw/scenario'
 require_relative 'meta'
 require_relative 'trains'
 require_relative 'round/stock'
@@ -11,7 +11,7 @@ module Engine
     module G1822PnwShort
       class Game < G1822PNW::Game
         include_meta(G1822PnwShort::Meta)
-        include G1822::Scenario
+        include G1822PNW::Scenario
         include Trains
 
         attr_reader :paired_assoc, :paired_unassoc

--- a/lib/engine/game/g_1822_pnw_short/trains.rb
+++ b/lib/engine/game/g_1822_pnw_short/trains.rb
@@ -51,11 +51,7 @@ module Engine
             distance: 5,
             num: 2,
             price: 500,
-            events: [
-              {
-                'type' => 'close_concessions',
-              },
-            ],
+            events: [],
           },
           {
             name: '6',

--- a/lib/engine/game/g_1822_pnw_srs/game.rb
+++ b/lib/engine/game/g_1822_pnw_srs/game.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../g_1822_pnw/game'
-require_relative '../g_1822/scenario'
+require_relative '../g_1822_pnw/scenario'
 require_relative 'meta'
 require_relative 'trains'
 
@@ -10,7 +10,7 @@ module Engine
     module G1822PnwSrs
       class Game < G1822PNW::Game
         include_meta(G1822PnwSrs::Meta)
-        include G1822::Scenario
+        include G1822PNW::Scenario
         include Trains
 
         STARTING_COMPANIES = %w[P1 P2 P3 P5 P7 P9 P10 P11 P14 P15 P16 P18

--- a/lib/engine/game/g_1822_pnw_srs/trains.rb
+++ b/lib/engine/game/g_1822_pnw_srs/trains.rb
@@ -51,11 +51,7 @@ module Engine
             distance: 5,
             num: 1,
             price: 500,
-            events: [
-              {
-                'type' => 'close_concessions',
-              },
-            ],
+            events: [],
           },
           {
             name: '6',


### PR DESCRIPTION
Removes `close_concessions` from `TRAINS` and `can_convert_concessions` from `PHASES`, removing them from the info page (fixes #11552) and preventing majors from starting in phase 4 (fixes #11081).

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`