### PR TITLE
[System18] Russia and Mississippi fixes

### DIFF
--- a/lib/engine/game/g_system18/game.rb
+++ b/lib/engine/game/g_system18/game.rb
@@ -943,7 +943,7 @@ module Engine
 
           # delete shares after giving share value to shareholders
           entity.share_holders.keys.each do |share_holder|
-            unless share_holder == entity
+            if share_holder != entity && share_holder != @share_pool
               total = 0
               share_holder.shares_of(entity).each do |share|
                 @bank.spend(share.price, share_holder)
@@ -969,7 +969,7 @@ module Engine
 
           # move tokens if room in national and doesn't already have a token in the same hex
           # NOTE: this isn't robust - it only works for simple city revenues
-          entity.tokens.select(&:city).sort_by { |t| t.city.revenue }.reverse_each do |token|
+          entity.tokens.select(&:city).sort_by { |t| t.city.max_revenue }.reverse_each do |token|
             new_token = national.next_token
 
             city = token.city

--- a/lib/engine/game/g_system18/map_ms_customization.rb
+++ b/lib/engine/game/g_system18/map_ms_customization.rb
@@ -246,7 +246,7 @@ module Engine
 
         def map_ms_reorder_players
           # call base game method if players have no privates
-          return self.class.superclass.instance_method(:reorder_players).bind_call(self) unless @players.any? do |p|
+          return Engine::Game::Base.instance_method(:reorder_players).bind_call(self) unless @players.any? do |p|
                                                                                                   !p.companies.empty?
                                                                                                 end
 

--- a/lib/engine/game/g_system18/map_ms_customization.rb
+++ b/lib/engine/game/g_system18/map_ms_customization.rb
@@ -245,7 +245,10 @@ module Engine
         end
 
         def map_ms_reorder_players
-          return unless @players.any? { |p| !p.companies.empty? }
+          # call base game method if players have no privates
+          return self.class.superclass.instance_method(:reorder_players).bind_call(self) unless @players.any? do |p|
+                                                                                                  !p.companies.empty?
+                                                                                                end
 
           # find positional companies
           plast = @players.find { |p| p.companies.empty? }
@@ -253,6 +256,7 @@ module Engine
           p2 = @players.find { |p| p.companies.find { |c| c.sym == 'P2' } } || plast
           p3 = @players.find { |p| p.companies.find { |c| c.sym == 'P3' } } || plast
 
+          # remove privates from players
           @players.each { |p| p.companies.clear }
 
           @players = [p1, p2, p3, plast].take(@players.size)
@@ -346,6 +350,8 @@ module Engine
         end
 
         def map_ms_train_warranted?(train)
+          return false unless train.owner == @depot
+
           %w[2 3 4 5].include?(train.name)
         end
       end

--- a/lib/engine/game/g_system18/map_ms_customization.rb
+++ b/lib/engine/game/g_system18/map_ms_customization.rb
@@ -247,8 +247,8 @@ module Engine
         def map_ms_reorder_players
           # call base game method if players have no privates
           return Engine::Game::Base.instance_method(:reorder_players).bind_call(self) unless @players.any? do |p|
-                                                                                                  !p.companies.empty?
-                                                                                                end
+                                                                                               !p.companies.empty?
+                                                                                             end
 
           # find positional companies
           plast = @players.find { |p| p.companies.empty? }

--- a/lib/engine/game/g_system18/map_russia_customization.rb
+++ b/lib/engine/game/g_system18/map_russia_customization.rb
@@ -484,6 +484,10 @@ module Engine
 
         def map_russia_or_set_finished
           depot.export! if phase.name.to_i < 8
+          # fix the fact turn has already advanced by the time we get here
+          @turn -= 1
+          game_end_check
+          @turn += 1
         end
 
         def map_russia_can_issue_shares_for_train?(entity)

--- a/lib/engine/game/g_system18/step/buy_sell_par_bid_merge.rb
+++ b/lib/engine/game/g_system18/step/buy_sell_par_bid_merge.rb
@@ -45,6 +45,9 @@ module Engine
             @game.bank.spend(share_price.price * 2, entity)
 
             action = Action::Par.new(entity, corporation: corporation, share_price: share_price)
+            # give the generated Par action the same time stamp as the action that triggered the auction win
+            # this prevents problems with a programmed pass triggering on the Par
+            action.created_at = @game.actions.last.created_at
             process_par(action)
 
             # Clear the corporation of 'share' cash grabbed earlier.

--- a/lib/engine/game/g_system18/step/buy_train.rb
+++ b/lib/engine/game/g_system18/step/buy_train.rb
@@ -53,8 +53,9 @@ module Engine
           end
 
           def buy_train_action(action)
+            warranted = @game.train_warranted?(action.train)
             super
-            return unless @game.train_warranted?(action.train)
+            return unless warranted
 
             @log << "#{action.entity.name} receives a warranty for the #{action.train.name} train"
             action.train.name = action.train.name + '*'


### PR DESCRIPTION
Fixes #12016
Fixes #12023 
Fixes #12025 
Fixes #12028
Fixes #12032 

Will likely require pins.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

For Russia map:
1. Fixed game ending too late when 8 train was exported
2. Fixed issue when auto-passing immediately after a minor was auctioned in a SR
3. Fixed problems with nationalizing a corp with shares in market and/or more tokens than SPX could take

For Mississippi map:
1. Fixed player ordering that wasn't happening after a SR
2. Fixed bug with giving "used" trains warranties

### Screenshots

### Any Assumptions / Hacks
