### PR TITLE
[dev] fix quotes in db script, fix scripts/db/dump.sh

### DIFF
--- a/scripts/db/create_scrubbed.sh
+++ b/scripts/db/create_scrubbed.sh
@@ -3,7 +3,7 @@ set -e
 
 # Creates a new copy of the db with user info other than usernames scrubbed out.
 
-if [ $(hostname) = "18xxgames" ]; then
+if [ $(hostname) = '18xxgames' ]; then
     echo "Don't run this on prod"
     exit 1
 fi
@@ -17,7 +17,7 @@ set -x
 ./scripts/db/load_from_backup.sh
 
 # scrub the local data
-docker compose exec --env DB_LOG_LEVEL=fatal rack bundle exec ruby -e "load 'scripts/db_scrub.rb'; scrub_all_users!"
+docker compose exec --env DB_LOG_LEVEL=fatal rack bundle exec ruby -e 'load "scripts/db_scrub.rb"; scrub_all_users!'
 
 # dump the scrubbed data
-./scripts/db/dump.sh "db.backup.scrubbed.$(date +"%Y%m%d.%H%M").gz"
+./scripts/db/dump.sh "db.backup.scrubbed.$(date +'%Y%m%d.%H%M').gz"

--- a/scripts/db/dump.sh
+++ b/scripts/db/dump.sh
@@ -12,13 +12,15 @@ else
     DB_FILE="${1}"
 fi
 
+DB_FILE_PATH_IN_CONTAINER=${DB_FILE_PATH_IN_CONTAINER:-/home/db/}
+
 DB_CONTAINER_NAME=$(docker ps --filter name="db.?1" --format '{{.Names}}')
 
 # create gzipped backup file in docker container
-docker exec -i ${DB_CONTAINER_NAME} bash -c "pg_dump --host localhost --port ${DB_PORT} --user ${DB_USER} --no-password --exclude-table schema_info --exclude-table message_bus --data-only --format t ${DB_NAME} | gzip > /home/db/${DB_FILE}"
+docker exec -i ${DB_CONTAINER_NAME} bash -c "pg_dump --host localhost --port ${DB_PORT} --user ${DB_USER} --no-password --exclude-table schema_info --exclude-table message_bus --data-only --format t ${DB_NAME} | gzip > ${DB_FILE_PATH_IN_CONTAINER}${DB_FILE}"
 
 # copy backup to host
-docker cp ${DB_CONTAINER_NAME}:/home/db/${DB_FILE} .
+docker cp ${DB_CONTAINER_NAME}:${DB_FILE_PATH_IN_CONTAINER}${DB_FILE} .
 
 # remove backup from docker container
-docker exec -i ${DB_CONTAINER_NAME} rm -v /home/db/${DB_FILE}
+docker exec -i ${DB_CONTAINER_NAME} rm -v ${DB_FILE_PATH_IN_CONTAINER}${DB_FILE}


### PR DESCRIPTION
* copy-pasting the old "scrub the local data" command lead to this error:

> `bash: !": event not found`

* apparently the user on the db container is root and there is no "db" user?
