### PR TITLE
[1824] Correct train limit for minor, fixes #12049

### DIFF
--- a/lib/engine/game/g_1824/phases.rb
+++ b/lib/engine/game/g_1824/phases.rb
@@ -40,7 +40,7 @@ module Engine
             name: '6',
             on: '6',
             # Minor is not available in phase 6, but as merge to Staatsbahn
-            # happends at end of OR, we can let minor keep its 2 trains
+            # happens at end of OR, we can let minor keep its 2 trains
             train_limit: { minor: 2, major: 2, national: 3 },
             tiles: %i[yellow green brown],
             operating_rounds: 3,
@@ -48,14 +48,17 @@ module Engine
           {
             name: '8',
             on: '8',
-            train_limit: { major: 2, national: 3 },
+            # Similar to phase 6, it is possible to reach phase 8 while minor
+            # still remains (merged at the end of OR)
+            train_limit: { minor: 2, major: 2, national: 3 },
             tiles: %i[yellow green brown gray],
             operating_rounds: 3,
           },
           {
             name: '10',
             on: '10',
-            train_limit: { major: 2, national: 3 },
+            # See phase 8
+            train_limit: { minor: 2, major: 2, national: 3 },
             tiles: %i[yellow green brown gray],
             operating_rounds: 3,
           },


### PR DESCRIPTION
Fixes #12049

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

This might break some game, but it is a rare occasion so probably not.

This applies to both 1824 and 1824 Cisleithania - they use the same phase table. (Although 2 player Cisleithania has no UG formation, and KK forms in phase 5.)

Physical charters for minors actually state "Train limit = 2" for minors, so it was not correct to use Train limit = 0 for later phases.

### Explanation of Change

KK1/KK2 must be able to keep trains when KK merge is triggered during an OR, as the merge happens after that OR.
As train rush can even reach phase 8 (and possibly even phase 10?) it is needed to have a train limit of 2 the full game.

### Screenshots
<img width="1331" height="334" alt="image" src="https://github.com/user-attachments/assets/1293ee2b-0cef-4485-93f1-09ef6d1a471e" />

### Any Assumptions / Hacks

Earlier assumption was that minor would never survive all the way to phase 8 - that was wrong....
