### PR TITLE
[1824] Fix error with tokens, fixes #12017

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -280,9 +280,8 @@ module Engine
         end
 
         def operating_round(round_num)
-          Engine::Round::Operating.new(self, [
+          G1824::Round::Operating.new(self, [
             G1824::Step::KkTokenChoice,
-            Engine::Step::HomeToken,
             G1837::Step::Bankrupt,
             G1824::Step::DiscardTrain,
             Engine::Step::SpecialTrack,

--- a/lib/engine/game/g_1824/round/operating.rb
+++ b/lib/engine/game/g_1824/round/operating.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/operating'
+
+module Engine
+  module Game
+    module G1824
+      module Round
+        class Operating < Engine::Round::Operating
+          def pending_tokens
+            []
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1824_cisleithania/game.rb
+++ b/lib/engine/game/g_1824_cisleithania/game.rb
@@ -196,10 +196,9 @@ module Engine
         end
 
         def operating_round(round_num)
-          Engine::Round::Operating.new(self, [
+          G1824::Round::Operating.new(self, [
             G1837::Step::Bankrupt,
             G1824::Step::KkTokenChoice,
-            Engine::Step::HomeToken,
             G1824::Step::DiscardTrain,
             G1824Cisleithania::Step::BondToken,
             Engine::Step::SpecialTrack,


### PR DESCRIPTION
Fixes #12017

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

N/A

### Explanation of Change

1824 place home token when corporation operates the first time. For some reason this caused an issue in 1824.

### Screenshots

N/A

### Any Assumptions / Hacks

Have added pending_tokens to 1824 round, to avoid getting the error.