### PR TITLE
[System18] make all optional rules automatically mutex

### DIFF
--- a/lib/engine/game/g_system18/meta.rb
+++ b/lib/engine/game/g_system18/meta.rb
@@ -106,10 +106,7 @@ module Engine
           },
         ].freeze
 
-        MUTEX_RULES = [
-          %i[map_NEUS map_France map_Twisting_Tracks map_UK_Limited map_China_Rapid_Development map_Poland map_Britain
-             map_Britain_N map_Britain_S map_Northern_Italy map_MS map_Scotland map_Russia],
-        ].freeze
+        MUTEX_RULES = [OPTIONAL_RULES.map { |r| r[:sym] }].freeze
       end
     end
   end


### PR DESCRIPTION
Just a small thing I thought of when I came across System18's `meta.rb` while looking at #11973 and #12000. Seems easier to deal with long-term.