### PR TITLE
[1824] Add deep freeze of trains

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -60,7 +60,7 @@ module Engine
         # Rule IX. This differ from 1837 as players in 1824 do not go bankrupt.
         GAME_END_CHECK = { bank: :full_or }.freeze
 
-        EVENTS_TEXT = Base::EVENTS_TEXT.merge(
+        EVENTS_TEXT = Base::EVENTS_TEXT.dup.merge(
           'buy_across' => ['Buy Across', 'Trains can be bought between companies'],
           'close_mountain_railways' => ['Mountain Railways Close', 'Any still open Montain railways are exchanged or closed'],
           'sd_formation' => ['SD formation', 'SD forms at the end of the OR'],
@@ -69,7 +69,7 @@ module Engine
           'kk_formation' => ['k&k formation', 'KK forms at the end of the OR'],
         ).freeze
 
-        STATUS_TEXT = Base::STATUS_TEXT.merge(
+        STATUS_TEXT = Base::STATUS_TEXT.dup.merge(
           'may_exchange_coal_railways' => ['Coal Railway exchange', 'May exchange Coal Railways during SR'],
           'may_exchange_mountain_railways' => ['Mountain Railway exchange', 'May exchange Mountain Railways during SR']
         ).freeze
@@ -81,10 +81,6 @@ module Engine
           4 => 'Arlbergbahn',
           5 => 'Karawankenbahn',
           6 => 'Wocheinerbahn',
-        }.freeze
-
-        ASSIGNMENT_TOKENS = {
-          'coal' => '/icons/1837/coalcar.svg',
         }.freeze
 
         # Modified from 1837 as 1824 does not have single shares in Pre-staatsbahn
@@ -121,14 +117,16 @@ module Engine
           true
         end
 
+        def game_trains
+          self.class::TRAINS.dup.deep_freeze
+        end
+
         # Modified base version as the number of trains vary between player count and variant
         def init_train_handler
           train_count_map = num_trains_map
           trains = game_trains.flat_map do |train|
-            t = train
-            t = possibly_adjust_events_based_on_player_count(t)
-            Array.new(train_count_map[t[:name]]) do |index|
-              Train.new(**t, index: index)
+            Array.new(train_count_map[train[:name]]) do |index|
+              Train.new(**train, index: index)
             end
           end
 
@@ -137,10 +135,6 @@ module Engine
 
         def num_trains_map
           self.class::TRAIN_COUNT_STANDARD
-        end
-
-        def possibly_adjust_events_based_on_player_count(train)
-          train
         end
 
         def init_companies(players)

--- a/lib/engine/game/g_1824_cisleithania/game.rb
+++ b/lib/engine/game/g_1824_cisleithania/game.rb
@@ -32,13 +32,7 @@ module Engine
         BUKOWINA_SOURCES = %w[E12 B9].freeze
         BUKOWINA_TARGETS = %w[D25 E24 E26].freeze
 
-        EVENTS_TEXT = Base::EVENTS_TEXT.merge(
-          'buy_across' => ['Buy Across', 'Trains can be bought between companies'],
-          'close_mountain_railways' => ['Mountain Railways Close', 'Any still open Montain railways are exchanged or closed'],
-          'sd_formation' => ['SD formation', 'SD forms at the end of the OR'],
-          'exchange_coal_companies' => ['Coal Companies Exchange', 'All remaining coal companies are exchanged'],
-          'ug_formation' => ['UG formation', 'UG forms at the end of the OR'],
-          'kk_formation' => ['k&k formation', 'KK forms at the end of the OR'],
+        EVENTS_TEXT = G1824::Game::EVENTS_TEXT.dup.merge(
           'close_construction_railways' => ['Close Construction Railways', 'All construction minors are closed'],
           'vienna_tokened' => ['Vienna tokened',
                                'When Vienna is upgraded to Brown the last token of the bond railway is placed there'],
@@ -57,32 +51,37 @@ module Engine
           super
         end
 
-        def possibly_adjust_events_based_on_player_count(train)
-          return train unless two_player?
+        def game_trains
+          return super unless two_player?
 
-          # KK forms on 5 trains instead of 6 trains, and UG is not present when 2 players
-          close_construction_event = 'close_construction_railways'
+          unless @game_trains
+            trains = super.map(&:dup)
 
-          if train[:name] == '4' && !@close_construction_company_when_first_5_sold
-            train[:events] = add_event(train, close_construction_event)
+            _train_2, _train_3, train_4, train_5, train_6, _train_8, _train_10,
+            _train_1g, _train_2g, _train_3g, _train_4g, _train_5g = trains
+
+            train_4_events = train_4[:events].dup
+            train_4_events << { 'type' => 'close_construction_railways' } unless @close_construction_company_when_first_5_sold
+
+            # KK forms on 5 trains instead of 6 trains, and UG is not present when 2 players
+            train_5_events = [{ 'type' => 'exchange_coal_companies' }, { 'type' => 'kk_formation' },
+                              { 'type' => 'vienna_tokened' }]
+            train_5_events << { 'type' => 'close_construction_railways' } if @close_construction_company_when_first_5_sold
+
+            train_4[:events] = train_4_events
+            train_5[:events] = train_5_events
+            train_6[:events] = []
+
+            @game_trains = trains.deep_freeze
           end
-
-          if train[:name] == '5'
-            train[:events] = [{ 'type' => 'exchange_coal_companies' }, { 'type' => 'kk_formation' }]
-            train[:events] = add_event(train, close_construction_event) if @close_construction_company_when_first_5_sold
-            train[:events] = add_event(train, 'vienna_tokened')
-          end
-
-          train[:events] = [] if train[:name] == '6'
-
-          train
+          @game_trains
         end
 
         def num_trains_map
           if two_player?
-            self.class::TRAIN_COUNT_2P_CISLETHANIA
+            self.class::TRAIN_COUNT_2P_CISLETHANIA.freeze
           else
-            self.class::TRAIN_COUNT_3P_CISLETHANIA
+            self.class::TRAIN_COUNT_3P_CISLETHANIA.freeze
           end
         end
 
@@ -462,15 +461,6 @@ module Engine
 
         def closed_construction
           @close_construction_company_when_first_5_sold ? '5' : '4'
-        end
-
-        def add_event(train, event)
-          events = train[:events]
-          added_event = { 'type' => event }
-
-          events << added_event unless events.include?(added_event)
-
-          events
         end
 
         def create_construction_railway_from_bought_pre_staatsbahn(company, minor)


### PR DESCRIPTION
1824 Cisleithania setup for 2 players did modify 1824 which caused validation to fail.

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

**Note! When I run activate_all for 1824 family (with this commit applied) it shows that 2 1824 Cisleithania games are broken. But this was caused by the fix for player order during SR1 that was merged last week.**

## Implementation Notes
Uses deep_freeze as well as avoiding modify base when setting up 1824 Cisleithania.

### Explanation of Change
Similar change that 1849 did.

### Screenshots
N/A

### Any Assumptions / Hacks
N/A