### PR TITLE
[1825] removes Unit 2's 6-trains and gray tiles when Kit 3 is included.

### DIFF
--- a/lib/engine/game/g_1825/game.rb
+++ b/lib/engine/game/g_1825/game.rb
@@ -288,9 +288,14 @@ module Engine
 
           case @units.keys.sort.map(&:to_s).join
           when '1'
-            add_train_list(trains, { '2' => 6, '3' => 4, '4' => 3, '5' => 4  })
+            add_train_list(trains, { '2' => 6, '3' => 4, '4' => 3, '5' => 4 })
           when '2'
-            add_train_list(trains, { '2' => 5, '3' => 3, '4' => 2, '5' => 3, '6' => 2 })
+            if @kits[3]
+              # Special exception: don't use 6-trains included in Unit 2 when using Kit 3
+              add_train_list(trains, { '2' => 5, '3' => 3, '4' => 2, '5' => 3 })
+            else
+              add_train_list(trains, { '2' => 5, '3' => 3, '4' => 2, '5' => 3, '6' => 2 })
+            end
           when '3'
             # extra 5/3T/U3 for minors
             add_train_list(trains, { '2' => 5, '3' => 3, '4' => 1, '5' => 3, '7' => 2, '3T' => 1, 'U3' => 1 })

--- a/lib/engine/game/g_1825/map.rb
+++ b/lib/engine/game/g_1825/map.rb
@@ -213,6 +213,9 @@ module Engine
           '66' => 1,
           '67' => 1,
           '68' => 1,
+        }.deep_freeze
+
+        UNIT2_GRAY_TILES = {
           '49' => 1,
           '50' => 1,
           '51' => 2,
@@ -570,7 +573,11 @@ module Engine
         def game_tiles
           gtiles = {}
           append_game_tiles(gtiles, UNIT1_TILES) if @units[1]
-          append_game_tiles(gtiles, UNIT2_TILES) if @units[2]
+          if @units[2]
+            append_game_tiles(gtiles, UNIT2_TILES)
+            # Special exception: don't use gray tiles included in Unit 2 when using Kit 3
+            append_game_tiles(gtiles, UNIT2_GRAY_TILES) unless @kits[3]
+          end
           append_game_tiles(gtiles, UNIT3_TILES) if @units[3]
           append_game_tiles(gtiles, R1_TILES) if @regionals[1]
           append_game_tiles(gtiles, R2_TILES) if @regionals[2]


### PR DESCRIPTION
Fixes #11928

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

As noted in the bug report, the special rules of Kit 3 indicate to not include the 6-trains and gray tiles in Unit 2 when combining them. I modified to code to exclude Unit 2's 6-trains and gray tiles when Kit 3 is included.

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
