### PR TITLE
[dev] run workflows for all PRs, split up steps

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,24 +4,30 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ '*' ]
 
 env:
     OPAL_PREFORK_DISABLE: "true"
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
+  build_and_test:
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.2
-    - name: Build and test with Rake
+    - name: Bundler
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
-        bundle exec rake
+    - name: RuboCop
+      run: |
+        bundle exec rake rubocop
+    - name: Opal
+      run: |
+        bundle exec rake compile_all
+    - name: RSpec
+      run: |
+        bundle exec rake spec_parallel

--- a/Rakefile
+++ b/Rakefile
@@ -12,13 +12,22 @@ unless ENV['RACK_ENV'] == 'production'
     task.requires << 'rubocop-performance'
   end
 
+  desc 'Build the main JavaScript files'
+  task :compile do
+    Assets.new.combine
+  end
+
+  desc 'Build the main JavaScript files and all game-specific files'
+  task :compile_all do
+    Assets.new.combine(:all)
+  end
+
   desc 'Run spec in parallel'
   task :spec_parallel do
-    Assets.new.combine
     ParallelTests::CLI.new.run(['--type', 'rspec'])
   end
 
-  task default: %i[spec_parallel rubocop]
+  task default: %i[compile spec_parallel rubocop]
 end
 
 # Migrate


### PR DESCRIPTION
* set `runs-on` to same Ubuntu version as server

* `branches [ '*' ]` enables PRs into branches other than `master`; this allows a PR to target the branch of another PR, so that it can have a smaller diff and have a review requested before another PR it depends on gets merged

* We have occasionally seen GitHub Actions failures where tests in `spec/assets_spec.rb` fail with error messages about the rendered HTML. My best guess is this is caused by the JS not all being compiled before the tests start running in parallel. The new step setup ensures that all the JavaScript is built before any tests are started.

* splitting up the steps makes it more immediately clear where a problem is, and shows which parts of the build and test process regularly take the most time

* the `Rakefile` changes keeps the default `rake` task unchanged


<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
