### PR TITLE
[System18] Update Gotland to not export trains when new corporations floated

### DIFF
--- a/lib/engine/game/g_system18/map_gotland_customization.rb
+++ b/lib/engine/game/g_system18/map_gotland_customization.rb
@@ -360,13 +360,13 @@ module Engine
 
           @log << "#{corporation.name} floats"
 
+          # Track newly floated corporations for the current stock round
+          track_newly_floated(corporation) if @round.is_a?(GSystem18::Round::Stock)
+
           return if %i[incremental none].include?(corporation.capitalization)
 
           @bank.spend(corporation.par_price.price * corporation.total_shares, corporation)
           @log << "#{corporation.name} receives #{format_currency(corporation.cash)}"
-
-          # Track newly floated corporations for the current stock round
-          track_newly_floated(corporation) if @round.is_a?(GSystem18::Round::Stock)
         end
 
         # ----- Rival share randomizer -----


### PR DESCRIPTION
Update Gotland to not export trains when new corporations floated

Can break existing games

Fixes #12067


## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
