### PR TITLE
[System18] Update Gotland to not allow dumping to rival

### DIFF
--- a/lib/engine/game/g_system18/game.rb
+++ b/lib/engine/game/g_system18/game.rb
@@ -503,7 +503,7 @@ module Engine
             Engine::Step::DiscardTrain,
             Engine::Step::Exchange,
             Engine::Step::SpecialTrack,
-            Engine::Step::BuySellParShares,
+            GSystem18::Step::BuySellParShares,
           ]
         end
 

--- a/lib/engine/game/g_system18/map_gotland_customization.rb
+++ b/lib/engine/game/g_system18/map_gotland_customization.rb
@@ -559,6 +559,13 @@ module Engine
               new_stock_round
             end
         end
+
+        def map_gotland_can_dump?(entity, bundle)
+          corporation = bundle.corporation
+          return false if (corporation.share_holders[rival] || 0) > (corporation.share_holders[entity] - bundle.percent)
+
+          bundle.can_dump?(entity)
+        end
       end
     end
   end

--- a/lib/engine/game/g_system18/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_system18/step/buy_sell_par_shares.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares'
+
+module Engine
+  module Game
+    module GSystem18
+      module Step
+        class BuySellParShares < Engine::Step::BuySellParShares
+          def can_dump?(entity, bundle)
+            if @game.respond_to?("map_#{@game.cmap_name}_can_dump?")
+              return @game.send("map_#{@game.cmap_name}_can_dump?", entity, bundle)
+            end
+
+            super
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
It should not be allowed to dump to rivals

Might break existing games

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
