### PR TITLE
[1824] Add some shenanigans texts, fixes #12027

### DIFF
--- a/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
+++ b/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
@@ -151,6 +151,14 @@ module Engine
             reserved.none? { |s| s.percent == 20 }
           end
 
+          def action_is_shenanigan?(_entity, _other_entity, _action, _corporation, _corp_buying)
+            return 'Exchange of Coal Minor' if action.is_a?(Action::SpecialBuy)
+            return 'Payoff of player debt' if action.is_a?(Action::PayoffPlayerDebt)
+            return 'Partial payoff of player debt' if action.is_a?(Action::PayoffPlayerDebtPartial)
+
+            super
+          end
+
           private
 
           def exchangable_ability(entity)


### PR DESCRIPTION
Added shenanigans texts for all special actions that exists in 1824 stock round.

Fixes #12027

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Have added shenanigan texts for the 3 extra actions available in 1824 SRs.

### Explanation of Change

See issue - strange log texts.

### Screenshots

N/A

### Any Assumptions / Hacks

N/A
