### PR TITLE
[dropped cash 3/5] add `game_end_reason` to Game object, add tests requiring it for fixtures

### DIFF
--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -924,6 +924,7 @@ module Engine
         def add_subsidy(corporation, hex)
           return unless (subsidy = @subsidies_by_hex.delete(hex.coordinates))
 
+          @log << "#{corporation.name} receives the #{subsidy[:name]}" unless subsidy[:name] == 'No Subsidy'
           hex.tile.icons.reject! { |icon| icon.name.include?('subsidy') }
           subsidy_company = create_company_from_subsidy(subsidy)
           assign_boomtown_subsidy(hex, corporation) if subsidy_company.id == 'S8'


### PR DESCRIPTION
Do not merge this PR directly; see #12086

----

* requires `end_game!()` to be called with the reason for ending it
* expose the reason `.game_end_reason`
* require fixtures to have a `game_end_reason` key
    * require alpha games to have at least one fixture with a `game_end_reason` that is not `manually_ended`
    * require beta/production games to have at least one fixture for each `game_end_reason`
    * exceptions do currently exist in constants at the top of `spec/lib/engine/fixtures_required_spec.rb`; no examples for those title/game end reason combinations were found in the real DB