### PR TITLE
[dropped cash 4/5] fix player loans, refactor player loans into base engine objects

### DIFF
--- a/lib/engine/game/g_18_ny/step/buy_train.rb
+++ b/lib/engine/game/g_18_ny/step/buy_train.rb
@@ -119,6 +119,13 @@ module Engine
             @train_salvaged = true
             @game.salvage_train(action.train)
           end
+
+          def help
+            return if !@round.active_train_loan && !can_take_loan?(current_entity)
+
+            'Once a loan is taken, a train must be purchased. Use the undo button to return the loans' \
+              ' in order to pass without purchasing a train.'
+          end
         end
       end
     end


### PR DESCRIPTION
Do not merge this PR directly; see #12086

----

I found some weird behavior and comments--plus a lot of duplicated code--around
player loans while I was working on other parts of #12000. It seemed best to
handle the loan-specific changes separately from the rest.

* `G1844:Player` was added only for tracking `@debt`; move that onto
  `Engine::Player`, and add `@penalty` for debt which counts against the
  player's score but can never be repaid

* add debt and loan methods to `Spender`

* add `@debt` to the Bank, so that all debt given to players can be tracked; add
  test for each fixture to ensure the net debt is 0

* add methods and constants to `Game::Base` to manage player loans

Notable assumptions:

1) loans are not really outside money

Loans weren't always taken from the bank; there was a comment copy-pasted
numerous times that "the money from loans is outside money, doesnt [sic] count
toards the normal bank money." I think this stemmed from a misinterpretation of
1822's rule 4.3.5, which states "The sum of any loans in play does not count
towards the bank limit of £12,000 (i.e. treat the loan as coming from a separate
source, not the bank)."

In 1822, when a player receives a loan, they get cash from the bank, and then
immediately spend that cash (back to the bank) on a train. When playing at a
physical table, an extra stack of chips is often used to track the remaining
balance of the player's debt. The important point is that the stack does not
count as coming from the bank, even though the initial cash in the loan did come
from the bank.

Now the amount owed by the player is tracked on their `@debt`, and the `Bank`
uses its own `@debt` to also track the total amount owed it; the sum of each
player's `@debt` and the `Bank`'s `@debt` should always be zero

2) 18ESP doesn't need to track interest separately from the debt

18ESP had code to track debt and interest separately, and code for some strange
math to apply some of a payment to the principal and some to the interest, but
that code never apparently ran; the UI does not present an optional to partially
pay off the debt if the player's cash is less than the total debt amount.

https://github.com/tobymao/18xx/blob/d96bdc6ddd61aff5f7ea5793b3a7d18b58ec21c7/lib/engine/game/g_18_esp/game.rb#L1058-L1077
