### PR TITLE
[1824] Fix issue with buying Staatsbahn in SR1, fixed #12076

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -598,22 +598,20 @@ module Engine
           # This part has been simplified in 1824, as a minor can only have one owner
           # and if its a lesser pre-staatsbahn it should correspond to a 10% share in
           # the mergee, otherwise 20%.
-          minor.share_holders.each do |sh, _|
-            num_shares = sh.shares_of(minor).size
-            next if num_shares.zero?
 
-            num_shares = 2 if coal_minor?(minor) || minor.id.end_with?('1')
+          owner = minor.owner
+          num_shares = coal_minor?(minor) || minor.id.end_with?('1') ? 2 : 1
 
-            share = corporation.shares.find { |s| !s.buyable && s.percent == num_shares * 10 }
-            @log << "#{sh.name} receives #{num_shares} share#{num_shares > 1 ? 's' : ''} of #{corporation.name}"
-            share.buyable = true
+          share = corporation.shares.find { |s| !s.buyable && s.percent == num_shares * 10 }
+          @log << "#{owner.name} receives #{num_shares} share#{num_shares > 1 ? 's' : ''} of #{corporation.name}"
+          share.buyable = true
 
-            # 1824 fix. We explicitly set allow_president_change to true here as we otherwise get a strange
-            # behavior when presidency decided for nationals. Might need revisiting.
-            @share_pool.transfer_shares(share.to_bundle, sh, allow_president_change: true)
-            if @round.respond_to?(:non_paying_shares) && operated_this_round?(minor)
-              @round.non_paying_shares[sh][corporation] += num_shares
-            end
+          # 1824 fix. We explicitly set allow_president_change to true here as we otherwise get a strange
+          # behavior when presidency decided for nationals. Might need revisiting.
+          @share_pool.transfer_shares(share.to_bundle, owner, allow_president_change: true)
+
+          if @round.respond_to?(:non_paying_shares) && operated_this_round?(minor)
+            @round.non_paying_shares[owner][corporation] += num_shares
           end
 
           if minor.cash.positive?

--- a/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
+++ b/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require_relative '../../../step/buy_sell_par_shares'
+require_relative 'buy_sell_par_shares'
 
 module Engine
   module Game
     module G1824
       module Step
-        class BuySellParExchangeShares < Engine::Step::BuySellParShares
+        class BuySellParExchangeShares < G1824::Step::BuySellParShares
           EXCHANGE_ACTIONS = %w[buy_shares].freeze
           BUY_ACTION = %w[special_buy].freeze
           PURCHASE_ACTIONS = Engine::Step::BuySellParShares::PURCHASE_ACTIONS + [Action::SpecialBuy]
@@ -38,10 +38,6 @@ module Engine
             return EXCHANGE_ACTIONS if @game.mountain_railway?(entity) && @game.mountain_railway_exchangable?
 
             []
-          end
-
-          def visible_corporations
-            @game.sorted_corporations.reject { |c| c.type == :minor || c.type == :construction_railway }
           end
 
           def can_buy?(entity, bundle)
@@ -141,14 +137,6 @@ module Engine
             @game.payoff_player_loan(player, payoff_amount: action.amount)
             @round.last_to_act = player
             @round.current_actions << action
-          end
-
-          def allow_president_change?(corporation)
-            # In case of Staatsbahn, president change is only allowed after formation
-            return false if @game.staatsbahn?(corporation) && !corporation.floated?
-
-            reserved = corporation.reserved_shares
-            reserved.none? { |s| s.percent == 20 }
           end
 
           private

--- a/lib/engine/game/g_1824/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1824/step/buy_sell_par_shares.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares'
+
+module Engine
+  module Game
+    module G1824
+      module Step
+        class BuySellParShares < Engine::Step::BuySellParShares
+          def visible_corporations
+            @game.sorted_corporations.reject { |c| c.closed? || c.type == :minor || c.type == :construction_railway }
+          end
+
+          def allow_president_change?(corporation)
+            # In case of Staatsbahn, president change is only allowed after formation
+            return false if @game.staatsbahn?(corporation) && !corporation.floated?
+
+            reserved = corporation.reserved_shares
+            reserved.none? { |s| s.percent == 20 }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1824/step/buy_sell_par_shares_first_sr.rb
+++ b/lib/engine/game/g_1824/step/buy_sell_par_shares_first_sr.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require_relative '../../../step/buy_sell_par_shares'
+require_relative 'buy_sell_par_shares'
 
 module Engine
   module Game
     module G1824
       module Step
-        class BuySellParSharesFirstSr < Engine::Step::BuySellParShares
+        class BuySellParSharesFirstSr < G1824::Step::BuySellParShares
           def can_sell?(_entity, _bundle)
             false
           end
@@ -17,10 +17,6 @@ module Engine
 
           def can_exchange?(_entity)
             false
-          end
-
-          def visible_corporations
-            @game.sorted_corporations.reject { |c| c.closed? || c.type == :minor }
           end
         end
       end

--- a/lib/engine/game/g_1824_cisleithania/step/buy_sell_par_shares_first_sr.rb
+++ b/lib/engine/game/g_1824_cisleithania/step/buy_sell_par_shares_first_sr.rb
@@ -36,7 +36,7 @@ module Engine
           def visible_corporations
             return [] if @game.two_player? && @game.unbought_companies?
 
-            @game.sorted_corporations.reject { |c| c.closed? || c.type == :minor || c.type == :construction_railway }
+            super
           end
 
           def process_buy_company(action)


### PR DESCRIPTION
There was a bug so that if buying SD share in SR1, you became president. This caused issues later, when SD was formed, as president share was no longer among the reserved.

This bug was fixed earlier for SR2+, but was missing for SR1. Have now refactored a bit so that methods shared between SR1 and SR2+ can be put in the BuySellParShares base class of 1824. This means it is also available for 1824 Cisleithania as the Buy Sell steps inherits from 1824.

Fixes #12076

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

This fix will break the game that reported the issue. It will also break any other game in which Staatsbahn shares are bought in SR1 (which is quite rare, as this share wont be having any effect until much later).

## Implementation Notes

See above

### Explanation of Change

See above

### Screenshots

N/A

### Any Assumptions / Hacks

N/A
