### PR TITLE
[1824] Trigger Forced MR exchange also during OR, fixes #12070

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -278,6 +278,7 @@ module Engine
             G1824::Step::KkTokenChoice,
             G1837::Step::Bankrupt,
             G1824::Step::DiscardTrain,
+            G1824::Step::ForcedMountainRailwayExchange,
             Engine::Step::SpecialTrack,
             G1824::Step::Track,
             Engine::Step::Token,

--- a/lib/engine/game/g_1824_cisleithania/game.rb
+++ b/lib/engine/game/g_1824_cisleithania/game.rb
@@ -200,6 +200,7 @@ module Engine
             G1824::Step::KkTokenChoice,
             G1824::Step::DiscardTrain,
             G1824Cisleithania::Step::BondToken,
+            G1824::Step::ForcedMountainRailwayExchange, # In case train export after OR set triggers exchage
             Engine::Step::SpecialTrack,
             G1824Cisleithania::Step::Track,
             G1824Cisleithania::Step::Token,


### PR DESCRIPTION
Fixes #12070

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

Breaks a couple of games where forced MR exchange moves in time.

## Implementation Notes

Just add Foced step to OR - it was only present in SR.

### Explanation of Change

Should normally occur in OR, but needed in SR as well, in case an export of train after OR triggers the event.

### Screenshots

N/A

### Any Assumptions / Hacks

N/A
