### PR TITLE
[1824] Correct voluntary MR exchange, fixes #12020

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -461,10 +461,7 @@ module Engine
         end
 
         def exchange_entities
-          # Only one MR to exchange at a time - if we show all here they appear as multiple buttons in GUI
-          # under selected corporation. See #11988.
-          unclosed = @companies.reject(&:closed?)
-          unclosed.empty? ? [] : [unclosed.first]
+          @companies.reject(&:closed?)
         end
 
         def mountain_railway?(entity)

--- a/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
+++ b/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
@@ -8,7 +8,6 @@ module Engine
       module Step
         class BuySellParExchangeShares < Engine::Step::BuySellParShares
           EXCHANGE_ACTIONS = %w[buy_shares].freeze
-          BUY_ACTION = %w[special_buy].freeze
           PURCHASE_ACTIONS = Engine::Step::BuySellParShares::PURCHASE_ACTIONS + [Action::SpecialBuy]
 
           def actions(entity)


### PR DESCRIPTION
Fixes #12020

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

Should not break any games. The correction make is possible to do an action that was not possible before.

## Implementation Notes

It seems there was a fix in the 1824 code, to handle some GUI bug. Have now removed that code and
it does work.

### Explanation of Change

All MRs should be returned by 1824 as possible exhcanges, and then the GUI will filter out the ones
that are owned by the current entity.

### Screenshots

N/A

### Any Assumptions / Hacks

Have removed a faulty hack.