### PR TITLE
Add functionality for 1862 Solo

### DIFF
--- a/lib/engine/game/g_1862_solo/company.rb
+++ b/lib/engine/game/g_1862_solo/company.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative '../../company'
+
+module Engine
+  module Game
+    module G1862Solo
+      class Company < Engine::Company
+        attr_accessor :ipo_row_index
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_solo/corporation.rb
+++ b/lib/engine/game/g_1862_solo/corporation.rb
@@ -6,8 +6,23 @@ module Engine
   module Game
     module G1862Solo
       class Corporation < Engine::Corporation
-        def total_shares
-          7
+        def floated?
+          @floated
+        end
+
+        def closed?
+          @closed
+        end
+
+        def close!
+          @closed = true
+          @floated = false
+        end
+
+        def percent_to_float
+          return 0 if @floated
+
+          @ipo_owner.percent_of(self) - 70
         end
       end
     end

--- a/lib/engine/game/g_1862_solo/game.rb
+++ b/lib/engine/game/g_1862_solo/game.rb
@@ -27,20 +27,49 @@ module Engine
         end
 
         def setup_preround
-          @original_corporations = @corporations.dup
+          @base_tiles = []
+          @skip_round = {}
+          @lner_triggered = nil
+          @lner = nil
 
-          super
+          # remove reservations (nice to have in starting map)
+          @corporations.each { |corp| remove_reservation(corp) }
 
-          @original_corporations.reject { |c| @corporations.include?(c) }.each do |c|
-            hex = @hexes.find { |h| h.id == c.coordinates } # hex_by_id doesn't work here
-            old_tile = hex.tile
-            tile_string = ''
-            hex.tile = Tile.from_code(old_tile.name, 'brown', tile_string)
+          @double_parliament = false
+
+          # randomize order of corporations, then remove some based on player count
+          @offer_order = @corporations.sort_by { rand }
+          removed = @offer_order.take(4)
+          removed.each do |corp|
+            @offer_order.delete(corp)
+            @corporations.delete(corp)
+
+            remove_corporation_hex(corp)
+
+            @log << "Removing #{corp.name} from game"
           end
+
+          # add markers for remaining companies
+          @corporations.each { |corp| add_marker(corp) }
+
+          @chartered = {}
+
+          # randomize and distribute train permits
+          permit_list = 2.times.flat_map { %i[freight express local] }
+          permit_list.sort_by! { rand }
+          @all_permits = permit_list.dup
+          @permits = Hash.new { |h, k| h[k] = [] }
+          @original_permits = Hash.new { |h, k| h[k] = [] }
+
+          @corporations.each { |c| convert_to_full!(c) }
 
           # Build draw and draft decks for player hand and IPO rows
           @ipo_rows = [[], [], [], [], [], [], [], [], []]
           create_decks(@corporations)
+        end
+
+        def ready_corporations
+          @corporations.reject(:closed?)
         end
 
         def create_decks(corporations)
@@ -48,9 +77,12 @@ module Engine
 
           corporations.each do |corporation|
             corporation.ipo_shares.each do |share|
+              next if share.percent > 10
+
               company = convert_share_to_company(share)
               company.owner = bank
               draw_deck << company
+              @companies << company
             end
           end
 
@@ -61,7 +93,7 @@ module Engine
         # create a placeholder 'company' for shares in IPO
         def convert_share_to_company(share)
           description = "Certificate for #{share.percent}\% of #{share.corporation.full_name}."
-          Company.new(
+          G1862Solo::Company.new(
             sym: share.id,
             name: share.corporation.name,
             value: 0,
@@ -78,6 +110,9 @@ module Engine
         def deal_deck_to_ipo(deck)
           all_rows_indexes.each do |row|
             @ipo_rows[row] = deck.pop(6) # 6 shares per row
+            @ipo_rows[row].each do |company|
+              company.ipo_row_index = row
+            end
           end
         end
 
@@ -138,6 +173,10 @@ module Engine
           true
         end
 
+        def can_par_corporations?
+          @all_permits.any?
+        end
+
         def in_ipo?(company)
           @ipo_rows.flatten.include?(company)
         end
@@ -158,24 +197,46 @@ module Engine
           []
         end
 
+        def companies_to_payout(_ignore)
+          []
+        end
+
         def init_corporations(_stock_market)
           self.class::CORPORATIONS.map do |corp|
             corporation = corp.dup
+            corp.deep_freeze
             corporation[:float_percent] = 30
-            corporation[:shares] = [10, 10, 10, 10, 10, 10, 10]
+            corporation[:shares] = [30, 10, 10, 10, 10, 10, 10, 10]
             corporation[:max_ownership_percent] = 70
             corporation[:min_price] = 1
             initiated_corp = G1862Solo::Corporation.new(
               **corporation.merge(corporation_opts),
             )
-            initiated_corp.forced_share_percent = 10
+            initiated_corp.presidents_share.buyable = false
             initiated_corp
           end
         end
 
+        def stock_prices
+          par_prices
+        end
+
+        def par_prices
+          @par_prices ||= stock_market.market.first.select { |p| p.type == :par }
+        end
+
+        def repar_prices
+          @repar_prices ||= stock_market.market.first.select { |p| p.type == :repar }
+        end
+
         # So that value is not shown on company cards representing shares
-        def company_value(_company)
-          0
+        def company_value(company)
+          corporation = company.treasury.corporation
+          corporation.share_price ? corporation.share_price.price : 0
+        end
+
+        def company_header(_company)
+          '10% SHARE'
         end
 
         def show_value_of_companies?(_owner)
@@ -189,6 +250,12 @@ module Engine
         # Timeline information for INFO tab
         def timeline
           timeline = []
+
+          timeline << if @all_permits.empty?
+                        'Permits left to assign: None'
+                      else
+                        "Permits left to assign: #{@all_permits.map(&:to_s).join(', ')}"
+                      end
 
           all_rows_indexes.each do |i|
             ipo_row_i = ipo_timeline(i)
@@ -205,10 +272,68 @@ module Engine
           end
         end
 
+        def status_array(corp)
+          status = []
+          status << %w[Chartered bold] if @chartered[corp]
+          status << ["Par: #{format_currency(corp.original_par_price.price)}"] if corp.ipoed
+          status << ['Cannot start'] if @all_permits.empty? && !corp.ipoed
+          status << ["Permits: #{@permits[corp].map(&:to_s).join(',')}"] if corp.floated?
+          status
+        end
+
+        def assign_first_permit(corporation)
+          raise GameError, 'No permits left to assign' if @all_permits.empty?
+
+          permit = @all_permits.shift
+          @permits[corporation] << permit
+          @original_permits[corporation] << permit
+          @log << "#{corporation.name} is assigned a #{permit.to_s.capitalize} permit"
+        end
+
+        # TODO: I assume there is no obligations in 1862 Solo?
+        def enforce_obligations; end
+
+        # TODO: Should we use any special sorting in 1862 Solo?
+        def bank_sort(corporations)
+          corporations.sort_by(&:name)
+        end
+
+        # TODO: Should we use any special sorting in 1862 Solo?
+        def sorted_corporations
+          # Corporations sorted by some potential game rules
+          ipoed, others = corporations.partition(&:ipoed)
+          ipoed.sort + others
+        end
+
+        # TODO: Is this OK as 1862 solo version?
+        def available_to_start?(corporation)
+          legal_to_start?(corporation)
+        end
+
+        def remove_corporation(corp)
+          corp.close!
+
+          # TODO: If there are tile or token in this hex, freeze it instead
+          remove_corporation_hex(corp)
+
+          all_rows_indexes.each do |row|
+            @ipo_rows[row].reject! { |c| c.name == corp.name }
+          end
+
+          @log << "Removing #{corp.name} from game"
+        end
+
         private
 
         def all_rows_indexes
           (0..8)
+        end
+
+        def remove_corporation_hex(corp)
+          hex = @hexes.find { |h| h.id == corp.coordinates } # hex_by_id doesn't work here
+          old_tile = hex.tile
+          tile_string = ''
+          hex.tile = Tile.from_code(old_tile.name, 'brown', tile_string)
         end
       end
     end

--- a/lib/engine/game/g_1862_solo/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1862_solo/step/buy_sell_par_shares.rb
@@ -7,7 +7,7 @@ module Engine
     module G1862Solo
       module Step
         class BuySellParShares < Engine::Step::BuySellParShares
-          ACTIONS = %w[buy_company pass].freeze
+          ACTIONS = %w[buy_company choose pass].freeze
 
           def actions(entity)
             return [] unless entity == current_entity
@@ -17,17 +17,260 @@ module Engine
             actions
           end
 
-          # Shares only bought as companies
+          def round_state
+            super.merge(
+              {
+                bought_shares: [],
+              }
+            )
+          end
+
           def visible_corporations
-            []
+            @game.corporations.reject(&:closed?)
           end
 
           def can_buy_company?(player, company)
+            return false if company.value.zero?
+
             @game.ipo_rows.flatten.include?(company) && available_cash(player) >= company.value
+          end
+
+          # Cannot sell shares you have bought this SR
+          def can_sell?(_entity, bundle)
+            bundle.shares.none? { |s| @round.bought_shares.include?(s) }
+          end
+
+          def choice_available?(_entity)
+            true
+          end
+
+          def choices
+            []
+          end
+
+          def choice_name
+            nil
           end
 
           def get_par_prices(entity, _corp)
             @game.repar_prices.select { |p| p.price * 3 <= entity.cash }
+          end
+
+          def general_input_renderings_ipo_row(_entity, company, index)
+            renderings = []
+            return renderings if @game.ipo_rows[index].empty?
+
+            share = company.treasury
+
+            @game.all_rows_indexes.each do |i|
+              next if i == index || @game.ipo_rows[i].empty?
+              next unless company.treasury.corporation == @game.ipo_rows[i].first.treasury.corporation
+
+              renderings << ["move##{company.id}##{i}", "Move to IPO Row #{i + 1}"]
+            end
+
+            renderings << ["remove##{company.id}", "Remove #{company.name} from IPO Row #{index + 1}"]
+
+            if share.corporation.share_price
+              renderings << ["buy##{company.id}", "Buy #{company.name} for #{@game.company_value(company)}"]
+            elsif @game.can_par_corporations?
+              # TODO: Need to get all possible par prices - separate view?
+              # TODO: Is it possible to use interval?
+              price1 = @game.repar_prices.first.price
+              renderings << ["par_unchartered##{price1}##{company.id}", "Par at #{price1} (unchartered)"]
+              price2 = @game.par_prices.first.price
+              renderings << ["par_chartered##{price2}##{company.id}", "Par at #{price2} (chartered)"]
+            end
+
+            renderings
+          end
+
+          # Need to have false here as we are solo player
+          def bought?
+            false
+          end
+
+          def process_choose(action)
+            choice = action.choice
+            if choice.start_with?('buy')
+              action_buy(choice)
+            elsif choice.start_with?('deal')
+              action_deal(choice)
+            elsif choice.start_with?('move')
+              action_move(choice)
+            elsif choice.start_with?('par_chartered')
+              action_par_chartered(choice)
+            elsif choice.start_with?('par_unchartered')
+              action_par_unchartered(choice)
+            elsif choice.start_with?('remove')
+              action_remove(choice)
+            else
+              raise GameError, "Unknown choice #{choice}"
+            end
+
+            track_action(action, @game.players.first)
+          end
+
+          def process_pass(action)
+            action.entity.pass!
+          end
+
+          private
+
+          def action_buy(choice)
+            company = get_company_from_choice(choice)
+            price = @game.company_value(company)
+            share = company.treasury
+            corporation = share.corporation
+            owner = @game.bank
+            player = @game.players.first
+
+            @game.ipo_rows[company.ipo_row_index].delete(company)
+            buy_shares(player, ShareBundle.new([share]), allow_president_change: false)
+
+            player.spend(price, owner)
+
+            if !corporation.floated? && player.shares_by_corporation[corporation].size >= 3
+              @game.chartered[corporation] ? float_chartered_corporation(corporation) : float_unchartered_corporation(corporation)
+            end
+
+            cleanup_company(company)
+          end
+
+          def action_deal(choice)
+            @game.remove_corporation(random_corporation)
+            index = choice.split('#').last.to_i
+            @game.deal_to_ipo_row(index)
+            card_text = @game.cards_to_deal == 1 ? 'card is' : 'cards are'
+            @log << "#{@game.cards_to_deal} #{card_text} added to IPO Row #{index + 1}"
+          end
+
+          def action_move(choice)
+            parts = choice.split('#')
+            raise GameError, "Incorrect choice format #{choice}" unless parts.size == 3
+
+            id = parts[1]
+            index = parts[2].to_i
+            company = get_company(id)
+            @game.ipo_rows[company.ipo_row_index].delete(company)
+            @game.ipo_rows[index].prepend(company)
+            company.ipo_row_index = index
+            @log << "#{company.name} moves to top of IPO Row #{index + 1}"
+          end
+
+          def action_par_chartered(choice)
+            parts = choice.split('#')
+            raise GameError, "Incorrect choice format #{choice}" unless parts.size == 3
+
+            price = parts[1].to_i
+            id = parts[2].to_sym
+            company = get_company(id)
+            share = company.treasury
+            corporation = share.corporation
+            @game.chartered[corporation] = true
+
+            par_corporation(share, corporation, price, true)
+            cleanup_company(company)
+          end
+
+          def action_par_unchartered(choice)
+            parts = choice.split('#')
+            raise GameError, "Incorrect choice format #{choice}" unless parts.size == 3
+
+            price = parts[1].to_i
+            id = parts[2].to_sym
+            company = get_company(id)
+            share = company.treasury
+            corporation = share.corporation
+
+            @game.convert_to_incremental!(corporation)
+            corporation.tokens.pop # 3 -> 2
+            raise GameError, 'Wrong number of tokens for Unchartered Company' if corporation.tokens.size != 2
+
+            # Unchartered starts shares in treasury
+            corporation.shares.each { |s| s.owner = corporation }
+
+            par_corporation(share, corporation, price, false)
+            cleanup_company(company)
+
+            @game.remove_corporation(random_corporation)
+          end
+
+          def par_corporation(share, corporation, price, chartered)
+            @log << "#{corporation.name} pars at #{price}"
+            corporation.ipoed = true
+            shares_prices = chartered ? @game.par_prices : @game.repar_prices
+            # owner = chartered ? @game.bank : corporation
+            player = @game.players.first
+            share_price = shares_prices.find { |p| p.price == price }
+            @game.stock_market.set_par(corporation, share_price)
+            buy_shares(player, ShareBundle.new([share]), allow_president_change: true)
+          end
+
+          def action_remove(choice)
+            company = get_company_from_choice(choice)
+            @log << "#{company.name} drops from IPO Row #{company.ipo_row_index + 1}"
+            cleanup_company(company)
+            share = company.treasury
+            corporation = share.corporation
+            @game.remove_corporation(corporation)
+          end
+
+          def get_company_from_choice(choice)
+            id = choice.split('#').last
+            get_company(id)
+          end
+
+          def get_company(id)
+            company = @game.company_by_id(id)
+            raise GameError, "Company with ID #{id} not found in IPO rows" unless company
+
+            company
+          end
+
+          def random_corporation
+            # Get a random corporatiion, which player does not own any shares of. TODO: Is this correct?
+            @game.corporations.reject { |c| c.closed? || c.ipoed || player_owns_any_shares_of?(c) }.min_by { rand }
+          end
+
+          def player_owns_any_shares_of?(corp)
+            @game.players.first.shares_by_corporation[corp].any?
+          end
+
+          def cleanup_company(company)
+            @round.bought_shares << company.treasury
+            @game.ipo_rows[company.ipo_row_index].delete(company)
+            company.close!
+          end
+
+          def float_chartered_corporation(corporation)
+            corporation.floated = true
+
+            cash = corporation.par_price.price * 10
+            @log << "Chartered #{corporation.name} floats and receives #{cash}"
+            @game.bank.spend(cash, corporation)
+
+            token_cost = 60 * 3
+            @log << "#{corporation.name} buys 3 tokens and pays #{token_cost}"
+
+            corporation.spend(token_cost, @game.bank)
+            @game.assign_first_permit(corporation)
+          end
+
+          def float_unchartered_corporation(corporation)
+            corporation.floated = true
+
+            cash = corporation.par_price.price * 5
+            @log << "Non-chartered #{corporation.name} floats and receives #{cash}"
+            @game.bank.spend(cash, corporation)
+
+            # TODO, unchartered should buy 2 to 7 tokens, not always 3
+            token_cost = 40 * 3
+            @log << "#{corporation.name} buys 3 tokens and pays #{token_cost}"
+            corporation.spend(token_cost, @game.bank)
+
+            @game.assign_first_permit(corporation)
+            @game.remove_corporation(random_corporation)
           end
         end
       end


### PR DESCRIPTION
Add functionality for 1862 Solo Stock Round. Still not a playable game.

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

There are no games in the database so it should not affect anything.
It should also not affect 1862 base game - have not made any changes of that code, and use dup during setup to avoiding changing base classes.

## Implementation Notes

#### Change of general functionality
- For IPO rows it is now possible to add general choices to a company in an IPO rows, and not just buy_company. This is done by adding the method general_input_rendering_ipo_row to a game. This method should return a list with [a, b] where a = a string containing the choice name b = a string with description It is up to the step of the game to handle this by adding a process_choose which handles the action which has action.choice with matching choice name.

1. Add Permits which are assigned when corporation floats. Cannot float when no permits remain unassigned.
2. Add actions to IPO rows (using general_input_rendering_ipo_rows) a) Buy, which buys a(n already IPOed) top share in an IPO row. This floats the corporation when 30% sold. b) Move, which moves a top share in an IPO row to another IPO row (which has the same corporation on top). c) Remove, which removes a top share, and close the corporation, removing all shares. d) Par, which pars the corporation, either unchartered or chartered, with suitable functions. e) Deal, which adds 6 to an empty IPO row, and removes a corporation.
3. Add IPO row and permit information to Info page.
4. Sell actions is possible, but need to be revisited. It correctly stops you from selling shares you have bought the same SR.

#### Remaining issues
1. Chartered corporation does not do anythin during ORs
2. Unchartered corporations get to buy 3 tokens, but it should be 2-7
3. Removing a corporation does "bomb" starting hex. If there are things in the starting hex it should be "freezed" instead.
4. Only lowest available par value is shown as an option. Should we show all using similar choices or are there some other way we can do this?
5. Having president's share as reserved 30% might not be good. First attempt did just use 70% but then first share was president's share and it caused issues. This way at least it was only regular shares available.
6. We need to check if we handle unfloated corporations properly:
   - skipped during OR without affecting share price
   - sold shares get half price, as train less. Also need to check they end up in bank pool, and cannot be bought directly by player.
7. Mulligan is not supported. Probably not needed, as you can always create a new solo game.

### Explanation of Change

Attempt to get Stock Round to get full functionality in 1862 Solo. Remaining issues are described above.

### Screenshots

<img width="1009" height="1372" alt="image" src="https://github.com/user-attachments/assets/b90c459a-1e28-4c20-a383-20f11a4a9255" />

### Any Assumptions / Hacks

Have added some TODOs to the code.