### PR TITLE
[dev] Update DEVELOPMENT.md to clarify port 9292 needed.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,7 +17,7 @@ This will create a VM hosted by Github just for you with the repo already cloned
 
 You are able to run `make` from the Terminal tab to build and start the 18xx server (based on the current branch checked out)
 
-After the server is running, a pop-up in the bottom right should appear informing you that the server can be opened in a browser.  
+After the server is running, a pop-up in the bottom right should appear informing you that the server can be opened in a browser.
 
 If that pop-up doesn't appear or if the url opens on a different port than `9292`, open the `Ports` tab in the Codespace, hover the "local address" for port `9292` and click the globe to open the server in a browser.
 


### PR DESCRIPTION
<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes
Simple text update in DEVELOPMENT file.

### Explanation of Change
From Safari after doing a build, the default url opened in the browser is not using port 9292 which is needed.  Adding some clarification.
