### PR TITLE
[dev] run fixtures in specs and in browser with `strict: true`

### DIFF
--- a/assets/app/game_manager.rb
+++ b/assets/app/game_manager.rb
@@ -16,6 +16,7 @@ module GameManager
     base.needs :connection, default: nil, store: true
     base.needs :flash_opts, default: {}, store: true
     base.needs :game_classes_loaded, default: {}, store: true
+    base.needs :strict, default: false, store: true
   end
 
   def create_hotseat(**opts)
@@ -48,6 +49,7 @@ module GameManager
 
   def enter_fixture(path)
     @connection.get("/fixtures/#{path}.json", '') do |data|
+      store(:strict, true, skip: true)
       store(:game_data, data, skip: false)
     end
   end

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -80,9 +80,9 @@ module View
         LOGGER.debug do
           @_logger ||= {}
           @_logger[:process] = Time.now
-          'Processing game actions...'
+          "Processing game actions, strict: #{strict}..."
         end
-        @game = Engine::Game.load(@game_data, at_action: cursor, user: @user&.dig('id'))
+        @game = Engine::Game.load(@game_data, at_action: cursor, user: @user&.dig('id'), strict: strict)
         LOGGER.debug do
           "Done processing game actions: #{Time.now - @_logger[:process]} seconds"
         end
@@ -502,6 +502,14 @@ module View
 
     def step
       @game.round.active_step
+    end
+
+    def strict
+      if (param = Lib::Params['strict'])
+        !%w[f false].include?(param)
+      else
+        @strict
+      end
     end
   end
 end

--- a/scripts/validate.rb
+++ b/scripts/validate.rb
@@ -184,7 +184,7 @@ def validate_all(*titles, families: true, game_ids: nil, strict: false, status: 
 
   games = Game.eager(:user, :players, :actions).where(**where_args3).all
   _ = games.each do |game|
-    data[game.id]=run_game(game, silent: silent)
+    data[game.id]=run_game(game, strict: strict, silent: silent)
   end
   puts "#{$count}/#{$total} avg #{$total_time / $total}"
   data['summary']={'failed':$count, 'total':$total, 'total_time':$total_time, 'avg_time':$total_time / $total}

--- a/spec/fixture_cache.rb
+++ b/spec/fixture_cache.rb
@@ -28,7 +28,7 @@ class FixtureCache
     if game && ((game.last_processed_action || 0) <= action)
       game.process_to_action(action)
     else
-      game = Engine::Game.load(data, at_action: action)
+      game = Engine::Game.load(data, at_action: action, strict: true)
       @cache[title][file][:game] = game
     end
     @cache[title][file].delete(:game) if clear_cache


### PR DESCRIPTION
add URL param to run any game in browser with `strict: true`, only fixtures will default to `true`

also fix `validate_all()` passing `strict: true` through to `run_game()`

#11973

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
