### PR TITLE
[1824] Correct buyer of train, fixes #12138

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -580,7 +580,7 @@ module Engine
 
           # Rule IV.2, bullet 8: Coal Railways start with a g train bought from the depot
           g_train = depot.upcoming.select { |t| goods_train?(t.name) }.shift
-          log << "#{id} buys a #{g_train.name} train from the depot for #{format_currency(g_train.price)}"
+          log << "#{minor.id} buys a #{g_train.name} train from the depot for #{format_currency(g_train.price)}"
           buy_train(minor, g_train, g_train.price)
 
           regional_railway = get_associated_regional_railway(minor)


### PR DESCRIPTION
Fixes #12138

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

Only change of log text - no other effect.

## Implementation Notes
N/A

### Explanation of Change
Use name of minor instead, to log buyer.

### Screenshots

Log after correction:
[16:22] piton becomes the president of MLB
[16:22] MLB receives 120G
[16:22] MLB buys a 1g train from the depot for 120G

### Any Assumptions / Hacks
N/A