### PR TITLE
[18SJ] Correct private text, fixes #12136

### DIFF
--- a/lib/engine/game/g_18_sj/entities.rb
+++ b/lib/engine/game/g_18_sj/entities.rb
@@ -99,7 +99,7 @@ module Engine
             name: 'Motala Verkstad',
             value: 90,
             revenue: 20,
-            desc: 'Once during the game, immediately before the run trains action, owning corporation may buy one or '\
+            desc: 'Once during the game, immediately before the run trains action, the owning corporation may buy one or '\
                   'more new trains from the bank. The regular buy train action must be skipped by this corporation '\
                   'in the operating round when the ability is used. Using this ability does not close this private.',
             sym: 'MV',


### PR DESCRIPTION
Fixes #12136

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

Only textual change of private text, no other effect.

## Implementation Notes

Description changed for Motala Verkstad.

### Explanation of Change

Functionality is correct. Have more or less copied the text from AAG rulebook.

### Screenshots

<img width="495" height="380" alt="image" src="https://github.com/user-attachments/assets/192351c2-de6a-4d68-8081-de9ed3d0ba8e" />

### Any Assumptions / Hacks

N/A
