### PR TITLE
[core] throw more informative `GameError` when target action for `undo` cannot be found

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -768,7 +768,14 @@ module Engine
           case action['type']
           when 'undo'
             undo_to = if (id = action['action_id'])
-                        id.zero? ? 0 : actions.index { |a| a['id'] == action['action_id'] } + 1
+                        if id.zero?
+                          0
+                        else
+                          idx = actions.index { |a| a['id'] == id }
+                          raise ActionError, "Could not find target action_id for undo action: #{action}" if idx.nil?
+
+                          idx + 1
+                        end
                       else
                         filtered_actions.rindex { |a| a && a['type'] != 'message' } || 0
                       end


### PR DESCRIPTION
old message was this:

    #<NoMethodError: undefined method `+' for nil:NilClass>

now, much more descriptive and helpful for identifying the problem:

    Uncaught GameError: Could not find target action_id for undo action:
    {"type"=>"undo", "entity"=>"ERIE", "action_id"=>574,
    "entity_type"=>"corporation", "id"=>586, "user"=>4866, "created_at"=>1745320579}

also `validate.rb`: include `@broken_action` in the game data



<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
