### PR TITLE
[1824] Fix tile lay error, fix #12158

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -197,6 +197,11 @@ module Engine
           from.paths_are_subset_of?(to.paths) && to.color == :green && from.towns.one? && to.towns.one?
         end
 
+        # 1824 does not have any special cases here so use base version instead of 1837 version
+        def legal_tile_rotation?(_entity, _hex, _tile)
+          true
+        end
+
         # 1824 version differ from 1837 as a national can become in receivership, and tie breaker is different
         def set_national_president!(national, tie_breaker)
           current_president = national.owner || national


### PR DESCRIPTION
Fixes #12158

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Copied base version of legal_tile_rotation to 1824 game, which will fix this for both 1824 and 1824 Cisleithania.

### Explanation of Change

1837 had some special cases implemented in 1837 game file. This was triggered by 1824 Cisleithania. 
As 1824 (or Cisleithania) does not have any special rotation cases this issue is fixed by using base version.

I considered making a change in 1837 but not clear what that would be.

### Screenshots

N/A

### Any Assumptions / Hacks

N/A
