### PR TITLE
[core] `Step::Route`: require `entity` to be `current_entity`

### DIFF
--- a/lib/engine/step/route.rb
+++ b/lib/engine/step/route.rb
@@ -8,6 +8,7 @@ module Engine
       ACTIONS = %w[run_routes].freeze
 
       def actions(entity)
+        return [] unless entity == current_entity
         return [] if !entity.operator? || @game.route_trains(entity).empty? || !@game.can_run_route?(entity)
 
         ACTIONS


### PR DESCRIPTION
discovered while editing fixtures for #12164, without this the engine will accept a `run_routes` action from another entity
