### PR TITLE
[dev] add helper method for more convenient debugging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,10 @@ Layout/MultilineOperationIndentation:
 Layout/SpaceBeforeBrackets:
   Enabled: false
 
+Lint/Debugger:
+  DebuggerMethods:
+    Engine: debug!
+
 Lint/MissingSuper: # TODO enable & check offenses
   Enabled: false
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -167,6 +167,14 @@ e.g. `docker compose exec rack rspec spec/lib/engine/game/fixtures_spec.rb -e '1
 
 See also `public/fixtures/README.md` for more details on fixture tests and debugging.
 
+#### Debugging
+
+Add a call to `debug!` from `lib/engine/debug.rb` to set a breakpoint in the
+code. `debug!` works on both the Ruby (via
+[pry-byebug](https://github.com/deivid-rodriguez/pry-byebug)) and JavaScript
+([`debugger`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger))
+sides.
+
 #### Profiling the code
 
 Run `docker compose exec rack rake stackprof[spec/fixtures/18_chesapeake/1277.json]` (or other file) to load and process the json file 1000 times. This will generate a stackprof.dump which can be further analyzed

--- a/lib/engine.rb
+++ b/lib/engine.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'engine/debug'
 require_relative 'engine/deep_freeze'
 require_relative 'engine/jaro_winkler'
 require_relative 'engine/logger'

--- a/lib/engine/debug.rb
+++ b/lib/engine/debug.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# sets a breakpoint that works on the server and in the browser; once the
+# breakpoint is hit, navigate up the call stack* to reach the code where you
+# inserted the breakpoint
+#
+# * Ruby: `up` in the IRB console; JavaScript: use the call stack panel in the
+# browser's dev tools
+def debug!(js: true, ruby: true)
+  if ENV['RACK_ENV'] == 'production'
+    LOGGER.warn 'Should not call debug! in production; skipping breakpoint'
+    return
+  end
+
+  if RUBY_ENGINE == 'opal'
+    `debugger;` if js
+  elsif ruby
+    # rubocop:disable Lint/Debugger
+    require 'pry-byebug'
+    binding.pry
+    # rubocop:enable Lint/Debugger
+  end
+
+  nil
+end


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

* adds globally available function, `debug!` for more convenient setting of breakpoints
* `debug!` works for local testing in Ruby as well as in the browser
    * if `binding.pry` is hit when loading a game in the browser, it throws an error since `pry-byebug` cannot be imported and `binding.pry` is undefined; with `debug!` the standard JS `debugger` call is hit instead
* more convenient breakpoints in unit tests, no `require` statement needed
* the added rubocop config means any usages of `debug!` will cause a violation, which should be enough to keep any `debug!` calls out of prod

### Any Assumptions / Hacks

* the `debugger` JS statement needs something after it in the function to work, which is why `debug!` explicitly returns `nil`
* `engine/debug` is imported in `engine.rb`, but since `pry-byebug` is only imported inside the function call, it won't cause an error in prod (if it is somehow added despite RuboCop)
* if `debug!` is somehow called in prod on the server, a warning will be logged but the breakpoint will not be reached, and no attempt to import `pry-byebug` will be made
    * tested: locally modified `Gemfile` and `Gemfile.lock` so that `pry-byebug` was not installed, and confirmed that there is no problem with importing `lib/engine/debug.rb`; an error is only thrown when `debug!` is actually called