### PR TITLE
[dev] ignore emacs tmp files in dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,7 @@ db/data/
 log/
 .git*
 db.backup*
+
+#*#
+*~
+.#*


### PR DESCRIPTION
Maybe solves occasional docker volume issues I'm encountering? Sometimes a file I've edited on my mac will not seem to be picked up with the correct contents by the running ruby process in the docker container.

These might just be Docker/macOS problems but I recently noticed it happen specifically with a file that had changes but went unsaved for ~30 seconds.