### PR TITLE
[core/1822CA] make `slot` not required for `Action::PlaceToken`

### DIFF
--- a/lib/engine/action/place_token.rb
+++ b/lib/engine/action/place_token.rb
@@ -8,9 +8,9 @@ module Engine
       attr_reader :city, :slot
       attr_accessor :cost, :token
 
-      REQUIRED_ARGS = %i[city slot].freeze
+      REQUIRED_ARGS = %i[city].freeze
 
-      def initialize(entity, city:, slot:, cost: nil, tokener: nil, token_type: nil)
+      def initialize(entity, city:, slot: nil, cost: nil, tokener: nil, token_type: nil)
         super(entity)
         @city = city
         @slot = slot


### PR DESCRIPTION
Follow up to #12156; some actions had changes like this in that PR because of fixtures; requiring `slot` broke no fixture tests but did cause some games to fail validation once it was deployed.

1822CA may be the only affected game; its destination token step does not provide a `slot`, and it is not the only step that processes `place_token` where the slot is not actually used during the processing.

allows these games to be _un_-pinned:

```
{"1822CA"=>
  [186175,
   189426,
   193258,
   195126,
   196533,
   197292,
   197804,
   199815,
   201899,
   203273,
   205006,
   205350,
   213385,
   216359,
   218093,
   219734,
   221155],
 "1822CA ERS"=>[201351, 204869, 207532, 215467, 220361, 220908]}
```

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`