### PR TITLE
[1824 Cisleithania] Remove game creation from Alpha

### DIFF
--- a/lib/engine/game/g_1824_cisleithania/meta.rb
+++ b/lib/engine/game/g_1824_cisleithania/meta.rb
@@ -12,7 +12,7 @@ module Engine
 
         DEPENDS_ON = '1824'
 
-        DEV_STAGE = :alpha
+        DEV_STAGE = :prealpha
 
         GAME_IS_VARIANT_OF = G1824::Meta
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1824-Cisleithania-map'.freeze


### PR DESCRIPTION
Due to some bugs related to UG1 it is impossible to make a correct play. So disable creation of new games of 1824 Cisleithania for now.

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

Does not exist already created games.

## Implementation Notes
N/A

### Explanation of Change
N/A

### Screenshots
N/A

### Any Assumptions / Hacks
N/A
