### PR TITLE
[1871 TOP] fixes corp display order in SRs

### DIFF
--- a/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
+++ b/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
@@ -124,16 +124,19 @@ module Engine
           end
 
           def visible_corporations
-            corps = Array(@game.corporations).compact.reject(&:closed?)
+            corps = @game.corporations
 
-            # Split IPOed vs not
-            ipoed, _others = corps.partition(&:ipoed)
+            # First, display ipoed corporations in descending operating order
+            ipoed = corps.select(&:ipoed)
 
-            # Grab PEIR corps that aren’t IPOed
-            peir_not_ipoed = Array(corps[0..6]).compact.reject(&:ipoed)
+            # Next, select non-ipoed PEIR corporations
+            peir_not_ipoed = corps[0..6].reject(&:ipoed)
 
+            # Only display non-ipoed PEIR corps if an open tranch space is available
             ordered = ipoed.sort
             ordered.concat(peir_not_ipoed) if @game.tranch_available?
+
+            # Finally, display the PEIR itself
             ordered << @game.peir
 
             ordered


### PR DESCRIPTION
Fixes #11103

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

I changed the sorting method for visible_corporations. 

Before, the way it was sorted, it showed them in this order:
- Mainline
- Shortline
- ipoed PEIR corps in Tranche 1
- ipoed PEIR corps in Tranche 2
- ipoed PEIR corps in Tranche 3
- non-ipoed PEIR corps
- IPOed non-PEIR corps

Which is not at all how users of the site expect them to be sorted. 

Now, it shows the corporations in this order:

- IPOed corps in descending operating order
- non-IPOed PEIR corps if there are tranche spaces available
- PEIR

In the end, the Mainline and Shortline are labelled. They don't need to also be the first two to appear in the list by default. 

### Screenshots

Before: 
<img width="1119" height="1161" alt="image" src="https://github.com/user-attachments/assets/0b2e2799-9225-4e18-ab43-9195f5cf33c4" />


After change: 
<img width="1094" height="676" alt="image" src="https://github.com/user-attachments/assets/62daced9-95f0-4cae-9725-d6031298eed8" />


### Any Assumptions / Hacks
