### PR TITLE
[1871 TOP] removes trains from PEIR on close

### DIFF
--- a/lib/engine/game/g_1871/game.rb
+++ b/lib/engine/game/g_1871/game.rb
@@ -609,6 +609,10 @@ module Engine
             company_by_id('KM')&.close!
             @log << 'Closing the PEIR'
             peir.set_cash(0, @bank)
+            peir.trains.dup.each do |train|
+              @log << "#{peir.name} discards #{train.name}, removed from game"
+              remove_train(train)
+            end
             peir.close!
             return
           end


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Currently, if/when the PEIR closes, the trains it has stay in the corp. This is an aesthetic fix, discarding the trains from the PEIR which removes them from the game (discarded trains are destroyed in 1871). It's more relevant in this game, since the PEIR remains visible in the Game tab after closing. 

(Mind you, I could also just remove it from the Game tab if closed, if that's preferred)

### Screenshots

### Any Assumptions / Hacks
