### PR TITLE
[core/dev] fix handling chats with auto actions and/or undo targets

### DIFF
--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -195,6 +195,8 @@ module View
           line_props[:style][:fontWeight] = 'bold' if line.is_a?(String) && line.start_with?('--')
 
           if line.is_a?(Engine::Action::Message)
+            next [] if line.message.empty?
+
             line_props[:style][:fontWeight] = 'bold'
             line_props[:style][:marginTop] = '0.5em'
 

--- a/models/game.rb
+++ b/models/game.rb
@@ -137,25 +137,6 @@ class Game < Base
   end
 
   def to_h(include_actions: false, logged_in_user_id: nil)
-    remove_messages = players.none? { |p| p.id == logged_in_user_id } && user_id != logged_in_user_id
-
-    actions_h =
-      if include_actions
-        actions.map do |db_action|
-          action = db_action.to_h
-          if remove_messages && action['type'] == 'message' && action['auto_actions'] && !action['auto_actions'].empty?
-            action.delete('message')
-            action.delete('user')
-            action.merge!(action['auto_actions'].shift)
-            action['id'] = db_action.action_id
-          end
-          action
-        end
-      else
-        []
-      end
-
-    actions_h.reject! { |a| a['type'] == 'message' } if remove_messages
     settings_h = settings.to_h
 
     # Move user settings and hide from other players
@@ -177,7 +158,7 @@ class Game < Base
       round: round,
       acting: acting.to_a,
       result: result.to_h,
-      actions: actions_h,
+      actions: actions_h(include_actions: include_actions, logged_in_user_id: logged_in_user_id),
       loaded: include_actions,
       created_at: created_at_ts,
       updated_at: updated_at_ts,
@@ -188,5 +169,29 @@ class Game < Base
   def validate
     super
     errors.add(:finished_at, 'must be set for finished games') if status == 'finished' && !finished_at
+  end
+
+  # Remove chat messages for players not in the game. Keeps the chat action (but
+  # removes the `message` contents) if the action is the target for an undo, or
+  # if it has auto actions attached.
+  def actions_h(include_actions: false, logged_in_user_id: nil)
+    return [] unless include_actions
+
+    remove_messages = players.none? { |p| p.id == logged_in_user_id } && user_id != logged_in_user_id
+    undo_targets = actions.filter_map { |a| a.action['type'] == 'undo' && a.action['action_id'] }.to_set
+
+    actions.filter_map do |db_action|
+      action = db_action.to_h
+      if remove_messages && action['type'] == 'message'
+        # rubocop:disable Style/GuardClause
+        if undo_targets.include?(action['id']) || (action['auto_actions'] && !action['auto_actions'].empty?)
+          action['message'] = ''
+        else
+          next
+        end
+        # rubocop:enable Style/GuardClause
+      end
+      action
+    end
   end
 end


### PR DESCRIPTION
* model: set `message` to an empty string when the action must be included in the response

* view: if a chat message is an empty string, don't display it

* scrubbing: replace all chat messages with empty strings but keep the actions around

In #12148 I had found some `undo` actions that had an `action_id` pointing to an action that seemed to not exist; turns out there were pointing at chat messages that were filtered by `#to_h` in `models/game.rb`. This change solves that problem and is a better solution than #12178 for auto_actions.



<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
