### PR TITLE
fix import in 1822PNW step

### DIFF
--- a/lib/engine/game/g_1822_pnw/step/acquire_company.rb
+++ b/lib/engine/game/g_1822_pnw/step/acquire_company.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../../../step/route'
+require_relative '../../g_1822/step/acquire_company'
 
 module Engine
   module Game


### PR DESCRIPTION
fixes pinned 1822PNW games breaking, will need to repin them to this commit

not tagging this with `pins`, as I already re-pinned the games that need this fix

### Screenshots

Before:
<img width="1582" height="1034" alt="Screenshot 2025-10-27 at 21 20 44" src="https://github.com/user-attachments/assets/0cc37889-46d0-4851-ba90-b3303249ad0f" />

After (I already created a `.js.gz` file for this commit, rsync'd it to the prod `pinned/` dir, and repinned the games):

<img width="1582" height="1034" alt="Screenshot 2025-10-27 at 21 23 41" src="https://github.com/user-attachments/assets/02cd62be-874f-40e0-bdce-c8f0db7905fc" />

