### PR TITLE
[core/1822/1822PNW] local and E-train routing fixes

### DIFF
--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -1053,6 +1053,8 @@ module Engine
         end
 
         def ski_haus_revenue(route)
+          return 0 if train_type(route.train) == :etrain
+
           route.all_hexes.any? { |hex| ski_hex?(hex) } ? 30 : 0
         end
 

--- a/lib/engine/route.rb
+++ b/lib/engine/route.rb
@@ -259,7 +259,9 @@ module Engine
     end
 
     def check_cycles!
-      return if @train.local?
+      return if @train.local? &&
+                connection_data.one? &&
+                connection_data[0][:left] == connection_data[0][:right]
 
       cycles = {}
 


### PR DESCRIPTION
* core: only short circuit from `check_cycles!` for local trains that are actually running locally, i.e., using a single stop. In the 1822 family, LP trains are permanent trains that are local but can also encounter cycles if running from a city to a town after the yellow phase; fixes #11784

* 1822PNW: E-trains cannot get the Ski Haus private bonus; fixes #12190

* 1822 family: require E-train routes to start and stop at tokened cities; if all tokens are already included and the route is extending beyond the tokened cities, raise `RouteTooLong` so the autorouter can abort searching longer routes.

    * 1822 rulebook: 5.11.21: "There is no limit to the number of locations that an E-train can stop at, other than that imposed by the number of tokens on the map and the route between them."



<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`