### PR TITLE
[Core] disable Restart Turn button during auctions

### DIFF
--- a/assets/app/view/game/restart_turn_button.rb
+++ b/assets/app/view/game/restart_turn_button.rb
@@ -25,7 +25,7 @@ module View
       end
 
       def button_disabled?
-        !@game.undo_possible || !@game.turn_start_action_id
+        !@game.undo_possible || !@game.turn_start_action_id || @game.round.is_a?(Engine::Round::Auction)
       end
     end
   end


### PR DESCRIPTION
Fixes #6605

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Hitting the Restart Turn button during auctions can cause problems, notably in waterfall auctions where it can rewind the entire waterfall.

I added a simple exception to disable the Restart Turn button if @game.round.is_a?(Engine::Round::Auction)

I did consider the fact that this could potentially affect games that use Auction rounds in unexpected ways, but in the end, disabling the Restart Turn button doesn't impact the gameplay in any way, at worst a player might need to click undo 2-3 times. 

### Screenshots

### Any Assumptions / Hacks
