### PR TITLE
[front page] Reset filters button clears selection

### DIFF
--- a/assets/app/view/game_row_filters.rb
+++ b/assets/app/view/game_row_filters.rb
@@ -11,10 +11,12 @@ module View
       url_search_params = Lib::Params::URLSearchParams.new
       return '' if url_search_params.unsupported
 
+      title_elm = render_title(url_search_params)
+
       h('div#game_filters.game_row', { key: @header }, [
         h(:h2, 'Filters'),
-        render_title(url_search_params),
-        render_reset,
+        title_elm,
+        render_reset(title_elm),
       ])
     end
 
@@ -39,15 +41,16 @@ module View
       h('select', attrs, game_options)
     end
 
-    def render_reset
+    def render_reset(title_elm)
       attrs = {
         on: {
-          click: lambda do |_|
-            `document.querySelector('#game_filters select').value = ''`
+          click: lambda do
+            Native(title_elm)&.elm&.value = ''
             update_filters('')
           end,
         },
       }
+
       h('button', attrs, 'Reset filters')
     end
 


### PR DESCRIPTION
Fixes #7998


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Currently, if you filter for a game on the homepage of the site, and then click the `Reset filters` button, it clears the filter, but  leaves the previously selected filter game in the drop-down menu. 

This corrects that so that clicking `Reset filters` also clears the drop-down selection and resets it to (All titles)

### Screenshots

### Any Assumptions / Hacks
