### PR TITLE
[1824] President cannot help in non-Emergency buy, fixes #12182

### DIFF
--- a/lib/engine/game/g_1824/step/buy_train.rb
+++ b/lib/engine/game/g_1824/step/buy_train.rb
@@ -47,8 +47,37 @@ module Engine
             !depot_g_trains.empty?
           end
 
+          def president_may_contribute?(entity, _shell = nil)
+            must_buy_train?(entity)
+          end
+
+          def can_ebuy_sell_shares?(entity)
+            owner = entity.owner
+            available_cash = entity.cash + owner.cash
+
+            prices = [cheapest_train_price(entity), cheapest_discountable_train_price(entity)].select(&:positive?)
+            return false if prices.empty?
+
+            available_cash < prices.min
+          end
+
           def pass_if_cannot_buy_train?(_entity)
             false
+          end
+
+          def cheapest_train_price(corporation)
+            return buyable_trains(corporation).map(&:price).min unless buyable_trains(corporation).empty?
+
+            0
+          end
+
+          def cheapest_discountable_train_price(corporation)
+            return 0 unless discountable_trains_allowed?(corporation)
+
+            discountable_trains = @game.discountable_trains_for(corporation)
+            return discountable_trains.map(&:price).min unless discountable_trains.empty?
+
+            0
           end
 
           def must_take_player_loan?(entity)


### PR DESCRIPTION
Also, do only show shares to sell if available cash is lower than cheapest train purchase or exchange.

Fixes #12182

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

Did not find any games broken by this fix when doing vaildate vs backup from 2025-10-29, but if there are they can be archived.

## Implementation Notes

N/A

### Explanation of Change

Current 1837 implementation did disturb a bit, so use 1824 specific.

Also, do only show share sale if that is needed to finance a train purchase.

### Screenshots

N/A

### Any Assumptions / Hacks

N/A
