### PR TITLE
[1862] require corp to lay home tile

### DIFF
--- a/lib/engine/game/g_1862/step/track.rb
+++ b/lib/engine/game/g_1862/step/track.rb
@@ -25,6 +25,19 @@ module Engine
             super
           end
 
+          def process_pass(action)
+            raise GameError, "Must lay home track tile for #{action.entity.name}" if must_lay_track?(action.entity)
+
+            log_pass(action.entity)
+            pass!
+          end
+
+          def must_lay_track?(entity)
+            return false unless entity == current_entity
+
+            @game.hex_by_id(entity.coordinates).tile.color == :white
+          end
+
           def track_upgrade?(_from, to, _hex)
             # this also takes care of adding small stations, since that is never yellow to yellow
             to.color != :yellow || to.label.to_s == 'N'


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Per rule 7.2, a corporation _must_ lay its home tile on its first operating turn. Since all non-offboards in this game start white, I've added a check in the process_path method to raise a GameError if the hex_by_id(entity.coordinates).tile.color == :white.

This was discussed in Issue #7614 . I didn't label this PR as fixing that issue, because there are other issues raised there. 

Any games where they passed the Track step without laying the home tile will need to be pinned, and there's no way around that. 

### Screenshots

### Any Assumptions / Hacks
