### PR TITLE
[Core/1862] Confirm pass (when under obligation in 1862)

### DIFF
--- a/assets/app/view/game/pass.rb
+++ b/assets/app/view/game/pass.rb
@@ -10,11 +10,43 @@ module View
       needs :actions, default: []
 
       def render
+        # This lambda runs *before* the PassButton executes its action
+        confirm_before = lambda do
+          # Recompute step on every click
+          step =
+            if @game.round.respond_to?(:active_step)
+              @game.round.active_step
+            else
+              @game.round
+            end
+
+          needs_confirm = step.respond_to?(:confirm_pass?) && step&.confirm_pass?
+          message =
+            if step.respond_to?(:confirm_pass_message) && (m = step.confirm_pass_message).to_s.strip != ''
+              m
+            else
+              'Are you sure you want to pass?'
+            end
+
+          do_pass = -> { process_action(Engine::Action::Pass.new(@game.pass_entity(@user))) }
+
+          if needs_confirm
+            store(:confirm_opts, { message: message, click: do_pass }, skip: false)
+            false # stop default behavior (PassButton won’t run process_action yet)
+          else
+            true # allow PassButton to proceed normally
+          end
+        end
+
         children = []
         if @actions.include?('pass')
-          children << h(PassButton)
-          children << h(PassAutoButton) if @game.round.show_auto? && @game.active_players_id.include?(@user&.dig('id'))
+          children << h(PassButton, before_process_pass: confirm_before)
+
+          if @game.round.show_auto? && @game.active_players_id.include?(@user&.dig('id'))
+            children << h(PassAutoButton, before_process_pass: confirm_before)
+          end
         end
+
         h(:div, children.compact)
       end
     end

--- a/assets/app/view/game/pass_auto_button.rb
+++ b/assets/app/view/game/pass_auto_button.rb
@@ -7,11 +7,15 @@ module View
     class PassAutoButton < Snabberb::Component
       include Actionable
 
+      # Return truthy to proceed, false or :halt to cancel
+      needs :before_process_pass, default: -> { true }, store: true
+
       def render
         props = {
           on: {
             click: lambda do
-              process_action(Engine::Action::ProgramSharePass.new(@game.current_entity))
+              proceed = @before_process_pass.call
+              process_action(Engine::Action::ProgramSharePass.new(@game.current_entity)) unless [false, :halt].include?(proceed)
             end,
           },
         }

--- a/assets/app/view/game/pass_button.rb
+++ b/assets/app/view/game/pass_button.rb
@@ -8,14 +8,16 @@ module View
       include Actionable
 
       needs :for_player, default: nil
-      needs :before_process_pass, default: -> {}, store: true
+      needs :before_process_pass, default: -> { true }, store: true
 
       def render
         props = {
           on: {
             click: lambda do
-              @before_process_pass.call
-              process_action(Engine::Action::Pass.new(@for_player || @game.pass_entity(@user)))
+              proceed = @before_process_pass.call
+              unless [false, :halt].include?(proceed)
+                process_action(Engine::Action::Pass.new(@for_player || @game.pass_entity(@user)))
+              end
             end,
           },
         }

--- a/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
@@ -9,6 +9,14 @@ module Engine
         class BuySellParShares < Engine::Step::BuySellParShares
           UNCHARTERED_TOKEN_COST = 40
 
+          def confirm_pass?
+            @game.current_entity.companies.any?
+          end
+
+          def confirm_pass_message
+            'You are still under obligation to float a Chartered Company. Pass?'
+          end
+
           def can_buy?(entity, bundle)
             return unless bundle&.buyable
 

--- a/lib/engine/step/base.rb
+++ b/lib/engine/step/base.rb
@@ -57,6 +57,9 @@ module Engine
         pass!
       end
 
+      def confirm_pass? = false
+      def confirm_pass_message = 'Pass?'
+
       def skip!
         log_skip(current_entity) if !@acted && current_entity
         pass!


### PR DESCRIPTION
Fixes #10322

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

In 1862, if you leave a stock round without floating certain corporations, they are closed and the owner of the presidency is penalised for it. A user requested some kind of warning to users when they pass in the stock round while still under obligation to float a corporation. 

As I was working on this, I found the most logical solution here would be to have a yellow `Confirm?` bar like the one used for consenting train buys from other players, among other things. This was a bit outside of my normal wheelhouse, but I believe I've accomplished what I was aiming to do.

This PR adds a `confirm_pass?` check to /lib/engine/step/base.rb that defaults to false, as well as a `confirm_pass_text` default. Then it modifies the relevant elements of /assets/app/view (pass, pass_button, and pass_auto_button) to implement this check. 

I imported more that three dozen completed games (all different titles) from the site, and all loaded fine. From what I can tell, there's no reason why this would impact any existing games, since they'll all have the `confirm_pass?` method defined as false by default. 

I recognise that I'm implementing changes to core functions of the site, so please scrutinize every character of this PR!

### Screenshots

<img width="1080" height="695" alt="image" src="https://github.com/user-attachments/assets/93e62439-9ec6-4d06-8998-b50f685f8423" />


### Any Assumptions / Hacks
