### PR TITLE
[18Norway] improve market color

### DIFF
--- a/lib/engine/game/g_18_norway/game.rb
+++ b/lib/engine/game/g_18_norway/game.rb
@@ -70,7 +70,7 @@ module Engine
              165Y 180Y 195Y 220Y 245Y 270Y 300Y 330Y 365Y 400Y 440Y 480Y],
            ].freeze
         STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(
-          pays_bonus_3: :white,
+          pays_bonus_3: :green,
           only_president: :gray
         ).freeze
         MARKET_TEXT = Base::MARKET_TEXT.merge(


### PR DESCRIPTION
Fixes #11744

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

User noted that the color used for when a corp is in the triple-jump portion of the market doesn't really display well on charters in light mode: 

<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/78bb78a6-334d-4360-92cb-e652e2977304" />

I changed the color to a light green, this will display well in light and dark modes. 

<img width="779" height="203" alt="image" src="https://github.com/user-attachments/assets/fb382dd8-869e-4142-9a19-650ca6d78b46" />


### Screenshots

### Any Assumptions / Hacks
