### PR TITLE
[1862] Adds help text for unfloated chartered companies

### DIFF
--- a/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1862/step/buy_sell_par_shares.rb
@@ -10,7 +10,7 @@ module Engine
           UNCHARTERED_TOKEN_COST = 40
 
           def help
-            return if current_entity.companies.none?
+            return if current_entity.companies.empty?
 
             company_plural = current_entity.companies.size > 1 ? 'Companies' : 'Company'
 


### PR DESCRIPTION
Fixes #10322 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Adds a `help` message above the Pass button in the Stock Round if the player is still under obligation to float one or more Chartered Companies.

### Screenshots

<img width="472" height="282" alt="image" src="https://github.com/user-attachments/assets/e9e8c98c-2eec-4dfb-bbc9-d87c5ae3fe2e" />

### Any Assumptions / Hacks
