### PR TITLE
[1824 Family] Only show single MR when doing forced MR exchange, fixes #12205

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -471,7 +471,7 @@ module Engine
           # In case of a forced MR exchange, we only want to show one MR for a player
           # as the player can only exchange the MR with the lowest number. We do not
           # do this always as a player can do an unforced exchange with any MR.
-          candidates.group_by(&:owner).transform_values(&:first).values
+          candidates.group_by(&:owner).map { |_o, c| c.first }
         end
 
         def mountain_railway?(entity)


### PR DESCRIPTION
Fixes #12205 

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

This should not break any games as it is an UI change.

## Implementation Notes

When in forced MR exchange, ensure only one exchange button appear for a player, even if owning more than one. Need to do exchange one at a time.

### Explanation of Change

If player select another MR than the one with lowest number, the game crashes and is broken.

But even more so, allowing exchange of non-lowest MR is breaking the rules, as a player might be doing an exchange in front of a player with a lower MR number. 

The alternative would be to show some error message if exchange is attempted with wrong MR, but I think not showing later ones is a better UX.

### Screenshots

N/A

### Any Assumptions / Hacks

N/A