### PR TITLE
[core] fix non-current entities getting `actions` in `Step::Dividend`

### DIFF
--- a/lib/engine/step/dividend.rb
+++ b/lib/engine/step/dividend.rb
@@ -10,6 +10,7 @@ module Engine
       ACTIONS = %w[dividend].freeze
 
       def actions(entity)
+        return [] unless entity == current_entity
         return [] if entity.company? || total_revenue.zero?
 
         ACTIONS


### PR DESCRIPTION
Fixes #12194



<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

----

Found broken games:

`[201363, 221366, 202063, 211971, 207883, 211835, 213693, 220506, 201857, 207769, 222707, 187532, 207088, 190721, 220216, 211607, 221003, 223114, 228109, 229127, 222154, 229618]`

At these links you can see a corporation paying dividends and getting the share price change (and even treasury cash when withholding!) that is different from the corporation that just ran trains.

1822
* https://18xx.games/game/223114?action=1220

1830
* https://18xx.games/game/190721?action=878
* https://18xx.games/game/229127?action=845
* https://18xx.games/game/229618?action=1039

1844
* https://18xx.games/game/211835?action=451

1846
* https://18xx.games/game/211971?action=971

1849
* https://18xx.games/game/207769?action=689

1860
* https://18xx.games/game/207088?action=724

1862
* https://18xx.games/game/187532?action=734
* https://18xx.games/game/201363?action=898
* https://18xx.games/game/201857?action=647
* https://18xx.games/game/202063?action=764
* https://18xx.games/game/211607?action=592
* https://18xx.games/game/221366?action=667
* https://18xx.games/game/222707?action=844

1889
* https://18xx.games/game/220216?action=219
* https://18xx.games/game/228109?action=728

1894
* https://18xx.games/game/213693?action=1057

18Carolinas
* https://18xx.games/game/220506?action=443

18USA
* https://18xx.games/game/207883?action=2282
* https://18xx.games/game/221003?action=1262
* https://18xx.games/game/222154?action=2671
