### PR TITLE
[1822 family] show info about exporting trains / minor flotation in bid boxes

### DIFF
--- a/assets/app/view/game/company.rb
+++ b/assets/app/view/game/company.rb
@@ -186,7 +186,8 @@ module View
               backgroundColor: color_for(:bg2),
               color: color_for(:font2),
             }
-            children << h(:div, { style: status_style }, @game.company_status_str(@company))
+            statuses = Array(@game.company_status_str(@company))
+            children << h(:div, { style: status_style }, statuses.map { |s| h(:div, s) })
           end
 
           unless @interactive

--- a/lib/engine/depot.rb
+++ b/lib/engine/depot.rb
@@ -149,5 +149,9 @@ module Engine
     def player
       nil
     end
+
+    def inspect
+      "<#{self.class.name}>"
+    end
   end
 end

--- a/lib/engine/game/g_1822/round/stock.rb
+++ b/lib/engine/game/g_1822/round/stock.rb
@@ -120,12 +120,7 @@ module Engine
             minor.reservation_color = :white
 
             # Get the correct par price according to phase
-            current_phase = @game.phase.name.to_i
-            max_par_price = @game.stock_market.par_prices.map(&:price).max
-            par_price_to_find = current_phase == 1 ? @game.class::MINOR_START_PAR_PRICE : bid_amount / 2
-            par_price_to_find = max_par_price if par_price_to_find > max_par_price
-
-            share_price = @game.stock_market.par_prices.find { |pp| pp.price <= par_price_to_find }
+            share_price = @game.minor_float_share_price(bid)
             presidency_price = share_price.price * 2
 
             # Set the par price of the minor, player buys presidency
@@ -138,11 +133,7 @@ module Engine
             minor.spend(minor.cash, @game.bank)
 
             # Move the correct amount to money to the minor. This is according to phase of the game
-            treasury = if current_phase < 3
-                         presidency_price
-                       else
-                         bid_amount
-                       end
+            treasury = @game.minor_float_starting_cash(bid_amount, presidency_price)
 
             # Spend the remaining bid amount
             excess = bid_amount - presidency_price

--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -911,12 +911,8 @@ module Engine
           entity.trains.count { |t| !extra_train?(t) } < train_limit(entity)
         end
 
-        def company_status_str(company)
-          if company == company_reserve_tiles && @reserved_tiles&.any?
-            return "[#{@reserved_tiles.map { |t| "##{t.name}" }.join(', ')}]"
-          end
-
-          super
+        def company_status_game_specific(company)
+          "[#{@reserved_tiles.map { |t| "##{t.name}" }.join(', ')}]" if company == company_reserve_tiles && @reserved_tiles&.any?
         end
 
         # Stubbed out because this game doesn't use it, but base 22 does

--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -455,9 +455,9 @@ module Engine
           concessions = @companies.select { |c| c.id[0] == self.class::COMPANY_CONCESSION_PREFIX }
           privates = @companies.select { |c| c.id[0] == self.class::COMPANY_PRIVATE_PREFIX }
 
-          c1 = concessions.find { |c| c.id == bidbox_start_concession }
-          concessions.delete(c1)
-          concessions.unshift(c1)
+          @c1 = concessions.find { |c| c.id == bidbox_start_concession }
+          concessions.delete(@c1)
+          concessions.unshift(@c1)
 
           p1 = privates.find { |c| c.id == bidbox_start_private }
           privates.delete(p1)
@@ -694,11 +694,43 @@ module Engine
           company.close!
         end
 
-        def company_status_str(company)
-          index = bidbox_minors.index(company) || bidbox_concessions.index(company) || bidbox_privates.index(company)
-          return "Bid box #{index + 1}" if index
+        def company_status_game_specific(_company); end
 
-          nil
+        def bidbox_status_str(company)
+          if company == @c1
+            if @round.highest_bid(company)
+              [
+                'Bid box 1',
+                "M18 Float Order: #{minor_float_index(company) + 1}",
+                "Share Price: #{format_currency(50)}",
+                "Starting Cash: #{format_currency(100)}",
+              ]
+            else
+              ['Bid box 1']
+            end
+          else
+            super
+          end
+        end
+
+        def minor_float_index(company)
+          return super unless bidbox_concessions.first.id == bidbox_start_concession
+          return super unless @round.highest_bid(@c1)
+
+          c1_par = self.class::MINOR_START_PAR_PRICE
+
+          if company == @c1
+            will_float = minors_to_float
+            will_float.find_index { |mb, _index| minor_float_share_price(mb).price == c1_par } || will_float.size
+          elsif minor_float_share_price(@round.highest_bid(company)).price == c1_par
+            super + 1
+          else
+            super
+          end
+        end
+
+        def minor_float_train_export_verb
+          'give NDEM'
         end
 
         def terrain?(tile, terrain)

--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -1139,12 +1139,7 @@ module Engine
           company.close!
         end
 
-        def company_status_str(company)
-          index = bidbox_minors.index(company) || bidbox_privates.index(company)
-          return "Bid box #{index + 1}" if index
-
-          nil
-        end
+        def company_status_game_specific(_company); end
 
         def status_str(corporation)
           return super unless regional_railway?(corporation)


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Adds text informing what will happen due to bids or lack of bids on Minor companies in the 1822 family. Shows what train(s) will be exported, and what a Minor's starting share price, treasury, and float order will be.

The rules for these values and how they change over the early phases of the game can be confusing/hard to remember for inexperienced or rusty 1822 players.

### Screenshots

#### 1822MX

FCM concession, multiple minors starting at $50 with $100 treasury, multiple exporting trains:

<img width="1313" height="686" alt="Screenshot 2025-10-21 at 18 26 18" src="https://github.com/user-attachments/assets/77713372-b1a6-4962-8053-e21176a157c8" />

Minor in bidbox 1 will export multiple trains:

<img width="1313" height="546" alt="Screenshot 2025-10-21 at 18 26 51" src="https://github.com/user-attachments/assets/babd82a0-2484-40d8-9a6f-e6f576450794" />

No more L trains to export, float order for same share price is determined first by highest bid rather than bid box number or turn order of the bidders, and starting cash now matches the bid:

<img width="1300" height="323" alt="Screenshot 2025-10-21 at 18 27 17" src="https://github.com/user-attachments/assets/c1c46757-e00b-4e20-b1cc-7966b2f10d6d" />

### Any Assumptions / Hacks

1822MX gets special handling for Minor 18, which is paired with the FCM concession in the auction and always floats first amongst $50 minors.

1822MX indicates that removed minors will give their trains to NDEM; the other titles say the trains will be removed.

1822Africa's rules and code for bid boxes are a little bit different, and consequently it does not yet have the same updates with these changes. I have never played 1822Africa and have little experience with its code, and I'm mainly focused on #12193 right now, so I wanted to get the PR these changes open now instead of waiting till I get around to adding it for 1822Africa.

