### PR TITLE
[1824 Family] Consider remaining MR for valid actions left, fixes #12195

### DIFF
--- a/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
+++ b/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
@@ -24,6 +24,8 @@ module Engine
               actions << 'pass' if actions.one?
             end
 
+            actions << 'pass' if add_pass_to_allow_mr_change?(entity, actions)
+
             # If debt exists, add actions to pay off
             if player_debt.positive? && entity.cash.positive?
               actions << 'payoff_player_debt'
@@ -160,6 +162,15 @@ module Engine
             return false unless exchange
 
             !@game.mountain_railway_exchangable? || !@game.exchangable_for_mountain_railway?(entity, corporation)
+          end
+
+          def add_pass_to_allow_mr_change?(entity, actions)
+            # There might be that we have no other possible actions, but still have an MR we might want to exchange
+            return false unless entity.player?
+            return false unless @game.mountain_railway_exchangable?
+            return false if bought? || actions.include?('pass')
+
+            @game.companies.find { |c| @game.mountain_railway?(c) && c.owner == entity }
           end
         end
       end


### PR DESCRIPTION
If there is a possible MR exchange available, ensure that pass is available actions, so that game do not skip player when no other possible action left.

Fixes #12195

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

This should break some games (as there should be out of order stock actions) but for some reason all games validate OK.

## Implementation Notes

Should only add Pass as an possible action, if there is no Pass among actions, and there is a legal possibility to exchange an MR.

### Explanation of Change

Now the user will get a Pass, and then they can click on one of the regionals and get a button choice to Exchange for each MR they have. (Exchange is a buy action, so only one per turn.)

### Screenshots

N/A

### Any Assumptions / Hacks

N/A