### PR TITLE
[1822/family] fix E-train running to English Channel and France

### DIFF
--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -45,6 +45,8 @@ module Engine
         COMPANY_CHPR = 'P28' # Station Swap
         COMPANY_5X_REVENUE = 'P9'
         COMPANY_HSBC = nil # Grimsby/Hull Bridge
+        ENGLISH_CHANNEL_HEX = nil
+        FRANCE_HEX = nil
 
         COMPANY_WINNIPEG_TOKEN = 'P10'
 

--- a/lib/engine/game/g_1822_mx/game.rb
+++ b/lib/engine/game/g_1822_mx/game.rb
@@ -63,6 +63,8 @@ module Engine
         COMPANY_LCDR = nil
         COMPANY_OSTH = nil
         COMPANY_LUR = nil # Move Card
+        ENGLISH_CHANNEL_HEX = nil
+        FRANCE_HEX = nil
 
         PRIVATE_COMPANIES_ACQUISITION = {
           'P1' => { acquire: %i[major], phase: 5 },

--- a/lib/engine/game/g_1822_nrs/game.rb
+++ b/lib/engine/game/g_1822_nrs/game.rb
@@ -16,6 +16,8 @@ module Engine
         include G1822::Scenario
 
         BIDDING_BOX_START_MINOR = nil
+        ENGLISH_CHANNEL_HEX = nil
+        FRANCE_HEX = nil
 
         CERT_LIMIT = { 2 => 27, 3 => 16, 4 => 13, 5 => 10, 6 => 9, 7 => 8 }.freeze
 

--- a/lib/engine/game/g_1822_pnw/game.rb
+++ b/lib/engine/game/g_1822_pnw/game.rb
@@ -117,6 +117,8 @@ module Engine
         COMPANY_OSTH = nil
         COMPANY_LUR = 'P21' # Move Card
         COMPANY_10X_REVENUE = nil
+        ENGLISH_CHANNEL_HEX = nil
+        FRANCE_HEX = nil
 
         PRIVATE_COMPANIES_ACQUISITION = {
           'P1' => { acquire: %i[major], phase: 5 },


### PR DESCRIPTION
* moves English Channel logic to top of `check_distance`, so the `english_channel_visit()` return value can be used in the E-train computation

* allow E-train to run to the France offboard, provided English Channel is also visited and tokened

* explicitly set `ENGLISH_CHANNEL_HEX` and `FRANCE_HEX` to `nil` in other 1822 family games (1822Africa already has this); if those constants are `nil`, return from `english_channel_visit()` before checking visits

Broken in #12192

Fixes #12215


<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`