### PR TITLE
[Engine V2] init

### DIFF
--- a/assets/app/lib/whats_this.rb
+++ b/assets/app/lib/whats_this.rb
@@ -37,6 +37,7 @@ module Lib
                 attrs: {
                   href: @url,
                   title: @tooltip,
+                  target: '_blank',
                 },
                 style: { 'text-decoration' => 'underline dotted' },
               },

--- a/assets/app/lib/whats_this.rb
+++ b/assets/app/lib/whats_this.rb
@@ -10,6 +10,14 @@ module Lib
       end
     end
 
+    module EngineV2
+      def engine_v2_whats_this
+        h(Component,
+          tooltip: 'Various work-in-progress changes to make the game Engine more efficient.',
+          url: 'https://github.com/tobymao/18xx/wiki/Engine-V2')
+      end
+    end
+
     class Component < Snabberb::Component
       needs :tooltip
       needs :url

--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -11,6 +11,7 @@ module View
     include GameManager
     include Lib::Settings
     include Lib::WhatsThis::AutoRoute
+    include Lib::WhatsThis::EngineV2
 
     needs :mode, default: :multi, store: true
     needs :flash_opts, default: {}, store: true
@@ -99,6 +100,7 @@ module View
           end
 
           inputs << render_random_seed
+          inputs << render_engine_v2 if should_render_engine_v2?
           inputs << render_optional if should_render_optional?
           inputs << render_game_info
         end
@@ -455,6 +457,7 @@ module View
           title: game_params[:title],
         }
         game_data[:settings][:seed] = game_params[:seed] if game_params[:seed]
+        game_data[:settings][:use_engine_v2] = game_params[:use_engine_v2] if game_params[:use_engine_v2]
 
       when :json
         begin
@@ -710,6 +713,23 @@ module View
     def update_player_range(meta)
       title = meta.title
       @min_p[title], @max_p[title] = meta::PLAYER_RANGE
+    end
+
+    def render_engine_v2
+      render_input(
+        'Use Engine V2 (experimental)',
+        id: 'use_engine_v2',
+        type: :checkbox,
+        container_style: { paddingLeft: '0.5rem' },
+        attrs: { checked: false },
+        siblings: [engine_v2_whats_this],
+      )
+    end
+
+    def should_render_engine_v2?
+      # for now, only available locally for any contributors
+      # https://github.com/tobymao/18xx/issues/12193
+      !@production
     end
   end
 end

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -13,6 +13,7 @@ module View
     include GameManager
     include Lib::Settings
     include Lib::WhatsThis::AutoRoute
+    include Lib::WhatsThis::EngineV2
     include Lib::ProfileLink
 
     needs :user
@@ -242,6 +243,7 @@ module View
       if @gdata['status'] == 'new'
         children << h(:div, [h(:i, 'Invite only game')]) if @gdata.dig('settings', 'unlisted')
         children << h(:div, [h(:i, ['Auto Routing', auto_route_whats_this])]) if @gdata.dig('settings', 'auto_routing')
+        children << h(:div, [h(:i, ['Engine V2', engine_v2_whats_this])]) if @gdata.dig('settings', 'use_engine_v2')
       end
       children << h(:div, [h(:strong, 'Description: '), @gdata['description']]) unless @gdata['description'].empty?
 

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -80,9 +80,15 @@ module View
         LOGGER.debug do
           @_logger ||= {}
           @_logger[:process] = Time.now
-          "Processing game actions, strict: #{strict}..."
+          "Processing game actions, strict: #{strict}, use_engine_v2: #{use_engine_v2}..."
         end
-        @game = Engine::Game.load(@game_data, at_action: cursor, user: @user&.dig('id'), strict: strict)
+        @game = Engine::Game.load(
+          @game_data,
+          at_action: cursor,
+          user: @user&.dig('id'),
+          strict: strict,
+          use_engine_v2: use_engine_v2
+        )
         LOGGER.debug do
           "Done processing game actions: #{Time.now - @_logger[:process]} seconds"
         end
@@ -515,6 +521,16 @@ module View
       else
         @strict
       end
+    end
+
+    # https://github.com/tobymao/18xx/issues/12193
+    def use_engine_v2
+      if (param = Lib::Params['v2'])
+        return false if param.start_with?('f')
+        return true if param.start_with?('t')
+      end
+
+      @game_data.dig('settings', 'use_engine_v2')
     end
   end
 end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -69,6 +69,7 @@ module Engine
       pin = kwargs[:pin] || settings['pin']
       seed = kwargs[:seed] || settings['seed']
       optional_rules = kwargs[:optional_rules] || settings['optional_rules'] || []
+      use_engine_v2 = kwargs[:use_engine_v2] || settings['use_engine_v2']
 
       init_kwargs = %i[description min_players max_players settings created_at updated_at finished_at].to_h do |key|
         [key, data[key] || data[key.to_s]]
@@ -82,6 +83,7 @@ module Engine
         pin: pin,
         seed: seed,
         optional_rules: optional_rules,
+        use_engine_v2: use_engine_v2,
         **init_kwargs
       )
     end
@@ -95,7 +97,7 @@ module Engine
                   :tiles, :turn, :total_loans, :undo_possible, :redo_possible, :round_history, :all_tiles,
                   :optional_rules, :exception, :last_processed_action, :broken_action,
                   :turn_start_action_id, :last_turn_start_action_id, :programmed_actions, :round_counter,
-                  :manually_ended, :seed, :game_end_reason, :game_end_trigger
+                  :manually_ended, :seed, :game_end_reason, :game_end_trigger, :use_engine_v2
 
       # Game end check is described as a dictionary
       # with reason => after
@@ -571,8 +573,13 @@ module Engine
         optional_rules: [],
         user: nil,
         seed: nil,
+        use_engine_v2: false,
         **init_kwargs
       )
+        # experimental flag; see
+        # https://github.com/tobymao/18xx/issues/12193
+        @use_engine_v2 = use_engine_v2
+
         @id = id
         @init_kwargs = init_kwargs
         @turn = 1

--- a/routes/game.rb
+++ b/routes/game.rb
@@ -207,6 +207,7 @@ class Api
               unlisted: r.params['unlisted'],
               optional_rules: r.params['optional_rules'],
               auto_routing: r.params['auto_routing'],
+              use_engine_v2: r.params['use_engine_v2'],
               is_async: r.params['async'],
             },
             title: title,


### PR DESCRIPTION
Starting on #12193. No functional changes in the game engine yet.

My in-progress changes can be seen in the branches on my fork starting with "v2" ([link](https://github.com/michaeljb/18xx.games/branches/all?query=v2&lastTab=overview)).

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

* adds `Game` attr to use as a flag for new changes, `@use_engine_v2`
* adds scaffolding to create a game via the UI with the flag
    * the option on the create game page to use the flag is only available locally - so for now, any code contributors will be able to local testing of Engine V2, but it will not be available to players of the public site
* the URL query param `v2` can be used to override a game's saved Engine V2 setting

### Screenshots

"Use Engine V2" checkbox when creating new game:

<img width="500" height="513" alt="Screenshot 2025-11-02 at 12 04 19" src="https://github.com/user-attachments/assets/11247a78-f3aa-4853-b52a-9f55fe839322" />

Game card:

<img width="340" height="186" alt="Screenshot 2025-11-02 at 12 07 33" src="https://github.com/user-attachments/assets/247ccdfc-6327-4cca-b05c-56a5a50b2831" />

