### PR TITLE
[1852 MO] fix East St Louis as optional stop

### DIFF
--- a/lib/engine/game/g_18_mo/game.rb
+++ b/lib/engine/game/g_18_mo/game.rb
@@ -378,9 +378,8 @@ module Engine
           # return if not enough normal stops
           return visits if normal_stops.size < paying_distance['pay']
 
-          # remove smallest normal stop that has less revenue than dit
-          worst_stop = normal_stops.min_by { |stop| stop.route_revenue(route.phase, route.train) }
-          visits.reject { |stop| stop == worst_stop }
+          # ignore the optional dit stop
+          normal_stops
         end
 
         def setup_turn


### PR DESCRIPTION
the existing code removes the lowest-value city instead of East St Louis, and contrary to the comment, doesn't even make sure the value of the removed city is lower than $30

Fixes #12199

<img width="1250" height="536" alt="Screenshot 2025-11-02 at 21 57 48" src="https://github.com/user-attachments/assets/b471d1ec-0ea5-48d0-a61a-b2200b4d4e66" />
