### PR TITLE
[18Ardennes] Remove incorrect certificate limit check

### DIFF
--- a/lib/engine/game/g_18_ardennes/step/post_conversion_shares.rb
+++ b/lib/engine/game/g_18_ardennes/step/post_conversion_shares.rb
@@ -79,8 +79,7 @@ module Engine
           # Checks whether a player can afford to buy a share in the corporation
           # that has just been converted.
           def can_buy_any?(player)
-            @game.num_certs(corporation) < @game.cert_limit(corporation) &&
-              player.cash >= corporation.share_price.price &&
+            player.cash >= corporation.share_price.price &&
               corporation.holding_ok?(player, 10)
           end
 


### PR DESCRIPTION
### Explanation of Change

This removes an unneeded and incorrect check against certificate limit when buying shares after a public company is converted to a ten share company.

There should not be a certificate limit check here as a player is allowed to go above certificate limit during an operating round, and only has to sell down if they are still above limit at the next stock round.

The check is incorrect as it was actually checking the number of shares in the converted company's treasury, not the number of certificates held by the player.

Fixes tobymao#12225.

This breaks a few games where the post-conversion share-buying step was being skipped. Running the validation script against a database snapshot identified two broken games: 204508 and 227104 (the latter is the one where the bug was spotted). The database is a few weeks old, so it's possible there are more affected games now. The default migrate script was able to fix 227104 by inserting a pass, but now 204058. Both games are finished.


### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`