### PR TITLE
[18Ardennes] Allow any sales before starting a public company

### DIFF
--- a/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
+++ b/lib/engine/game/g_18_ardennes/step/buy_sell_par_shares_companies.rb
@@ -180,8 +180,6 @@ module Engine
           end
 
           def process_par(action)
-            check_too_much_sold(action)
-
             super
 
             major = action.corporation
@@ -240,34 +238,6 @@ module Engine
             when Engine::Action::SellCompany
               action.company.value
             end
-          end
-
-          # A player is only allowed to sell shares (or the GL minor) before
-          # starting a public company if they use the cash from the sale to
-          # start the public company at a higher price than would have been
-          # possible without the sale. This method throws an error if the par
-          # price could have been used with fewer items sold.
-          def check_too_much_sold(par_action)
-            return if @round.current_actions.empty?
-
-            player = par_action.entity
-            major = par_action.corporation
-            minor = @game.pledged_minors[major]
-
-            par_price = par_action.share_price
-            par_cost = (3 * par_price.price) -
-                       @game.minor_sale_value(minor, par_price)
-            surplus_cash = available_cash(player) - par_cost
-
-            return if @round.current_actions.all? do |sale_action|
-              cheapest_sale(sale_action) > surplus_cash
-            end
-
-            msg = 'More shares have been sold than were needed to start ' \
-                  "#{major.id} at a par price of " \
-                  "#{@game.format_currency(par_price.price)}. Either choose " \
-                  'a higher par price or undo some or all of the sales.'
-            raise GameError, msg
           end
         end
       end


### PR DESCRIPTION
### Explanation of Change

Remove restrictions on selling shares before starting a public company. Before this change the sale would only be allowed if the money from the sale was used to launch the new company at a higher price. This could lead to a situation where a new public company could not be started as the player did not have any free certificate slots, but were not allowed to sell any shares to free up a slot, as they already had enough money to start the new company at the highest par price.

The implementation had been based on a misreading of section 5.3 of the 18Ardennes rules. This mentions using money to increase the par price, but that is an example of why this might be done, not a requirement for the sale to be allowed.

Fixes tobymao#12185.

No games will be broken by this change. This will be making selling shares possible where it was before, but the player will always have had other actions available, so there is not an extra step introduced.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`