### PR TITLE
[1822, 1822MX, 1822PNW, 1822CA] Fix: Update game end descriptions for 1822 games to clarify bank break timing

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -57,6 +57,10 @@ module Engine
         }.freeze
 
         GAME_END_CHECK = { bank: :full_or, stock_market: :current_or }.freeze
+	GAME_END_REASONS_TIMING_TEXT = {
+	  current_or: 'Next end of an OR',
+	  full_or: 'Next end of a complete OR set (if bank breaks during an OR). Next end of an OR (if bank breaks during an SR).',
+	}.freeze
         GAME_END_ON_NOTHING_SOLD_IN_SR1 = true
         GAME_END_LOCK_FIRST_TRIGGER = true
 

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -57,10 +57,11 @@ module Engine
         }.freeze
 
         GAME_END_CHECK = { bank: :full_or, stock_market: :current_or }.freeze
-	GAME_END_REASONS_TIMING_TEXT = {
-	  current_or: 'Next end of an OR',
-	  full_or: 'Next end of a complete OR set (if bank breaks during an OR). Next end of an OR (if bank breaks during an SR).',
-	}.freeze
+        GAME_END_REASONS_TIMING_TEXT = {
+          current_or: 'Next end of an OR',
+          full_or: 'Next end of a complete OR set (if bank breaks during an OR). ' \
+                   'Next end of an OR (if bank breaks during an SR).',
+        }.freeze
         GAME_END_ON_NOTHING_SOLD_IN_SR1 = true
         GAME_END_LOCK_FIRST_TRIGGER = true
 

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -66,7 +66,7 @@ module Engine
           full_or: 'Next end of a complete OR set, with one additional OR added on ' \
                    '(if bank breaks during an OR). Next end of an OR (if bank breaks during an SR).',
         }.freeze
-                
+
         PRIVATE_MAIL_CONTRACTS = %w[P22 P23].freeze
         PRIVATE_SMALL_MAIL_CONTRACTS = %w[P24 P25].freeze
         PRIVATE_PHASE_REVENUE = %w[P8 P9].freeze

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -63,7 +63,7 @@ module Engine
 
         GAME_END_REASONS_TIMING_TEXT = {
           current_or: 'Next end of an OR',
-          full_or: 'Next end of a complete OR set, with one additional OR added on',
+          full_or: 'Next end of a complete OR set, with one additional OR added on (if bank breaks during an OR). Next end of an OR (if bank breaks during an SR).',
         }.freeze
 
         PRIVATE_MAIL_CONTRACTS = %w[P22 P23].freeze

--- a/lib/engine/game/g_1822_ca/game.rb
+++ b/lib/engine/game/g_1822_ca/game.rb
@@ -63,9 +63,10 @@ module Engine
 
         GAME_END_REASONS_TIMING_TEXT = {
           current_or: 'Next end of an OR',
-          full_or: 'Next end of a complete OR set, with one additional OR added on (if bank breaks during an OR). Next end of an OR (if bank breaks during an SR).',
+          full_or: 'Next end of a complete OR set, with one additional OR added on ' \
+                   '(if bank breaks during an OR). Next end of an OR (if bank breaks during an SR).',
         }.freeze
-
+                
         PRIVATE_MAIL_CONTRACTS = %w[P22 P23].freeze
         PRIVATE_SMALL_MAIL_CONTRACTS = %w[P24 P25].freeze
         PRIVATE_PHASE_REVENUE = %w[P8 P9].freeze


### PR DESCRIPTION
The game end timing text in the Info tab was incomplete. It now explains that:
- If the bank breaks during an OR, the game ends after the current OR set (plus one additional OR for 1822CA)
- If the bank breaks during an SR, the game ends at the next end of an OR

Affects: 1822, 1822CA, 1822PNW, 1822MX

Fixes #12250

<!--

## Summary
Updates the game end timing descriptions in the Info tab for 1822, 1822CA, 1822PNW, and 1822MX to accurately reflect the rules for when the bank breaks.

## Problem
The Info tab showed: "Next end of a complete OR set" for bank breaking, which was incomplete and didn't explain the 1822-specific rule.

## Solution
Updated `GAME_END_REASONS_TIMING_TEXT` in:
- `lib/engine/game/g_1822/game.rb` (fixes 1822, 1822PNW, 1822MX)
- `lib/engine/game/g_1822_ca/game.rb` (fixes 1822CA)

The text now explains:
- If bank breaks during an OR → game ends after current OR set (+ 1 additional OR for 1822CA)
- If bank breaks during an SR → game ends at next end of an OR

## Testing
The game logic already works correctly. This change only updates the descriptive text shown to players in the Info tab.

## Games Affected
- 1822
- 1822CA
- 1822PNW
- 1822MX

## Before clicking "Create"

- [ ] Branch is derived from the latest `master` --  I forked my code about two hours ago.
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games -- This is just a text change.
- [ ] Code passes linter with `docker compose exec rack rubocop -a` -- Yes, it passed.
- [ ] Tests pass cleanly with `docker compose exec rack rake` -- The test suite did not generate any errors in the files I modified, nor indeed in any of the 1822 files.  It did generate a number of errors in other files, which I assume were pre-existing.


