### PR TITLE
[1868WY] fix development token actions

### DIFF
--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -1035,6 +1035,10 @@ module Engine
           timeline
         end
 
+        def development_company_by_id(id)
+          minor_by_id(id)
+        end
+
         def init_coal_companies
           @players.map.with_index do |player, index|
             coal_company = DevelopmentCompany.new(


### PR DESCRIPTION
Broken by [#12119](https://github.com/tobymao/18xx/pull/12119/files#diff-a2a1a01cc4a55337a338e7840ec3d4b2830bfdce23e59225850e36c5fe9e7630)
Fixes #12238

Creating the `DevelopmentCompany` class for the sake of the `spender` changed how the actions were stored, causing them to use `"entity_type": "development_company"` instead of `"entity_type": "minor"`.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`