### PR TITLE
[1824] Don't skip player in stock round if a mountain railway can be exchanged

### DIFF
--- a/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
+++ b/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
@@ -34,9 +34,16 @@ module Engine
           end
 
           def company_actions(entity)
-            return EXCHANGE_ACTIONS if @game.mountain_railway?(entity) && @game.mountain_railway_exchangable?
+            return [] if bought?
+            return [] unless entity.owned_by?(current_entity)
+            return [] unless @game.mountain_railway?(entity)
+            return [] unless @game.mountain_railway_exchangable?
 
-            []
+            EXCHANGE_ACTIONS
+          end
+
+          def blocking?
+            super || @game.companies.any? { |c| !company_actions(c).empty? }
           end
 
           def can_buy?(entity, bundle)


### PR DESCRIPTION
In a stock round, a player's turn was being skipped if there are no actions returned by a call to `actions(entity)`, even if they own a mountain railway company that could be exchanged for a share in a regional railway. The actions for the companies are calculated in a different method (`company_actions`) that is not checked when deciding whether this step can be skipped.

This adds a check to `company_actions` in `blocking?`. It also adds some more checks to `company_actions` to make sure that an action is only returned if the mountain railway is owned by the active player, and they have not already purchased a share in their current action.

Fixes tobymao#12258.

This needs to be reviewed by @perwestling before this is merged.

This breaks some games – players are now being given turns that were previously skipped. Running the validation script on a database dump from a few weeks ago identified these games as breaking: 222933, 223560, 224480, 224691, 226207, 226674, 226821, 226823, 226916, 230745. This should be fixable by migration (adding pass steps) but the default migration script could only fix a couple of the games (226674 and 226821), the rest got stuck in loops.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`