### PR TITLE
[1871] Remove a player from `pass_order` when they make a split action

### DIFF
--- a/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
+++ b/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
@@ -167,6 +167,7 @@ module Engine
             entity = action.entity
             raise GameError, "#{corporation.name} cannot be split" unless @game.can_split?(corporation, entity)
 
+            @round.pass_order.delete(entity)
             entity.unpass!
             # Set data needed for splitting
             @round.split_start(corporation)


### PR DESCRIPTION
Priority deal in 1871 is based on passing order. If a player has passed in a stock round they will be added to the `pass_order` array. If they then make a split action they need to be removed from this array, so the priority calculation is based on when the subsequently pass.

Fixes tobymao#12268.

This breaks a very small number of games (just 215908 and 233107 when validating against a not-particularly-recent DB dump). It would be unusual for this to have affected priority order often. It will only make a difference when a player passes in a stock round, then splits on their next turn, then passes on the one after, and another player's first pass falls somewhere between these two passes.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`