### PR TITLE
[1824] Add missing pass if MR exchange possible, fixes #12279

### DIFF
--- a/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
+++ b/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
@@ -30,7 +30,16 @@ module Engine
               actions << 'payoff_player_debt_partial'
             end
 
+            actions << 'pass' if add_pass_to_actions_as_mr_exchange_available?(entity, actions)
+
             actions
+          end
+
+          def add_pass_to_actions_as_mr_exchange_available?(entity, actions)
+            return false if actions.include?('pass')
+            return false unless entity == current_entity
+
+            @game.companies.any? { |c| !c.closed? && c.owner == entity && !company_actions(c).empty? }
           end
 
           def company_actions(entity)
@@ -43,7 +52,7 @@ module Engine
           end
 
           def blocking?
-            super || @game.companies.any? { |c| !company_actions(c).empty? }
+            super || @game.companies.any? { |c| !c.closed? && !company_actions(c).empty? }
           end
 
           def can_buy?(entity, bundle)


### PR DESCRIPTION
Fixes #12279 

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

No game should break by this, as the bug is a case where a game can get stuck. And this should remove this cause.
For non-broken games this should have no effect.

## Implementation Notes
This is a fix to an issue that could appear after the fix #12262 

### Explanation of Change
Adds a Pass if an MR exchange is possible, and actions do not contain Pass.

### Screenshots
N/A

### Any Assumptions / Hacks
N/A
