### PR TITLE
[18Mag] Avoid infinite recursion in `red_to_red_route?`

### DIFF
--- a/lib/engine/game/g_18_mag/game.rb
+++ b/lib/engine/game/g_18_mag/game.rb
@@ -758,7 +758,8 @@ module Engine
         end
 
         def red_to_red_route?(route)
-          route.stops.count { |stop| stop.tile.color == :red } > 1
+          route.visited_stops.first.tile.color == :red &&
+            route.visited_stops.last.tile.color == :red
         end
 
         def token_owner(entity)


### PR DESCRIPTION
There was a infinite loop occurring in games with the CIWR major company when a train was converted into a plus train.

`red_to_red_route?` was checking `route.stops`. This is calculated by calling `calculate_route` which, for a plus train, calls `revenue_for`. And that method calls `red_to_red` route.

Avoid this problem by looking at `route.visited_stops` instead of `route.stops`. The off-board hexes in 18Mag are all terminals, so we can just check if the first and last stops are both red tiles.

This would fail if it is possible to have a route that visits an off-board area but does not use it for its revenue. AFAIK this is not possible in 18Mag.

Fixes tobymao#11443.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`