### PR TITLE
[18Ardennes] Add missing 'not' to log message

### DIFF
--- a/lib/engine/game/g_18_ardennes/step/major_auction.rb
+++ b/lib/engine/game/g_18_ardennes/step/major_auction.rb
@@ -231,7 +231,7 @@ module Engine
                 'place a bid. One extra slot is needed for each public ' \
                 'company being started.'
               when :minors
-                "#{player.name} does have any minor companies that could " \
+                "#{player.name} does not have any minor companies that could " \
                 'be used to place a bid on a public company.'
               when :winning
                 "#{player.name} already is leading the auctions on all " \


### PR DESCRIPTION
The log message when a player does not have any minor companies to start a public company was missing the word 'not'.

Fixes tobymao#12298.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`