### PR TITLE
[View] Use relative height for timeline progress bar

### DIFF
--- a/assets/app/view/game/game_info.rb
+++ b/assets/app/view/game/game_info.rb
@@ -438,7 +438,7 @@ module View
             display: 'flex',
             flexDirection: 'column',
             boxSizing: 'border-box',
-            height: '55px',
+            height: '3.5em',
             padding: '4px',
             border: '1px solid rgba(0,0,0,0.2)',
             justifyContent: justify,


### PR DESCRIPTION
### Explanation of Change

The progress bar, shown in the timeline for some games, had a fixed height of 55px. This is fine for most cases, but if the user has changed their fonts to be larger than the default this could result in the text not fitting in visible space.

Change this to use a relative height of 3.5em. This will grow or shrink as the font size is changed.

Fixes tobymao#12303.

I've checked the rendering using Firefox and Chromium, both on Linux, for all the games with progress bars: 1840, 18CZ, 18MS, 18Zoo, 21Moon and Steam Over Holland. Everything looks fine to me. (Except, you could argue that some games should have shorter progress bars, if they only ever have a single line of text in the progress bar cells, but these games’ appearance is not changed by this PR).


### Screenshots

#### Existing code, progress bar height 55px

##### Font size 'medium'
> <img width="1128" height="90" alt="image" src="https://github.com/user-attachments/assets/6555f625-a73b-4949-9905-aa1ae2f57dfa" />

##### Font size 'very large'
> <img width="1203" height="120" alt="image" src="https://github.com/user-attachments/assets/782b93b0-3ccf-4a27-94ed-20437d6c8b36" />

##### Font size 'very small'
> <img width="755" height="81" alt="image" src="https://github.com/user-attachments/assets/044aae72-e292-4de8-b7fb-2e58da9126bb" />


#### New code, progress bar height 3.5em

##### Font size 'medium'
> <img width="1123" height="90" alt="image" src="https://github.com/user-attachments/assets/2a310676-a2a0-47df-9b1c-33d0bc7468a3" />

##### Font size 'very large'
> <img width="1210" height="141" alt="image" src="https://github.com/user-attachments/assets/8e039afe-bb8e-4cdc-a51c-8d05f7a0769c" />

##### Font size 'very small'
> <img width="757" height="56" alt="image" src="https://github.com/user-attachments/assets/5e80c39a-d004-4f92-80f5-371a8c17d873" />


### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`
