### PR TITLE
[1858 Switzerland] Move to beta status

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -18,6 +18,8 @@ module View
       message = <<~MESSAGE
         <p><a href="https://github.com/tobymao/18xx/wiki/1858-India">1858 India</a> is now in alpha.</p>
 
+        <p><a href="https://github.com/tobymao/18xx/wiki/1858-Switzerland">1858 Switzerland</a> is now in beta.</p>
+
         <p>Report bugs and make feature requests <a href='https://github.com/tobymao/18xx/issues'>on GitHub</a>.</p>
       MESSAGE
 

--- a/lib/engine/game/g_1858_switzerland/meta.rb
+++ b/lib/engine/game/g_1858_switzerland/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :alpha
+        DEV_STAGE = :beta
         PROTOTYPE = true
         DEPENDS_ON = '1858'
 


### PR DESCRIPTION
1858 Switzerland has been in alpha status for just over a year. A few bugs were found and fixed in the first few months, but nothing new has been raised since tobymao#11737 in May, and that was a spelling fix.

Move this game to beta status.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`