### PR TITLE
[1861/1867] Unlimited trains and updated game end checks

### DIFF
--- a/lib/engine/game/g_1861/game.rb
+++ b/lib/engine/game/g_1861/game.rb
@@ -128,7 +128,7 @@ module Engine
             distance: [{ 'nodes' => %w[city offboard], 'pay' => 8, 'visit' => 8 },
                        { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }],
             price: 1000,
-            num: 20,
+            num: 'unlimited',
             events: [{ 'type' => 'minors_nationalized' },
                      { 'type' => 'trainless_nationalization' }],
           },
@@ -138,7 +138,7 @@ module Engine
                        { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }],
             multiplier: 2,
             price: 600,
-            num: 20,
+            num: 'unlimited',
             available_on: '8',
           },
           {
@@ -147,7 +147,7 @@ module Engine
                        { 'nodes' => %w[city town], 'pay' => 0, 'visit' => 99 }],
             multiplier: 2,
             price: 1500,
-            num: 20,
+            num: 'unlimited',
             available_on: '8',
           },
         ].freeze

--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -275,7 +275,7 @@ module Engine
             distance: [{ 'nodes' => %w[city offboard], 'pay' => 8, 'visit' => 8 },
                        { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }],
             price: 1000,
-            num: 6,
+            num: 'unlimited',
             events: [{ 'type' => 'minors_nationalized' },
                      { 'type' => 'trainless_nationalization' },
                      { 'type' => 'train_trade_allowed' }],
@@ -294,7 +294,7 @@ module Engine
                        { 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 }],
             multiplier: 2,
             price: 600,
-            num: 20,
+            num: 'unlimited',
             available_on: '8',
             discount: {
               '5' => 275,
@@ -311,7 +311,7 @@ module Engine
                        { 'nodes' => %w[city town], 'pay' => 0, 'visit' => 99 }],
             multiplier: 2,
             price: 1500,
-            num: 20,
+            num: 'unlimited',
             available_on: '8',
             discount: {
               '5' => 275,


### PR DESCRIPTION
This PR updates 1861 and 1867 following some of @michaeljb's recent changes to core code:

- The last ranks of trains (8, 2+2 and 5+5E) are now unlimited.
- `game_end_signal_final_turn!` is overridden to remove the need for the `signal_game_end` event and some of the custom code associated with that.

There is also a small cleanup in the 1867 code, removing the hardcoded phase number check for train export, instead checking phase status.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`