### PR TITLE
[1824] Correct floating for non-parred regional, fixes #12228, #12275

### DIFF
--- a/lib/engine/game/g_1824/corporation.rb
+++ b/lib/engine/game/g_1824/corporation.rb
@@ -43,7 +43,7 @@ module Engine
         def floated?
           return false unless @floatable
 
-          @floated ||= (percent_to_float <= 0)
+          @floated ||= (percent_to_float <= 0 && !@par_price.nil? && @presidents_share&.owned_by_player?)
         end
 
         def float!
@@ -120,6 +120,14 @@ module Engine
         # True if no player owns 20% or more
         def unpresidentable?
           player_share_holders.reject { |_, p| p < 20 }.empty?
+        end
+
+        # Need to cover the case where a unassociated regional railway has reached floating without being parred
+        def floatable
+          return false unless super
+          return true unless @type == :major
+
+          !@par_price.nil?
         end
 
         private

--- a/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
+++ b/lib/engine/game/g_1824/step/buy_sell_par_exchange_shares.rb
@@ -110,7 +110,10 @@ module Engine
             company = action.entity
             bundle = action.bundle
             bundle.share_price = 0
-            buy_shares(company.owner, bundle, exchange: company)
+
+            # If a corporation has not been parred, an MR exchange cannot result in a presidency change. See rule IV.4.1 bullet 6.
+            buy_shares(company.owner, bundle, exchange: company, allow_president_change: !bundle.corporation.par_price.nil?)
+
             company.close!
 
             # Exchange is treated as a Buy, and no more actions allowed as Sell-Buy


### PR DESCRIPTION
Fixes #12228 and #12275

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

This correction is not expected to affect any ongoing games. If it does, it might that this bug existed in that game.

## Implementation Notes
- If a corporation (regional) is not parred, doing MR exchange should not give presidency to anyone
- If a corporation is not parred, it cannot be floated by an MR exchange
- Text for needed for floating has been updated with "Par to float" for the not-parred-but-50%-exchanged case

### Explanation of Change
This is to follow the 1824 rules for exchange.

To recreate the issue clone the game mentioned in the issue at start of SR3, and then using exchange on BH.

### Screenshots
Here is a clone of the game mentioned in the Issue, where MR only have been used to get BH shares.
<img width="661" height="278" alt="image" src="https://github.com/user-attachments/assets/0c727ef2-cfc4-4239-92b4-98297ed43ab1" />

Yet another BH exchanged reaching 50%, but not floated as not parred.
<img width="655" height="277" alt="image" src="https://github.com/user-attachments/assets/aae122d3-5632-46d8-896c-22c09f14184a" />

And if later BH is parred it now looks like.
<img width="331" height="491" alt="image" src="https://github.com/user-attachments/assets/d6754123-1296-410d-b4cf-7dbd9d74ec7f" />


### Any Assumptions / Hacks
N/A
