### PR TITLE
[Core] Improved error message on creating an empty ShareBundle

### DIFF
--- a/lib/engine/share_bundle.rb
+++ b/lib/engine/share_bundle.rb
@@ -7,8 +7,9 @@ module Engine
 
     def initialize(shares, percent = nil)
       @shares = Array(shares).dup
-      raise 'All shares must be from the same corporation' unless @shares.map(&:corporation).uniq.one?
-      raise 'All shares must be owned by the same owner' unless @shares.map(&:owner).uniq.one?
+      raise GameError, 'A share bundle must contain at least one share' if @shares.empty?
+      raise GameError, 'All shares must be from the same corporation' unless @shares.map(&:corporation).uniq.one?
+      raise GameError, 'All shares must be owned by the same owner' unless @shares.map(&:owner).uniq.one?
 
       @percent = percent || @shares.sum(&:percent)
       @share_price = nil


### PR DESCRIPTION
If you tried to create a ShareBundle, passing an empty array as the `shares` parameter, then you would get an error thrown with the description 'All shares must be from the same corporation'. That isn't the clearest error message.

This commit changes the error description to 'A share bundle must contain at least one share'.

It also changes any errors thrown by the ShareBundle constructor to be GameErrors instead of RuntimeErrors.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`