### PR TITLE
[TOP1871] disable Done button in token selection until at least one is chosen

### DIFF
--- a/lib/engine/game/g_1871/round/stock.rb
+++ b/lib/engine/game/g_1871/round/stock.rb
@@ -200,6 +200,8 @@ module Engine
               split_pick_branch(branch)
             when SPLIT_PICK_TOKENS
               if choose.choice == 'done'
+                raise GameError, "#{@split_branch.full_name} must swap at least one token" unless @split_branch.tokens.first&.used
+
                 @log << "#{current_entity.name} is done swapping tokens"
                 split_next
               else


### PR DESCRIPTION
Fixes #12327

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

User reports that they split a corporation and were able to select no home token for the branch corporation, which caused the game to error out when they attempted to float that corp in a subsequent SR.

Currently, when selecting tokens while splitting a corporation, the code was set to only include a Done button if the parent corporation has fewer than 4 tokens. The problem with this is that a corporation can be split more than once, and after the first time, it already has fewer than 4 tokens before any are given to the new branch corp. I modified the code to only include the Done button once the new branch corp's first token is used. 

### Screenshots

### Any Assumptions / Hacks
