### PR TITLE
[Core] Remove stray space from log message

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2312,7 +2312,7 @@ module Engine
         return if rusted_trains.empty?
 
         @log << "-- Event: #{rusted_trains.uniq.join(', ')} trains rust " \
-                "( #{owners.map { |c, t| "#{c} x#{t}" }.join(', ')}) --"
+                "(#{owners.map { |c, t| "#{c} x#{t}" }.join(', ')}) --"
       end
 
       def show_progress_bar?


### PR DESCRIPTION
The log message when trains rust had an extra space after the opening bracket. Remove this.

Before:
> [10:42] -- Event: 2 trains rust ( IR x3, TR x3) --

After:
> [10:42] -- Event: 2 trains rust (IR x3, TR x3) --


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`