### PR TITLE
[18RoyalGorge] Add Stretch Goal private Y8 Madam Evens

### DIFF
--- a/lib/engine/game/g_18_royal_gorge/entities.rb
+++ b/lib/engine/game/g_18_royal_gorge/entities.rb
@@ -117,6 +117,19 @@ module Engine
               { type: 'no_buy' },
             ],
           },
+          {
+            sym: 'Y7',
+            name: 'Madam Evens (Y7)',
+            desc: 'Once purchased by a company the brothel token starts in Denver (K1). '\
+                  'The brothel generates an additional $10 revenue only for the holding corporation. '\
+                  'In the Brown Phase, the brothel is moved to Salida (B10) and becomes a $20 revenue. '\
+                  'This private never closes.',
+            value: 50,
+            revenue: 5,
+            abilities: [
+              # +$10 revenue in Denver; moves to Salida in brown and increases to $20 revenue
+            ],
+          },
         ].freeze
 
         GREEN_COMPANIES = [

--- a/lib/engine/game/g_18_royal_gorge/entities.rb
+++ b/lib/engine/game/g_18_royal_gorge/entities.rb
@@ -117,6 +117,9 @@ module Engine
               { type: 'no_buy' },
             ],
           },
+        ].freeze
+
+        YELLOW_COMPANIES_EXTRA = [
           {
             sym: 'Y8',
             name: 'Madam Evens (Y8)',

--- a/lib/engine/game/g_18_royal_gorge/entities.rb
+++ b/lib/engine/game/g_18_royal_gorge/entities.rb
@@ -118,8 +118,8 @@ module Engine
             ],
           },
           {
-            sym: 'Y7',
-            name: 'Madam Evens (Y7)',
+            sym: 'Y8',
+            name: 'Madam Evens (Y8)',
             desc: 'Once purchased by a company the brothel token starts in Denver (K1). '\
                   'The brothel generates an additional $10 revenue only for the holding corporation. '\
                   'In the Brown Phase, the brothel is moved to Salida (B10) and becomes a $20 revenue. '\

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -1038,7 +1038,7 @@ module Engine
         end
 
         def mdm_evens
-          @mdm_evens ||= company_by_id('Y7')
+          @mdm_evens ||= company_by_id('Y8')
         end
 
         def upgrades_to?(from, to, special = false, selected_company: nil)

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -68,8 +68,6 @@ module Engine
 
         PRESIDENT_SALES_TO_MARKET = Set['CF&I', 'VGC'].freeze
 
-        # Stretch Goal Companies Variant not yet fully implemented, there switching variant by default to false
-        STRETCH_GOAL_COMPANIES_VARIANT = false
         COMPANIES_CLOSE_PHASE_5 = %w[Y2 Y3 Y4 Y5 Y6 G2 G3 G5 G6 B3 B4 B5].freeze
 
         EVENTS_TEXT = Base::EVENTS_TEXT.merge(
@@ -114,7 +112,7 @@ module Engine
         ST_CLOUD_ICON_NAME = 'SCH'
 
         MDM_EVENS_START_HEX = 'K1'
-        MDM_EVENS_BROWN_HEX = 'B10'
+        MDM_EVENS_BROWN_HEX = 'C11'
         MDM_EVENS_START_BONUS = 10
         MDM_EVENS_BROWN_BONUS = 20
         MDM_EVENS_BONUS_STR = ' (Madam Evens)'
@@ -141,13 +139,19 @@ module Engine
           'Treasury'
         end
 
+        def include_stretch_goal_companies?
+          # Stretch Goal Companies Variant not yet fully implemented, there switching variant by default to false
+          false
+        end
+
         def game_companies
           yellow_companies = YELLOW_COMPANIES.dup
+          yellow_companies_extra = YELLOW_COMPANIES_EXTRA.dup
           green_companies = GREEN_COMPANIES.dup
           brown_companies = BROWN_COMPANIES.dup
 
-          # remove strech goal companies if variant is not chosen
-          yellow_companies.reject! { |c| c[:sym] == 'Y8' } unless STRETCH_GOAL_COMPANIES_VARIANT
+          # add stretch goal companies if variant is chosen
+          yellow_companies += yellow_companies_extra if include_stretch_goal_companies?
           yellow_companies.sort_by { rand }.take(2).sort_by { |c| c[:value] } +
             green_companies.sort_by { rand }.take(2).sort_by { |c| c[:value] } +
             brown_companies.sort_by { rand }.take(1)
@@ -207,16 +211,15 @@ module Engine
           @sulphur_springs_connected = false
           @updated_sulphur_springs_company_revenue = false
 
-          @st_cloud_icon = Part::Icon.new("18_royal_gorge/#{ST_CLOUD_ICON_NAME}", ST_CLOUD_ICON_NAME)
           setup_st_cloud_hotel
 
-          @mdm_evens_icon = Part::Icon.new("18_royal_gorge/#{MDM_EVENS_ICON_NAME}", MDM_EVENS_ICON_NAME)
           setup_mdm_evens
         end
 
         def setup_st_cloud_hotel
           return unless st_cloud_hotel
 
+          @st_cloud_icon = Part::Icon.new("18_royal_gorge/#{ST_CLOUD_ICON_NAME}", ST_CLOUD_ICON_NAME)
           @st_cloud_hex = hex_by_id(ST_CLOUD_START_HEX)
           @st_cloud_hex.tile.icons << @st_cloud_icon
         end
@@ -224,6 +227,7 @@ module Engine
         def setup_mdm_evens
           return unless mdm_evens
 
+          @mdm_evens_icon = Part::Icon.new("18_royal_gorge/#{MDM_EVENS_ICON_NAME}", MDM_EVENS_ICON_NAME)
           @mdm_evens_hex = hex_by_id(MDM_EVENS_START_HEX)
           @mdm_evens_hex.tile.icons << @mdm_evens_icon
           @mdm_evens_bonus = MDM_EVENS_START_BONUS

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -147,7 +147,7 @@ module Engine
           brown_companies = BROWN_COMPANIES.dup
 
           # remove strech goal companies if variant is not chosen
-          yellow_companies.reject! { |c| c[:sym] == 'Y7' } unless STRETCH_GOAL_COMPANIES_VARIANT
+          yellow_companies.reject! { |c| c[:sym] == 'Y8' } unless STRETCH_GOAL_COMPANIES_VARIANT
           yellow_companies.sort_by { rand }.take(2).sort_by { |c| c[:value] } +
             green_companies.sort_by { rand }.take(2).sort_by { |c| c[:value] } +
             brown_companies.sort_by { rand }.take(1)

--- a/public/icons/18_royal_gorge/MDE.svg
+++ b/public/icons/18_royal_gorge/MDE.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
+ <circle cx="4" cy="4" r="4" fill="#FFF"/>
+ <text x="4" y="5.0999999" font-family="Arial" font-size="3.25px" font-weight="700" text-anchor="middle" lengthAdjust="spacingAndGlyphs" textLength="7.1999998">EVENS</text>
+</svg>


### PR DESCRIPTION
Belongs to #12283

Adding private asset Y8 Madam Evens to Royal Gorge. Part of the proposed enhancement to include stretch goal private companies. 

Y8 Madam Evens follows the logic of Y2 St Cloud Hotel with the addition to increase bonus in brown phase.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ]  Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Beginner - first PR. I kept it small only with Y8 change. The game variant "KS stretch goal private companies" includes Y7, Y8, G7 and B7. 

Therefore I have switched it by default off until the variant is fully implemented

` # Stretch Goal Companies Variant not yet fully implemented, there switching variant by default to false
        STRETCH_GOAL_COMPANIES_VARIANT = false`

### Explanation of Change

Used the implementation of Y2 St cloud hotel as basis

### Screenshots

### Any Assumptions / Hacks
