### PR TITLE
[Profile page] implements Change Password function

### DIFF
--- a/assets/app/user_manager.rb
+++ b/assets/app/user_manager.rb
@@ -20,7 +20,8 @@ module UserManager
 
   def edit_user(params)
     @connection.safe_post('/user/edit', params) do |data|
-      store(:user, data, skip: false)
+      store(:user, data['user'], skip: false) if data['user']
+      store(:flash_opts, data['flash_opts'], skip: false) if data['flash_opts']
     end
   end
 

--- a/assets/app/view/user.rb
+++ b/assets/app/view/user.rb
@@ -105,6 +105,7 @@ module View
         ]),
         render_tile_colors,
         render_route_colors,
+        render_password_change,
         h('div#settings__buttons', { style: { marginTop: '1rem' } }, [
           render_button('Save Changes') { submit },
           render_button('Reset to Defaults') { reset_settings },
@@ -115,6 +116,33 @@ module View
       ]
 
       render_form(title, inputs)
+    end
+
+    def render_password_change
+      h('div#settings__password', [
+        h(:h3, 'Change Password'),
+        render_input(
+          'Current Password',
+          id: :current_password,
+          type: :password,
+          attrs: { autocomplete: 'current-password' },
+          input_style: { width: '13rem' },
+        ),
+        render_input(
+          'New Password',
+          id: :new_password,
+          type: :password,
+          attrs: { autocomplete: 'new-password' },
+          input_style: { width: '13rem' },
+        ),
+        render_input(
+          'Confirm New Password',
+          id: :new_password_confirmation,
+          type: :password,
+          attrs: { autocomplete: 'new-password' },
+          input_style: { width: '13rem' },
+        ),
+      ])
     end
 
     def render_signup
@@ -470,6 +498,31 @@ module View
 
       ]
       h(:div, children)
+    end
+
+    def params
+      param = super
+
+      new_pw = (param[:new_password] || param['new_password']).to_s.strip
+
+      if new_pw.empty?
+        %i[current_password new_password new_password_confirmation].each { |k| param.delete(k) }
+        %w[current_password new_password new_password_confirmation].each { |k| param.delete(k) }
+      end
+
+      param
+    end
+
+    def clear_password_inputs
+      %i[current_password new_password new_password_confirmation].each do |k|
+        next unless @inputs[k]
+
+        input_elm(k).value = ''
+      end
+    end
+
+    def password_change_attempted?(p)
+      (p[:new_password] || p['new_password']).to_s.strip != ''
     end
   end
 end


### PR DESCRIPTION
Fixes #2586

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Allows users to change their password from their profile page without having to use the Forgot My Password function. 

### Screenshots

The feature in the profile page: 
<img width="1036" height="185" alt="image" src="https://github.com/user-attachments/assets/970f0d7d-d46c-47a4-91bd-6db899e8f07b" />

Error if the passwords don't match: 
<img width="321" height="57" alt="image" src="https://github.com/user-attachments/assets/9042f613-784d-4a39-93a9-0ebe168f7533" />

Error if they enter the incorrect current password:
<img width="227" height="53" alt="image" src="https://github.com/user-attachments/assets/dd920c26-1923-4208-9761-9ad5547cb695" />

Confirmation when it is successful: 
<img width="347" height="56" alt="image" src="https://github.com/user-attachments/assets/26ca7061-127f-484b-8c5c-f95024af39b6" />


### Any Assumptions / Hacks
