### PR TITLE
[1824] Remove possibility to declare bankruptcy

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -282,7 +282,6 @@ module Engine
         def operating_round(round_num)
           G1824::Round::Operating.new(self, [
             G1824::Step::KkTokenChoice,
-            G1837::Step::Bankrupt,
             G1824::Step::DiscardTrain,
             G1824::Step::ForcedMountainRailwayExchange,
             Engine::Step::SpecialTrack,
@@ -776,6 +775,10 @@ module Engine
             end
           token = Engine::Token.new(national, price: price)
           national.tokens.unshift(token)
+        end
+
+        def can_go_bankrupt?(_entity, _corporation)
+          false
         end
 
         private


### PR DESCRIPTION
Not allowed in 1824 to go bankrupt.

Fixes #12343 

(It does not fix the issue as such, but removing the possibility of declaring bankruptcy means that situation should never occur.)

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

Game the fails here are games where bankruptcy has been declared.
Those are illegal games and can be archived/removed.

## Implementation Notes

1837 Bankrupt step should not be used in 1824.
By implementing can_go_bankrupt? to always return false, the Declare Bankruptcy button will never appear.

### Explanation of Change

1824 does not have bankruptcy. Instead the players take a loan, and continue to play to the bitter end.

### Screenshots

N/A

### Any Assumptions / Hacks

N/A

