### PR TITLE
[18USA] Unlmited 8-trains and Pullman cars

### DIFF
--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -157,10 +157,10 @@ module Engine
                     name: '8',
                     distance: 8,
                     price: 1100,
-                    num: 40,
+                    num: 'unlimited',
                     events: [{ 'type' => 'signal_end_game' }],
                   },
-                  { name: 'P', distance: 0, price: 200, available_on: '5', num: 20 }].freeze
+                  { name: 'P', distance: 0, price: 200, available_on: '5', num: 'unlimited' }].freeze
 
         def game_trains
           return seventeen_trains if @optional_rules.include?(:seventeen_trains)


### PR DESCRIPTION
Both 8-trains and Pullman cars are supposed to be unlimited, so make them so.

Fixes tobymao#12360. That was a crash attempting to export a train when all 40 of the 8-trains had been purchased.

And this allows one item on the long list of games in #12237 to be ticked off.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`