### PR TITLE
[18CO] Fixed issue in Event: Home station reservations removed

### DIFF
--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -1390,15 +1390,17 @@ module Engine
 
           @corporations.each do |corporation|
             next if corporation.ipoed
+
             tile = hex_by_id(corporation.coordinates).tile
-            # When E15 tile is upgraded - the cities array on the tile has 2 elements rather than 3. 
-            # The positions of reservations rearrange, so it's safer to just iterate over all cities than to rely on original positions.
+            # When E15 tile is upgraded - the cities array on the tile has 2 elements rather than 3.
+            # The positions of reservations rearrange
+            # It's safer to just iterate over all cities than to rely on original positions.
             tile.cities.each do |city|
               city.remove_reservation!(corporation)
             end
           end
         end
-        
+
         def tile_lays(_entity)
           return REDUCED_TILE_LAYS if @phase.status.include?('reduced_tile_lay')
 


### PR DESCRIPTION
# [18CO] Fixed issue in Event: Home station reservations removed

Fixes #11765

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

The number of cities on tile F15 changes from 3 to 2 when tile is upgraded to green. Old code for clearing reservations tried to reach index 2 on 2-element array and then tried to call remove_reservation! on nil. 

I've changed the code to just go over all cities in hexes in question and remove all reservation for not-floated corporations

### Screenshots

### Any Assumptions / Hacks
