### PR TITLE
[System18] Gotland - removes last bit of narrow track

### DIFF
--- a/lib/engine/game/g_system18/map_gotland_customization.rb
+++ b/lib/engine/game/g_system18/map_gotland_customization.rb
@@ -295,7 +295,7 @@ module Engine
               ['D7'] => d_tile('D7'),
             },
             red: {
-              ['B1'] => 'offboard=revenue:green_50|brown_70,format:%d-X;path=a:0,b:_0,track:narrow',
+              ['B1'] => 'offboard=revenue:green_50|brown_70,format:%d-X;path=a:0,b:_0',
             },
             blue: {
               %w[A12] => 'offboard=revenue:yellow_10|brown_20;path=a:5,b:_0',


### PR DESCRIPTION
Fixes #12366

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Looks like when @patrikolesen submitted pull https://github.com/tobymao/18xx/pull/12224/, he left one bit of narrow track in the code. This removes it. 

### Screenshots

### Any Assumptions / Hacks
