### PR TITLE
[System18 Gotland] Don't increment `@turn` after nationalization round

### DIFF
--- a/lib/engine/game/g_system18/map_gotland_customization.rb
+++ b/lib/engine/game/g_system18/map_gotland_customization.rb
@@ -502,10 +502,10 @@ module Engine
         end
 
         # ----- Nationalize -----
-        def new_nationalization_round(round_num)
+        def new_nationalization_round
           GSystem18::Round::GotlandNationalization.new(self, [
               GSystem18::Step::GotlandNationalizeCorporation,
-              ], round_num: round_num)
+              ])
         end
 
         def nationalized?(entity)
@@ -595,12 +595,8 @@ module Engine
         def map_gotland_next_round!
           @round =
             case @round
-            when GSystem18::Round::DifficultySelection
-              rival_share_randomizer
-              new_stock_round
-            when GSystem18::Round::GotlandNationalization
-              @turn += 1
-              or_set_finished
+            when GSystem18::Round::DifficultySelection,
+                 GSystem18::Round::GotlandNationalization
               rival_share_randomizer
               new_stock_round
             when Engine::Round::Stock
@@ -616,7 +612,7 @@ module Engine
                 or_round_finished
                 or_set_finished
                 if @phase.status.include?('nr_or')
-                  new_nationalization_round(@round.round_num)
+                  new_nationalization_round
                 else
                   new_stock_round
                 end


### PR DESCRIPTION
After the start of phase 3, `@turn` was being incremented twice in each set of rounds, once after the second operating round and once after the nationalisation round. This was causing the game to end too early after the final phase was reached, it was ending after the nationalisation round after the set of operating rounds where the first 8-train was bought, when there should have been another pair of operating rounds played.

This PR stops the turn from being incremented after a nationalisation round.

This also changes the initialisation of the `Round::GotlandNationalization` object, a `round_num` parameter is no longer passed. There is only a single nationalization round in a set of rounds, so this parameter isn't needed. Without this change the game would still end too early, `@game.round_num` is 2 during a nationalisation round as it is not reset until the first operating round in a set, and so the `end_game!` check after the nationalisation round thinks this is the last round in a set.

Fixes tobymao#12367.

[CC: @patrikolesen]

### Implementation notes
This is not going to break any existing games, but there are a couple of games in the database which have ended too early. I'm guessing that these will remain finished, as there aren't any new actions that would change their status.


### Screenshots

Operating round history before this change. Note that there are only operating rounds in odd-numbered turns after the start of phase 3.
<img width="688" height="226" alt="Image" src="https://github.com/user-attachments/assets/8cdd93f3-ee8d-4e90-8bbf-a25dafb8d381" />

Operating round history after this change, with another couple of ORs added to get to the end of the game..
<img width="755" height="229" alt="image" src="https://github.com/user-attachments/assets/a40473ec-a304-45a1-b483-dd1aa0fba0a8" />


### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`