### PR TITLE
[21Moon] Prevent buying trains across during EMR

### DIFF
--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -46,6 +46,7 @@ module Engine
         SELL_MOVEMENT = :down_block
         SOLD_OUT_INCREASE = true
         POOL_SHARE_DROP = :down_block
+        EBUY_FROM_OTHERS = :never
         IMPASSABLE_HEX_COLORS = %i[purple orange].freeze
         TRACK_RESTRICTION = :city_permissive
 


### PR DESCRIPTION
According to section 11.7 of the rules, if a corporation uses emergency money raising then it can only purchase a transport (train) from the bank. This money cannot be used to purchase a transport from another corporation.

Fixes tobymao#12375.

This breaks at least four existing games (IDs 200745, 204228, 221859, 240889). These will need to be pinned.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`