### PR TITLE
Add kickstarter link 1880 romania

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -16,6 +16,8 @@ module View
 
     def render_notification
       message = <<~MESSAGE
+        <p>1880 Romania is Lonny&apos;s latest 18xx game, and is now live on <a href="https://www.kickstarter.com/projects/1840vienna/1880-romania">Kickstarter</a></p>
+
         <p><a href="https://github.com/tobymao/18xx/wiki/1858-India">1858 India</a> is now in alpha.</p>
 
         <p><a href="https://github.com/tobymao/18xx/wiki/1858-Switzerland">1858 Switzerland</a> is now in beta.</p>


### PR DESCRIPTION
Add link for Kickstarter of 1880 Romania, to first page.

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Screenshots

<img width="474" height="306" alt="image" src="https://github.com/user-attachments/assets/7cea343c-a376-4932-84ce-23a6154e8866" />
