### PR TITLE
[Front page] Add 1880 Romania Kickstarter link

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -16,6 +16,8 @@ module View
 
     def render_notification
       message = <<~MESSAGE
+        <p>1880 Romania is Lonny&apos;s latest 18xx game, and is now live on <a href="https://www.kickstarter.com/projects/1840vienna/1880-romania">Kickstarter</a></p>
+
         <p><a href="https://github.com/tobymao/18xx/wiki/1858-India">1858 India</a> is now in alpha.</p>
 
         <p><a href="https://github.com/tobymao/18xx/wiki/1858-Switzerland">1858 Switzerland</a> is now in beta.</p>


### PR DESCRIPTION
Adds a kickstarter link for 1880 Romania to front page.

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Screenshots

<img width="474" height="306" alt="image" src="https://github.com/user-attachments/assets/3fecfeb9-1d64-41a9-b00d-8cde388e6556" />
