### PR TITLE
[System18 Gotland] 4-trains are rusted by 8-trains

### DIFF
--- a/lib/engine/game/g_system18/map_gotland_customization.rb
+++ b/lib/engine/game/g_system18/map_gotland_customization.rb
@@ -134,6 +134,7 @@ module Engine
           find_train(trains, '2')[:num] = 6
           find_train(trains, '3')[:num] = 5
           find_train(trains, '4')[:num] = 4
+          find_train(trains, '4')[:rusts_on] = '8'
           find_train(trains, '5')[:num] = 3
           find_train(trains, '6')[:num] = 2
           find_train(trains, '8')[:num] = 8


### PR DESCRIPTION
Gotland doesn't have diesels. According to the rules, 4 trains should be rusted by 8 trains, but the rusting schedule has not been amended for this.

Fixes #12379.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`