### PR TITLE
[1880 Romania] Add Transilvania 2p variant

### DIFF
--- a/lib/engine/game/g_1880/step/buy_train.rb
+++ b/lib/engine/game/g_1880/step/buy_train.rb
@@ -40,9 +40,13 @@ module Engine
           def pass!
             train_name = @game.depot.upcoming.first.name
             train_index = @game.depot.upcoming.first.index
-            return super if (train_name == '8E' && train_index == 1) || %w[10 2P].include?(train_name) || !discard_trains?
+            return super if avoid_discarding_all_trains?(train_name, train_index)
 
             discard_all_trains(train_name)
+          end
+
+          def avoid_discarding_all_trains?(train_name, train_index)
+            (train_name == '8E' && train_index == 1) || %w[10 2P].include?(train_name) || !discard_trains?
           end
 
           def discard_trains?

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -35,6 +35,46 @@ module Engine
             G1880::Step::BuySellParShares,
           ])
         end
+
+        # Used for disabled 1880 methods
+        def dummy_company
+          @dummy ||= Company.new(
+            name: 'Dummy Company',
+            sym: 'DUMMY',
+            value: 0,
+          )
+          @dummy.close!
+          @dummy
+        end
+
+        # 1880 China method. Not used in this variant.
+        def rocket
+          dummy_company
+        end
+
+        # 1880 China method. Not used in this variant.
+        def force_exchange_rocket; end
+
+        # 1880 China method. Not used in this variant.
+        def ferry_hexes
+          []
+        end
+
+        # 1880 China method. Not used in this variant.
+        def ferry_company
+          dummy_company
+        end
+
+        # 1880 China method. Not used in this variant.
+        def taiwan_company
+          dummy_company
+        end
+
+        # 1880 China method. Not used in this variant.
+        def taiwan_hex; end
+
+        # 1880 China method. Not used in this variant.
+        def trans_siberian_bonus?(_stops); end
       end
     end
   end

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -36,20 +36,21 @@ module Engine
           ])
         end
 
-        # Used for disabled 1880 methods
-        def dummy_company
-          @dummy ||= Company.new(
+        def setup
+          super
+
+          # Used for disabled 1880 methods
+          @dummy_company ||= Company.new(
             name: 'Dummy Company',
             sym: 'DUMMY',
             value: 0,
           )
-          @dummy.close!
-          @dummy
+          @dummy_company.close!
         end
 
         # 1880 China method. Not used in this variant.
         def rocket
-          dummy_company
+          @dummy_company
         end
 
         # 1880 China method. Not used in this variant.
@@ -62,12 +63,12 @@ module Engine
 
         # 1880 China method. Not used in this variant.
         def ferry_company
-          dummy_company
+          @dummy_company
         end
 
         # 1880 China method. Not used in this variant.
         def taiwan_company
-          dummy_company
+          @dummy_company
         end
 
         # 1880 China method. Not used in this variant.

--- a/lib/engine/game/g_1880_romania/meta.rb
+++ b/lib/engine/game/g_1880_romania/meta.rb
@@ -19,6 +19,15 @@ module Engine
         GAME_TITLE = '1880 Romania'
 
         PLAYER_RANGE = [3, 6].freeze
+
+        GAME_VARIANTS = [
+          {
+            sym: :transilvania,
+            name: 'Transilvania',
+            title: '1880 Romania Transilvania',
+            desc: 'Alternate map for 2 players, shorter game',
+          },
+        ].freeze
       end
     end
   end

--- a/lib/engine/game/g_1880_romania_transilvania.rb
+++ b/lib/engine/game/g_1880_romania_transilvania.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1880RomaniaTransilvania
+    end
+  end
+end

--- a/lib/engine/game/g_1880_romania_transilvania/game.rb
+++ b/lib/engine/game/g_1880_romania_transilvania/game.rb
@@ -102,7 +102,7 @@ module Engine
             G1880::Step::Token,
             G1880::Step::Route,
             G1880::Step::Dividend,
-            G1880::Step::BuyTrain,
+            G1880RomaniaTransilvania::Step::BuyTrain,
             G1880::Step::CheckFIConnection,
           ], round_num: round_num)
         end

--- a/lib/engine/game/g_1880_romania_transilvania/game.rb
+++ b/lib/engine/game/g_1880_romania_transilvania/game.rb
@@ -66,16 +66,28 @@ module Engine
           unless @game_trains
             @game_trains = super.map(&:dup)
             trains_2, trains_2p, trains_3, trains_3p, trains_4, trains_4p, trains_6, trains_6e, trains_8, trains_8e = @game_trains
+
             trains_2[:num] = 6
+
             trains_2p[:num] = 3
+
             trains_3[:num] = 3
+
             trains_3p[:num] = 2
+            # Remove close_p7 event since P7 is not used in this variant]
+            trains_3p[:events] = [{ 'type' => 'communist_takeover' }]
+
             trains_4[:num] = 2
+
             trains_4p[:num] = 2
+
             trains_6[:num] = 2
+
             trains_6e[:num] = 1
             trains_6e[:events] = [{ 'type' => 'signal_end_game', 'when' => 1 }]
+
             trains_8[:num] = 'unlimited'
+
             trains_8e[:num] = 0
           end
           @game_trains
@@ -106,54 +118,6 @@ module Engine
             G1880::Step::CheckFIConnection,
           ], round_num: round_num)
         end
-
-        def dummy_company
-          @dummy ||= Company.new(
-            name: 'Dummy Company',
-            sym: 'DUMMY',
-            value: 0,
-          )
-          @dummy.close!
-          @dummy
-        end
-
-        # Not used in this variant
-        def rocket
-          dummy_company
-        end
-
-        # Not used in this variant
-        def rocket_train; end
-        def fix_rocket_ability; end
-        def force_exchange_rocket; end
-
-        # P0 and P5 not used in this variant. P1 is assumed to have the same effect as in base game.
-        def p0; end
-        def p5; end
-
-        # Not used in this variant
-        def ferry_hexes
-          []
-        end
-
-        # Not used in this variant
-        def ferry_company
-          dummy_company
-        end
-
-        # Not used in this variant
-        def taiwan_company
-          dummy_company
-        end
-
-        # Not used in this variant
-        def taiwan_hex; end
-
-        # Not used in this variant
-        def trans_siberian_bonus?(_stops); end
-
-        # Not used in this variant
-        def event_close_p7!; end
       end
     end
   end

--- a/lib/engine/game/g_1880_romania_transilvania/game.rb
+++ b/lib/engine/game/g_1880_romania_transilvania/game.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require_relative 'meta'
+require_relative '../g_1880_romania/game'
+require_relative 'map'
+require_relative '../g_1880_romania/entities'
+
+module Engine
+  module Game
+    module G1880RomaniaTransilvania
+      class Game < G1880Romania::Game
+        include_meta(G1880RomaniaTransilvania::Meta)
+        include Map
+
+        CERT_LIMIT = { 2 => 11 }.freeze
+
+        STARTING_CASH = { 2 => 350 }.freeze
+
+        GAME_END_REASONS_TEXT = {
+          final_train: '6E train sold or exported',
+        }.freeze
+
+        GAME_END_REASONS_TIMING_TEXT = {
+          one_more_full_or_set: '3 ORs ending with the Corporation that triggered game end',
+        }.freeze
+
+        GAME_END_DESCRIPTION_REASON_MAP_TEXT = {
+          final_train: '6E train was sold or exported',
+        }.freeze
+
+        def game_companies
+          companies = COMPANIES.map(&:dup)
+          kept_companies = %w[P1 P3 P5 P8]
+          companies.select { |c| kept_companies.include?(c[:sym]) }
+        end
+
+        def game_minors
+          minors = MINORS.map(&:dup)
+
+          kept_minors = %w[1 4 5]
+          coordinates = {
+            '1' => 'D2',
+            '4' => 'B8',
+            '5' => 'J4',
+          }.freeze
+          minors
+          .select { |m| kept_minors.include?(m[:sym]) }
+          .each { |m| m[:coordinates] = coordinates[m[:sym]] }
+        end
+
+        def game_corporations
+          corporations = CORPORATIONS.map(&:dup)
+          kept_corporations = %w[BR CR SZ TR]
+          coordinates = {
+            'BR' => 'D6',
+            'CR' => 'E3',
+            'SZ' => 'G1',
+            'TR' => 'L6',
+          }.freeze
+          corporations
+          .select { |c| kept_corporations.include?(c[:sym]) }
+          .each { |m| m[:coordinates] = coordinates[m[:sym]] }
+        end
+
+        def game_trains
+          unless @game_trains
+            @game_trains = super.map(&:dup)
+            trains_2, trains_2p, trains_3, trains_3p, trains_4, trains_4p, trains_6, trains_6e, trains_8, trains_8e = @game_trains
+            trains_2[:num] = 6
+            trains_2p[:num] = 3
+            trains_3[:num] = 3
+            trains_3p[:num] = 2
+            trains_4[:num] = 2
+            trains_4p[:num] = 2
+            trains_6[:num] = 2
+            trains_6e[:num] = 1
+            trains_6e[:events] = [{ 'type' => 'signal_end_game', 'when' => 1 }]
+            trains_8[:num] = 'unlimited'
+            trains_8e[:num] = 0
+          end
+          @game_trains
+        end
+
+        def par_chart
+          @par_chart ||=
+            share_prices.sort_by { |sp| -sp.price }.to_h { |sp| [sp, [nil, nil]] }
+        end
+
+        def stock_round
+          G1880::Round::Stock.new(self, [
+            Engine::Step::Exchange,
+            G1880::Step::BuySellParShares,
+          ])
+        end
+
+        def operating_round(round_num)
+          G1880::Round::Operating.new(self, [
+            Engine::Step::HomeToken,
+            Engine::Step::Exchange,
+            Engine::Step::DiscardTrain,
+            G1880::Step::Track,
+            G1880::Step::Token,
+            G1880::Step::Route,
+            G1880::Step::Dividend,
+            G1880::Step::BuyTrain,
+            G1880::Step::CheckFIConnection,
+          ], round_num: round_num)
+        end
+
+        def dummy_company
+          @dummy ||= Company.new(
+            name: 'Dummy Company',
+            sym: 'DUMMY',
+            value: 0,
+          )
+          @dummy.close!
+          @dummy
+        end
+
+        # Not used in this variant
+        def rocket
+          dummy_company
+        end
+
+        # Not used in this variant
+        def rocket_train; end
+        def fix_rocket_ability; end
+        def force_exchange_rocket; end
+
+        # P0 and P5 not used in this variant. P1 is assumed to have the same effect as in base game.
+        def p0; end
+        def p5; end
+
+        # Not used in this variant
+        def ferry_hexes
+          []
+        end
+
+        # Not used in this variant
+        def ferry_company
+          dummy_company
+        end
+
+        # Not used in this variant
+        def taiwan_company
+          dummy_company
+        end
+
+        # Not used in this variant
+        def taiwan_hex; end
+
+        # Not used in this variant
+        def trans_siberian_bonus?(_stops); end
+
+        # Not used in this variant
+        def event_close_p7!; end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880_romania_transilvania/map.rb
+++ b/lib/engine/game/g_1880_romania_transilvania/map.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require_relative '../g_1880_romania/map'
+
+module Engine
+  module Game
+    module G1880RomaniaTransilvania
+      module Map
+        include G1880Romania::Map
+
+        LAYOUT = :pointy
+        AXES = { x: :letter, y: :number }.freeze
+
+        LOCATION_NAMES = {
+          'G1' => 'Satu Mare',
+          'K1' => 'Sighetu Marmației',
+          'Q1' => 'Czernowitz',
+          'D2' => 'Viena / Budapešta',
+          'J2' => 'Baia-Mare',
+          'P2' => 'Rădăuți',
+          'E3' => 'Oradea',
+          'G3' => 'Margita / Simleu',
+          'I3' => 'Zalău',
+          'K3' => 'Dej',
+          'M3' => 'Bistrița',
+          'J4' => 'Cluj-Napoca',
+          'L4' => 'Târgu Mureș',
+          'D19' => 'Bacău',
+          'A5' => 'Sinnicolau Mare',
+          'C5' => 'Arad',
+          'K5' => 'Turda',
+          'M5' => 'Mediaș',
+          'D6' => 'Timișoara',
+          'H6' => 'Deva / Hunedoara',
+          'J6' => 'Alba Iulia',
+          'L6' => 'Sibiu',
+          'N6' => 'Făgăraș',
+          'P6' => 'Brașov',
+          'E7' => 'Reșița',
+          'B8' => 'Belgrad',
+          'D8' => 'Oravița / Moldova Veche',
+        }.freeze
+
+        HEXES = {
+          white: {
+            # no cities or towns
+            %w[I1 F2 H2 D4 F4 E5 B6 F6 C7 F8] => '',
+            %w[L2 N2 O3 G5 I5 G7] => 'upgrade=cost:40,terrain:mountain',
+            %w[H4 N4 I7] => 'upgrade=cost:30,terrain:mountain',
+            ['O5'] => 'upgrade=cost:20,terrain:mountain',
+
+            # town
+            ['K1'] => 'town=revenue:0;upgrade=cost:40,terrain:mountain',
+            %w[M3 N6] => 'town=revenue:0;upgrade=cost:30,terrain:mountain',
+            %w[K3 K5 M5] => 'town=revenue:0;upgrade=cost:10,terrain:mountain',
+
+            # double towns
+            ['G3'] => 'town=revenue:0;town=revenue:0',
+            ['D8'] => 'town=revenue:0;town=revenue:0;icon=image:port',
+            ['H6'] => 'town=revenue:0;town=revenue:0;upgrade=cost:20,terrain:mountain',
+
+            # city
+            %w[E3 J4 L4 C5 D6] => 'city=revenue:0',
+            ['G1'] => 'city=revenue:0;label=T',
+            ['L6'] => 'city=revenue:0;upgrade=cost:20,terrain:mountain',
+
+            # town and city
+            %w[J2 I3] => 'town=revenue:0;city=revenue:0',
+            ['J6'] => 'town=revenue:0;city=revenue:0;upgrade=cost:20,terrain:mountain',
+            ['E7'] => 'town=revenue:0;city=revenue:0;upgrade=cost:40,terrain:mountain',
+          },
+          gray: {
+            ['P2'] => 'town=revenue:20;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0',
+            ['A5'] => 'town=revenue:20;path=a:4,b:_0;path=a:5,b:_0',
+            ['P6'] => 'city=revenue:yellow_20|green_30|brown_40|gray_50;path=a:1,b:_0;path=a:2,b:_0',
+          },
+          red: {
+            ['D2'] => 'city=revenue:yellow_20|green_30|brown_50|gray_70;path=a:4,b:_0,terminal:1;path=a:5,b:_0,terminal:1',
+            ['B8'] => 'city=revenue:yellow_20|green_30|brown_50|gray_70;path=a:3,b:_0,terminal:1;path=a:4,b:_0,terminal:1',
+            ['Q1'] => 'city=revenue:yellow_30|green_40|brown_50|gray_60;path=a:0,b:_0,terminal:1',
+            ['K7'] => 'offboard=revenue:yellow_10|green_20|brown_40|gray_50,hide:1,groups:Istanbul;'\
+                      'path=a:3,b:_0,terminal:1;border=edge:4',
+            ['M7'] => 'offboard=revenue:yellow_10|green_30|brown_40|gray_50,groups:Istanbul;path=a:2,b:_0,terminal:1;'\
+                      'border=edge:1',
+          },
+        }.freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880_romania_transilvania/meta.rb
+++ b/lib/engine/game/g_1880_romania_transilvania/meta.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative '../meta'
+require_relative '../g_1880_romania/meta'
+
+module Engine
+  module Game
+    module G1880RomaniaTransilvania
+      module Meta
+        include Game::Meta
+        include G1880Romania::Meta
+
+        DEPENDS_ON = '1880 Romania'
+
+        DEV_STAGE = :prealpha
+
+        # This does not seem to work, this variant do not appear under 1880 Romania
+        # GAME_IS_VARIANT_OF = G1880Romania::Meta
+
+        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1880-Romania-Transilvania-map'.freeze
+        GAME_TITLE = '1880 Romania Transilvania'.freeze
+
+        PLAYER_RANGE = [2, 2].freeze
+        OPTIONAL_RULES = [].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880_romania_transilvania/meta.rb
+++ b/lib/engine/game/g_1880_romania_transilvania/meta.rb
@@ -14,8 +14,7 @@ module Engine
 
         DEV_STAGE = :prealpha
 
-        # This does not seem to work, this variant do not appear under 1880 Romania
-        # GAME_IS_VARIANT_OF = G1880Romania::Meta
+        GAME_IS_VARIANT_OF = G1880Romania::Meta
 
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1880-Romania-Transilvania-map'.freeze
         GAME_TITLE = '1880 Romania Transilvania'.freeze

--- a/lib/engine/game/g_1880_romania_transilvania/step/buy_train.rb
+++ b/lib/engine/game/g_1880_romania_transilvania/step/buy_train.rb
@@ -7,7 +7,7 @@ module Engine
     module G1880RomaniaTransilvania
       module Step
         class BuyTrain < G1880::Step::BuyTrain
-          def avoid_discarding_all_trains?(train_name, train_index)
+          def avoid_discarding_all_trains?(train_name, _train_index)
             %w[8 2P].include?(train_name) || !discard_trains?
           end
         end

--- a/lib/engine/game/g_1880_romania_transilvania/step/buy_train.rb
+++ b/lib/engine/game/g_1880_romania_transilvania/step/buy_train.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1880/step/buy_train'
+
+module Engine
+  module Game
+    module G1880RomaniaTransilvania
+      module Step
+        class BuyTrain < G1880::Step::BuyTrain
+          def avoid_discarding_all_trains?(train_name, train_index)
+            %w[8 2P].include?(train_name) || !discard_trains?
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an initial commit that implements a variant using a 2-player Transilvania map. Based on 1880 Romania it removes and changes things based on the variant by Lonny.

Some steps and methods from 1880 China is not applicable for 1880 Romania Transilvania and has therefor been overridden with empty implementation.

Privates are a subset of the ones in 1880 Romania.

Corporations and Foreign investors use different coordinates compared to 1880 Romania.

Remove Assign as not used in Transilvania

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Based on 1880 China and 1880 Romania.

Implementation has gone a bit further compared to 1880 Romania.

### Explanation of Change

There exists several variants in 1880 Romania. This is the 2 player using a special Transilvania map - a smaller one.

### Screenshots

<img width="571" height="464" alt="image" src="https://github.com/user-attachments/assets/a5a372e0-589b-4ac5-8ed0-be8f5ad6cca7" />

<img width="858" height="491" alt="image" src="https://github.com/user-attachments/assets/073b6aa6-6467-4344-a71f-ad54c55aefec" />

<img width="701" height="537" alt="image" src="https://github.com/user-attachments/assets/7fd2490a-3887-4d16-aded-4235112fec6c" />

<img width="481" height="649" alt="image" src="https://github.com/user-attachments/assets/4e96ed67-0f74-4fbf-ae05-ec18e27ad50c" />


### Any Assumptions / Hacks

Some of the disabling of 1880 China functionality might be changed in case this is done in 1880 Romania as well.