### PR TITLE
[1832] London Investment private implementation

### DIFF
--- a/lib/engine/game/g_1832/entities.rb
+++ b/lib/engine/game/g_1832/entities.rb
@@ -287,10 +287,12 @@ module Engine
             abilities: [{
               type: 'exchange',
               owner_type: 'player',
-              corporations: 'any',
+              corporations: 'london',
+              count: 1,
+              remove_when_used_up: false,
               from: 'ipo',
             },
-                        { type: 'no_buy' }],
+            { type: 'no_buy' }],
             color: nil,
           },
           {

--- a/lib/engine/game/g_1832/entities.rb
+++ b/lib/engine/game/g_1832/entities.rb
@@ -287,7 +287,7 @@ module Engine
             abilities: [{
               type: 'exchange',
               owner_type: 'player',
-              corporations: 'london',
+              corporations: 'ipoed',
               when: 'owning_player_sr_turn',
               count: 1,
               remove_when_used_up: false,

--- a/lib/engine/game/g_1832/entities.rb
+++ b/lib/engine/game/g_1832/entities.rb
@@ -288,6 +288,8 @@ module Engine
               type: 'exchange',
               owner_type: 'player',
               corporations: 'london',
+              owner_type: 'player',
+              when: 'owning_player_sr_turn',
               count: 1,
               remove_when_used_up: false,
               from: 'ipo',

--- a/lib/engine/game/g_1832/entities.rb
+++ b/lib/engine/game/g_1832/entities.rb
@@ -293,7 +293,7 @@ module Engine
               remove_when_used_up: false,
               from: 'ipo',
             },
-            { type: 'no_buy' }],
+                        { type: 'no_buy' }],
             color: nil,
           },
           {

--- a/lib/engine/game/g_1832/entities.rb
+++ b/lib/engine/game/g_1832/entities.rb
@@ -288,7 +288,6 @@ module Engine
               type: 'exchange',
               owner_type: 'player',
               corporations: 'london',
-              owner_type: 'player',
               when: 'owning_player_sr_turn',
               count: 1,
               remove_when_used_up: false,

--- a/lib/engine/game/g_1832/entities.rb
+++ b/lib/engine/game/g_1832/entities.rb
@@ -290,7 +290,7 @@ module Engine
               corporations: 'ipoed',
               when: 'owning_player_sr_turn',
               count: 1,
-              remove_when_used_up: false,
+              remove_when_used_up: true,
               from: 'ipo',
             },
                         { type: 'no_buy' }],

--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -21,7 +21,7 @@ module Engine
         include G1832::Phases
         include G1832::Trains
 
-        attr_accessor :sell_queue, :reissued, :coal_token_counter, :coal_company_sold_or_closed
+        attr_accessor :sell_queue, :reissued, :coal_token_counter, :coal_company_sold_or_closed, :london_corporation
 
         CORPORATION_CLASS = G1832::Corporation
         CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT = true
@@ -238,13 +238,6 @@ module Engine
           @coal_hex ||= hex_by_id('B14')
         end
 
-        def london_company
-          @london_company || nil
-        end
-
-        def assign_london_company(corporation)
-          @london_company = corporation
-        end
 
         def exchange_corporations(exchange_ability)
           candidates = case exchange_ability.corporations
@@ -264,16 +257,6 @@ module Engine
           candidates.reject(&:closed?)
         end
 
-        def use!(**_kwargs)
-          @used = true
-
-          @count_this_or += 1 if @count_per_or
-
-          return unless @count
-
-          @count -= 1
-          owner.remove_ability(self) if !@count.positive? && @remove_when_used_up
-        end
 
         def revenue_for(route, stops)
           revenue = super

--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -240,21 +240,8 @@ module Engine
 
 
         def exchange_corporations(exchange_ability)
-          candidates = case exchange_ability.corporations
-                       when 'any'
-                         corporations
-                       when 'ipoed'
-                         corporations.select(&:ipoed)
-                       when 'london'
-                         corporations.select do |c|
-                           !@round.current_actions.any? do |x|
-                             x.instance_of?(Action::BuyShares)
-                           end && !c.player_share_holders.none? && !c.operated? && exchange_ability.count > 0
-                         end
-                       else
-                         exchange_ability.corporations.map { |c| corporation_by_id(c) }
-                       end
-          candidates.reject(&:closed?)
+          super
+          candidates.reject(&:closed?).reject(&:operated?)
         end
 
 

--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -254,7 +254,7 @@ module Engine
                      when 'ipoed'
                        corporations.select(&:ipoed)
                     when 'london'
-                      corporations.select { |c| c.floated? && !c.operated? && exchange_ability.count > 0}
+                      corporations.select { |c| !c.player_share_holders.none? && !c.operated? && exchange_ability.count > 0}
                     else
                        exchange_ability.corporations.map { |c| corporation_by_id(c) }
                     end

--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -254,7 +254,7 @@ module Engine
                      when 'ipoed'
                        corporations.select(&:ipoed)
                     when 'london'
-                      corporations.select { |c| !c.player_share_holders.none? && !c.operated? && exchange_ability.count > 0}
+                      corporations.select { |c| (!@round.current_actions.any? { |x| x.instance_of?(Action::BuyShares) }) && !c.player_share_holders.none? && !c.operated? && exchange_ability.count > 0}
                     else
                        exchange_ability.corporations.map { |c| corporation_by_id(c) }
                     end

--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -9,6 +9,7 @@ require_relative 'phases'
 require_relative 'trains'
 require_relative '../base'
 require_relative 'step/exchange'
+require_relative 'step/dividend'
 
 module Engine
   module Game
@@ -116,7 +117,7 @@ module Engine
             G1832::Step::Track,
             G1832::Step::Token,
             Engine::Step::Route,
-            G1870::Step::Dividend,
+            G1832::Step::Dividend,
             Engine::Step::DiscardTrain,
             G1870::Step::BuyTrain,
             [G1832::Step::BuyCompany, { blocks: true }],
@@ -337,8 +338,6 @@ module Engine
 
           @skip_paths
         end
-
-
       end
     end
   end

--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -22,7 +22,8 @@ module Engine
         include G1832::Phases
         include G1832::Trains
 
-        attr_accessor :sell_queue, :reissued, :coal_token_counter, :coal_company_sold_or_closed, :london_corporation, :parred_this_sr
+        attr_accessor :sell_queue, :reissued, :coal_token_counter, :coal_company_sold_or_closed, :london_corporation,
+                      :parred_this_sr
 
         CORPORATION_CLASS = G1832::Corporation
         CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT = true
@@ -138,7 +139,7 @@ module Engine
           @sell_queue = []
           @reissued = {}
           @coal_token_counter = 5
-          @parred_this_sr = ["CG"]
+          @parred_this_sr = ['CG']
 
           coal_company.max_price = coal_company.value
 
@@ -241,12 +242,10 @@ module Engine
           @coal_hex ||= hex_by_id('B14')
         end
 
-
         def exchange_corporations(exchange_ability)
           candidates = super
           candidates.reject(&:closed?).reject(&:operated?).select { |c| @parred_this_sr.include?(c.id) }
         end
-
 
         def revenue_for(route, stops)
           revenue = super

--- a/lib/engine/game/g_1832/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1832/step/buy_sell_par_shares.rb
@@ -10,6 +10,10 @@ module Engine
           def visible_corporations
             @game.sorted_corporations.reject { |item| item.type == :system unless item.floated? }
           end
+          def process_par(action)
+            @game.parred_this_sr << action.corporation.id
+            super
+          end
         end
       end
     end

--- a/lib/engine/game/g_1832/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1832/step/buy_sell_par_shares.rb
@@ -10,6 +10,7 @@ module Engine
           def visible_corporations
             @game.sorted_corporations.reject { |item| item.type == :system unless item.floated? }
           end
+
           def process_par(action)
             @game.parred_this_sr << action.corporation.id
             super

--- a/lib/engine/game/g_1832/step/dividend.rb
+++ b/lib/engine/game/g_1832/step/dividend.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/dividend'
+require_relative '../../../step/half_pay'
+
+module Engine
+  module Game
+    module G1870
+      module Step
+        class Dividend < Engine::Step::Dividend
+          DIVIDEND_TYPES = %i[payout half withhold].freeze
+          include Engine::Step::HalfPay
+
+          def holder_for_corporation(entity)
+            entity
+          end
+
+          def share_price_change(_entity, revenue)
+            return { share_direction: :left, share_times: 1 } if revenue.zero?
+
+            return { share_direction: :right, share_times: 1 } if revenue == @game.routes_revenue(routes)
+
+            {}
+          end
+            def payout_shares(entity, revenue)
+                per_share = payout_per_share(entity, revenue)
+
+                payouts = {}
+                (@game.players + @game.corporations).each do |payee|
+                payout_entity(entity, payee, per_share, payouts)
+                end
+
+                receivers = payouts
+                            .sort_by { |_r, c| -c }
+                            .map { |receiver, cash| "#{@game.format_currency(cash)} to #{receiver.name}" }.join(', ')
+
+                if entity == @game.london_company
+                    @log << "London Investment closes"
+                    li =  @game.companies.find { |c| c.sym == 'P4' }
+                    li.close! if li
+                end
+                log_payout_shares(entity, revenue, per_share, receivers)
+            end           
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1832/step/dividend.rb
+++ b/lib/engine/game/g_1832/step/dividend.rb
@@ -9,15 +9,13 @@ module Engine
     module G1832
       module Step
         class Dividend < G1870::Step::Dividend
-
           def payout_shares(entity, revenue)
             super
             if entity == @game.london_corporation
-              @log << 'London Investment closes'
-              li = @game.company_by_id('P4')
+              li = @game.companies.find { |c| c.sym == 'P4' }
+              @log << 'London Investment closes' if li
               li.close! if li
             end
-            log_payout_shares(entity, revenue, per_share, receivers)
           end
         end
       end

--- a/lib/engine/game/g_1832/step/dividend.rb
+++ b/lib/engine/game/g_1832/step/dividend.rb
@@ -22,25 +22,26 @@ module Engine
 
             {}
           end
-            def payout_shares(entity, revenue)
-                per_share = payout_per_share(entity, revenue)
 
-                payouts = {}
-                (@game.players + @game.corporations).each do |payee|
-                payout_entity(entity, payee, per_share, payouts)
-                end
+          def payout_shares(entity, revenue)
+            per_share = payout_per_share(entity, revenue)
 
-                receivers = payouts
-                            .sort_by { |_r, c| -c }
-                            .map { |receiver, cash| "#{@game.format_currency(cash)} to #{receiver.name}" }.join(', ')
+            payouts = {}
+            (@game.players + @game.corporations).each do |payee|
+              payout_entity(entity, payee, per_share, payouts)
+            end
 
-                if entity == @game.london_company
-                    @log << "London Investment closes"
-                    li =  @game.companies.find { |c| c.sym == 'P4' }
-                    li.close! if li
-                end
-                log_payout_shares(entity, revenue, per_share, receivers)
-            end           
+            receivers = payouts
+                        .sort_by { |_r, c| -c }
+                        .map { |receiver, cash| "#{@game.format_currency(cash)} to #{receiver.name}" }.join(', ')
+
+            if entity == @game.london_company
+              @log << 'London Investment closes'
+              li = @game.companies.find { |c| c.sym == 'P4' }
+              li.close! if li
+            end
+            log_payout_shares(entity, revenue, per_share, receivers)
+          end
         end
       end
     end

--- a/lib/engine/game/g_1832/step/dividend.rb
+++ b/lib/engine/game/g_1832/step/dividend.rb
@@ -2,26 +2,13 @@
 
 require_relative '../../../step/dividend'
 require_relative '../../../step/half_pay'
+require_relative '../../g_1870/step/dividend'
 
 module Engine
   module Game
     module G1870
       module Step
-        class Dividend < Engine::Step::Dividend
-          DIVIDEND_TYPES = %i[payout half withhold].freeze
-          include Engine::Step::HalfPay
-
-          def holder_for_corporation(entity)
-            entity
-          end
-
-          def share_price_change(_entity, revenue)
-            return { share_direction: :left, share_times: 1 } if revenue.zero?
-
-            return { share_direction: :right, share_times: 1 } if revenue == @game.routes_revenue(routes)
-
-            {}
-          end
+        class Dividend < G1870::Step::Dividend
 
           def payout_shares(entity, revenue)
             per_share = payout_per_share(entity, revenue)

--- a/lib/engine/game/g_1832/step/dividend.rb
+++ b/lib/engine/game/g_1832/step/dividend.rb
@@ -14,7 +14,7 @@ module Engine
             super
             if entity == @game.london_corporation
               @log << 'London Investment closes'
-              li = @game.companies.find { |c| c.sym == 'P4' }
+              li = @game.company_by_id('P4')
               li.close! if li
             end
             log_payout_shares(entity, revenue, per_share, receivers)

--- a/lib/engine/game/g_1832/step/dividend.rb
+++ b/lib/engine/game/g_1832/step/dividend.rb
@@ -11,18 +11,8 @@ module Engine
         class Dividend < G1870::Step::Dividend
 
           def payout_shares(entity, revenue)
-            per_share = payout_per_share(entity, revenue)
-
-            payouts = {}
-            (@game.players + @game.corporations).each do |payee|
-              payout_entity(entity, payee, per_share, payouts)
-            end
-
-            receivers = payouts
-                        .sort_by { |_r, c| -c }
-                        .map { |receiver, cash| "#{@game.format_currency(cash)} to #{receiver.name}" }.join(', ')
-
-            if entity == @game.london_company
+            super
+            if entity == @game.london_corporation
               @log << 'London Investment closes'
               li = @game.companies.find { |c| c.sym == 'P4' }
               li.close! if li

--- a/lib/engine/game/g_1832/step/dividend.rb
+++ b/lib/engine/game/g_1832/step/dividend.rb
@@ -6,7 +6,7 @@ require_relative '../../g_1870/step/dividend'
 
 module Engine
   module Game
-    module G1870
+    module G1832
       module Step
         class Dividend < G1870::Step::Dividend
 

--- a/lib/engine/game/g_1832/step/dividend.rb
+++ b/lib/engine/game/g_1832/step/dividend.rb
@@ -11,11 +11,13 @@ module Engine
         class Dividend < G1870::Step::Dividend
           def payout_shares(entity, revenue)
             super
-            if entity == @game.london_corporation
-              li = @game.companies.find { |c| c.sym == 'P4' }
-              @log << 'London Investment closes' if li
-              li.close! if li
-            end
+            return unless entity == @game.london_corporation
+
+            li = @game.companies.find { |c| c.sym == 'P4' }
+            return unless li
+
+            @log << 'London Investment closes'
+            li.close!
           end
         end
       end

--- a/lib/engine/game/g_1832/step/exchange.rb
+++ b/lib/engine/game/g_1832/step/exchange.rb
@@ -20,12 +20,10 @@ module Engine
 
             buy_shares(company.owner, bundle, exchange: company)
             @round.players_history[company.owner][bundle.corporation] << action if @round.respond_to?(:players_history)
-            if company.name == 'London Investment'
-              @game.assign_london_company(bundle.corporation)
-              ability.use!
-              @round.current_actions << action
-            end
-            company.close! if company.name != 'London Investment'
+            @game.assign_london_corporation(bundle.corporation)
+            ability.use!
+            @round.current_actions << action
+            company.close!
           end
         end
       end

--- a/lib/engine/game/g_1832/step/exchange.rb
+++ b/lib/engine/game/g_1832/step/exchange.rb
@@ -11,10 +11,6 @@ module Engine
           def process_buy_shares(action)
             company = action.entity
             bundle = action.bundle
-            unless (ability = @game.abilities(company, :exchange))
-              raise GameError,
-                    "Could not assign #{company.name} to #{target.name}; :exchange ability not found"
-            end
             raise GameError, "Cannot exchange #{action.entity.id} for #{bundle.corporation.id}" unless can_exchange?(company,
                                                                                                                      bundle)
 

--- a/lib/engine/game/g_1832/step/exchange.rb
+++ b/lib/engine/game/g_1832/step/exchange.rb
@@ -16,7 +16,7 @@ module Engine
 
             buy_shares(company.owner, bundle, exchange: company)
             @round.players_history[company.owner][bundle.corporation] << action if @round.respond_to?(:players_history)
-            @game.assign_london_corporation(bundle.corporation)
+            @game.london_corporation = bundle.corporation
             ability.use!
             @round.current_actions << action
             company.close!

--- a/lib/engine/game/g_1832/step/exchange.rb
+++ b/lib/engine/game/g_1832/step/exchange.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative '../../../step/exchange'
-require_relative '../../../step/share_buying'
 
 module Engine
   module Game

--- a/lib/engine/game/g_1832/step/exchange.rb
+++ b/lib/engine/game/g_1832/step/exchange.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/exchange'
+require_relative '../../../step/share_buying'
+
+
+module Engine
+  module Game
+    module G1832
+      module Step
+        class Exchange < Engine::Step::Exchange
+
+        ACTIONS = %w[buy_shares].freeze
+
+        def actions(entity)
+            return ACTIONS if can_exchange?(entity)
+
+            []
+        end
+
+        def blocks?
+            false
+        end
+
+        def process_buy_shares(action)
+            company = action.entity
+            bundle = action.bundle
+            unless (ability = @game.abilities(company, :exchange))
+            raise GameError,
+                "Could not assign #{company.name} to #{target.name}; :exchange ability not found"
+            end
+            raise GameError, "Cannot exchange #{action.entity.id} for #{bundle.corporation.id}" unless can_exchange?(company, bundle)
+            buy_shares(company.owner, bundle, exchange: company)
+            @round.players_history[company.owner][bundle.corporation] << action if @round.respond_to?(:players_history)
+            if company.name == 'London Investment'
+                @game.assign_london_company(bundle.corporation)
+                ability.use!
+                @round.next_entity_index!
+            end
+            if company.name != 'London Investment'
+                company.close!
+            end
+        end
+
+
+        def can_buy?(entity, bundle)
+            can_gain?(entity, bundle, exchange: true)
+        end
+
+
+        def can_exchange?(entity, bundle = nil)
+            return false unless entity.company?
+            return false unless (ability = @game.abilities(entity, :exchange))
+
+            owner = entity.owner
+            return can_gain?(owner, bundle, exchange: true) if bundle
+
+            shares = []
+            @game.exchange_corporations(ability).each do |corporation|
+            shares << corporation.reserved_shares.first if ability.from.include?(:reserved)
+            shares << corporation.available_share if ability.from.include?(:ipo)
+            shares << @game.share_pool.shares_by_corporation[corporation]&.first if ability.from.include?(:market)
+            end
+
+            @log << "Can exchange #{entity.name} from #{entity.owner}: "
+            shares.compact.any? { |s| can_gain?(entity.owner, s&.to_bundle, exchange: true)}
+        end
+
+
+
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1832/step/exchange.rb
+++ b/lib/engine/game/g_1832/step/exchange.rb
@@ -8,17 +8,6 @@ module Engine
     module G1832
       module Step
         class Exchange < Engine::Step::Exchange
-          ACTIONS = %w[buy_shares].freeze
-
-          def actions(entity)
-            return ACTIONS if can_exchange?(entity)
-
-            []
-          end
-
-          def blocks?
-            false
-          end
 
           def process_buy_shares(action)
             company = action.entity

--- a/lib/engine/game/g_1832/step/exchange.rb
+++ b/lib/engine/game/g_1832/step/exchange.rb
@@ -35,7 +35,7 @@ module Engine
             if company.name == 'London Investment'
                 @game.assign_london_company(bundle.corporation)
                 ability.use!
-                @round.next_entity_index!
+                @round.current_actions << action
             end
             if company.name != 'London Investment'
                 company.close!

--- a/lib/engine/game/g_1832/step/exchange.rb
+++ b/lib/engine/game/g_1832/step/exchange.rb
@@ -62,7 +62,6 @@ module Engine
             shares << @game.share_pool.shares_by_corporation[corporation]&.first if ability.from.include?(:market)
             end
 
-            @log << "Can exchange #{entity.name} from #{entity.owner}: "
             shares.compact.any? { |s| can_gain?(entity.owner, s&.to_bundle, exchange: true)}
         end
 

--- a/lib/engine/game/g_1832/step/exchange.rb
+++ b/lib/engine/game/g_1832/step/exchange.rb
@@ -11,15 +11,16 @@ module Engine
           def process_buy_shares(action)
             company = action.entity
             bundle = action.bundle
-            raise GameError, "Cannot exchange #{action.entity.id} for #{bundle.corporation.id}" unless can_exchange?(company,
-                                                                                                                     bundle)
+            unless (ability = @game.abilities(company, :exchange))
+            raise GameError,
+                "Could not assign #{company.name} to #{target.name}; :exchange ability not found"
+            end
 
-            buy_shares(company.owner, bundle, exchange: company)
+           buy_shares(company.owner, bundle, exchange: company)
             @round.players_history[company.owner][bundle.corporation] << action if @round.respond_to?(:players_history)
             @game.london_corporation = bundle.corporation
             ability.use!
             @round.current_actions << action
-            company.close!
           end
         end
       end

--- a/lib/engine/game/g_1832/step/exchange.rb
+++ b/lib/engine/game/g_1832/step/exchange.rb
@@ -28,27 +28,6 @@ module Engine
             end
             company.close! if company.name != 'London Investment'
           end
-
-          def can_buy?(entity, bundle)
-            can_gain?(entity, bundle, exchange: true)
-          end
-
-          def can_exchange?(entity, bundle = nil)
-            return false unless entity.company?
-            return false unless (ability = @game.abilities(entity, :exchange))
-
-            owner = entity.owner
-            return can_gain?(owner, bundle, exchange: true) if bundle
-
-            shares = []
-            @game.exchange_corporations(ability).each do |corporation|
-              shares << corporation.reserved_shares.first if ability.from.include?(:reserved)
-              shares << corporation.available_share if ability.from.include?(:ipo)
-              shares << @game.share_pool.shares_by_corporation[corporation]&.first if ability.from.include?(:market)
-            end
-
-            shares.compact.any? { |s| can_gain?(entity.owner, s&.to_bundle, exchange: true) }
-          end
         end
       end
     end

--- a/lib/engine/game/g_1832/step/exchange.rb
+++ b/lib/engine/game/g_1832/step/exchange.rb
@@ -7,16 +7,15 @@ module Engine
     module G1832
       module Step
         class Exchange < Engine::Step::Exchange
-
           def process_buy_shares(action)
             company = action.entity
             bundle = action.bundle
             unless (ability = @game.abilities(company, :exchange))
-            raise GameError,
-                "Could not assign #{company.name} to #{target.name}; :exchange ability not found"
+              raise GameError,
+                    "Could not assign #{company.name} to #{target.name}; :exchange ability not found"
             end
 
-           buy_shares(company.owner, bundle, exchange: company)
+            buy_shares(company.owner, bundle, exchange: company)
             @round.players_history[company.owner][bundle.corporation] << action if @round.respond_to?(:players_history)
             @game.london_corporation = bundle.corporation
             ability.use!

--- a/lib/engine/game/g_1832/step/track.rb
+++ b/lib/engine/game/g_1832/step/track.rb
@@ -29,7 +29,7 @@ module Engine
 
           def choices
             choices = []
-            choices << ['Buy Coal Token'] if can_buy_coal_token?(current_entity)
+            choices << ['Buy Coal Token ($80)'] if can_buy_coal_token?(current_entity)
             choices
           end
 
@@ -38,8 +38,7 @@ module Engine
           end
 
           def process_choose(action)
-            buy_coal_token(action.entity) if action.choice == 'Buy Coal Token'
-            @round.num_laid_track += 1
+            buy_coal_token(action.entity) if action.choice == 'Buy Coal Token ($80)'
           end
 
           def buy_coal_token(corporation)

--- a/lib/engine/game/g_1832/step/track.rb
+++ b/lib/engine/game/g_1832/step/track.rb
@@ -27,18 +27,16 @@ module Engine
             actions.uniq
           end
 
-          def choices
-            choices = []
-            choices << ['Buy Coal Token ($80)'] if can_buy_coal_token?(current_entity)
-            choices
-          end
+          def choices  
+            can_buy_coal_token?(current_entity) ? { 'buy_coal_token' => 'Buy Coal Token ($80)' } : {}  
+          end  
 
           def choice_name
             'Additional Track Actions'
           end
 
           def process_choose(action)
-            buy_coal_token(action.entity) if action.choice == 'Buy Coal Token ($80)'
+            buy_coal_token(action.entity) if action.choice == 'buy_coal_token'
           end
 
           def buy_coal_token(corporation)

--- a/lib/engine/game/g_1832/step/track.rb
+++ b/lib/engine/game/g_1832/step/track.rb
@@ -27,9 +27,9 @@ module Engine
             actions.uniq
           end
 
-          def choices  
-            can_buy_coal_token?(current_entity) ? { 'buy_coal_token' => 'Buy Coal Token ($80)' } : {}  
-          end  
+          def choices
+            can_buy_coal_token?(current_entity) ? { 'buy_coal_token' => 'Buy Coal Token ($80)' } : {}
+          end
 
           def choice_name
             'Additional Track Actions'


### PR DESCRIPTION

<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Implementation Notes

### Explanation of Change

- Implements missing features of London Investment Private:
- Counts as purchasing action
- Pays revenue until corp exchanged for pays first dividend

- Changed WV Coal fields private to not count as a track lay (despite being mentioned in the checklist, I didn't see this requirement anywhere in the rules, if I'm wrong let me know and I'll undo this change

I'd like to get 1832 working online, so more changes will be coming soon!

### Screenshots

### Any Assumptions / Hacks
