### PR TITLE
[1824] Assign national presidency with equal shareholding

### DIFF
--- a/lib/engine/game/g_1824/game.rb
+++ b/lib/engine/game/g_1824/game.rb
@@ -218,7 +218,7 @@ module Engine
           tie_breaker |= @players
 
           president_factors = president_candidates.to_h do |player, percent|
-            [[percent, -1 * tie_breaker.index(player), player == current_president ? 1 : 0], player]
+            [[percent, -1 * tie_breaker.index(player)], player]
           end
           president = president_factors[president_factors.keys.max]
           return if current_president == president


### PR DESCRIPTION
The `tie_breaker` argument passed to the `set_national_president!` method is ordered by the ownership of the minors, ordered by the minor symbol. This means that the owner of SD1/KK1/UG1 will be the first player in the array. So when we sort to find the new president, we want to be looking for the lowest index in this array, not the highest.

Fixes tobymao#12384.

There's a small chance this could break existing games, if a presidency is assigned to a different player, changing certificate counts. These games will need to be pinned or archived.

### Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`