### PR TITLE
[Core] Reduce graph redundant walks from backtracking

### DIFF
--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -176,9 +176,8 @@ module Engine
         # Backtracking optimization to not backtrack to edges already reachable from this edge, avoiding redundant walks
         reachable_edges_from_edge = []
         if backtracking && skip && @tile.converging_exit?(skip)
-          reachable_edges_from_edge = hex.paths[skip].reject do |p|
-                                        p == self
-                                      end.flat_map(&:edges).map(&:num).reject { |e| e == skip }
+          reachable_edges_from_edge =
+            hex.paths[skip].reject { |p| p == self }.flat_map(&:edges).map(&:num).reject { |e| e == skip }
         end
 
         edges.each do |edge|


### PR DESCRIPTION
Graph walks with backtracking can exponentially increase the amount of paths that need to walk when converging track is encountered. To explain, here is an example:

<img width="110" height="113" alt="image" src="https://github.com/user-attachments/assets/415a119d-48ad-40d4-8ece-9763a7ba368f" />

The south east edge is 0. Each path is given a color: blue, red, green.

Consider a walk coming from edge 3. It first will walk the red path to its full depth and then walk the blue path to its full depth. After completing the red path walk, all further paths down that network are forgotten, so that they can be run by the blue path (see converging logic in the path.rb walk code). Why? Well the blue path may be able to walk that same path in the opposite direction, opening up new areas of the network.

Backtracking makes it worse. The red path will backtrack to the green path, which will build a network out beyond edge 0. Then after the red path is fully explored, the converging logic will have us forget that network, and the blue path will build the same network again out from edge 0 AND backtrack across green to build the same network that the red path build out from edge 5. In the current code with backtracking enabled, this means we've built networks out through edge 0 and edge 5 twice, doubling the compute. Now imagine a series of tiles like this, the compute grows fast. In late game 1837, the token graph compute can time out and lock-up the game.

This PR introduces a simple optimization, that I believe will always be safe. That optimization is to first find all the edges that are reachable from the originating edge. For edge 3, that would be 0 and 5. Then when deciding whether or not to backtrack, if the backtrack would reach an edge that is already reachable, don't backtrack. Since the green path opens up edge 0 for the red path and we see that the blue path already has edge 0 covered, we won't backtrack. The same will be true for the blue path when it evaluates backtracking over green to edge 5. Since its covered by the red path, it won't walk through the green backtrack.

In my testing of late game 1837, this optimization reduced the token graph walk compute time from ~5-6 seconds to 0.7 seconds. 

Before moving forward, I'd like to get some feedback on the approach and if there are any edge cases I'm not thinking of.

Also, there are more complex brown track that my optimization doesn't account for yet.

<img width="113" height="111" alt="image" src="https://github.com/user-attachments/assets/2ea44c53-c5c8-400c-a481-65cd4f5f67de" />

A walk that originates at edge 3 has two different ways of backtracking to end up at edge 1; however, since edge 3 doesn't directly connect to edge 1, it isn't considered. The algorithm would have to go two levels deep to find this redundant walk. Is that going too far? I'd have to figure out which backtrack gets to run and which doesn't since the two path walks from edge 3 are separate walks orchestrated by the path on H26.

This was actually my second approach. My first approach was to globally track directional path walks (ignoring converging). The ideas was that if one path was walked from edge 0 to 3, we already computed whatever network is beyond that and don't need to do it again. However, in testing, I found that it messed up distance calculations. If the first route to go down a path wasn't the shortest between points A and B, a second shorter route, wouldn't walk the redundant directional path, and thus the shorter route would be omitted. I discovered the issue testing 18NY where tokens cost per hex distance across the railroad network (not as the crow flies). It could also be an issue for hex trains or 1870 destinations. I liked that it was a more general solution, but alas, I don't think there is a path forward here. I'm including in my write-up in case someone else sees a way to make it work.