### PR TITLE
[18Norway] Remove V’s free ship ability when used

### DIFF
--- a/lib/engine/game/g_18_norway/game.rb
+++ b/lib/engine/game/g_18_norway/game.rb
@@ -190,6 +190,8 @@ module Engine
           corporation_by_id('V').add_ability(Engine::Ability::Base.new(
             type: 'free_ship',
             description: 'Free S3 ship before phase 4',
+            count: 1,
+            remove_when_used_up: true,
           ))
 
           switcher.add_ability(Engine::Ability::Base.new(


### PR DESCRIPTION
The ability that gives V a free S3 ship was not being removed after it was used. This meant that if V sold its free S3 ship to another company it could then be given another free one.

This changes V’s ability to have a count of one, so the company can never be given more than a single free ship.

Fixes tobymao#12407.

This will break any game where V has been given any extra free S3 ships. Those games will need to be pinned.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

[CC: @patrikolesen]