### PR TITLE
[1868WY] Clear `city_towns` when making ghost town

### DIFF
--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -1522,8 +1522,9 @@ module Engine
           hex.tile.location_name = GHOST_TOWN_NAME
 
           if hex.tile.preprinted
-            hex.tile.cities.reject! { true }
-            hex.tile.towns.reject! { true }
+            hex.tile.cities.clear
+            hex.tile.towns.clear
+            hex.tile.city_towns.clear
             hex.remove_assignment!(pure_oil.id) if hex.assigned?(pure_oil.id)
             return
           end


### PR DESCRIPTION
When a preprinted (white) hex was being converted to a ghost town, the city and town were removed from the hex, but the `city_towns` array wasn't being cleared. This is the property that is checked in `boom?` and so that method was returning true. And that meant that `upgrades_to?` was rejecting all tiles, making it impossible to lay plain track on the hex.

This clears the `city_towns` array when the tile is converted to a ghost town. It also changes the code for removing the town and city to use `Array.clear` instead of `Array.reject! { true }` as we don't need an iterator to do this.

Fixes tobymao#12417.

I don't believe that this will need any games to be pinned.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`