### PR TITLE
[1840] Fix spelling in log message

### DIFF
--- a/lib/engine/game/g_1840/step/reassign_trains.rb
+++ b/lib/engine/game/g_1840/step/reassign_trains.rb
@@ -76,7 +76,7 @@ module Engine
             @log << if reassignments.empty?
                       "#{entity.owner.name} does not reassign any trains"
                     else
-                      "#{entity.owner.name} reassignes trains: #{reassignments.join(', ')}"
+                      "#{entity.owner.name} reassigns trains: #{reassignments.join(', ')}"
                     end
             pass!
           end


### PR DESCRIPTION
`reassignes` → `reassigns`

Fixes tobymao#12426.