### PR TITLE
Regularize GAME_LOCATION for various games

### DIFF
--- a/lib/engine/game/g_1812/meta.rb
+++ b/lib/engine/game/g_1812/meta.rb
@@ -13,7 +13,7 @@ module Engine
 
         GAME_SUBTITLE = 'The Cradle Of Steam Railways'
         GAME_DESIGNER = 'Ian D. Wilson'
-        GAME_LOCATION = 'North-East England'
+        GAME_LOCATION = 'Northeastern England'
         GAME_PUBLISHER = :golden_spike
         GAME_RULES_URL = 'https://drive.google.com/file/d/0B1SWz2pNe2eAZUY2UHNvUFNxUGc/view?usp=sharing&resourcekey=0-D5kk65ZoyT-dR6hSKAmggQ'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1812'

--- a/lib/engine/game/g_1822_pnw/meta.rb
+++ b/lib/engine/game/g_1822_pnw/meta.rb
@@ -15,7 +15,7 @@ module Engine
         GAME_DESIGNER = 'Ken Kuhn'.freeze
         GAME_IMPLEMENTER = 'Michael Alexander'.freeze
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1822PNW'.freeze
-        GAME_LOCATION = 'Pacific Northwest'.freeze
+        GAME_LOCATION = 'Pacific Northwest, USA'.freeze
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'https://boardgamegeek.com/filepage/269597/1822pnw-rules'.freeze
         GAME_TITLE = '1822PNW'.freeze

--- a/lib/engine/game/g_1828/meta.rb
+++ b/lib/engine/game/g_1828/meta.rb
@@ -12,7 +12,7 @@ module Engine
 
         GAME_IMPLEMENTER = 'Chris Rericha based on 1828 by J C Lawrence'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1828.Games'
-        GAME_LOCATION = 'North East, USA'
+        GAME_LOCATION = 'Northeastern USA'
         GAME_RULES_URL = 'https://kanga.nu/~claw/1828/1828-Rules.pdf'
         GAME_TITLE = '1828.Games'
 

--- a/lib/engine/game/g_1840/meta.rb
+++ b/lib/engine/game/g_1840/meta.rb
@@ -10,7 +10,7 @@ module Engine
 
         GAME_SUBTITLE = 'Vienna Tramways'
         GAME_DESIGNER = 'Leonhard Orgler'
-        GAME_LOCATION = 'Vienna - Austria'
+        GAME_LOCATION = 'Vienna, Austria'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1840'
         GAME_PUBLISHER = :lonny_games
         GAME_RULES_URL = 'https://www.lonny.at/app/download/10197449884/Rules_ENG_final-compr.pdf'

--- a/lib/engine/game/g_1846/meta.rb
+++ b/lib/engine/game/g_1846/meta.rb
@@ -12,7 +12,7 @@ module Engine
 
         GAME_DESIGNER = 'Thomas Lehmann'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1846'
-        GAME_LOCATION = 'Midwest, USA'
+        GAME_LOCATION = 'Midwestern USA'
         GAME_PUBLISHER = %i[gmt_games golden_spike].freeze
         GAME_RULES_URL = 'https://gmtwebsiteassets.s3.us-west-2.amazonaws.com/1846/1846-RULES-2021.pdf'
         GAME_SUBTITLE = 'The Race for the Midwest'

--- a/lib/engine/game/g_1850/meta.rb
+++ b/lib/engine/game/g_1850/meta.rb
@@ -14,7 +14,7 @@ module Engine
         GAME_SUBTITLE = 'The MidWest'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1850'
         GAME_DESIGNER = 'Bill Dixon'
-        GAME_LOCATION = 'The Midwestern USA'
+        GAME_LOCATION = 'Midwestern USA'
         PUBLISHER = :golden_spike
         GAME_RULES_URL = 'https://www.tckroleplaying.com/bg/1850/1850-Rules.pdf'
 

--- a/lib/engine/game/g_1860/meta.rb
+++ b/lib/engine/game/g_1860/meta.rb
@@ -13,7 +13,7 @@ module Engine
         GAME_SUBTITLE = 'Railways on the Isle of Wight'
         GAME_DESIGNER = 'Mike Hutton'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1860'
-        GAME_LOCATION = 'Isle of Wight'
+        GAME_LOCATION = 'Isle of Wight, England'
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = 'https://boardgamegeek.com/filepage/238952/third-edition-rules'
 

--- a/lib/engine/game/g_18_dixie/meta.rb
+++ b/lib/engine/game/g_18_dixie/meta.rb
@@ -13,7 +13,7 @@ module Engine
         GAME_SUBTITLE = 'The Railroads Come to the Deep South'
         GAME_DESIGNER = 'Mark Derrick'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Dixie'
-        GAME_LOCATION = 'USA South'
+        GAME_LOCATION = 'Southern USA'
         GAME_PUBLISHER = :golden_spike
         GAME_RULES_URL = 'https://18xx.games' # TODO: Make a stable rules link
 

--- a/lib/engine/game/g_18_hiawatha/meta.rb
+++ b/lib/engine/game/g_18_hiawatha/meta.rb
@@ -13,7 +13,7 @@ module Engine
 
         GAME_DESIGNER = 'Michael Carter, Anthony Fryer, & Nick Neylon'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Hiawatha'
-        GAME_LOCATION = 'Midwest USA'
+        GAME_LOCATION = 'Midwestern USA'
         GAME_TITLE = '18 Hiawatha'
         GAME_RULES_URL = 'https://boardgamegeek.com/filepage/279677/18-hiawatha-rules-from-mainline-issue-1'
         GAME_ISSUE_LABEL = '18Hiawatha'

--- a/lib/engine/game/g_18_jpt/meta.rb
+++ b/lib/engine/game/g_18_jpt/meta.rb
@@ -12,7 +12,7 @@ module Engine
 
         GAME_TITLE = '18JP-T'
         GAME_SUBTITLE = 'Railroading in Japan'
-        GAME_LOCATION = 'Greater Tokyo'
+        GAME_LOCATION = 'Greater Tokyo, Japan'
         GAME_DESIGNER = 'Toryo Hojo'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18JPT'
         GAME_PUBLISHER = :loserdogs

--- a/lib/engine/game/g_18_nl/meta.rb
+++ b/lib/engine/game/g_18_nl/meta.rb
@@ -11,7 +11,7 @@ module Engine
         DEV_STAGE = :production
 
         GAME_DESIGNER = 'Helmut Ohley'
-        GAME_LOCATION = 'The Netherlands'
+        GAME_LOCATION = 'Netherlands'
         GAME_RULES_URL = 'http://ohley.de/18nl/1830NLSummaryofrules.pdf'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18NL'
 

--- a/lib/engine/game/g_18_scan/meta.rb
+++ b/lib/engine/game/g_18_scan/meta.rb
@@ -11,7 +11,7 @@ module Engine
         DEV_STAGE = :prealpha
 
         GAME_DESIGNER = 'David G.D. Hecht'
-        GAME_LOCATION = 'Scandinavian peninsula'
+        GAME_LOCATION = 'Scandinavian Peninsula'
         GAME_PUBLISHER = %i[deep_thought_games golden_spike].freeze
         GAME_RULES_URL = 'https://boardgamegeek.com/filepage/233108/18scan-rules-v10-dtd-30-sep-2005'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Scan'

--- a/lib/engine/game/g_18_texas/meta.rb
+++ b/lib/engine/game/g_18_texas/meta.rb
@@ -11,7 +11,7 @@ module Engine
         DEV_STAGE = :production
         PROTOTYPE = false
 
-        GAME_LOCATION = 'Texas, United States'
+        GAME_LOCATION = 'Texas, USA'
         GAME_DESIGNER = 'Scott Petersen'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Texas'
         GAME_PUBLISHER = :all_aboard_games

--- a/lib/engine/game/g_18_usa/meta.rb
+++ b/lib/engine/game/g_18_usa/meta.rb
@@ -13,7 +13,7 @@ module Engine
 
         GAME_DESIGNER = 'Edward Reece, Mark Hendrickson, and Shawn Fox'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18USA'
-        GAME_LOCATION = 'United States'
+        GAME_LOCATION = 'United States of America'
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = {
           '18USA Rules' => 'https://boardgamegeek.com/filepage/238949/18usa-rules-all-aboard-games-2022',

--- a/lib/engine/game/g_steam_over_holland/meta.rb
+++ b/lib/engine/game/g_steam_over_holland/meta.rb
@@ -12,7 +12,7 @@ module Engine
 
         GAME_TITLE = 'Steam Over Holland'
         GAME_DESIGNER = 'Bart van Dijk'
-        GAME_LOCATION = 'The Netherlands'
+        GAME_LOCATION = 'Netherlands'
         GAME_RULES_URL = 'https://boardgamegeek.com/filepage/47246/corrected-english-manual-v2'
         GAME_INFO_URL = ''
 


### PR DESCRIPTION
The use of "US" and "USA" was not particularly consistent; the same goes for "East X" versus "Eastern X" and similar derivations.  When a location was a city or region, this generally now includes the country.  Some specific notes:

* At the time of The Old Prince 1871, PEI was not yet actually part of Canada.
* "North East England" has a special meaning as one of the nine regions of England, and 1812 covers more area than that, hence the change to "Northeastern England" (which, as far as I know, has no official definition).
* "Netherlands" vs. "The Netherlands" is pretty arbitrary.  I went for the shorter one.

(Feel free to toss this in the bin if it's more work than it's worth to incorporate it.)