### PR TITLE
[18Cuba] Tile laying yellow

### DIFF
--- a/lib/engine/game/g_18_cuba/game.rb
+++ b/lib/engine/game/g_18_cuba/game.rb
@@ -247,15 +247,16 @@ module Engine
           corp = selected_company || @round&.current_entity&.corporation
 
           super.reject do |t|
-            tile_blocked_for_corp?(t, corp, tile.hex)
+            # Hex not available for selector, therefore passing nil and ignoring home hex check for minors
+            tile_blocked_for_corp?(t, corp, nil, for_selector: true)
           end
         end
 
-        def tile_blocked_for_corp?(tile, corp)
+        def tile_blocked_for_corp?(tile, corp, hex, for_selector: false)
           return false unless corp
 
           if corp.type == :minor
-            minor_tile_blocked?(tile, corp.tokens.first.hex)
+            minor_tile_blocked?(tile, corp.tokens.first.hex, hex, for_selector: for_selector)
           else
             major_tile_blocked?(tile)
           end
@@ -264,19 +265,22 @@ module Engine
         private
 
         def tile_has_only_track_type?(tile, track_type)
-          # Returns true if the tile contains only paths of the specified track type
-          # that is not allowed for the corporation
+          # Returns true if all paths on the tile are of the given track type
           tile.paths.all? { |path| path.track == track_type }
         end
 
-        def minor_tile_blocked?(tile, home_hex)
-          # Returns true if a tile is illegal for a minor:
-          # home hex forbids pure rejected track (broad for minors),
-          # other hexes also forbid city tiles
-          return tile_has_only_track_type?(tile, :broad) if tile.hex == home_hex
+        def minor_tile_blocked?(tile, home_hex, current_hex, for_selector: false)
+          # Determines if a tile is illegal for a minor:
+          # - Tiles with only broad tracks are always illegal
+          # - City tiles are illegal except on the minor's home hex
+          # - When `for_selector` is true, the home/city rule is ignored because the hex is unknown
+          pure_broad = tile_has_only_track_type?(tile, :broad)
 
-          !tile.cities.empty? ||
-            tile_has_only_track_type?(tile, :broad)
+          return pure_broad if for_selector
+
+          return pure_broad if current_hex == home_hex
+
+          !tile.cities.empty? || pure_broad
         end
 
         def major_tile_blocked?(tile)

--- a/lib/engine/game/g_18_cuba/step/track.rb
+++ b/lib/engine/game/g_18_cuba/step/track.rb
@@ -10,6 +10,7 @@ module Engine
         class Track < Engine::Step::Track
           def tracker_available_hex(entity, hex)
             # TODO: FC logic with fee payments
+            # TODO: upgrade logic ensure narrow track connect to narrow track and broad to broad
             corp = entity.corporation? ? entity : @game.current_entity
 
             # 18Cuba: minors cannot build cities except on their home hex
@@ -21,11 +22,10 @@ module Engine
           end
 
           def potential_tiles(entity, hex)
-            # TODO: upgrade logic to be checked
             corp = entity.corporation? ? entity : @game.current_entity
 
             super.reject do |tile|
-              @game.tile_blocked_for_corp?(tile, corp)
+              @game.tile_blocked_for_corp?(tile, corp, hex)
             end
           end
         end


### PR DESCRIPTION
This PR implements the first part (yellow) of the track-laying rules for minor and major companies in 18Cuba, focusing on which tiles can be laid in which hexes. It enforces restrictions on tile types, track gauge, and hex locations, aligning with the game rules.

**Minors**
May lay only yellow city tiles with narrow gauge track (:narrow) except for their home hex, where they may lay the sugar mill tiles with broad and narrow gauge tracks

**Majors**
May lay only yellow city tiles with standard gauge track (:broad). City tiles in white-circle cities must use only one city tiles.

Open todos for next PRs:
- "none left" tiles which are illegal should not be shown in the UI. Struggling a bit with this - any hint welcome...
- Upgrade logic to be checked
- FC logic with fees

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

`tracker_available_hex` prevents minors from laying tiles in non-home hex cities.
`potential_tiles filters` out illegal tiles for both minor and major companies:
`minor_tile_blocked?` prevents minors from laying disallowed track types and non-home city tiles.
`major_tile_blocked?` prevents majors from laying yellow tiles with incorrect track type.
Helper `tile_has_only_track_type?` checks if a tile contains only a specific track type.

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
