### PR TITLE
[1894] Clear active step after adding pending home token

### DIFF
--- a/lib/engine/game/g_1894/game.rb
+++ b/lib/engine/game/g_1894/game.rb
@@ -377,7 +377,7 @@ module Engine
               hex = hex_by_id(coordinate)
               tile = hex&.tile
               if tile.color != :brown
-                # Don't take the token that's alerady pending
+                # Don't take the token that's already pending
                 token = corporation.tokens.find { |t| !t.used && !@round.pending_tokens.find { |p_t| p_t[:token] == t } }
                 tile.cities.first.place_token(corporation, token, free: true)
               else
@@ -411,6 +411,11 @@ module Engine
               hexes: [hex],
               token: corporation.next_token,
             }
+            # The pending token is appended after the first call to
+            # Round::Operating::active_step so the home token step was not
+            # active and Step::Track is set as the active step. Clear this
+            # step so that the home token can be placed.
+            @round.clear_cache!
           end
         end
 


### PR DESCRIPTION
The call to add a pending home token for a brown tile happens after the start of a company's operating turn which means that the home token step has already been found to be inactive and the track step has been made active. This was causing the game to be stuck as the company could have a track step with no tokens on the board.

This clears the active step, so that the home token can be placed.

Also fixes a typo in a nearby comment.

Fixes tobymao#12422.

This doesn't break any existing games.

[CC: @Galatolol]


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`