### PR TITLE
[21Moon] Enforce game's EMR rules properly.

### DIFF
--- a/lib/engine/game/g_21_moon/step/buy_train.rb
+++ b/lib/engine/game/g_21_moon/step/buy_train.rb
@@ -77,6 +77,7 @@ module Engine
           def setup
             super
             @destination_bases = []
+            @used_emergency_funding = false
           end
 
           def process_sell_shares(action)
@@ -86,6 +87,7 @@ module Engine
               raise GameError, 'President may not sell shares while corporation can sell treasury shares.'
             end
 
+            @used_emergency_funding = true
             super
           end
 
@@ -98,7 +100,29 @@ module Engine
 
             raise GameError, "#{corporation.name} cannot sell share bundle: #{bundle.shares}" unless bundle_index
 
+            @used_emergency_funding = true
             @game.sell_shares_and_change_price(bundle)
+          end
+
+          def buyable_trains(entity)
+            trains = super
+            return trains unless cross_buy_blocked?(entity)
+
+            trains.reject(&:owned_by_corporation?)
+          end
+
+          def spend_minmax(entity, train)
+            if train.owned_by_corporation?
+              return [0, 0] if cross_buy_blocked?(entity)
+
+              return [1, buying_power(entity)]
+            end
+
+            super
+          end
+
+          def cross_buy_blocked?(_entity)
+            @used_emergency_funding
           end
 
           def process_buy_train(action)


### PR DESCRIPTION
Fixes #12424

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

This game's EMR is a bit particular. Once the corp issues shares, it's considered to be in EMR, and can no longer cross buy any trains. 

I've added a check for any EMR actions that would prevent cross-buying if any of the other abilities have been used. 

I think I've covered all the bases with this, and it works as expected now, from my testing. 

### Screenshots

### Any Assumptions / Hacks
