### PR TITLE
[1849] corrects corp order calculation when new corp is started

### DIFF
--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -605,9 +605,13 @@ module Engine
 
           same_spot.each do |sp, corps|
             current_order = corps.sort
-            moved, unmoved = current_order.partition { |c| just_moved.include?(c) }
+
+            newly_floated, others = current_order.partition { |c| !c.operated? }
+            moved, unmoved = others.partition { |c| just_moved.include?(c) }
+
             moved_ordered = moved.sort_by { |c| old_operating_order.index(c) }
-            new_order = unmoved + moved_ordered
+
+            new_order = unmoved + moved_ordered + newly_floated
             next if current_order == new_order
 
             @log << 'Updating operating order for sold (and moved) corporations now


### PR DESCRIPTION
Fixes #12421

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

There was an edge case not accounted for in the initial code for 1849. I've included a screenshot of the 1849 rules for selling stock, as they have a specific rule in section 3 and the paragraph below, which is slightly unusual for 18xx.

Currently, the code in place accommodates those rules perfectly when it comes to selling shares. Where it doesn't work is when shares are sold, a new corp is started, and the price of the sold shares lands in the same price box as that of a newly started corp. My understanding of the rule as written would be that you perform all the sales, adjust the order of the corporations that were just sold which ended up in the same price box, and only _then_ would you add the newly started corp's token to the bottom of that stack of tokens. As it's coded now, the newly started corp falls into the "unmoved" triage and ends up on top of the moved price markers. 

This new code corrects that, to put the newly started corporation at the bottom of the stack.

***NOTE*** some games will need to be pinned, including the one in the linked report. This will affect both 1849 and 1849 Kingdom Of Two Sicilies.

### Screenshots

<img width="421" height="444" alt="image" src="https://github.com/user-attachments/assets/35016302-7a6b-4342-b32e-c5ebf971a072" />


### Any Assumptions / Hacks
