### PR TITLE
[core] add "webhook user" checks to Create Account page

### DIFF
--- a/models/user.rb
+++ b/models/user.rb
@@ -24,11 +24,14 @@ class User < Base
   ]).freeze
 
   def update_settings(params)
+    self.settings ||= {}
     self.name = params['name'] if params['name']
     self.email = params['email'] if params['email']
+
     params.each do |key, value|
       settings[key] = value if SETTINGS.include?(key)
     end
+
     settings['is_async'] =
       if params['live'] == true
         false
@@ -85,11 +88,15 @@ class User < Base
     validates_format(/^[^\s].*$/, :name, message: 'may not start with a whitespace')
     validates_format(/^[^@\s]+@[^@\s]+\.[^@\s]+$/, :email)
 
-    if settings['webhook'] && (
-        (settings['webhook_user_id']&.strip || '') == '' ||
-        settings['webhook_user_id']&.include?(' ')
-      )
-      errors.add(:webhook_user_id, 'spaces are not allowed in the user id. look at the wiki for more info')
-    end
+    validate_webhook_user_id
+  end
+
+  def validate_webhook_user_id
+    return if settings.to_h['webhook'].to_s.strip == ''
+
+    user_id = settings.to_h['webhook_user_id'].to_s
+
+    errors.add(:webhook_user_id, 'Webhook ID may not be empty') if user_id.strip.empty?
+    errors.add(:webhook_user_id, 'Webhook ID may not contain spaces') if user_id.include?(' ')
   end
 end

--- a/routes/user.rb
+++ b/routes/user.rb
@@ -17,7 +17,7 @@ class Api
         # POST '/api/user/'
         r.is do
           user = User.new
-          user.password = r.params['password'] if r.params['password'].present?
+          user.password = r.params['password'] unless r.params['password']&.strip&.empty?
           user.update_settings(r.params)
           user.save
 

--- a/routes/user.rb
+++ b/routes/user.rb
@@ -17,7 +17,7 @@ class Api
         # POST '/api/user/'
         r.is do
           user = User.new
-          user.password = r.params['password']
+          user.password = r.params['password'] if r.params['password'].present?
           user.update_settings(r.params)
           user.save
 

--- a/routes/user.rb
+++ b/routes/user.rb
@@ -16,19 +16,12 @@ class Api
 
         # POST '/api/user/'
         r.is do
-          params = {
-            name: r.params['name']&.strip,
-            email: r.params['email'],
-            password: r.params['password'],
-            settings: {
-              notifications: r.params['notifications'],
-              webhook: r.params['webhook'],
-              webhook_url: r.params['webhook_url'],
-              webhook_user_id: r.params['webhook_user_id'],
-            },
-          }.reject { |_, v| v.empty? }
+          user = User.new
+          user.password = r.params['password']
+          user.update_settings(r.params)
+          user.save
 
-          login_user(User.create(params))
+          login_user(user)
         end
 
         # POST '/api/user/forgot'


### PR DESCRIPTION
Fixes #12299

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Currently, if a user selects the webhook option during account creation and either leaves the Webhook User ID field blank or puts a space in the user name, they're allowed to click Create Account, but when trying to click the "I agree to the privacy policy" button on the next page, they get the error shown in the screenshot below.

The problem is, they have no way of going back to the previous page to correct the issue, and the account is already created, so they're forced to delete the account and restart from scratch.

I updated the user creation flow to use `User.new`,  `user.update_settings(r.params)` ,  and `user.save` instead of `User.create(params)` to ensure the webhook-related fields are populated before validation runs. Then I added webhook user ID validation to User#validate

This checks that webhook_user_id is not blank and does not contain spaces when webhook is enabled.

I also made sure update_settings was resilient by initializing settings when nil using `self.settings ||= {}`

Now, Webhook validation now runs during Create Account instead of only after accepting the privacy policy, and has separate errors depending if the field is blank or has spaces in it.

As a final change, I took out the mention to "look the wiki" from the error message, because there's nothing in the wiki about spaces in Webhook names.

### Screenshots

current error prior to fix: 

<img width="834" height="139" alt="image" src="https://github.com/user-attachments/assets/bc536574-6239-433c-bdff-78707ebd841a" />


### Any Assumptions / Hacks
