### PR TITLE
[System18] Charters shouldn't count agaist cert limit

### DIFF
--- a/lib/engine/game/g_system18/game.rb
+++ b/lib/engine/game/g_system18/game.rb
@@ -295,6 +295,7 @@ module Engine
         TILE_UPGRADES_MUST_USE_MAX_EXITS = [].freeze
         DISCARDED_TRAINS = :remove
         REMOVE_UNUSED_RESERVATIONS = false
+        CERT_LIMIT_INCLUDES_PRIVATES = true
 
         def find_map_name
           optional_rules&.find { |r| r.to_s.include?('map_') }&.to_s&.delete_prefix('map_')&.downcase

--- a/lib/engine/game/g_system18/map_britain_customization.rb
+++ b/lib/engine/game/g_system18/map_britain_customization.rb
@@ -510,6 +510,7 @@ module Engine
           redef_const(:TILE_UPGRADES_MUST_USE_MAX_EXITS, %i[unlabeled_cities])
           redef_const(:TILE_LAYS, [{ lay: true, upgrade: true, cost: 0 }, { lay_replaced: :if_green_upgraded }])
           redef_const(:REMOVE_UNUSED_RESERVATIONS, true)
+          redef_const(:CERT_LIMIT_INCLUDES_PRIVATES, false)
         end
 
         def map_britain_setup

--- a/lib/engine/game/g_system18/map_northern_italy_customization.rb
+++ b/lib/engine/game/g_system18/map_northern_italy_customization.rb
@@ -274,6 +274,7 @@ module Engine
           redef_const(:STATUS_TEXT, { 'local_tokens' => ['Local Tokens', 'Can only token in home region'] })
           redef_const(:SELL_MOVEMENT, :down_share)
           redef_const(:SOLD_OUT_INCREASE, true)
+          redef_const(:CERT_LIMIT_INCLUDES_PRIVATES, false)
         end
 
         def map_northern_italy_company_header(_company)

--- a/lib/engine/game/g_system18/map_poland_customization.rb
+++ b/lib/engine/game/g_system18/map_poland_customization.rb
@@ -248,6 +248,7 @@ module Engine
         def map_poland_constants
           redef_const(:CURRENCY_FORMAT_STR, 'zł%s')
           redef_const(:STATUS_TEXT, { 'local_tokens' => ['Local Tokens', 'Can only token in home country'] })
+          redef_const(:CERT_LIMIT_INCLUDES_PRIVATES, false)
         end
 
         def map_poland_company_header(_company)


### PR DESCRIPTION
Fixes #12122

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

I just added the CERT_LIMIT_INCLUDES_PRIVATES = false constant to the relevant games, and a `true` one to the game.rb. 

I thought about using a redef_const in `def setup` checking for games with the CharterAuction step, but decided this might not be ideal since it's possible future games might want a charter auction where the charters do count. 

I included the `pins` tag, but the only situation I can think of where it might come up is when a player is forced to sell down due to being at cert limit, and I'm not sure that would actually break the game if their cert count were reduced. 

### Screenshots

### Any Assumptions / Hacks
