### PR TITLE
[1840] refactor train_actions_always_use_operating_round_view

### DIFF
--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -454,8 +454,7 @@ module View
            Engine::Round::Draft
         h(Game::Round::Auction, game: @game, user: @user)
       when Engine::Round::Merger
-        if !(%w[buy_train scrap_train reassign_trains] & current_entity_actions).empty? &&
-              @game.train_actions_always_use_operating_round_view?
+        if @round.use_operating_round_view?(current_entity_actions)
           h(Game::Round::Operating, game: @game)
         else
           h(Game::Round::Merger, game: @game)

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -3520,6 +3520,10 @@ module Engine
         false
       end
 
+      def train_actions_always_use_operating_round_view?
+        false
+      end
+
       def show_map_legend?
         false
       end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -3536,14 +3536,6 @@ module Engine
         train.name
       end
 
-      # If a game overrides this to true, then if the possible actions for the current entity include any of
-      #   buy_train, scrap_train, or reassign_train then
-      # the Operating view will be used instead of the Merger round view for train actiosn in a merger round.
-      # See https://github.com/tobymao/18xx/issues/7169
-      def train_actions_always_use_operating_round_view?
-        false
-      end
-
       def nav_bar_color
         @phase.current[:tiles].last
       end

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -905,10 +905,6 @@ module Engine
                        'Purple → Yellow: -400 | Orange: -300 | Red: -100 | Purple +200  '].freeze
         end
 
-        def train_actions_always_use_operating_round_view?
-          true
-        end
-
         def sorted_corporations
           @sorted_corporations_for_company_round || operating_order
         end

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -908,6 +908,10 @@ module Engine
         def sorted_corporations
           @sorted_corporations_for_company_round || operating_order
         end
+
+        def train_actions_always_use_operating_round_view?
+          false
+        end
       end
     end
   end

--- a/lib/engine/game/g_1840/round/acquisition.rb
+++ b/lib/engine/game/g_1840/round/acquisition.rb
@@ -26,7 +26,7 @@ module Engine
           end
 
           def use_operating_round_view?(actions)
-            !(%w[buy_train scrap_train reassign_trains] & actions).empty?
+            actions.intersect?(%w[buy_train scrap_train reassign_trains])
           end
         end
       end

--- a/lib/engine/game/g_1840/round/acquisition.rb
+++ b/lib/engine/game/g_1840/round/acquisition.rb
@@ -24,6 +24,10 @@ module Engine
           def select_entities
             @game.sorted_corporations.select { |item| item.type == :major && @game.corporate_card_minors(item).size < 3 }
           end
+
+          def use_operating_round_view?(actions)
+            !(%w[buy_train scrap_train reassign_trains] & actions).empty?
+          end
         end
       end
     end

--- a/lib/engine/round/merger.rb
+++ b/lib/engine/round/merger.rb
@@ -17,8 +17,10 @@ module Engine
         true
       end
 
-      def use_operating_round_view?(_actions)
-        true
+      def use_operating_round_view?(current_entity_actions)
+        return false unless @game.train_actions_always_use_operating_round_view?
+
+        (%w[buy_train scrap_train reassign_trains] & current_entity_actions).any?
       end
     end
   end

--- a/lib/engine/round/merger.rb
+++ b/lib/engine/round/merger.rb
@@ -20,7 +20,7 @@ module Engine
       def use_operating_round_view?(current_entity_actions)
         return false unless @game.train_actions_always_use_operating_round_view?
 
-        (%w[buy_train scrap_train reassign_trains] & current_entity_actions).any?
+        current_entity_actions.intersect?(%w[buy_train scrap_train reassign_trains])
       end
     end
   end

--- a/lib/engine/round/merger.rb
+++ b/lib/engine/round/merger.rb
@@ -16,6 +16,10 @@ module Engine
       def merger?
         true
       end
+
+      def use_operating_round_view?(_actions)
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #7169

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

There was a nearly four-year old bug report about this "hacky" code in 1840. I think this is a better implementation.

Note that the report also mentioned 18USA. This should work for 18USA too, but I'm not familiar with that game so I didn't want to tweak it without more knowledge. 

### Screenshots

### Any Assumptions / Hacks
