### PR TITLE
[core] Deprecate can_act

### DIFF
--- a/assets/app/view/game/alternate_corporations.rb
+++ b/assets/app/view/game/alternate_corporations.rb
@@ -23,8 +23,6 @@ module View
           card_style[:border] = '1px dashed'
         end
 
-        card_style[:border] = '4px solid' if @game.round.can_act?(@corporation)
-
         if selected?
           card_style[:backgroundColor] = 'lightblue'
           card_style[:color] = 'black'
@@ -60,8 +58,6 @@ module View
           card_style[:backgroundColor] = convert_hex_to_rgba(color_for(:bg2), factor)
           card_style[:border] = '1px dashed'
         end
-
-        card_style[:border] = '4px solid' if @game.round.can_act?(@corporation)
 
         if selected?
           card_style[:backgroundColor] = 'lightblue'
@@ -316,7 +312,7 @@ module View
           card_style[:border] = '1px dashed'
         end
 
-        card_style[:border] = '4px solid' if @game.round.can_act?(@corporation)
+        card_style[:border] = '4px solid' if @game.round.active_step&.current_entity == @corporation
 
         if selected?
           card_style[:backgroundColor] = 'lightblue'

--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -58,7 +58,7 @@ module View
           card_style[:border] = '1px dashed'
         end
 
-        card_style[:border] = '4px solid' if @game.round.can_act?(@corporation)
+        card_style[:border] = '4px solid' if @game.round.active_step&.current_entity == @corporation
 
         if selected?
           card_style[:backgroundColor] = 'lightblue'

--- a/assets/app/view/game/entity_list.rb
+++ b/assets/app/view/game/entity_list.rb
@@ -43,7 +43,7 @@ module View
 
           style = entity_props[:style]
 
-          if @acting_entity == entity || @round.can_act?(entity)
+          if @acting_entity == entity
             style[:textDecoration] = 'underline'
             style[:fontSize] = '1.1rem'
             style[:fontWeight] = 'bold'

--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -24,8 +24,10 @@ module View
       needs :show_companies, default: true
 
       def render
+        active = @game.round.active_step&.active_entities&.include?(@player)
+
         card_style = {
-          border: @game.round.can_act?(@player) ? '4px solid' : '1px solid gainsboro',
+          border: active ? '4px solid' : '1px solid gainsboro',
           paddingBottom: '0.2rem',
         }
         card_style[:display] = @display

--- a/lib/engine/game/g_rolling_stock/round/acquisition.rb
+++ b/lib/engine/game/g_rolling_stock/round/acquisition.rb
@@ -32,10 +32,6 @@ module Engine
           def finished?
             @game.finished || @entities.all?(&:passed?)
           end
-
-          def can_act?(player)
-            active_step&.active_entities&.include?(player)
-          end
         end
       end
     end

--- a/lib/engine/game/g_rolling_stock/round/closing.rb
+++ b/lib/engine/game/g_rolling_stock/round/closing.rb
@@ -30,10 +30,6 @@ module Engine
           def finished?
             @game.finished || @entities.all?(&:passed?)
           end
-
-          def can_act?(player)
-            active_step&.active_entities&.include?(player)
-          end
         end
       end
     end

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -63,11 +63,6 @@ module Engine
         active_step&.active_entities || []
       end
 
-      # TODO: This is deprecated
-      def can_act?(entity)
-        active_step&.current_entity == entity
-      end
-
       def pass_description
         active_step.pass_description
       end


### PR DESCRIPTION
Fixes #7900

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

`can_act?` has been listed as deprecated on the site for about 5 years. The only place in the code it was still used was in Rolling Stock. 

I removed the method, and adjusted the relevant View pages to perform the same action. In alternate_corporations.rb, I removed it entirely from render_independent_mine and render_public_mine, since those entries appear to have been put in for 1873, but that game no longer referenced can_act? anywhere, and it didn't seem to actually use it anywhere from what I could see in a few games on the site. 

### Screenshots

### Any Assumptions / Hacks
