### PR TITLE
[18USA] Enforce track stub connection to New York City

### DIFF
--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -4,6 +4,7 @@ require_relative '../g_1817/game'
 require_relative 'meta'
 require_relative 'map'
 require_relative 'entities'
+require_relative '../stubs_are_restricted'
 
 module Engine
   module Game
@@ -12,6 +13,7 @@ module Engine
         include_meta(G18USA::Meta)
         include G18USA::Entities
         include G18USA::Map
+        include StubsAreRestricted
 
         attr_accessor :pending_rusting_event, :p8_hexes
         attr_reader :jump_graph, :subsidies_by_hex, :recently_floated, :plain_yellow_city_tiles, :plain_green_city_tiles,


### PR DESCRIPTION
Hexes D26 and E27 have track stubs indicating that yellow tiles must be laid connecting those hexes to New York City. But this rule was not being enforced and it was possible to lay a yellow tile illegally.

This enforces these connections.

Fixes tobymao#12441.

Pins are needed. Tested against a recent-ish copy of the game database, this broke 40 games where yellow tiles had been laid in D26 or E27 that did not connect to NYC (game IDs: 164663, 202874, 205172, 208451, 210930, 211848, 212473, 214972, 216999, 220882, 221265, 222617, 224585, 229029, 232428, 233286, 235866, 242152, 244421, 201729, 201973, 203940, 204796, 206537, 210620, 214329, 216148, 217362, 221821, 223583, 228330, 231578, 233008, 234362, 235887, 237886, 238943, 242188, 242449, 242834.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`