### PR TITLE
[1841] Add 'Bayard' to the description of concession 1

### DIFF
--- a/lib/engine/game/g_1841/entities.rb
+++ b/lib/engine/game/g_1841/entities.rb
@@ -10,7 +10,7 @@ module Engine
         def game_companies
           companies = [
             {
-              name: '1 Società della Strada di Ferro da Napoli a Nocera e Castellamunare',
+              name: '1 Società della Strada di Ferro da Napoli a Nocera e Castellamunare (Bayard)',
               sym: 'Bayard',
               value: 50,
               revenue: 20,


### PR DESCRIPTION
This concession is referred to as the Bayard in the game log and game rules, so add this to the company name.

Fixes tobymao#12439.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`