### PR TITLE
[18Texas] Change to USA in GAME_LOCATION

### DIFF
--- a/lib/engine/game/g_18_texas/meta.rb
+++ b/lib/engine/game/g_18_texas/meta.rb
@@ -11,7 +11,7 @@ module Engine
         DEV_STAGE = :production
         PROTOTYPE = false
 
-        GAME_LOCATION = 'Texas, United States'
+        GAME_LOCATION = 'Texas, USA'
         GAME_DESIGNER = 'Scott Petersen'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18Texas'
         GAME_PUBLISHER = :all_aboard_games


### PR DESCRIPTION
Part of the work on #12446.  The plan is to change all of the instances of 'United States [of America]' to USA for consistency and brevity.