### PR TITLE
[1812] Change North-East to North Eastern England

### DIFF
--- a/lib/engine/game/g_1812/meta.rb
+++ b/lib/engine/game/g_1812/meta.rb
@@ -13,7 +13,7 @@ module Engine
 
         GAME_SUBTITLE = 'The Cradle Of Steam Railways'
         GAME_DESIGNER = 'Ian D. Wilson'
-        GAME_LOCATION = 'North-East England'
+        GAME_LOCATION = 'North Eastern England'
         GAME_PUBLISHER = :golden_spike
         GAME_RULES_URL = 'https://drive.google.com/file/d/0B1SWz2pNe2eAZUY2UHNvUFNxUGc/view?usp=sharing&resourcekey=0-D5kk65ZoyT-dR6hSKAmggQ'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1812'


### PR DESCRIPTION
Part of the work on #12446.  "North-East England" has a specific meaning as an official region, and 1812 spans a greater range of England than said region.