### PR TITLE
[18USA] Change GAME_LOCATION to 'Continental USA'

### DIFF
--- a/lib/engine/game/g_18_usa/meta.rb
+++ b/lib/engine/game/g_18_usa/meta.rb
@@ -13,7 +13,7 @@ module Engine
 
         GAME_DESIGNER = 'Edward Reece, Mark Hendrickson, and Shawn Fox'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18USA'
-        GAME_LOCATION = 'United States'
+        GAME_LOCATION = 'United States of America'
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = {
           '18USA Rules' => 'https://boardgamegeek.com/filepage/238949/18usa-rules-all-aboard-games-2022',

--- a/lib/engine/game/g_18_usa/meta.rb
+++ b/lib/engine/game/g_18_usa/meta.rb
@@ -13,7 +13,7 @@ module Engine
 
         GAME_DESIGNER = 'Edward Reece, Mark Hendrickson, and Shawn Fox'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18USA'
-        GAME_LOCATION = 'United States of America'
+        GAME_LOCATION = 'Continental USA'
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = {
           '18USA Rules' => 'https://boardgamegeek.com/filepage/238949/18usa-rules-all-aboard-games-2022',


### PR DESCRIPTION
Part of the work on #12446.  It's a bit weird to actually lengthen one of these, but given that part of the regularization is making them all say "USA," not having this match would be even more weird, I believe.