### PR TITLE
[18NL] Elide 'The' from GAME_LOCATION

### DIFF
--- a/lib/engine/game/g_18_nl/meta.rb
+++ b/lib/engine/game/g_18_nl/meta.rb
@@ -11,7 +11,7 @@ module Engine
         DEV_STAGE = :production
 
         GAME_DESIGNER = 'Helmut Ohley'
-        GAME_LOCATION = 'The Netherlands'
+        GAME_LOCATION = 'Netherlands'
         GAME_RULES_URL = 'http://ohley.de/18nl/1830NLSummaryofrules.pdf'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18NL'
 


### PR DESCRIPTION
Part of the work on #12446.  The argument for removing 'The' is that it matches both 'United Kingdom' and 'United States', in that the colloquial usage in a sentence almost always has the article but the standalone name does not.