### PR TITLE
[SOH] Remove 'The' from GAME_LOCATION

### DIFF
--- a/lib/engine/game/g_steam_over_holland/meta.rb
+++ b/lib/engine/game/g_steam_over_holland/meta.rb
@@ -12,7 +12,7 @@ module Engine
 
         GAME_TITLE = 'Steam Over Holland'
         GAME_DESIGNER = 'Bart van Dijk'
-        GAME_LOCATION = 'The Netherlands'
+        GAME_LOCATION = 'Netherlands'
         GAME_RULES_URL = 'https://boardgamegeek.com/filepage/47246/corrected-english-manual-v2'
         GAME_INFO_URL = ''
 


### PR DESCRIPTION
Part of the work on #12446.  The argument for removing 'The' is that it matches both 'United Kingdom' and 'United States', in that the colloquial usage in a sentence almost always has the article but the standalone name does not.