### PR TITLE
[1817] removes bridge warning if already assigned

### DIFF
--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -767,7 +767,7 @@ module Engine
 
             routes.each do |route|
               route.stops.each do |stop|
-                if (company = all_hexes[stop.hex.id])
+                if (company = all_hexes[stop.hex.id]) && !stop.hex.assigned?('bridge')
                   warnings << "Using #{company.name} on #{stop.hex.id} will improve revenue"
                 end
               end


### PR DESCRIPTION
Fixes #12462 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Currently, the warning in the screenshot below is displayed if the corp has the bridge private and the route includes one of the valid hexes, but there's no exception made if the hex already has a bridge token assigned. I added that additional gate.

### Screenshots

<img width="344" height="379" alt="image" src="https://github.com/user-attachments/assets/66cd7bd0-8c0b-433b-a89c-3d2873356173" />

### Any Assumptions / Hacks
