### PR TITLE
Roling Stock: fix multiple receivership acquisitions

### DIFF
--- a/lib/engine/game/g_rolling_stock/step/receiver_propose_and_purchase.rb
+++ b/lib/engine/game/g_rolling_stock/step/receiver_propose_and_purchase.rb
@@ -44,7 +44,7 @@ module Engine
             add_next_receiver_offer
           end
 
-          def process_response(action)
+          def process_respond(action)
             super
 
             add_next_receiver_offer if receiver_offers.empty?


### PR DESCRIPTION
Fixes #12466 

It's possible that it will require pins. There are a couple dozen active Rolling Stock and Rolling Stock Starts games. Not sure any of them have a receivership corporation that is in a position to buy multiple companies from the Private Investor.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Latent bug. Receivership  step `receiver_propose_and_purchase.rb`  overrides the standard `propose_and_purchase.rb` and has an overriding method called `process_response`, but the base method is called `process_respond`. This fixes the typo. 

### Screenshots

### Any Assumptions / Hacks
