### PR TITLE
[game_page] disable ArrowUp and ArrowDown hotkeys unless in History mode

### DIFF
--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -289,9 +289,14 @@ module View
           end
         when '-', '0', '+' # + on qwertz
           button_click('zoom' + key)
-        when 'Home', 'End', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'
+        when 'Home', 'End', 'ArrowLeft', 'ArrowRight'
           button_click('hist_' + key)
           event.preventDefault
+        when 'ArrowUp', 'ArrowDown'
+          if Lib::Params['action']
+            button_click('hist_' + key)
+            event.preventDefault
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #10529

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Exactly what the title says. This makes it so that the up and down arrow keys move the screen up and down, rather than jumping you through the history. If you've already gone back in history, then it works as before. 

### Screenshots

### Any Assumptions / Hacks
