### PR TITLE
[18ESP] skip token swap check if merging corp is out of tokens

### DIFF
--- a/lib/engine/game/g_18_esp/step/acquire.rb
+++ b/lib/engine/game/g_18_esp/step/acquire.rb
@@ -90,10 +90,9 @@ module Engine
           end
 
           def can_swap?
-            return merged_token_in_shared_city? unless mz?(@merging.last)
+            return false unless @merging.first.next_token
+            return false if mz?(@merging.last)
 
-            @merging.first.next_token &&
-            !mz?(@merging.last) &&
             merged_token_in_shared_city?
           end
 

--- a/lib/engine/game/g_18_esp/step/acquire.rb
+++ b/lib/engine/game/g_18_esp/step/acquire.rb
@@ -16,7 +16,11 @@ module Engine
           end
 
           def auto_actions(entity)
-            return super if @merging
+            if @merging
+              return [Engine::Action::Choose.new(entity, choice: 'charter')] unless can_swap?
+
+              return super
+            end
             return [Engine::Action::Pass.new(entity)] unless can_merge?(entity)
 
             super

--- a/lib/engine/game/g_18_esp/step/acquire.rb
+++ b/lib/engine/game/g_18_esp/step/acquire.rb
@@ -16,14 +16,13 @@ module Engine
           end
 
           def auto_actions(entity)
-            if @merging
-              return [Engine::Action::Choose.new(entity, choice: 'charter')] unless can_swap?
-
-              return super
+            if @merging && !can_swap?
+              [Engine::Action::Choose.new(entity, choice: 'charter')]
+            elsif !@merging && !can_merge?(entity)
+              [Engine::Action::Pass.new(entity)]
+            else
+              super
             end
-            return [Engine::Action::Pass.new(entity)] unless can_merge?(entity)
-
-            super
           end
 
           def merge_name(_entity = nil)


### PR DESCRIPTION
Fixes #11690 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

I cleaned up the can_swap? method and now it skips the manual check if the acquiring corp doesn't have a token left to swap. 

### Screenshots

### Any Assumptions / Hacks
