### PR TITLE
[1828] Fix Erie home station lay

### DIFF
--- a/lib/engine/game/g_1828/step/track.rb
+++ b/lib/engine/game/g_1828/step/track.rb
@@ -11,12 +11,28 @@ module Engine
           include AcquireVaTunnelCoalMarker
 
           def update_token!(action, entity, tile, old_tile)
-            if action.hex.id == 'E15' && (token = tile.cities.flat_map(&:tokens).find(&:itself))
-              # If there are blocking tokens in both cities, no decisions to be made
-              return if @game.blocking_token?(token)
+            if action.hex.id == 'E15'
+              # When track is first laid on E15, trigger Erie to place its home token if already floated
+              if old_tile.paths.empty? && !tile.paths.empty?
+                erie = @game.corporation_by_id('ERIE')
+                if erie && !erie.closed? && erie.floated? && !erie.tokens.first&.used &&
+                    @round.pending_tokens.none? { |p| p[:entity] == erie }
+                  @round.pending_tokens << {
+                    entity: erie,
+                    hexes: [action.hex],
+                    token: erie.find_token_by_type,
+                  }
+                  @log << "#{erie.name} must choose city for home token"
+                end
+              end
 
-              # Otherwise, the token owner gets to decide the token location
-              entity = token.corporation
+              if (token = tile.cities.flat_map(&:tokens).find(&:itself))
+                # If there are blocking tokens in both cities, no decisions to be made
+                return if @game.blocking_token?(token)
+
+                # Otherwise, the token owner gets to decide the token location
+                entity = token.corporation
+              end
             end
 
             super(action, entity, tile, old_tile)


### PR DESCRIPTION
Fixes #11805

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Per the rules (quoted below) if Erie is floated but not yet operated, Erie should be given the opportunity to lay its home station as soon as E15 is upgraded. This update seems to fix all possible issues, based on my testing.

Also, I tested against 20 completed games on the site, and all loaded fine, so I think this won't require pins.

### Screenshots

<img width="976" height="519" alt="image" src="https://github.com/user-attachments/assets/e2494912-1276-449f-ae78-34ad11790ce4" />


### Any Assumptions / Hacks
