### PR TITLE
[1832] pre-alpha update - Implement P2. Cotton Warehouse

### DIFF
--- a/assets/app/view/game/hex.rb
+++ b/assets/app/view/game/hex.rb
@@ -193,6 +193,19 @@ module View
         case @role
         when :map
           if @actions.include?('assign')
+            step = @game.round.active_step(@entity)
+            if step.respond_to?(:needs_city_selection?) && @entity && step.needs_city_selection?(@entity, @hex)
+              # First click on Atlanta: dispatch action (logs message, sets pending state).
+              # Re-store selected_company before rAF fires so player can immediately click a city.
+              process_action(Engine::Action::Assign.new(@entity, target: @hex))
+              store(:selected_company, @entity, skip: true)
+              return
+            end
+
+            if step.respond_to?(:pending_city_selection?) && @entity && step.pending_city_selection?(@entity, @hex)
+              return # already pending; city slot clicks handle the city choice
+            end
+
             process_action(Engine::Action::Assign.new(@entity, target: @hex))
             return store(:selected_company, nil, skip: true)
           end

--- a/assets/app/view/game/part/city_slot.rb
+++ b/assets/app/view/game/part/city_slot.rb
@@ -83,6 +83,15 @@ module View
           children << render_boom if @city&.boom
           children << render_slot_icon if @city&.slot_icons&.[](@slot_index)
           children << h(Token, token: @token, radius: radius, game: @game) if @token
+          if @game&.highlight_city_assignment?(@city)
+            children << h(:circle, attrs: {
+                            r: @radius + 5,
+                            fill: 'none',
+                            stroke: '#d4af37',
+                            'stroke-width': 3,
+                            'stroke-dasharray': 6,
+                          })
+          end
 
           props = {
             on: { click: ->(event) { on_click(event) } },
@@ -151,6 +160,15 @@ module View
           entity = @selected_company || step.current_entity
 
           return unless step.available_hex(entity, @tile.hex)
+
+          assign_step = @game.round.step_for(entity, 'assign')
+          if assign_step.respond_to?(:available_city) && assign_step&.available_city(entity, @city, @tile.hex)
+            event.JS.stopPropagation
+            city_index = @tile.cities.index(@city)
+            process_action(Engine::Action::Assign.new(entity, target: @tile.hex, city: city_index))
+            store(:selected_company, nil, skip: true)
+            return
+          end
 
           remove_token_step = @game.round.step_for(entity, 'remove_token')
           place_token_step = @game.round.step_for(entity, 'place_token')

--- a/lib/engine/action/assign.rb
+++ b/lib/engine/action/assign.rb
@@ -5,24 +5,27 @@ require_relative 'base'
 module Engine
   module Action
     class Assign < Base
-      attr_reader :target
+      attr_reader :target, :city
 
       REQUIRED_ARGS = %i[target].freeze
 
-      def initialize(entity, target:)
+      def initialize(entity, target:, city: nil)
         super(entity)
         @target = target
+        @city = city
       end
 
       def self.h_to_args(h, game)
-        { target: game.get(h['target_type'], h['target']) }
+        { target: game.get(h['target_type'], h['target']), city: h['city'] }
       end
 
       def args_to_h
-        {
+        hash = {
           'target' => @target.id,
           'target_type' => type_s(@target),
         }
+        hash['city'] = @city unless @city.nil?
+        hash
       end
     end
   end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -3299,6 +3299,10 @@ module Engine
         false
       end
 
+      def highlight_city_assignment?(_city)
+        false
+      end
+
       def show_value_of_companies?(entity)
         entity&.player?
       end

--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -108,7 +108,7 @@ module Engine
             Engine::Step::Bankrupt,
             Engine::Step::Exchange,
             G1832::Step::BuyCompany,
-            G1870::Step::Assign,
+            G1832::Step::Assign,
             G1870::Step::SpecialTrack,
             G1832::Step::Track,
             G1832::Step::Token,
@@ -218,6 +218,13 @@ module Engine
           @cotton_company ||= company_by_id('P3')
         end
 
+        def highlight_city_assignment?(city)
+          hex = city.hex
+          return false unless hex.assigned?('P2')
+
+          hex.assignments['P2'] == hex.tile.cities.index(city)
+        end
+
         def can_hold_above_corp_limit?(_entity)
           true
         end
@@ -240,7 +247,14 @@ module Engine
           revenue = super
 
           cotton = 'P2'
-          revenue += 10 if route.corporation.assigned?(cotton) && stops.any? { |stop| stop.hex.assigned?(cotton) }
+          if route.corporation.assigned?(cotton) && stops.any? do |stop|
+               next false unless stop.hex.assigned?(cotton)
+
+               city_index = stop.hex.assignments[cotton]
+               city_index.is_a?(Integer) ? stop.hex.tile.cities.index(stop) == city_index : true
+             end
+            revenue += 10
+          end
 
           revenue += (route.corporation.assigned?('P3') ? 20 : 10) if stops.any? { |stop| stop.hex.assigned?('P3') }
 

--- a/lib/engine/game/g_1832/step/assign.rb
+++ b/lib/engine/game/g_1832/step/assign.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/assign'
+require_relative '../../g_1870/step/assign'
+
+module Engine
+  module Game
+    module G1832
+      module Step
+        class Assign < G1870::Step::Assign
+          ATLANTA_HEX = 'F10'
+          PENDING_CITY = -1
+
+          # Atlanta has been clicked but a city not yet chosen
+          def pending_city_selection?(entity, hex)
+            entity == @game.port_company &&
+              hex.id == ATLANTA_HEX &&
+              hex.assigned?(entity.id) &&
+              hex.assignments[entity.id] == PENDING_CITY
+          end
+
+          # Atlanta is eligible for assignment and hasn't been clicked yet
+          def needs_city_selection?(entity, hex)
+            entity == @game.port_company &&
+              hex.id == ATLANTA_HEX &&
+              hex.tile.cities.size > 1 &&
+              !hex.assigned?(entity.id)
+          end
+
+          # City slots in Atlanta become clickable once it's been selected (pending)
+          def available_city(entity, _city, hex)
+            pending_city_selection?(entity, hex)
+          end
+
+          def process_assign(action)
+            entity = action.entity
+            target = action.target
+
+            return super unless target.is_a?(Engine::Hex) &&
+                                entity == @game.port_company &&
+                                target.id == ATLANTA_HEX &&
+                                target.tile.cities.size > 1
+
+            unless (ability = @game.abilities(entity, :assign_hexes))
+              raise GameError, "Could not assign #{entity.name} to #{target.name}; :assign_hexes ability not found"
+            end
+
+            if action.city.nil?
+              # First click: mark Atlanta as pending and log
+              if pending_city_selection?(entity, target)
+                raise GameError, "#{entity.name} is already awaiting city selection at #{target.location_name}"
+              end
+
+              assignable_hexes = ability.hexes.map { |h| @game.hex_by_id(h) }.compact
+              Engine::Assignable.remove_from_all!(assignable_hexes, entity.id) do |unassigned|
+                @log << "#{entity.name} is unassigned from #{unassigned.name}"
+              end
+              target.assign!(entity.id, PENDING_CITY)
+              @log << "#{target.location_name} selected - must choose which city to assign the #{entity.name} to"
+            else
+              # City chosen: complete the assignment
+              unless pending_city_selection?(entity, target)
+                raise GameError, "#{target.location_name} must be selected before choosing a city"
+              end
+
+              target.assign!(entity.id, action.city)
+              ability.use!
+              @log << "#{entity.name} is assigned to #{target.location_name} (city #{action.city + 1})"
+
+              return if !ability.count&.zero? || !ability.closed_when_used_up
+
+              @game.company_closing_after_using_ability(entity)
+              entity.close!
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1832/step/assign.rb
+++ b/lib/engine/game/g_1832/step/assign.rb
@@ -32,14 +32,15 @@ module Engine
             pending_city_selection?(entity, hex)
           end
 
+          def atlanta_cotton_port?(entity, hex)
+            entity == @game.port_company && hex.id == ATLANTA_HEX
+          end
+
           def process_assign(action)
             entity = action.entity
             target = action.target
 
-            return super unless target.is_a?(Engine::Hex) &&
-                                entity == @game.port_company &&
-                                target.id == ATLANTA_HEX &&
-                                target.tile.cities.size > 1
+            return super unless atlanta_cotton_port?(entity, target)
 
             unless (ability = @game.abilities(entity, :assign_hexes))
               raise GameError, "Could not assign #{entity.name} to #{target.name}; :assign_hexes ability not found"


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Implements assigning the Cotton Warehouse ability to a specific city in Atlanta.

It's a two step process. First you select the private and then click Atlanta, then you select the city in question. A light halo highlight shows up around the selected city, shown below.

### Screenshots
<img width="188" height="190" alt="image" src="https://github.com/user-attachments/assets/411d7420-8241-4774-b6f6-1f04ddb6cec4" />


### Any Assumptions / Hacks
