### PR TITLE
[Rolling Stock] Fix RSS receivership order for OS

### DIFF
--- a/lib/engine/game/g_rolling_stock/step/receiver_propose_and_purchase.rb
+++ b/lib/engine/game/g_rolling_stock/step/receiver_propose_and_purchase.rb
@@ -92,7 +92,9 @@ module Engine
           end
 
           def elegible_receiver_and_company
-            @game.operating_order.select(&:receivership?).each do |candidate|
+            receivers = @game.operating_order.select(&:receivership?)
+            oversea_corp, others = receivers.partition { |corp| @game.abilities(corp, :overseas) }
+            (oversea_corp + others).each do |candidate|
               @game.foreign_investor.companies.sort_by(&:value).reverse_each do |company|
                 return [candidate, company] if candidate.cash >= foreign_price(candidate, company)
               end


### PR DESCRIPTION
Fixes #12472

Like #12467 , this may require pins, although it seems unlikely - I've only found one RSS game (ID 210560) that was affected by this bug.

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
Latent bug. In the "Acquisition" phase, we calculated Foreign Investor priority differently between corps in receivership and active corps - they should be calculated in the same way. The code change mirrors [the existing method](https://github.com/tobymao/18xx/blob/master/lib/engine/game/g_rolling_stock/game.rb#L659) for calculating FI priority of active corps.

### Screenshots

### Any Assumptions / Hacks
