### PR TITLE
Allows front page "Filter" to select multiple titles

### DIFF
--- a/assets/app/lib/params.rb
+++ b/assets/app/lib/params.rb
@@ -30,8 +30,7 @@ module Lib
       def get_all(key)
         return [] if @unsupported
 
-        result = Native(`Array.from(#{@native.to_n}.getAll(#{key}))`)
-        result.to_a
+        @native.getAll(key)
       end
 
       def []=(key, value)
@@ -43,12 +42,12 @@ module Lib
       end
 
       def set_array(key, values)
-        @native&.delete(key)
-        Array(values).each { |v| `#{@native.to_n}.append(#{key}, #{v})` }
+        @native.delete(key)
+        values.each { |v| @native.append(key, v) }
       end
 
       def to_query_string
-        (@native&.toString() || '').gsub('%5B%5D', '[]')
+        @native&.toString() || ''
       end
     end
   end

--- a/assets/app/lib/params.rb
+++ b/assets/app/lib/params.rb
@@ -27,6 +27,13 @@ module Lib
         @native&.get(key)
       end
 
+      def get_all(key)
+        return [] if @unsupported
+
+        result = Native(`Array.from(#{@native.to_n}.getAll(#{key}))`)
+        result.to_a
+      end
+
       def []=(key, value)
         if !value || value.to_s.empty?
           @native&.delete(key)
@@ -35,8 +42,13 @@ module Lib
         end
       end
 
+      def set_array(key, values)
+        @native&.delete(key)
+        Array(values).each { |v| `#{@native.to_n}.append(#{key}, #{v})` }
+      end
+
       def to_query_string
-        @native&.toString() || ''
+        (@native&.toString() || '').gsub('%5B%5D', '[]')
       end
     end
   end

--- a/assets/app/view/game_row_filters.rb
+++ b/assets/app/view/game_row_filters.rb
@@ -16,15 +16,14 @@ module View
       h('div#game_filters.game_row', { key: @header }, [
         h(:h2, 'Filters'),
         title_elm,
-        render_reset(title_elm),
+        render_reset,
       ])
     end
 
     private
 
     def render_title(url_search_params)
-      raw = url_search_params['title'] || ''
-      selected_titles = raw.split('.').map { |t| t.strip.gsub('~', '.') }.reject(&:empty?)
+      selected_titles = url_search_params.get_all('title[]')
 
       # Build lookup for display names
       title_display = {}
@@ -46,7 +45,7 @@ module View
         return if title.empty?
 
         new_titles = (selected_titles + [title]).uniq
-        url_search_params['title'] = new_titles.map { |t| t.gsub('.', '~') }.join('.')
+        url_search_params.set_array('title[]', new_titles)
         update_filters(url_search_params.to_query_string)
         target.JS['value'] = ''
       end
@@ -59,7 +58,7 @@ module View
           display = title_display[t] || t
           on_remove = lambda do
             new_titles = selected_titles.reject { |x| x == t }
-            url_search_params['title'] = new_titles.empty? ? '' : new_titles.map { |t| t.gsub('.', '~') }.join('.')
+            url_search_params.set_array('title[]', new_titles)
             update_filters(url_search_params.to_query_string)
           end
 
@@ -91,7 +90,7 @@ module View
       h(:div, children)
     end
 
-    def render_reset(_title_elm)
+    def render_reset
       attrs = {
         on: {
           click: lambda do

--- a/assets/app/view/game_row_filters.rb
+++ b/assets/app/view/game_row_filters.rb
@@ -24,7 +24,7 @@ module View
 
     def render_title(url_search_params)
       raw = url_search_params['title'] || ''
-      selected_titles = raw.split('.').map(&:strip).reject(&:empty?)
+      selected_titles = raw.split('.').map { |t| t.strip.gsub('~', '.') }.reject(&:empty?)
 
       # Build lookup for display names
       title_display = {}
@@ -46,7 +46,7 @@ module View
         return if title.empty?
 
         new_titles = (selected_titles + [title]).uniq
-        url_search_params['title'] = new_titles.join('.')
+        url_search_params['title'] = new_titles.map { |t| t.gsub('.', '~') }.join('.')
         update_filters(url_search_params.to_query_string)
         target.JS['value'] = ''
       end
@@ -59,7 +59,7 @@ module View
           display = title_display[t] || t
           on_remove = lambda do
             new_titles = selected_titles.reject { |x| x == t }
-            url_search_params['title'] = new_titles.empty? ? '' : new_titles.join('.')
+            url_search_params['title'] = new_titles.empty? ? '' : new_titles.map { |t| t.gsub('.', '~') }.join('.')
             update_filters(url_search_params.to_query_string)
           end
 

--- a/assets/app/view/game_row_filters.rb
+++ b/assets/app/view/game_row_filters.rb
@@ -25,7 +25,7 @@ module View
     private
 
     def render_title(url_search_params)
-      selected_titles = url_search_params.get_all('title[]')
+      selected_titles = url_search_params.get_all('title')
 
       # Build lookup for display names
       title_display = {}
@@ -47,7 +47,7 @@ module View
         return if title.empty?
 
         new_titles = (selected_titles + [title]).uniq
-        url_search_params.set_array('title[]', new_titles)
+        url_search_params.set_array('title', new_titles)
         update_filters(url_search_params.to_query_string)
         target.JS['value'] = ''
       end
@@ -60,7 +60,7 @@ module View
           display = title_display[t] || t
           on_remove = lambda do
             new_titles = selected_titles.reject { |x| x == t }
-            url_search_params.set_array('title[]', new_titles)
+            url_search_params.set_array('title', new_titles)
             update_filters(url_search_params.to_query_string)
           end
 
@@ -93,19 +93,14 @@ module View
     end
 
     def render_mode(url_search_params)
-      current = url_search_params['mode'] || 'all'
-
-      buttons = [
-        { label: 'All', value: 'all' },
-        { label: 'Live', value: 'live' },
-        { label: 'Async', value: 'async' },
-      ].map do |opt|
-        active = current == opt[:value]
+      current = url_search_params['mode'] || ''
+      options = { 'All' => '', 'Live' => 'live', 'Async' => 'async' }
+      buttons = options.map do |label, value|
         on_click = lambda do
-          url_search_params['mode'] = opt[:value] == 'all' ? '' : opt[:value]
+          url_search_params['mode'] = value
           update_filters(url_search_params.to_query_string)
         end
-
+        active = current == value
         h(:button, {
             style: {
               padding: '4px 12px',
@@ -116,7 +111,7 @@ module View
               fontWeight: active ? 'bold' : 'normal',
             },
             on: { click: on_click },
-          }, opt[:label])
+          }, label)
       end
 
       h(:div, { style: { display: 'flex', margin: '6px 0' } }, buttons)

--- a/assets/app/view/game_row_filters.rb
+++ b/assets/app/view/game_row_filters.rb
@@ -23,29 +23,78 @@ module View
     private
 
     def render_title(url_search_params)
-      selected_value = url_search_params['title']
-      game_options = [h(:option, { attrs: { value: '' } }, '(All titles)')]
+      raw = url_search_params['title'] || ''
+      selected_titles = raw.split('.').map(&:strip).reject(&:empty?)
+
+      # Build lookup for display names
+      title_display = {}
       Engine::VISIBLE_GAMES_WITH_VARIANTS.sort_by(&:display_title).each do |meta|
-        value = meta.title
-        game_options << h(:option, { attrs: { value: value, selected: value == selected_value } }, meta.display_title)
+        title_display[meta.title] = meta.display_title
       end
-      title_change = lambda do |e|
-        title = e.JS['currentTarget'].JS['value']
-        url_search_params['title'] = title
+
+      # Dropdown options: exclude already-selected titles
+      game_options = [h(:option, { attrs: { value: '' } }, '(Add a title filter...)')]
+      title_display.each do |value, display|
+        next if selected_titles.include?(value)
+
+        game_options << h(:option, { attrs: { value: value } }, display)
+      end
+
+      on_select = lambda do |e|
+        target = e.JS['currentTarget']
+        title = target.JS['value']
+        return if title.empty?
+
+        new_titles = (selected_titles + [title]).uniq
+        url_search_params['title'] = new_titles.join('.')
         update_filters(url_search_params.to_query_string)
+        target.JS['value'] = ''
       end
-      attrs = {
-        on: { input: title_change },
-        style: { maxWidth: '90vw' },
-      }
-      h('select', attrs, game_options)
+
+      children = []
+
+      # Render chips for selected titles
+      unless selected_titles.empty?
+        chips = selected_titles.map do |t|
+          display = title_display[t] || t
+          on_remove = lambda do
+            new_titles = selected_titles.reject { |x| x == t }
+            url_search_params['title'] = new_titles.empty? ? '' : new_titles.join('.')
+            update_filters(url_search_params.to_query_string)
+          end
+
+          h(:span, {
+              style: {
+                display: 'inline-flex',
+                alignItems: 'center',
+                background: '#4a4a4a',
+                color: '#fff',
+                borderRadius: '3px',
+                padding: '2px 6px',
+                margin: '2px',
+                fontSize: '0.9em',
+              },
+            }, [
+            h(:span, "\u{1F682} #{display}"),
+            h(:span, {
+                style: { marginLeft: '4px', cursor: 'pointer', fontWeight: 'bold' },
+                on: { click: on_remove },
+              }, "\u00d7"),
+          ])
+        end
+
+        children << h(:div, { style: { marginBottom: '4px' } }, chips)
+      end
+
+      children << h('select', { on: { input: on_select }, style: { maxWidth: '90vw' } }, game_options)
+
+      h(:div, children)
     end
 
-    def render_reset(title_elm)
+    def render_reset(_title_elm)
       attrs = {
         on: {
           click: lambda do
-            Native(title_elm)&.elm&.value = ''
             update_filters('')
           end,
         },

--- a/assets/app/view/game_row_filters.rb
+++ b/assets/app/view/game_row_filters.rb
@@ -12,10 +12,12 @@ module View
       return '' if url_search_params.unsupported
 
       title_elm = render_title(url_search_params)
+      mode_elm = render_mode(url_search_params)
 
       h('div#game_filters.game_row', { key: @header }, [
         h(:h2, 'Filters'),
         title_elm,
+        mode_elm,
         render_reset,
       ])
     end
@@ -88,6 +90,36 @@ module View
       children << h('select', { on: { input: on_select }, style: { maxWidth: '90vw' } }, game_options)
 
       h(:div, children)
+    end
+
+    def render_mode(url_search_params)
+      current = url_search_params['mode'] || 'all'
+
+      buttons = [
+        { label: 'All', value: 'all' },
+        { label: 'Live', value: 'live' },
+        { label: 'Async', value: 'async' },
+      ].map do |opt|
+        active = current == opt[:value]
+        on_click = lambda do
+          url_search_params['mode'] = opt[:value] == 'all' ? '' : opt[:value]
+          update_filters(url_search_params.to_query_string)
+        end
+
+        h(:button, {
+            style: {
+              padding: '4px 12px',
+              cursor: 'pointer',
+              background: active ? '#4a4a4a' : '#ddd',
+              color: active ? '#fff' : '#333',
+              border: '1px solid #888',
+              fontWeight: active ? 'bold' : 'normal',
+            },
+            on: { click: on_click },
+          }, opt[:label])
+      end
+
+      h(:div, { style: { display: 'flex', margin: '6px 0' } }, buttons)
     end
 
     def render_reset

--- a/models/game.rb
+++ b/models/game.rb
@@ -18,6 +18,9 @@ class Game < Base
       FROM games
       WHERE status = '%<status>s'
         AND (:titles IS NULL OR title = ANY(:titles))
+        AND (:mode IS NULL
+             OR (:mode = 'async' AND COALESCE((settings->>'is_async')::boolean, false))
+             OR (:mode = 'live' AND NOT COALESCE((settings->>'is_async')::boolean, false)))
         AND NOT (status = 'new' AND COALESCE((settings->>'unlisted')::boolean, false))
       ORDER BY created_at DESC
       LIMIT #{QUERY_LIMIT}
@@ -34,6 +37,9 @@ class Game < Base
         ON g.id = ug.id
       WHERE g.status = '%<status>s'
         AND (:titles IS NULL OR g.title = ANY(:titles))
+        AND (:mode IS NULL
+             OR (:mode = 'async' AND COALESCE((g.settings->>'is_async')::boolean, false))
+             OR (:mode = 'live' AND NOT COALESCE((g.settings->>'is_async')::boolean, false)))
         AND ug.id IS NULL
         AND NOT (g.status = 'new' AND COALESCE((settings->>'unlisted')::boolean, false))
       ORDER BY g.%<ordered_by>s DESC
@@ -97,6 +103,8 @@ class Game < Base
 
         Sequel.pg_array(titles)
       end
+      mode = opts['mode']&.strip
+      kwargs[:mode] = mode && !mode.empty? && %w[live async].include?(mode) ? mode : nil
       kwargs[:status] = %w[new active]
       kwargs[:limit] = 1000
       fetch(user ? LOGGED_IN_QUERY : LOGGED_OUT_QUERY, **kwargs).all.map(&:to_h)

--- a/models/game.rb
+++ b/models/game.rb
@@ -17,7 +17,7 @@ class Game < Base
       SELECT *
       FROM games
       WHERE status = '%<status>s'
-        AND (:title IS NULL OR :title = title)
+        AND (:titles IS NULL OR title = ANY(string_to_array(:titles, '.')))
         AND NOT (status = 'new' AND COALESCE((settings->>'unlisted')::boolean, false))
       ORDER BY created_at DESC
       LIMIT #{QUERY_LIMIT}
@@ -33,7 +33,7 @@ class Game < Base
       LEFT JOIN user_games ug
         ON g.id = ug.id
       WHERE g.status = '%<status>s'
-        AND (:title IS NULL OR :title = g.title)
+        AND (:titles IS NULL OR g.title = ANY(string_to_array(:titles, '.')))
         AND ug.id IS NULL
         AND NOT (g.status = 'new' AND COALESCE((settings->>'unlisted')::boolean, false))
       ORDER BY g.%<ordered_by>s DESC
@@ -91,7 +91,7 @@ class Game < Base
       }.transform_values { |v| v&.to_i || 0 }
 
       kwargs[:user_id] = user.id if user
-      kwargs[:title] = opts['title'] != '' ? opts['title'] : nil
+      kwargs[:titles] = opts['title']&.then { |t| t.strip.empty? ? nil : t }
       kwargs[:status] = %w[new active]
       kwargs[:limit] = 1000
       fetch(user ? LOGGED_IN_QUERY : LOGGED_OUT_QUERY, **kwargs).all.map(&:to_h)

--- a/models/game.rb
+++ b/models/game.rb
@@ -18,9 +18,7 @@ class Game < Base
       FROM games
       WHERE status = '%<status>s'
         AND (:titles IS NULL OR title = ANY(:titles))
-        AND (:mode IS NULL
-             OR (:mode = 'async' AND COALESCE((settings->>'is_async')::boolean, false))
-             OR (:mode = 'live' AND NOT COALESCE((settings->>'is_async')::boolean, false)))
+        AND (:mode IS NULL OR COALESCE((settings->>'is_async')::boolean, true) = (:mode = 'async'))
         AND NOT (status = 'new' AND COALESCE((settings->>'unlisted')::boolean, false))
       ORDER BY created_at DESC
       LIMIT #{QUERY_LIMIT}

--- a/models/game.rb
+++ b/models/game.rb
@@ -17,7 +17,7 @@ class Game < Base
       SELECT *
       FROM games
       WHERE status = '%<status>s'
-        AND (:titles IS NULL OR title = ANY(string_to_array(:titles, '.')))
+        AND (:titles IS NULL OR title = ANY(string_to_array(:titles, '|')))
         AND NOT (status = 'new' AND COALESCE((settings->>'unlisted')::boolean, false))
       ORDER BY created_at DESC
       LIMIT #{QUERY_LIMIT}
@@ -33,7 +33,7 @@ class Game < Base
       LEFT JOIN user_games ug
         ON g.id = ug.id
       WHERE g.status = '%<status>s'
-        AND (:titles IS NULL OR g.title = ANY(string_to_array(:titles, '.')))
+        AND (:titles IS NULL OR g.title = ANY(string_to_array(:titles, '|')))
         AND ug.id IS NULL
         AND NOT (g.status = 'new' AND COALESCE((settings->>'unlisted')::boolean, false))
       ORDER BY g.%<ordered_by>s DESC
@@ -91,7 +91,12 @@ class Game < Base
       }.transform_values { |v| v&.to_i || 0 }
 
       kwargs[:user_id] = user.id if user
-      kwargs[:titles] = opts['title']&.then { |t| t.strip.empty? ? nil : t }
+      kwargs[:titles] = opts['title']&.then do |t|
+        t = t.strip
+        next nil if t.empty?
+
+        t.split('.').map { |s| s.gsub('~', '.') }.join('|')
+      end
       kwargs[:status] = %w[new active]
       kwargs[:limit] = 1000
       fetch(user ? LOGGED_IN_QUERY : LOGGED_OUT_QUERY, **kwargs).all.map(&:to_h)

--- a/models/game.rb
+++ b/models/game.rb
@@ -17,7 +17,7 @@ class Game < Base
       SELECT *
       FROM games
       WHERE status = '%<status>s'
-        AND (:titles IS NULL OR title = ANY(string_to_array(:titles, '|')))
+        AND (:titles IS NULL OR title = ANY(:titles))
         AND NOT (status = 'new' AND COALESCE((settings->>'unlisted')::boolean, false))
       ORDER BY created_at DESC
       LIMIT #{QUERY_LIMIT}
@@ -33,7 +33,7 @@ class Game < Base
       LEFT JOIN user_games ug
         ON g.id = ug.id
       WHERE g.status = '%<status>s'
-        AND (:titles IS NULL OR g.title = ANY(string_to_array(:titles, '|')))
+        AND (:titles IS NULL OR g.title = ANY(:titles))
         AND ug.id IS NULL
         AND NOT (g.status = 'new' AND COALESCE((settings->>'unlisted')::boolean, false))
       ORDER BY g.%<ordered_by>s DESC
@@ -92,10 +92,10 @@ class Game < Base
 
       kwargs[:user_id] = user.id if user
       kwargs[:titles] = opts['title']&.then do |t|
-        t = t.strip
-        next nil if t.empty?
+        titles = Array(t).map(&:strip).reject(&:empty?)
+        next nil if titles.empty?
 
-        t.split('.').map { |s| s.gsub('~', '.') }.join('|')
+        Sequel.pg_array(titles)
       end
       kwargs[:status] = %w[new active]
       kwargs[:limit] = 1000

--- a/models/game.rb
+++ b/models/game.rb
@@ -35,9 +35,7 @@ class Game < Base
         ON g.id = ug.id
       WHERE g.status = '%<status>s'
         AND (:titles IS NULL OR g.title = ANY(:titles))
-        AND (:mode IS NULL
-             OR (:mode = 'async' AND COALESCE((g.settings->>'is_async')::boolean, false))
-             OR (:mode = 'live' AND NOT COALESCE((g.settings->>'is_async')::boolean, false)))
+        AND (:mode IS NULL OR COALESCE((g.settings->>'is_async')::boolean, true) = (:mode = 'async'))
         AND ug.id IS NULL
         AND NOT (g.status = 'new' AND COALESCE((settings->>'unlisted')::boolean, false))
       ORDER BY g.%<ordered_by>s DESC

--- a/routes/game.rb
+++ b/routes/game.rb
@@ -185,7 +185,8 @@ class Api
       end
 
       r.get do
-        { games: Game.home_games(user, **r.params) }
+        params = Rack::Utils.parse_query(r.query_string)
+        { games: Game.home_games(user, **params) }
       end
 
       # POST '/api/game[/*]'


### PR DESCRIPTION
Titles are added as small chips below Filter section and can be individually deleted by clicking (x) on the chip. URL schema list titles separated by "." Players can bookmark preferred games as https://18xx.games/?title=1846.1889.1817 

**Claude code** output summary:
 models/game.rb (backend):
  - SQL queries now use ANY(:titles) instead of :title = title (lines 20, 36)
  - Title param is split on dot  into a Sequel.pg_array (line 94-95)
  - Single title still works (array of one), empty/nil means no filter

  assets/app/view/game_row_filters.rb (frontend):
  - Dropdown acts as a picker — selecting a title adds it to the filter and resets the dropdown
  - Selected titles appear as dark chips with × buttons to remove individually
  - Already-selected titles are hidden from the dropdown
  - URL uses dot separated format: ?title=1846.1889
  - "Reset filters" clears all selected titles
  
  
<img width="469" height="203" alt="Screenshot 2026-04-04 022905" src="https://github.com/user-attachments/assets/a8bd7f30-6762-45f0-8f35-c83600653455" />

<img width="315" height="42" alt="Screenshot 2026-04-04 022923" src="https://github.com/user-attachments/assets/679acdd8-c216-42ff-ac74-4863c63a8538" />

<img width="548" height="1292" alt="Screenshot 2026-04-04 024253" src="https://github.com/user-attachments/assets/d823f51b-3e2e-4690-8846-d3f3c13d7a69" />
