### PR TITLE
[18 Christmas Eve] Remove stock_market from GAME_END_CHECK

### DIFF
--- a/lib/engine/game/g_18_christmas_eve/game.rb
+++ b/lib/engine/game/g_18_christmas_eve/game.rb
@@ -20,7 +20,6 @@ module Engine
 
         GAME_END_CHECK = {
           bankrupt: :immediate,
-          stock_market: :current_round,
           bank: :full_or,
           final_phase: :one_more_full_or_set,
         }.freeze


### PR DESCRIPTION
Neither the 18Chesapeake nor the Uncle Lachlan’s 18 Christmas Eve rules mention the top of the stock market triggering the end of the game, and no spaces on the stock market are declared with an `endgame` type.

Fixes tobymao#12477.