### PR TITLE
[18Cuba] Narrow Gauge Graph

### DIFF
--- a/lib/engine/game/g_18_cuba/game.rb
+++ b/lib/engine/game/g_18_cuba/game.rb
@@ -134,6 +134,22 @@ module Engine
           initialize_tile_opposites!
           @unused_tiles = []
           @sugar_cubes = {}
+          @minor_graph = Graph.new(self, skip_track: :broad)
+        end
+
+        def init_graph
+          Graph.new(self, skip_track: :narrow)
+        end
+
+        def graph_for_entity(entity)
+          return @graph unless entity&.type == :minor
+
+          @minor_graph ||= Graph.new(self, skip_track: :broad)
+        end
+
+        def clear_graph
+          @minor_graph = nil
+          super
         end
 
         def init_tile_groups

--- a/lib/engine/game/g_18_cuba/game.rb
+++ b/lib/engine/game/g_18_cuba/game.rb
@@ -148,8 +148,16 @@ module Engine
         end
 
         def clear_graph
-          @minor_graph = nil
+          @minor_graph.clear
           super
+        end
+
+        def clear_graph_for_entity(entity)
+          if entity&.type == :minor
+            @minor_graph.clear
+          else
+            super
+          end
         end
 
         def init_tile_groups


### PR DESCRIPTION
This PR introduces entity-specific track graphs to enforce the gauge restrictions between minor and major companies in 18Cuba.

Minors can only build and trace routes using narrow gauge
Majors can only build and trace routes using standard (broad) gauge

This is implemented by assigning separate graph instances per entity type, ensuring that illegal connectivity is prevented at the graph level rather than during route validation.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

**Minor Companies**

“Once a tile has been placed in a minor company's sugar mill hex, it may lay tiles [...] reachable [...] using a route of narrow gauge track only.”
“A minor company may lay only yellow tiles with narrow gauge track (except the home city tile).”

Enforced via:
- Graph.new(... skip_track: :broad)
- Tile filtering (existing logic)

**Major Companies**

“Once a tile has been placed in a major company's home hex, it may lay tiles [...] reachable [...] using a route of standard gauge track only.”
“A major company may only lay yellow tiles with standard gauge track.”

Enforced via:
- init_graph skipping :narrow

**Connectivity Rules**

“A track tile may be built in such a way that it fails to connect to tracks on a neighboring tile.”
“A track tile may be laid in such a way that narrow gauge links with standard gauge across a hexside. Then both tracks have a dead end.”

Supported via:
- Mixed tiles are still allowed
- Dead-ends naturally emerge without special handling

### Screenshots

### Any Assumptions / Hacks
