### PR TITLE
[18Neb] Fix max bid calculation in the initial auction

### DIFF
--- a/lib/engine/game/g_18_neb/step/bid_auction.rb
+++ b/lib/engine/game/g_18_neb/step/bid_auction.rb
@@ -152,6 +152,13 @@ module Engine
           def max_bid(player, company)
             player.cash - committed_cash(player) + current_bid_amount(player, company)
           end
+
+          def current_bid_amount(player, company)
+            # Cash is only committed to an auction if the player has made the
+            # currently winning bid. Return zero if they have been outbid.
+            bid = highest_bid(company)
+            bid&.entity == player ? bid.price : 0
+          end
         end
       end
     end


### PR DESCRIPTION
The calculation of the maximum a player can afford to bid is incorrect: it is calculated as the player's cash, less the total of their winning bids, plus their bid on the current company. This last bit is potentially incorrect, if they have placed a bid on a company and then outbid they are being allowed to bid too much, as they are given credit for a bid that was not included in the winning bids calculation.

Fixes tobymao#12468.

This might break some games where players might have placed bids they could not afford. They would not have been able to end the auction round with an amount bid they could not pay, but there could still have been illegal bids which were subsequently overbid, or the bids were undone.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`