### PR TITLE
Add base game entities for 18OE (privates, concessions,

### DIFF
--- a/lib/engine/game/g_18_oe/entities.rb
+++ b/lib/engine/game/g_18_oe/entities.rb
@@ -1,0 +1,346 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G18OE
+      module Entities
+        COMPANIES = [
+          # === PRIVATES (auction rows 1-6 by face value tier) ===
+          # TODO: verify auction rows against physical opening packet layout
+
+          {
+            name: 'Robert Stephenson and Company',
+            sym: 'RSC',
+            value: 20,
+            revenue: 5,
+            auction_row: 1,
+          },
+          {
+            name: 'Ponts et Chaussees',
+            sym: 'PeC',
+            value: 20,
+            revenue: 5,
+            auction_row: 1,
+          },
+          {
+            name: 'Wien Sudbahnhof',
+            sym: 'WS',
+            value: 40,
+            revenue: 10,
+            auction_row: 2,
+            desc: 'During any RR\'s place token step, owner may place one of the RR\'s station tokens '\
+                  'for free. Token must be reachable. Sea zone costs still apply.',
+          },
+          {
+            name: 'Barclay, Bevan, Barclay and Tritton',
+            sym: 'BBBT',
+            value: 40,
+            revenue: 10,
+            auction_row: 2,
+            desc: 'Choose one: (1) Re-set par value of one owned regional or major to a valid par value; '\
+                  '(2) Reserve one share of a RR\'s stock for the owning player; '\
+                  '(3) Prevent one RR\'s share value marker from moving DOWN for rest of SR.',
+          },
+          {
+            name: 'Star Harbor Trading Company',
+            sym: 'SHTC',
+            value: 60,
+            revenue: 15,
+            auction_row: 3,
+            desc: 'Place token in a port city during a RR\'s lay token step. Owning RR may use it '\
+                  'as a public/private port for sea crossings. Does not consume a token position.',
+          },
+          {
+            name: 'Central Circle Transport Corporation',
+            sym: 'CCTC',
+            value: 60,
+            revenue: 15,
+            auction_row: 3,
+            desc: 'Place token in a non-port city during a RR\'s lay token step. Counts as a town '\
+                  'for owning RR. Revenue: Ph2=£10, Ph3-4=£20, Ph5-6=£40, Ph7-8=£60.',
+          },
+          {
+            name: 'White Cliffs Ferry',
+            sym: 'WCF',
+            value: 60,
+            revenue: 15,
+            auction_row: 3,
+            desc: 'At Train Phase 5 start, place one station token from a controlled RR on the '\
+                  'White Cliffs Ferry token position next to Lille. RR pays cost; no connection required.',
+          },
+          {
+            name: 'Hochberg Mining and Lumber Co.',
+            sym: 'HMLC',
+            value: 80,
+            revenue: 20,
+            auction_row: 4,
+            desc: 'Place token in a rough (green terrain, cost >=£45) hex during a controlled RR\'s '\
+                  'lay track step. Only owner\'s RRs may use track with this token. Another RR may '\
+                  'remove the token by paying original terrain cost + 1 tile point (nationals skip cost).',
+          },
+          {
+            name: 'Brandt and Brandau, Engineers',
+            sym: 'BBE',
+            value: 100,
+            revenue: 25,
+            auction_row: 5,
+            desc: '4 tokens; up to 2 per OR for owner\'s controlled RRs. Place token in rough (green) '\
+                  'terrain hex; yellow tile placed there at no terrain cost (still uses tile points). '\
+                  'Only owner\'s RRs may use track. Closes when last token is placed.',
+          },
+          {
+            name: 'Swift Metropolitan Line',
+            sym: 'SML',
+            value: 120,
+            revenue: 0,
+            auction_row: 6,
+            desc: 'At Train Phase 4+: designate one RR to receive one unclaimed rusted 2+2 train. '\
+                  'Does not count against train limit; cannot run on track already used by RR\'s other '\
+                  'trains in same OR; cannot be sold. Transfers to major when owning minor merges.',
+          },
+
+          # === CONCESSIONS (auction rows 7-8) ===
+          # TODO: verify face values and auction rows against physical opening packet layout
+
+          { name: 'Concession 1',  sym: 'CON1',  value: 100, revenue: 0, auction_row: 7 },
+          { name: 'Concession 2',  sym: 'CON2',  value: 100, revenue: 0, auction_row: 7 },
+          { name: 'Concession 3',  sym: 'CON3',  value: 100, revenue: 0, auction_row: 7 },
+          { name: 'Concession 4',  sym: 'CON4',  value: 100, revenue: 0, auction_row: 7 },
+          { name: 'Concession 5',  sym: 'CON5',  value: 100, revenue: 0, auction_row: 7 },
+          { name: 'Concession 6',  sym: 'CON6',  value: 100, revenue: 0, auction_row: 8 },
+          { name: 'Concession 7',  sym: 'CON7',  value: 100, revenue: 0, auction_row: 8 },
+          { name: 'Concession 8',  sym: 'CON8',  value: 100, revenue: 0, auction_row: 8 },
+          { name: 'Concession 9',  sym: 'CON9',  value: 100, revenue: 0, auction_row: 8 },
+          { name: 'Concession 10', sym: 'CON10', value: 100, revenue: 0, auction_row: 8 },
+
+          # === MINOR CHARTERS (auction rows 9-12) ===
+          # TODO: verify auction rows against physical opening packet layout
+
+          {
+            name: 'Silver Banner Line',
+            sym: 'A',
+            value: 120,
+            revenue: 0,
+            auction_row: 9,
+            abilities: [{ type: 'exchange', corporations: %w[A], owner_type: 'player', from: %w[ipo] }],
+          },
+          {
+            name: 'Orange Scroll Surveyors',
+            sym: 'B',
+            value: 120,
+            revenue: 0,
+            auction_row: 9,
+            abilities: [{ type: 'exchange', corporations: %w[B], owner_type: 'player', from: %w[ipo] }],
+          },
+          {
+            name: 'Golden Bell Marketplace',
+            sym: 'C',
+            value: 120,
+            revenue: 0,
+            auction_row: 9,
+            abilities: [{ type: 'exchange', corporations: %w[C], owner_type: 'player', from: %w[ipo] }],
+          },
+          {
+            name: 'Green Junction Mercantile',
+            sym: 'D',
+            value: 120,
+            revenue: 0,
+            auction_row: 10,
+            abilities: [{ type: 'exchange', corporations: %w[D], owner_type: 'player', from: %w[ipo] }],
+          },
+          {
+            name: 'Blue Coast Bridge Construction Company',
+            sym: 'E',
+            value: 120,
+            revenue: 0,
+            auction_row: 10,
+            abilities: [{ type: 'exchange', corporations: %w[E], owner_type: 'player', from: %w[ipo] }],
+          },
+          {
+            name: 'White Peak Mountain Railway',
+            sym: 'F',
+            value: 120,
+            revenue: 0,
+            auction_row: 10,
+            abilities: [{ type: 'exchange', corporations: %w[F], owner_type: 'player', from: %w[ipo] }],
+          },
+          {
+            name: 'Indigo Foundry and Iron Works',
+            sym: 'G',
+            value: 120,
+            revenue: 0,
+            auction_row: 11,
+            abilities: [{ type: 'exchange', corporations: %w[G], owner_type: 'player', from: %w[ipo] }],
+          },
+          {
+            name: 'Great Western Steamship Company',
+            sym: 'H',
+            value: 120,
+            revenue: 0,
+            auction_row: 11,
+            abilities: [{ type: 'exchange', corporations: %w[H], owner_type: 'player', from: %w[ipo] }],
+          },
+          {
+            name: 'Grey Locomotive Works',
+            sym: 'J',
+            value: 120,
+            revenue: 0,
+            auction_row: 11,
+            abilities: [{ type: 'exchange', corporations: %w[J], owner_type: 'player', from: %w[ipo] }],
+          },
+          {
+            name: 'Vermilion Seal Couriers',
+            sym: 'K',
+            value: 120,
+            revenue: 0,
+            auction_row: 12,
+            abilities: [{ type: 'exchange', corporations: %w[K], owner_type: 'player', from: %w[ipo] }],
+          },
+          {
+            name: 'Krasnaya Strela',
+            sym: 'L',
+            value: 120,
+            revenue: 0,
+            auction_row: 12,
+            abilities: [{ type: 'exchange', corporations: %w[L], owner_type: 'player', from: %w[ipo] }],
+          },
+          {
+            name: 'Compagnie Internationale des Wagons-Lits',
+            sym: 'M',
+            value: 120,
+            revenue: 0,
+            auction_row: 12,
+            abilities: [{ type: 'exchange', corporations: %w[M], owner_type: 'player', from: %w[ipo] }],
+          },
+        ].freeze
+
+        CORPORATIONS = [
+          # === 12 MINOR CORPORATIONS ===
+          {
+            name: 'Silver Banner Line',
+            logo: '18_oe/A',
+            sym: 'A',
+            tokens: [0, 20],
+            type: 'minor',
+            shares: [100],
+            float_percent: 100,
+            max_ownership_percent: 100,
+          },
+          {
+            name: 'Orange Scroll Surveyors',
+            logo: '18_oe/B',
+            sym: 'B',
+            tokens: [0, 20],
+            type: 'minor',
+            shares: [100],
+            float_percent: 100,
+            max_ownership_percent: 100,
+          },
+          {
+            name: 'Golden Bell Marketplace',
+            logo: '18_oe/C',
+            sym: 'C',
+            tokens: [0, 20],
+            type: 'minor',
+            shares: [100],
+            float_percent: 100,
+            max_ownership_percent: 100,
+          },
+          {
+            name: 'Green Junction Mercantile',
+            logo: '18_oe/D',
+            sym: 'D',
+            tokens: [0, 20],
+            type: 'minor',
+            shares: [100],
+            float_percent: 100,
+            max_ownership_percent: 100,
+          },
+          {
+            name: 'Blue Coast Bridge Construction Company',
+            logo: '18_oe/E',
+            sym: 'E',
+            tokens: [0, 20],
+            type: 'minor',
+            shares: [100],
+            float_percent: 100,
+            max_ownership_percent: 100,
+          },
+          {
+            name: 'White Peak Mountain Railway',
+            logo: '18_oe/F',
+            sym: 'F',
+            tokens: [0, 20],
+            type: 'minor',
+            shares: [100],
+            float_percent: 100,
+            max_ownership_percent: 100,
+          },
+          {
+            name: 'Indigo Foundry and Iron Works',
+            logo: '18_oe/G',
+            sym: 'G',
+            tokens: [0, 20],
+            type: 'minor',
+            shares: [100],
+            float_percent: 100,
+            max_ownership_percent: 100,
+          },
+          {
+            name: 'Great Western Steamship Company',
+            logo: '18_oe/H',
+            sym: 'H',
+            tokens: [0, 20],
+            type: 'minor',
+            shares: [100],
+            float_percent: 100,
+            max_ownership_percent: 100,
+          },
+          {
+            name: 'Grey Locomotive Works',
+            logo: '18_oe/J',
+            sym: 'J',
+            tokens: [0, 20],
+            type: 'minor',
+            shares: [100],
+            float_percent: 100,
+            max_ownership_percent: 100,
+          },
+          {
+            name: 'Vermilion Seal Couriers',
+            logo: '18_oe/K',
+            sym: 'K',
+            tokens: [0, 20],
+            type: 'minor',
+            shares: [100],
+            float_percent: 100,
+            max_ownership_percent: 100,
+          },
+          {
+            name: 'Krasnaya Strela',
+            logo: '18_oe/L',
+            sym: 'L',
+            tokens: [0, 20],
+            type: 'minor',
+            shares: [100],
+            float_percent: 100,
+            max_ownership_percent: 100,
+          },
+          {
+            name: 'Compagnie Internationale des Wagons-Lits',
+            logo: '18_oe/M',
+            sym: 'M',
+            tokens: [0, 20],
+            type: 'minor',
+            shares: [100],
+            float_percent: 100,
+            max_ownership_percent: 100,
+          },
+
+          # === REGIONALS & MAJORS ===
+          # Deferred — need home hex coordinates from map scans (openpoints.md 2.1)
+        ].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'meta'
+require_relative 'entities'
 require_relative '../base'
 
 module Engine
@@ -8,6 +9,7 @@ module Engine
     module G18OE
       class Game < Game::Base
         include_meta(G18OE::Meta)
+        include G18OE::Entities
         attr_accessor :minor_regional_order, :minor_available_regions, :minor_floated_regions, :regional_corps_floated
 
         MARKET = [


### PR DESCRIPTION
# 18OE: Add Base Game Entities (Privates, Concessions, Minors)

## Summary

Creates `lib/engine/game/g_18_oe/entities.rb` defining all opening-packet companies and
minor corporations for the base game, and wires it into `g_18_oe/game.rb`. Before this
change, `G18OE::Game` had no `COMPANIES` or `CORPORATIONS` constants, making the base game
unplayable standalone. The UK-FR variant is unaffected.

Covers openpoints.md **2.2** (12 minor corporations), **2.3** (10 privates), and **2.4**
(10 concession cards). Sections 2.1 (24 regionals) and 2.5 (full map) are deferred pending
map-scan images.

---

## Files Changed

### `lib/engine/game/g_18_oe/entities.rb` *(new)*

New module `G18OE::Entities` containing two constants:

#### `COMPANIES` — 32 entries in three groups

**10 Private Companies (auction rows 1–6)**

| Sym  | Name                              | Face Value | Revenue | Row |
|------|-----------------------------------|-----------|---------|-----|
| RSC  | Robert Stephenson and Company     | £20       | £5      | 1   |
| PeC  | Ponts et Chaussees                | £20       | £5      | 1   |
| WS   | Wien Sudbahnhof                   | £40       | £10     | 2   |
| BBBT | Barclay, Bevan, Barclay and Tritton | £40     | £10     | 2   |
| SHTC | Star Harbor Trading Company       | £60       | £15     | 3   |
| CCTC | Central Circle Transport Corporation | £60    | £15     | 3   |
| WCF  | White Cliffs Ferry                | £60       | £15     | 3   |
| HMLC | Hochberg Mining and Lumber Co.    | £80       | £20     | 4   |
| BBE  | Brandt and Brandau, Engineers     | £100      | £25     | 5   |
| SML  | Swift Metropolitan Line           | £120      | £0      | 6   |

All privates include a `desc:` string summarising their special ability (or note "no
special abilities" for RSC and PeC). Ability implementations are deferred to openpoints.md
section 8.

**10 Concession Cards (auction rows 7–8)**

CON1–CON5 in row 7, CON6–CON10 in row 8. Face value £100, revenue £0, no ability data.
The ordered-float execution mechanic is handled by game logic, not entity data.

> TODO: verify face values and exact auction rows against physical opening packet layout.

**12 Minor Charters (auction rows 9–12)**

| Sym | Name                                   | Row |
|-----|----------------------------------------|-----|
| A   | Silver Banner Line                     | 9   |
| B   | Orange Scroll Surveyors                | 9   |
| C   | Golden Bell Marketplace                | 9   |
| D   | Green Junction Mercantile              | 10  |
| E   | Blue Coast Bridge Construction Company | 10  |
| F   | White Peak Mountain Railway            | 10  |
| G   | Indigo Foundry and Iron Works          | 11  |
| H   | Great Western Steamship Company        | 11  |
| J   | Grey Locomotive Works                  | 11  |
| K   | Vermilion Seal Couriers                | 12  |
| L   | Krasnaya Strela                        | 12  |
| M   | Compagnie Internationale des Wagons-Lits | 12 |

Each charter has an `exchange` ability linking it to the corresponding minor corporation
(same `sym`), matching the pattern used in `g_18_oe_uk_fr/entities.rb`. Face value £120,
revenue £0.

> TODO: verify auction row grouping (3 per row, rows 9–12) against physical opening packet.

#### `CORPORATIONS` — 12 minor corporations

All 12 minors (A–M): `type: 'minor'`, `tokens: [0, 20]`, `shares: [100]`,
`float_percent: 100`, `max_ownership_percent: 100`, no `coordinates` (minors select home
city on float via `home_token_locations`). Logos reference existing `18_oe/<sym>` assets.

Regionals and majors remain as a deferred placeholder comment (need home hex coordinates
from map scans — openpoints.md 2.1).

---

### `lib/engine/game/g_18_oe/game.rb` *(modified)*

Two lines added:

```ruby
require_relative 'entities'   # line 4, after require_relative 'meta'
include G18OE::Entities       # line 12, after include_meta(G18OE::Meta)
```

---

## Inheritance / Override Notes

`G18OEUKFR::Game` includes `G18OEUKFR::Entities` *after* inheriting from `G18OE::Game`.
Ruby resolves `COMPANIES` and `CORPORATIONS` to the most recently included module, so the
UK-FR variant continues to use its own entity subset unchanged. No modifications were made
to any UK-FR files.

---

## Verification

1. Load `G18OE::Game` — no crash on nil `COMPANIES`/`CORPORATIONS`.
2. Load `G18OEUKFR::Game` — still uses UK-FR entity subset (4 minors, 7 regionals).
3. Open auction phase — 10 privates + 10 concessions + 12 minor charters appear in the
   opening packet (32 items total).
4. Purchase minor charter + exchange — minor corporation receives starting cash, capped at
   £180 per `buy_company` in `step/waterfall_auction.rb:31`.
5. Minor selects home city on float (no fixed coordinates; uses `home_token_locations`
   logic).

---

## Open Items (deferred)

- **2.1** — 24 regionals with home hex coordinates (needs map scans)
- **2.5** — Full European map layout (needs map scans)
- **Section 7** — Minor special ability implementations (A–M)
- **Section 8** — Private special ability implementations
- Auction row layout and concession face values marked with `# TODO` comments in code;
  verify against physical opening packet layout chart once available.
