### PR TITLE
[System18 Gotland] Player value is affected by difficulty level

### DIFF
--- a/lib/engine/game/g_system18/game.rb
+++ b/lib/engine/game/g_system18/game.rb
@@ -815,6 +815,12 @@ module Engine
           send("map_#{cmap_name}_game_end_check_values")
         end
 
+        def player_value(player)
+          return super unless respond_to?("map_#{cmap_name}_player_value")
+
+          send("map_#{cmap_name}_player_value", player)
+        end
+
         def rust?(train, purchased_train)
           !@deferred_rust.include?(train) && super
         end

--- a/lib/engine/game/g_system18/map_gotland_customization.rb
+++ b/lib/engine/game/g_system18/map_gotland_customization.rb
@@ -280,6 +280,10 @@ module Engine
           @difficulty_value ||= DIFFICULTY_VALUES[difficulty_level]
         end
 
+        def map_gotland_player_value(player)
+          player.value * difficulty_level_value
+        end
+
         def map_hexes
           {
             white: {


### PR DESCRIPTION
The player's score is: (share value + cash) × difficulty level (10/20/30/40 for easy/normal/hard/extra hard).

Fixes tobymao#12476.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`