### PR TITLE
[1840] Stop market limit marker from being shown

### DIFF
--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -55,6 +55,8 @@ module Engine
 
         NEXT_SR_PLAYER_ORDER = :most_cash
 
+        MARKET_SHARE_LIMIT = 100
+
         MARKET_TEXT = {
           par: 'City Corporation Par',
           par_2: 'Major Corporation Par',


### PR DESCRIPTION
1840 does not have any limits on sales to the share pool, other than not allowing the president's certificate from being sold. The code was correctly allowing sales to take the pool above 50%, but the 'L' pool limit marker was incorrectly being shown when five or more shares were in the pool.

Fixes tobymao#12493.

No pins are required. This doesn't change any behaviour, just whether the market limit marker is shown.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- ~Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`