### PR TITLE
[18Cuba] Train buy logic and rusting

### DIFF
--- a/lib/engine/game/g_18_cuba/game.rb
+++ b/lib/engine/game/g_18_cuba/game.rb
@@ -91,7 +91,7 @@ module Engine
             Engine::Step::Route,
             G18Cuba::Step::Dividend,
             Engine::Step::DiscardTrain,
-            Engine::Step::BuyTrain,
+            G18Cuba::Step::BuyTrain,
             [Engine::Step::BuyCompany, { blocks: true }],
           ], round_num: round_num)
         end

--- a/lib/engine/game/g_18_cuba/step/buy_train.rb
+++ b/lib/engine/game/g_18_cuba/step/buy_train.rb
@@ -13,13 +13,19 @@ module Engine
           end
 
           def buyable_trains(entity)
-            trains = super
+            track_type = entity.type == :minor ? :narrow : :broad
 
-            if entity.type == :minor
-              trains.select { |t| t.track_type == :narrow }
-            else
-              trains.select { |t| t.track_type == :broad }
+            if must_buy_train?(entity)
+              # Emergency buy: only depot/discard trains allowed (not from other companies),
+              # and only the cheapest of the correct track type.
+              available = @depot.depot_trains.select { |t| t.track_type == track_type }
+              cheapest_price = available.map { |t| t.price }.min
+              result = cheapest_price ? available.select { |t| t.price == cheapest_price } : []
+              return result
             end
+
+            # Normal buy: filter by track type.
+            return super.select { |t| t.track_type == track_type }
           end
 
           def buyable_train_variants(train, entity)
@@ -27,6 +33,12 @@ module Engine
             # 4n trains can downgrade to 4-1n.
             # Only the currently active variant (based on train.name) is buyable.
             return variants.select { |variant| variant[:name] == train.name } if train.variants.key?('4-1n')
+
+            # During emergency buy, only the cheapest variant is allowed.
+            if must_buy_train?(entity)
+              min_price = variants.map { |v| v[:price] }.min
+              return variants.select { |v| v[:price] == min_price }
+            end
 
             variants
           end

--- a/lib/engine/game/g_18_cuba/step/buy_train.rb
+++ b/lib/engine/game/g_18_cuba/step/buy_train.rb
@@ -19,13 +19,13 @@ module Engine
               # Emergency buy: only depot/discard trains allowed (not from other companies),
               # and only the cheapest of the correct track type.
               available = @depot.depot_trains.select { |t| t.track_type == track_type }
-              cheapest_price = available.map { |t| t.price }.min
+              cheapest_price = available.map(&:price).min
               result = cheapest_price ? available.select { |t| t.price == cheapest_price } : []
               return result
             end
 
             # Normal buy: filter by track type.
-            return super.select { |t| t.track_type == track_type }
+            super.select { |t| t.track_type == track_type }
           end
 
           def buyable_train_variants(train, entity)

--- a/lib/engine/game/g_18_cuba/step/buy_train.rb
+++ b/lib/engine/game/g_18_cuba/step/buy_train.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_train'
+
+module Engine
+  module Game
+    module G18Cuba
+      module Step
+        class BuyTrain < Engine::Step::BuyTrain
+          def round_state
+            # Track which minor corporations have exchanged for narrow gauge trains this OR
+            super.merge({ narrow_gauge_exchanged_by: [] })
+          end
+
+          def buyable_trains(entity)
+            trains = super
+
+            if entity.type == :minor
+              trains.select { |t| t.track_type == :narrow }
+            else
+              trains.select { |t| t.track_type == :broad }
+            end
+          end
+
+          def discountable_trains_allowed?(entity)
+            # Minors can only exchange for narrow gauge trains, and can only do so once per OR.
+            entity.type == :minor && !@round.narrow_gauge_exchanged_by.include?(entity.id)
+          end
+
+          def process_buy_train(action)
+            # If the player is exchanging a narrow gauge train, ensure they haven't already done so this OR,
+            # and track that they have.
+            if action.exchange
+              raise GameError, "#{action.entity.name} has already exchanged a narrow gauge train this OR" \
+                unless discountable_trains_allowed?(action.entity)
+
+              @round.narrow_gauge_exchanged_by << action.entity.id
+            end
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_cuba/step/buy_train.rb
+++ b/lib/engine/game/g_18_cuba/step/buy_train.rb
@@ -32,9 +32,9 @@ module Engine
             variants = super
             # Downgrade train variants (e.g. 4n-1) are not player-chooseable; only the current one is buyable.
             if train.variants.values.any? { |v| v[:event_downgrade_variant] }
-              return variants.select do |v|
-                       v[:name] == train.name
-                     end
+              result = variants.select { |v| v == train.variant }
+
+              return result
             end
 
             # During emergency buy, only the cheapest variant is allowed.

--- a/lib/engine/game/g_18_cuba/step/buy_train.rb
+++ b/lib/engine/game/g_18_cuba/step/buy_train.rb
@@ -30,9 +30,12 @@ module Engine
 
           def buyable_train_variants(train, entity)
             variants = super
-            # 4n trains can downgrade to 4-1n.
-            # Only the currently active variant (based on train.name) is buyable.
-            return variants.select { |variant| variant[:name] == train.name } if train.variants.key?('4-1n')
+            # Downgrade train variants (e.g. 4n-1) are not player-chooseable; only the current one is buyable.
+            if train.variants.values.any? { |v| v[:event_downgrade_variant] }
+              return variants.select do |v|
+                       v[:name] == train.name
+                     end
+            end
 
             # During emergency buy, only the cheapest variant is allowed.
             if must_buy_train?(entity)

--- a/lib/engine/game/g_18_cuba/step/buy_train.rb
+++ b/lib/engine/game/g_18_cuba/step/buy_train.rb
@@ -22,6 +22,15 @@ module Engine
             end
           end
 
+          def buyable_train_variants(train, entity)
+            variants = super
+            # 4n trains can downgrade to 4-1n.
+            # Only the currently active variant (based on train.name) is buyable.
+            return variants.select { |variant| variant[:name] == train.name } if train.variants.key?('4-1n')
+
+            variants
+          end
+
           def discountable_trains_allowed?(entity)
             # Minors can only exchange for narrow gauge trains, and can only do so once per OR.
             entity.type == :minor && !@round.narrow_gauge_exchanged_by.include?(entity.id)

--- a/lib/engine/game/g_18_cuba/trains.rb
+++ b/lib/engine/game/g_18_cuba/trains.rb
@@ -85,6 +85,7 @@ module Engine
             distance: 8,
             price: 700,
             track_type: :broad,
+            events: [{ 'type' => 'downgrade_4n_trains' }],
             variants: [
               {
                 name: '4D',
@@ -100,6 +101,7 @@ module Engine
             distance: 2,
             price: 80,
             track_type: :narrow,
+            available_on: '2',
             rusts_on: '4',
           },
           {
@@ -107,21 +109,39 @@ module Engine
             distance: 3,
             price: 160,
             track_type: :narrow,
+            available_on: '3',
             rusts_on: '6',
+            discount: { '2n' => 40 },
           },
           {
             name: '4n',
             distance: 4,
             price: 260,
             track_type: :narrow,
+            available_on: '4',
+            discount: { '3n' => 80 },
           },
           {
             name: '5n',
             distance: 5,
             price: 380,
             track_type: :narrow,
+            available_on: '5',
+            discount: { '4n' => 130, '4-1n' => 65 },
           },
           ].freeze
+
+        def event_downgrade_4n_trains!
+          @log << '-- Event: 4n trains downgrade to 4-1n trains --'
+          trains.each do |train|
+            next unless train.name == '4n'
+            next unless train.owned_by_corporation?
+
+            @log << "#{train.owner.name}'s 4n train downgrades to 4-1n"
+            train.name = '4-1n'
+            train.distance = 3
+          end
+        end
       end
     end
   end

--- a/lib/engine/game/g_18_cuba/trains.rb
+++ b/lib/engine/game/g_18_cuba/trains.rb
@@ -145,7 +145,7 @@ module Engine
             train.distance = 3
             train.variant[:name] = '4-1n'
             train.variant[:distance] = 3
-            train.variants['4-1n'] = train.variants.delete('4n') if train.variants.key?('4n')
+            train.variants.transform_keys!( { '4n' => '4n-1' })
           end
         end
       end

--- a/lib/engine/game/g_18_cuba/trains.rb
+++ b/lib/engine/game/g_18_cuba/trains.rb
@@ -120,6 +120,14 @@ module Engine
             track_type: :narrow,
             available_on: '4',
             discount: { '3n' => 80 },
+            variants: [
+              {
+                name: '4-1n',
+                distance: 3,
+                price: 130,
+                track_type: :narrow,
+              },
+            ],
           },
           {
             name: '5n',
@@ -141,11 +149,7 @@ module Engine
                     else
                       'Depot/Discard 4n train downgrades to 4-1n'
                     end
-            train.name = '4-1n'
-            train.distance = 3
-            train.variant[:name] = '4-1n'
-            train.variant[:distance] = 3
-            train.variants.transform_keys!({ '4n' => '4n-1' })
+            train.variant = '4-1n'
           end
         end
       end

--- a/lib/engine/game/g_18_cuba/trains.rb
+++ b/lib/engine/game/g_18_cuba/trains.rb
@@ -139,7 +139,7 @@ module Engine
             @log << if train.owned_by_corporation?
                       "#{train.owner.name}'s 4n train downgrades to 4-1n"
                     else
-                      'Depot and Discard 4n trains downgrade to 4-1n'
+                      'Depot/Discard 4n train downgrades to 4-1n'
                     end
             train.name = '4-1n'
             train.distance = 3

--- a/lib/engine/game/g_18_cuba/trains.rb
+++ b/lib/engine/game/g_18_cuba/trains.rb
@@ -145,7 +145,7 @@ module Engine
             train.distance = 3
             train.variant[:name] = '4-1n'
             train.variant[:distance] = 3
-            train.variants.transform_keys!( { '4n' => '4n-1' })
+            train.variants.transform_keys!({ '4n' => '4n-1' })
           end
         end
       end

--- a/lib/engine/game/g_18_cuba/trains.rb
+++ b/lib/engine/game/g_18_cuba/trains.rb
@@ -107,7 +107,7 @@ module Engine
           {
             name: '3n',
             distance: 3,
-            price: 160,
+            price: 180,
             track_type: :narrow,
             available_on: '3',
             rusts_on: '6',
@@ -135,11 +135,17 @@ module Engine
           @log << '-- Event: 4n trains downgrade to 4-1n trains --'
           trains.each do |train|
             next unless train.name == '4n'
-            next unless train.owned_by_corporation?
 
-            @log << "#{train.owner.name}'s 4n train downgrades to 4-1n"
+            @log << if train.owned_by_corporation?
+                      "#{train.owner.name}'s 4n train downgrades to 4-1n"
+                    else
+                      'Depot and Discard 4n trains downgrade to 4-1n'
+                    end
             train.name = '4-1n'
             train.distance = 3
+            train.variant[:name] = '4-1n'
+            train.variant[:distance] = 3
+            train.variants['4-1n'] = train.variants.delete('4n') if train.variants.key?('4n')
           end
         end
       end

--- a/lib/engine/game/g_18_cuba/trains.rb
+++ b/lib/engine/game/g_18_cuba/trains.rb
@@ -126,6 +126,7 @@ module Engine
                 distance: 3,
                 price: 130,
                 track_type: :narrow,
+                event_downgrade_variant: true,
               },
             ],
           },


### PR DESCRIPTION
Implements the narrow gauge train buy and exchange rules for minors, including the 4n→4-1n downgrade event triggered by the first 8/4D train purchase.

Includes also the emergency buy rule to only buy the cheapest train / variant from bank or bank pool

**Rules reference**

A minor railroad can exchange its n-train for the next higher type once per operating round. It receives half the value of the old train as a credit toward the new one. It cannot skip a type.

When the first 8 or 4D train is purchased, all 4n trains owned by corporations downgrade to 4-1n trains (distance 3, worth $130). A 4-1n can be exchanged for a 5n ($380) with a $65 credit, for a net cost of $315.

Emergency Financing: The train may be bought only from the bank or the bank pool, but not from another company. If different trains are available, then the director must buy the cheapest train available. The director may add only the amount of money needed in order to buy the train; thus, following the train purchase, the company will have no money le in its treasury.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes


#### `step/buy_train.rb` (new)

Custom BuyTrain step for 18Cuba:

- Minors may only buy narrow gauge trains (2n, 3n, 4n, 5n); majors may only buy broad gauge trains.
- Narrow gauge trains are now visible in the depot once the corresponding phase is active (`available_on`).
- Implements the once-per-OR exchange mechanic: a minor may trade in its current n-train for the next type, receiving half the original purchase price as a credit. Attempting to exchange a second time in the same OR raises an error.
- Exchange tracking uses `round_state` (resets automatically each OR), consistent with the pattern used in 1824.

#### `trains.rb`

- Added `available_on` 
- Added `discount` for n-train exchanges:
- Added `events: [{ 'type' => 'downgrade_4n_trains' }]` to the `8` train.
- Added event_downgrade_4n_trains!: when the first 8 or 4D train is purchased, all 4n trains (corporation-owned, depot, and discard) downgrade to the 4-1n variant. The 4-1n can be exchanged toward a 5n at a $65 credit — half the credit of a full 4n ($130).


### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
