### PR TITLE
[UI] Game data - Show additional details

### DIFF
--- a/assets/app/view/game/game_data.rb
+++ b/assets/app/view/game/game_data.rb
@@ -3,11 +3,13 @@
 # backtick_javascript: true
 
 require 'game_manager'
+require 'lib/profile_link'
 
 module View
   module Game
     class GameData < Snabberb::Component
       include GameManager
+      include Lib::ProfileLink
 
       needs :allow_clone, default: true
       needs :allow_delete, default: false
@@ -41,9 +43,10 @@ module View
       end
 
       def render_game_info
+        user = @game_data['user']
         [
           info_row('Description', @game_data['description']),
-          info_row('Host', @game_data['user'] && @game_data['user']['name']),
+          h(:p, ['Host: ', user ? profile_link(user['id'], user['name']) : '']),
           info_row('Created', format_time(@game_data['created_at'])),
           info_row('Last Updated', format_time(@game_data['updated_at'])),
         ]

--- a/assets/app/view/game/game_data.rb
+++ b/assets/app/view/game/game_data.rb
@@ -32,23 +32,15 @@ module View
       def render_game_info
         items = []
 
-        if (description = @game_data['description']).to_s != ''
-          items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Description: '), h(:span, description)])
-        end
+        items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Description: '), h(:span, description)])
 
-        if (host = @game_data.dig('user', 'name'))
-          items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Host: '), h(:span, host)])
-        end
+        items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Host: '), h(:span, host)])
 
-        if (created_at = @game_data['created_at'])
-          ts = Time.at(created_at.to_i)
-          items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Created: '), h(:span, ts.strftime('%F %T'))])
-        end
+        ts = Time.at(created_at.to_i)
+        items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Created: '), h(:span, ts.strftime('%F %T'))])
 
-        if (updated_at = @game_data['updated_at'])
-          ts = Time.at(updated_at.to_i)
-          items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Last Updated: '), h(:span, ts.strftime('%F %T'))])
-        end
+        ts = Time.at(updated_at.to_i)
+        items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Last Updated: '), h(:span, ts.strftime('%F %T'))])
 
         items
       end

--- a/assets/app/view/game/game_data.rb
+++ b/assets/app/view/game/game_data.rb
@@ -29,6 +29,30 @@ module View
         h(:div, props, children)
       end
 
+      def render_game_info
+        items = []
+
+        if (description = @game_data['description']).to_s != ''
+          items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Description: '), h(:span, description)])
+        end
+
+        if (host = @game_data.dig('user', 'name'))
+          items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Host: '), h(:span, host)])
+        end
+
+        if (created_at = @game_data['created_at'])
+          ts = Time.at(created_at.to_i)
+          items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Created: '), h(:span, ts.strftime('%F %T'))])
+        end
+
+        if (updated_at = @game_data['updated_at'])
+          ts = Time.at(updated_at.to_i)
+          items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Last Updated: '), h(:span, ts.strftime('%F %T'))])
+        end
+
+        items
+      end
+
       def render_game_data_buttons
         clone_game = lambda do
           @connection.unsubscribe(url(@game_data))
@@ -47,7 +71,6 @@ module View
         end
 
         buttons = [
-          h(:h3, 'Game Data'),
           h(:button, {
               on: { click: -> { store(:show_json, !@show_json) } },
               style: { width: '4.2rem' },
@@ -78,7 +101,7 @@ module View
 
         buttons.concat(render_random_seed)
 
-        h('div.margined', buttons)
+        h('div.margined', [h(:h3, 'Game Data')] + render_game_info + [h(:div, { style: { marginTop: '1rem' } }, buttons)])
       end
 
       def render_random_seed

--- a/assets/app/view/game/game_data.rb
+++ b/assets/app/view/game/game_data.rb
@@ -29,20 +29,27 @@ module View
         h(:div, props, children)
       end
 
+      def format_time(ts)
+        return '' unless ts
+
+        Time.at(ts.to_i).strftime('%F %T')
+      end
+
+      def info_row(label, value)
+        h(:div, [
+          h(:label, { style: { fontWeight: 'bold' } }, "#{label}: "),
+          h(:span, value.to_s),
+        ])
+      end
+
       def render_game_info
-        items = []
-
-        items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Description: '), h(:span, description)])
-
-        items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Host: '), h(:span, host)])
-
-        ts = Time.at(created_at.to_i)
-        items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Created: '), h(:span, ts.strftime('%F %T'))])
-
-        ts = Time.at(updated_at.to_i)
-        items << h(:div, [h(:label, { style: { fontWeight: 'bold' } }, 'Last Updated: '), h(:span, ts.strftime('%F %T'))])
-
-        items
+        data = @game_data
+        [
+          info_row('Description', data.dig['description']),
+          info_row('Host', data.dig('user', 'name')),
+          info_row('Created', format_time(data['created_at'])),
+          info_row('Last Updated', format_time(data['updated_at'])),
+        ]
       end
 
       def render_game_data_buttons

--- a/assets/app/view/game/game_data.rb
+++ b/assets/app/view/game/game_data.rb
@@ -43,12 +43,11 @@ module View
       end
 
       def render_game_info
-        data = @game_data
         [
-          info_row('Description', data.dig['description']),
-          info_row('Host', data.dig('user', 'name')),
-          info_row('Created', format_time(data['created_at'])),
-          info_row('Last Updated', format_time(data['updated_at'])),
+          info_row('Description', @game_data['description']),
+          info_row('Host', @game_data['user'] && @game_data['user']['name']),
+          info_row('Created', format_time(@game_data['created_at'])),
+          info_row('Last Updated', format_time(@game_data['updated_at'])),
         ]
       end
 

--- a/assets/app/view/game/game_data.rb
+++ b/assets/app/view/game/game_data.rb
@@ -32,14 +32,12 @@ module View
       def format_time(ts)
         return '' unless ts
 
-        Time.at(ts.to_i).strftime('%F %T')
+        t = Time.at(ts.to_i)
+        t > Time.now - 82_800 ? t.strftime('%T') : t.strftime('%F')
       end
 
       def info_row(label, value)
-        h(:div, [
-          h(:label, { style: { fontWeight: 'bold' } }, "#{label}: "),
-          h(:span, value.to_s),
-        ])
+        h(:p, "#{label}: #{value}")
       end
 
       def render_game_info

--- a/assets/app/view/game/game_data.rb
+++ b/assets/app/view/game/game_data.rb
@@ -3,13 +3,11 @@
 # backtick_javascript: true
 
 require 'game_manager'
-require 'lib/profile_link'
 
 module View
   module Game
     class GameData < Snabberb::Component
       include GameManager
-      include Lib::ProfileLink
 
       needs :allow_clone, default: true
       needs :allow_delete, default: false
@@ -29,27 +27,6 @@ module View
         children = [render_game_data_buttons]
         children << @json if @show_json
         h(:div, props, children)
-      end
-
-      def format_time(ts)
-        return '' unless ts
-
-        t = Time.at(ts.to_i)
-        t > Time.now - 82_800 ? t.strftime('%T') : t.strftime('%F')
-      end
-
-      def info_row(label, value)
-        h(:p, "#{label}: #{value}")
-      end
-
-      def render_game_info
-        user = @game_data['user']
-        [
-          info_row('Description', @game_data['description']),
-          h(:p, ['Host: ', user ? profile_link(user['id'], user['name']) : '']),
-          info_row('Created', format_time(@game_data['created_at'])),
-          info_row('Last Updated', format_time(@game_data['updated_at'])),
-        ]
       end
 
       def render_game_data_buttons
@@ -100,7 +77,7 @@ module View
 
         buttons.concat(render_random_seed)
 
-        h('div.margined', [h(:h3, 'Game Data')] + render_game_info + [h(:div, { style: { marginTop: '1rem' } }, buttons)])
+        h('div.margined', [h(:h3, 'Game Data'), h(:div, { style: { marginTop: '1rem' } }, buttons)])
       end
 
       def render_random_seed

--- a/assets/app/view/game/game_data.rb
+++ b/assets/app/view/game/game_data.rb
@@ -47,6 +47,7 @@ module View
         end
 
         buttons = [
+          h(:h3, 'Game Data'),
           h(:button, {
               on: { click: -> { store(:show_json, !@show_json) } },
               style: { width: '4.2rem' },
@@ -77,7 +78,7 @@ module View
 
         buttons.concat(render_random_seed)
 
-        h('div.margined', [h(:h3, 'Game Data'), h(:div, { style: { marginTop: '1rem' } }, buttons)])
+        h('div.margined', buttons)
       end
 
       def render_random_seed

--- a/assets/app/view/game/game_details.rb
+++ b/assets/app/view/game/game_details.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'game_manager'
+require 'lib/profile_link'
+
+module View
+  module Game
+    class GameDetails < Snabberb::Component
+      include GameManager
+      include Lib::ProfileLink
+
+      def render
+        h('div.margined', [
+          h(:h3, 'Game Details'),
+          *render_game_info,
+        ])
+      end
+
+      def format_time(ts)
+        return '' unless ts
+
+        t = Time.at(ts.to_i)
+        t > Time.now - 82_800 ? t.strftime('%T') : t.strftime('%F')
+      end
+
+      def info_row(label, value)
+        h(:p, "#{label}: #{value}")
+      end
+
+      def render_game_info
+        user = @game_data['user']
+        [
+          info_row('Description', @game_data['description']),
+          h(:p, ['Host: ', user ? profile_link(user['id'], user['name']) : '']),
+          info_row('Created', format_time(@game_data['created_at'])),
+          info_row('Last Updated', format_time(@game_data['updated_at'])),
+        ]
+      end
+    end
+  end
+end

--- a/assets/app/view/game/game_details.rb
+++ b/assets/app/view/game/game_details.rb
@@ -20,6 +20,9 @@ module View
         return '' unless ts
 
         t = Time.at(ts.to_i)
+        # Fallback for non-unix timestamps (e.g. used for hotseat games)
+        return ts.to_s if t.year < 2000
+
         t > Time.now - 82_800 ? t.strftime('%T') : t.strftime('%F')
       end
 
@@ -27,14 +30,22 @@ module View
         h(:p, "#{label}: #{value}")
       end
 
+      def host_display(user)
+        return '' unless user
+        return h(:span, user['name']) unless user['id'].to_i.positive?
+
+        profile_link(user['id'], user['name'])
+      end
+
       def render_game_info
         user = @game_data['user']
+        desc = @game_data['description']
         [
-          info_row('Description', @game_data['description']),
-          h(:p, ['Host: ', user ? profile_link(user['id'], user['name']) : '']),
+          (info_row('Description', desc) unless desc.to_s.empty?),
+          h(:p, ['Host: ', host_display(user)]),
           info_row('Created', format_time(@game_data['created_at'])),
           info_row('Last Updated', format_time(@game_data['updated_at'])),
-        ]
+        ].compact
       end
     end
   end

--- a/assets/app/view/game/tools.rb
+++ b/assets/app/view/game/tools.rb
@@ -25,8 +25,8 @@ module View
           h(RenameHotseat),
           *render_tools,
           h(AutoRouterSettings),
-          h(GameDetails),
           h(GameData, actions: @game.raw_actions.map(&:to_h)),
+          h(GameDetails),
           *help_links,
         ])
       end

--- a/assets/app/view/game/tools.rb
+++ b/assets/app/view/game/tools.rb
@@ -3,6 +3,7 @@
 require 'game_manager'
 require 'lib/storage'
 require 'view/game/game_data'
+require 'view/game/game_details'
 require 'view/game/notepad'
 require 'view/game/actionable'
 require 'view/game/auto_router_settings'
@@ -24,6 +25,7 @@ module View
           h(RenameHotseat),
           *render_tools,
           h(AutoRouterSettings),
+          h(GameDetails),
           h(GameData, actions: @game.raw_actions.map(&:to_h)),
           *help_links,
         ])


### PR DESCRIPTION
Fixes #12344

Add game metadata to the Game Data section in the Tools tab

Displays additional information about the game in the section "Game Details": description, host (user name), creation time, and last updated time. Each field is shown, also if data is null.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

- I decided to stick with the format like in the other sections of the tools page.
- I decided to go for an own section "Game Details" (first approach with Game Data had side effects and details were shown also in the box for "broken games")
- Time/Date format in the same way as on the start page.
- User name links to profile page


### Explanation of Change

### Screenshots

<img width="983" height="524" alt="image" src="https://github.com/user-attachments/assets/5aa06891-797f-40c9-8c50-b2c5afc4c9be" />


### Any Assumptions / Hacks
