### PR TITLE
[1849variants] EMR for settling bonds on corp close

### DIFF
--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -262,7 +262,7 @@ module Engine
         IFT_BUFFER = 3
 
         attr_accessor :swap_choice_player, :swap_location, :swap_other_player, :swap_corporation,
-                      :loan_choice_player,
+                      :loan_choice_player, :closing_after_bond_repayment,
                       :old_operating_order, :moved_this_turn,
                       :e_token_sold, :e_tokens_enabled, :issue_bonds_enabled, :buy_tokens_enabled
 
@@ -447,6 +447,17 @@ module Engine
         end
 
         def close_corporation(corporation, quiet: false)
+          president = corporation.owner
+          bond_shortfall = 0
+
+          if bonds? && corporation.loans.any?
+            bond_shortfall = repay_bond_on_close!(corporation)
+            if corporation.cash.negative?
+              self.closing_after_bond_repayment = { corp: corporation, quiet: quiet, player: president }
+              return
+            end
+            corporation.loans.clear
+          end
           remove_rsa_abilities(corporation)
           super
           corporation = reset_corporation(corporation)
@@ -463,6 +474,64 @@ module Engine
           end
           corporation.next_to_par = true if @corporations[index - 1].floated?
           update_garibaldi
+
+          self.loan_choice_player = president if bond_shortfall.positive? && president&.shares&.empty?
+        end
+
+        # Returns the unpaid amount (0 if fully repaid or EMR was triggered)
+        def repay_bond_on_close!(corporation)
+          owed = loan_value
+          @log << "#{corporation.name} must repay its outstanding bond of #{format_currency(owed)}"
+
+          corp_pays = [corporation.cash, owed].min
+          corporation.spend(corp_pays, bank) if corp_pays.positive?
+          remaining = owed - corp_pays
+          return 0 if remaining.zero?
+
+          president = corporation.owner
+          pres_pays = [president.cash, remaining].min
+          if pres_pays.positive?
+            @log << "#{president.name} contributes #{format_currency(pres_pays)} towards bond repayment"
+            president.spend(pres_pays, bank)
+            remaining -= pres_pays
+          end
+          return 0 if remaining.zero?
+
+          # If the president cannot raise enough to cover the remainder, sell all
+          # legally sellable shares (affecting share prices), give proceeds to the
+          # bank, and return the shortfall; the caller will offer the loan choice
+          if liquidity(president, emergency: true) < remaining
+            @log << "#{president.name} does not have enough liquidity to cover the bond shortfall"
+            @log << "#{president.name} sells all legally sellable shares, and is bankrupt"
+            president.shares_by_corporation(sorted: true).each do |c, _|
+              next unless (bundle = sellable_bundles(president, c).max_by(&:price))
+
+              price_before = bundle.shares.first.price
+              sell_shares_and_change_price(bundle)
+              moved_this_turn << bundle.corporation if price_before != bundle.shares.first.price
+            end
+            # president.cash is 0 after pres_pays; all cash here is from share sales
+            proceeds = president.cash
+            president.spend(proceeds, bank) if proceeds.positive?
+            return remaining - proceeds
+          end
+
+          @log << "#{corporation.name} still owes #{format_currency(remaining)} - emergency money raising required"
+          corporation.spend(remaining, bank, check_cash: false)
+          0
+        end
+
+        def complete_deferred_close
+          pending = closing_after_bond_repayment
+          return unless pending
+
+          corp = pending[:corp]
+          player = pending[:player]
+          corp.loans.clear
+          close_corporation(corp, quiet: pending[:quiet])
+          self.closing_after_bond_repayment = nil
+          reorder_corps
+          self.loan_choice_player = player if player&.shares&.empty?
         end
 
         def float_str(entity)

--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -451,9 +451,9 @@ module Engine
           bond_shortfall = 0
 
           if bonds? && corporation.loans.any?
-            bond_shortfall = repay_bond_on_close!(corporation)
+            bond_shortfall = leftover_bond_balance_on_close!(corporation)
             if corporation.cash.negative?
-              self.closing_after_bond_repayment = { corp: corporation, quiet: quiet, player: president }
+              @closing_after_bond_repayment = { corp: corporation, quiet: quiet, player: president }
               return
             end
             corporation.loans.clear
@@ -475,11 +475,11 @@ module Engine
           corporation.next_to_par = true if @corporations[index - 1].floated?
           update_garibaldi
 
-          self.loan_choice_player = president if bond_shortfall.positive? && president&.shares&.empty?
+          @loan_choice_player = president if bond_shortfall.positive? && president&.shares&.empty?
         end
 
         # Returns the unpaid amount (0 if fully repaid or EMR was triggered)
-        def repay_bond_on_close!(corporation)
+        def leftover_bond_balance_on_close!(corporation)
           owed = loan_value
           @log << "#{corporation.name} must repay its outstanding bond of #{format_currency(owed)}"
 
@@ -529,9 +529,9 @@ module Engine
           player = pending[:player]
           corp.loans.clear
           close_corporation(corp, quiet: pending[:quiet])
-          self.closing_after_bond_repayment = nil
+          @closing_after_bond_repayment = nil
           reorder_corps
-          self.loan_choice_player = player if player&.shares&.empty?
+          @loan_choice_player = player if player&.shares&.empty?
         end
 
         def float_str(entity)

--- a/lib/engine/game/g_1849/step/bankrupt.rb
+++ b/lib/engine/game/g_1849/step/bankrupt.rb
@@ -36,6 +36,9 @@ module Engine
             player.spend(player.cash, corp) if player.cash.positive?
             @game.close_corporation(corp)
 
+            # If bond repayment triggered EMR, post-close logic runs after EMR resolves
+            return if @game.closing_after_bond_repayment
+
             @game.reorder_corps
 
             # play continues if the player has any shares

--- a/lib/engine/game/g_1849/step/emergency_money_raising.rb
+++ b/lib/engine/game/g_1849/step/emergency_money_raising.rb
@@ -17,8 +17,9 @@ module Engine
             @active_entity = nil if @active_entity != cash_crisis_entity
             if !@active_entity && current == entity
               @active_entity = entity
+              reason = @game.closing_after_bond_repayment ? 'bond repayment' : 'loan interest'
               @game.log << "#{@active_entity.name} enters #{description} and owes"\
-                           " the bank #{@game.format_currency(needed_cash(@active_entity))} in loan interest"
+                           " the bank #{@game.format_currency(needed_cash(@active_entity))} in #{reason}"
             end
 
             actions = []
@@ -78,6 +79,7 @@ module Engine
             payee.spend(amount, debtor)
             @game.log << "#{payee.name} pays off #{debtor.name}'s debt of #{@game.format_currency(amount)}"
             @active_entity = nil
+            @game.complete_deferred_close
           end
 
           def process_sell_shares(action)
@@ -85,6 +87,7 @@ module Engine
             return if @active_entity.cash.negative?
 
             @active_entity = nil
+            @game.complete_deferred_close
           end
 
           # needed for bonds variant


### PR DESCRIPTION
Fixes #12486

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

the president should be on the hook for a bond when the corp can't pay it back on close. 

This fixes the issue. 

Will require pins for any games where this didn't happen, clearly.

### Screenshots

### Any Assumptions / Hacks
