### PR TITLE
[1880] Show capitalization status on corporation charter card

### DIFF
--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -536,11 +536,7 @@ module Engine
           status = ["Building Permits: #{corporation.building_permits}"]
           status << ["Presidency: #{corporation.presidents_percent}%"]
           if corporation.floated?
-            status << if corporation.fully_funded
-                        ['Capitalization: Full', 'bold']
-                      else
-                        ['Capitalization: Half', nil]
-                      end
+          status << ["Capitalization: #{corporation.fully_funded ? 'Full' : 'Half'}"] if corporation.floated?
           end
           status
         end

--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -535,6 +535,13 @@ module Engine
 
           status = ["Building Permits: #{corporation.building_permits}"]
           status << ["Presidency: #{corporation.presidents_percent}%"]
+          if corporation.floated?
+            status << if corporation.fully_funded
+                        ['Capitalization: Full', 'bold']
+                      else
+                        ['Capitalization: Half', nil]
+                      end
+          end
           status
         end
 

--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -535,9 +535,7 @@ module Engine
 
           status = ["Building Permits: #{corporation.building_permits}"]
           status << ["Presidency: #{corporation.presidents_percent}%"]
-          if corporation.floated?
           status << ["Capitalization: #{corporation.fully_funded ? 'Full' : 'Half'}"] if corporation.floated?
-          end
           status
         end
 


### PR DESCRIPTION
Corporations in 1880 receive capital in two tranches: 50% on float and the remaining 50% once 50% of shares have been sold. The charter card now displays "Capitalization: Half" or "Capitalization: Full" to make this status visible at a glance.

Fixes #12416 

<img width="1334" height="662" alt="image" src="https://github.com/user-attachments/assets/c268c61b-7570-411a-b663-12afaf238322" />


## Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
