### PR TITLE
[1817] Add link to 1817: Volatility Rules on Info tab

### DIFF
--- a/lib/engine/game/g_1817/meta.rb
+++ b/lib/engine/game/g_1817/meta.rb
@@ -16,7 +16,7 @@ module Engine
         GAME_PUBLISHER = :all_aboard_games
         GAME_RULES_URL = {
           'Rules' => 'https://cdn.shopify.com/s/files/1/0252/9371/7588/files/1817_Rules_v1.0_-_5_March_2015.pdf',
-          '1817: Volatility Rules' => 'https://boardgamegeek.com/filepage/233482/1817-volatility',
+          'Volatility Expansion Rules' => 'https://boardgamegeek.com/filepage/233482/1817-volatility',
         }.freeze
 
         PLAYER_RANGE = [3, 12].freeze

--- a/lib/engine/game/g_1817/meta.rb
+++ b/lib/engine/game/g_1817/meta.rb
@@ -14,7 +14,10 @@ module Engine
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1817'
         GAME_LOCATION = 'NYSE, USA'
         GAME_PUBLISHER = :all_aboard_games
-        GAME_RULES_URL = 'https://cdn.shopify.com/s/files/1/0252/9371/7588/files/1817_Rules_v1.0_-_5_March_2015.pdf'
+        GAME_RULES_URL = {
+          'Rules' => 'https://cdn.shopify.com/s/files/1/0252/9371/7588/files/1817_Rules_v1.0_-_5_March_2015.pdf',
+          '1817: Volatility Rules' => 'https://boardgamegeek.com/filepage/233482/1817-volatility',
+        }.freeze
 
         PLAYER_RANGE = [3, 12].freeze
         OPTIONAL_RULES = [


### PR DESCRIPTION
Fixes #12311


## Summary
- Adds a link to the 1817: Volatility Rules on the game Info tab, below the existing full rules link
- Converts `GAME_RULES_URL` from a single string to a Hash, using the existing multi-link rendering support already present in `game_meta.rb`

## Test plan
- [ ] Verify the Info tab for 1817 shows two rules links: "Rules" and "1817: Volatility Rules"
- [ ] Verify both links open the correct documents
- [ ] Rubocop: no offenses
- [ ] `rspec spec/lib/engine_spec.rb -e '1817'`: passes
- [ ] `rspec spec/lib/engine/game/fixtures_auto_actions_spec.rb -e '1817'`: passes

## Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [ ] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots
<img width="1154" height="1249" alt="image" src="https://github.com/user-attachments/assets/2f37db30-cccb-423d-b983-c1553182d59c" />

### Any Assumptions / Hacks
