### PR TITLE
[1817] disable corporate actions when owner has to sell shares

### DIFF
--- a/lib/engine/game/g_1817/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1817/step/buy_sell_par_shares.rb
@@ -17,7 +17,7 @@ module Engine
           MAX_BID = 400
 
           def actions(entity)
-            return corporate_actions(entity) if !entity.player? && entity.owned_by?(current_entity)
+            return corporate_actions(entity) if !entity.player? && entity.owned_by?(current_entity) && !must_sell?(current_entity)
 
             return [] unless entity.player?
 


### PR DESCRIPTION
Fixes #12510

I downloaded Kevin's game data, loaded it into a hotseat game and with my change, the Redeem button is gone and Kevin is forced to sell shares.