### PR TITLE
[core] [UI]  Add bankrupt player column

### DIFF
--- a/assets/app/view/game/entities.rb
+++ b/assets/app/view/game/entities.rb
@@ -10,13 +10,6 @@ module View
       needs :user
 
       def render
-        div_props = {
-          style: {
-            display: 'grid',
-            grid: 'auto / repeat(auto-fill, minmax(17rem, 1fr))',
-            gap: '3rem 1.2rem',
-          },
-        }
         players = @game.player_entities
         if (i = players.map(&:name).rindex(@user&.dig(:name)))
           players = players.rotate(i)
@@ -56,9 +49,33 @@ module View
           *extra_bank,
         ].compact)
 
-        children.concat(bankrupt_players.map { |p| h(:div, [h(Player, player: p, game: @game)]) })
+        grid = h(:div, {
+                   style: {
+                     display: 'grid',
+                     grid: 'auto / repeat(auto-fill, minmax(17rem, 1fr))',
+                     gap: '3rem 1.2rem',
+                     flex: '1',
+                     minWidth: '0',
+                   },
+                 }, children)
 
-        h('div#entities', div_props, children)
+        return h('div#entities', grid) if bankrupt_players.empty?
+
+        bankrupt_cards = bankrupt_players.map do |p|
+          h(:div, { style: { zoom: '0.5' } }, [h(Player, player: p, game: @game)])
+        end
+
+        bankrupt_col = h(:div, {
+                           style: {
+                             display: 'flex',
+                             flexDirection: 'column',
+                             gap: '0.5rem',
+                             flexShrink: '0',
+                             paddingLeft: '0.5rem',
+                           },
+                         }, bankrupt_cards)
+
+        h('div#entities', { style: { display: 'flex', alignItems: 'flex-start' } }, [grid, bankrupt_col])
       end
     end
   end

--- a/assets/app/view/game/entities.rb
+++ b/assets/app/view/game/entities.rb
@@ -49,17 +49,15 @@ module View
           *extra_bank,
         ].compact)
 
-        grid = h(:div, {
-                   style: {
-                     display: 'grid',
-                     grid: 'auto / repeat(auto-fill, minmax(17rem, 1fr))',
-                     gap: '3rem 1.2rem',
-                     flex: '1',
-                     minWidth: '0',
-                   },
-                 }, children)
+        grid_style = {
+          display: 'grid',
+          grid: 'auto / repeat(auto-fill, minmax(17rem, 1fr))',
+          gap: '3rem 1.2rem',
+        }
 
-        return h('div#entities', grid) if bankrupt_players.empty?
+        return h('div#entities', { style: grid_style }, children) if bankrupt_players.empty?
+
+        grid = h(:div, { style: grid_style.merge(flex: '1', minWidth: '0') }, children)
 
         bankrupt_cards = bankrupt_players.map do |p|
           h(:div, { style: { zoom: '0.5' } }, [h(Player, player: p, game: @game)])

--- a/assets/app/view/game/players.rb
+++ b/assets/app/view/game/players.rb
@@ -12,7 +12,23 @@ module View
           style: { margin: '1rem 0 1.5rem 0' },
         }
 
-        children = @game.player_entities.map { |p| h(Player, player: p, game: @game) }
+        all_players = @game.player_entities
+        active_players = all_players.reject(&:bankrupt)
+        bankrupt_players = all_players.select(&:bankrupt)
+
+        children = active_players.map { |p| h(Player, player: p, game: @game) }
+
+        unless bankrupt_players.empty?
+          bankrupt_col_props = {
+            style: {
+              display: 'inline-block',
+              verticalAlign: 'top',
+            },
+          }
+          bankrupt_children = bankrupt_players.map { |p| h(Player, player: p, game: @game, display: 'block') }
+          children << h(:div, bankrupt_col_props, bankrupt_children)
+        end
+
         active_step = @game.round.active_step
         children.unshift(h(Bank, game: @game)) if active_step.respond_to?(:seed_money) && active_step.seed_money
         h('div.players', props, children.compact)

--- a/assets/app/view/game/players.rb
+++ b/assets/app/view/game/players.rb
@@ -8,30 +8,31 @@ module View
       needs :game
 
       def render
-        props = {
-          style: { margin: '1rem 0 1.5rem 0' },
-        }
-
         all_players = @game.player_entities
         active_players = all_players.reject(&:bankrupt)
         bankrupt_players = all_players.select(&:bankrupt)
 
-        children = active_players.map { |p| h(Player, player: p, game: @game) }
-
-        unless bankrupt_players.empty?
-          bankrupt_col_props = {
-            style: {
-              display: 'inline-block',
-              verticalAlign: 'top',
-            },
-          }
-          bankrupt_children = bankrupt_players.map { |p| h(Player, player: p, game: @game, display: 'block') }
-          children << h(:div, bankrupt_col_props, bankrupt_children)
-        end
-
+        active_children = active_players.map { |p| h(Player, player: p, game: @game) }
         active_step = @game.round.active_step
-        children.unshift(h(Bank, game: @game)) if active_step.respond_to?(:seed_money) && active_step.seed_money
-        h('div.players', props, children.compact)
+        active_children.unshift(h(Bank, game: @game)) if active_step.respond_to?(:seed_money) && active_step.seed_money
+
+        outer_style = { margin: '1rem 0 1.5rem 0' }
+
+        return h('div.players', { style: outer_style }, active_children.compact) if bankrupt_players.empty?
+
+        bankrupt_cards = bankrupt_players.map { |p| h(:div, { style: { zoom: '0.5' } }, [h(Player, player: p, game: @game)]) }
+        bankrupt_col = h(:div, {
+                           style: {
+                             display: 'flex',
+                             flexDirection: 'column',
+                             gap: '0.5rem',
+                             flexShrink: '0',
+                             paddingLeft: '0.5rem',
+                           },
+                         }, bankrupt_cards)
+
+        h('div.players', { style: outer_style.merge(display: 'flex', alignItems: 'flex-start') },
+          [h(:div, { style: { flex: '1' } }, active_children.compact), bankrupt_col])
       end
     end
   end


### PR DESCRIPTION
Fixes #12059 

Title: Display bankrupt players in a column to save horizontal space

## Summary

- On the **Entities tab**, eliminated players are grouped into a single column on the right side of the layout rather than each occupying a separate column in the main grid. Cards are shown at 50% scale to minimize screen footprint while still showing relevant info.
- On the **Game tab**, bankrupt players appear in a 50%-scaled column to the right of the active players row, aligned to the same vertical position.
- When no players are bankrupt, both layouts are unchanged.

## Test plan

- [ ] Load a finished 1817 game with multiple eliminations and verify the Entities tab shows a compact column of scaled-down bankrupt player cards on the right, with active players and their corporations filling the main grid normally
- [ ] Verify the Game tab shows bankrupt players in a column to the right of the active player row at 50% scale
- [ ] Verify a game with no bankrupt players looks unchanged on both tabs
- [ ] Also ran rubocop and test suites.

## Implementation Notes

This seems like a decent way to handle those games that can generate multiple bankruptcies.  Won't matter for those games that end on bankruptcy of course, nor for low player-count games where there won't be more than 1 or 2 bankruptcies.  But for the 12-player 1817s that show up from time to time they'll probably like it.  I don't think it's a significant change to the UI, but it is a change so it would be worth a bit of thought as to whether we want to add this kind of feature or not.  I'll leave that to those at a higher pay grade than me! :-)

### Screenshots

This is the Entities tab of a 12-player 1817 game, with many bankrupts
<img width="3420" height="1266" alt="image" src="https://github.com/user-attachments/assets/a66a6522-5da2-4336-8055-efd30b861c42" />

This is the Entities tab of that same test game, early in the game with no bankrupts.
<img width="3439" height="1280" alt="image" src="https://github.com/user-attachments/assets/b7a019ee-0f6f-4b10-902f-b6e75f96043b" />


This is the Game tab of that same test game, showing the players listed at the bottom of the tab.
<img width="3396" height="1250" alt="image" src="https://github.com/user-attachments/assets/67b7a388-0f23-4235-8146-16f8a66096d0" />

This is the Game tab from that same game, early in the game with no bankrupts.
<img width="3423" height="1154" alt="image" src="https://github.com/user-attachments/assets/32e09e5b-d66f-45d9-803f-7fac6fb0b92e" />

### Any Assumptions / Hacks
