### PR TITLE
[1824] Improved bug fix for forced MR, fixes #12492

### DIFF
--- a/lib/engine/game/g_1824/step/forced_mountain_railway_exchange.rb
+++ b/lib/engine/game/g_1824/step/forced_mountain_railway_exchange.rb
@@ -78,7 +78,13 @@ module Engine
             bundle = action.bundle
 
             bundle.share_price = 0
-            @game.share_pool.buy_shares(player, bundle, exchange: company, exchange_price: 0)
+            @game.share_pool.buy_shares(
+              player,
+              bundle,
+              exchange: company,
+              exchange_price: 0,
+              allow_president_change: !bundle.corporation.par_price.nil?
+            )
             company.close!
             @game.forced_mountain_railway_exchange.shift
           end


### PR DESCRIPTION
If doing forced MR exchange, do not allow anyone to become president when exchanging unparred corporation

Fixes #12492 

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

Did validate all games in 1824 family on the somewhat dated database I had. 3 games broke, of which 2 already have been archived. It seems to only affect games where BH shares has been exchanged without par first, which is a pretty rare situation.

So I do expect only a handful games to break. These can be archived.

## Implementation Notes

Add check of president change allowed to forced MR exchange step in 1824.

### Explanation of Change

This is a remainder from fix #12317 as that only fixed exchange of MR during stock round, and the forced exchange during OR was not fixed. This PR do apply same change (not letting a player becoming president of a non-parred corporation) to the forced MR exchange step.

### Screenshots

N/A

### Any Assumptions / Hacks

N/A