### PR TITLE
[18SJ] Redeem textual clarification, fixes #12496

### DIFF
--- a/lib/engine/game/g_18_sj/game.rb
+++ b/lib/engine/game/g_18_sj/game.rb
@@ -51,9 +51,9 @@ module Engine
           endgame: 'Game end at end of current operating round',
           max_price: 'Double jump if double revenue if stock price is at least 90 kr',
           multiple_buy: 'Can buy more than one share in the corporation per turn, redeem all shares at no cost',
-          no_cert_limit: 'Corporation shares do not count towards cert limit, redeem one shares at half cost (rounded down)',
+          no_cert_limit: 'Corporation shares do not count towards cert limit, redeem one share at half cost (rounded down)',
           par: 'Available par values',
-          unlimited: 'Corporation shares can be held above 60%, redeem all shares at half cost (rounded down)',
+          unlimited: 'Corporation shares can be held above 60%, redeem all shares at half cost (rounded down per share)',
         ).freeze
 
         # New track must be usable, or upgrade city value


### PR DESCRIPTION
Fixes #12496

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

No affect on functionality, just text change in GUI

## Implementation Notes

Textual change that is shown in stock market

### Explanation of Change

See Issue

### Screenshots

<img width="939" height="777" alt="image" src="https://github.com/user-attachments/assets/6f22a100-d0e6-42b2-b585-d6373248f156" />

### Any Assumptions / Hacks

N/A