### PR TITLE
[18ESP] check if corporation reached destination after special tile lay

### DIFF
--- a/lib/engine/game/g_18_esp/step/special_track.rb
+++ b/lib/engine/game/g_18_esp/step/special_track.rb
@@ -9,6 +9,12 @@ module Engine
       module Step
         class SpecialTrack < Engine::Step::SpecialTrack
           include LayTileCheck
+
+          def process_lay_tile(action)
+            owner = action.entity.owner
+            super
+            owner.goal_reached!(:destination) if @game.check_for_destination_connection(owner)
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #11689

After a special track lay the check for the destination was just missing. Adding that check fixes the issue.

seems to work:
<img width="753" height="754" alt="image" src="https://github.com/user-attachments/assets/ccb8249e-77c6-4c0c-9b0b-ce69f1cf6f34" />
