### PR TITLE
[1822 Family] Remove extra slot created for destination token

### DIFF
--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -2088,6 +2088,12 @@ module Engine
                 token.price = self.class::TOKEN_PRICE
               end
             end
+
+            next unless corp_tokens_with_count.any? { |_, tc| tc.last > 1 }
+
+            # A token has been removed. Make sure we don't have an extra slot
+            # that was created for the destination token.
+            remove_cheater_slot!(city)
           end
         end
 
@@ -2237,6 +2243,21 @@ module Engine
           dest_hex = hex_by_id(corporation.destination_coordinates)
 
           "Destination: #{dest_hex.location_name} (#{dest_hex.name})"
+        end
+
+        # TODO: move this to City class
+        # If a city has had a slot added to accommodate a cheater token, and
+        # there is now an empty and unreserved slot in the city, move the
+        # cheater token to the empty slot and remove the extra slot.
+        def remove_cheater_slot!(city)
+          return unless city.slots > city.normal_slots
+
+          empty_slot = city.tokens.zip(city.reservations).index(&:none?)
+          return unless empty_slot
+
+          raise GameError, 'Cheater token not found' unless city.tokens.last.cheater
+
+          city.tokens[empty_slot] = city.tokens.pop
         end
 
         def setup_exchange_tokens


### PR DESCRIPTION
In 1822PNW a company can place its destination token in a city that had already been tokened by one of the minor companies used to form the major. There's a corner case where an extra slot is created for the destination token, but then the normal token is removed. If that happens then remove the slot that was added.

Fixes tobymao#12495.

This will require pins. At least seven 1822PNW games are broken by this, IDs 207908, 207939, 225621, 230518, 232085, 232730, 245335. In these games an unneeded slot was created for NP's destination token in Tahoma and later tokened by a different company.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`