### PR TITLE
[1840] Fix crash when all Y/O trains exhausted during CR1

### DIFF
--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -644,14 +644,7 @@ module Engine
 
         def available_trains
           index = [@cr_counter - 1, 0].max
-          trains = TRAIN_ORDER[index]
-
-          # Per rules VIII.5.3: if all Y and O trains are exhausted during CR1
-          # (the first tram-buying moment), R trains become available at 500
-          y_o_exhausted = @depot.upcoming.none? { |t| %w[Y1 O1].include?(t.name) }
-          trains = (trains + ['R1']).uniq if @cr_counter == 1 && y_o_exhausted
-
-          trains
+          TRAIN_ORDER[index]
         end
 
         def remove_obsolete_trains

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -644,7 +644,14 @@ module Engine
 
         def available_trains
           index = [@cr_counter - 1, 0].max
-          TRAIN_ORDER[index]
+          trains = TRAIN_ORDER[index]
+
+          # Per rules VIII.5.3: if all Y and O trains are exhausted during CR1
+          # (the first tram-buying moment), R trains become available at 500
+          y_o_exhausted = @depot.upcoming.none? { |t| %w[Y1 O1].include?(t.name) }
+          trains = (trains + ['R1']).uniq if @cr_counter == 1 && y_o_exhausted
+
+          trains
         end
 
         def remove_obsolete_trains

--- a/lib/engine/game/g_1840/meta.rb
+++ b/lib/engine/game/g_1840/meta.rb
@@ -13,7 +13,10 @@ module Engine
         GAME_LOCATION = 'Vienna, Austria'
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1840'
         GAME_PUBLISHER = :lonny_games
-        GAME_RULES_URL = 'https://www.lonny.at/app/download/10197449884/Rules_ENG_final-compr.pdf'
+        GAME_RULES_URL = {
+          'Rules' => 'https://www.lonny.at/app/download/10197449884/Rules_ENG_final-compr.pdf',
+          'FAQ' => 'https://boardgamegeek.com/filepage/226146/1840-faq',
+        }.freeze
 
         PLAYER_RANGE = [2, 6].freeze
 

--- a/lib/engine/game/g_1840/step/buy_train.rb
+++ b/lib/engine/game/g_1840/step/buy_train.rb
@@ -58,8 +58,10 @@ module Engine
 
           def cheapest_train_price(corporation)
             cheapest_train = buyable_trains(corporation).min_by(&:price)
-            cheapest_variant = buyable_train_variants(cheapest_train, corporation).first
-            cheapest_variant[:price]
+            return 0 unless cheapest_train
+
+            cheapest_variant = buyable_train_variants(cheapest_train, corporation).min_by { |v| v[:price] }
+            cheapest_variant ? cheapest_variant[:price] : 0
           end
 
           def process_buy_train(action)

--- a/lib/engine/game/g_1840/step/buy_train.rb
+++ b/lib/engine/game/g_1840/step/buy_train.rb
@@ -49,13 +49,13 @@ module Engine
 
           def can_buy_train?(entity = nil, _shell = nil)
             entity ||= current_entity
-            return false if @depot.depot_trains.none? { |t| buyable_train_variants(t, entity).any? }
+            return false unless buyable_depot_trains?(entity)
 
             super
           end
 
           def must_buy_train?(entity)
-            return false if @depot.depot_trains.none? { |t| buyable_train_variants(t, entity).any? }
+            return false unless buyable_depot_trains?(entity)
 
             scrappable_trains(entity).size.zero?
           end
@@ -63,7 +63,7 @@ module Engine
           def log_skip(entity)
             if !entity.minor? && entity.type != :city &&
                scrappable_trains(entity).empty? &&
-               @depot.depot_trains.none? { |t| buyable_train_variants(t, entity).any? }
+               !buyable_depot_trains?(entity)
               @log << "#{entity.name}'s obligation to own a tram is temporarily lifted, because no trams are available."
               return
             end
@@ -92,6 +92,12 @@ module Engine
           end
 
           def check_for_cheapest_train(train); end
+
+          private
+
+          def buyable_depot_trains?(entity)
+            @depot.depot_trains.any? { |t| !buyable_train_variants(t, entity).empty? }
+          end
         end
       end
     end

--- a/lib/engine/game/g_1840/step/buy_train.rb
+++ b/lib/engine/game/g_1840/step/buy_train.rb
@@ -47,8 +47,28 @@ module Engine
             @game.scrap_train(action.train, action.entity)
           end
 
+          def can_buy_train?(entity = nil, _shell = nil)
+            entity ||= current_entity
+            return false if @depot.depot_trains.none? { |t| buyable_train_variants(t, entity).any? }
+
+            super
+          end
+
           def must_buy_train?(entity)
+            return false if @depot.depot_trains.none? { |t| buyable_train_variants(t, entity).any? }
+
             scrappable_trains(entity).size.zero?
+          end
+
+          def log_skip(entity)
+            if !entity.minor? && entity.type != :city &&
+               scrappable_trains(entity).empty? &&
+               @depot.depot_trains.none? { |t| buyable_train_variants(t, entity).any? }
+              @log << "#{entity.name}'s obligation to own a tram is temporarily lifted, because no trams are available."
+              return
+            end
+
+            super
           end
 
           def must_take_player_loan?(corporation)
@@ -58,10 +78,8 @@ module Engine
 
           def cheapest_train_price(corporation)
             cheapest_train = buyable_trains(corporation).min_by(&:price)
-            return 0 unless cheapest_train
-
-            cheapest_variant = buyable_train_variants(cheapest_train, corporation).min_by { |v| v[:price] }
-            cheapest_variant ? cheapest_variant[:price] : 0
+            cheapest_variant = buyable_train_variants(cheapest_train, corporation).first
+            cheapest_variant[:price]
           end
 
           def process_buy_train(action)


### PR DESCRIPTION
When all Y and O trams are exhausted during the first CR (CR1), the game previously crashed because no trains were available to buy while corporations were still required to purchase one. Per rules VIII.5.3, R trains should become available at 500 in this case.

Also defensively fix cheapest_train_price to handle empty buyable_trains and empty variant lists, preventing a NoMethodError on nil.

Changes:
- `available_trains` now appends R1 to the available train list when
  in CR1 and all Y1/O1 trains are exhausted (per rules VIII.5.3)
- `cheapest_train_price` guards against nil when no buyable trains exist
- 
Fixes #12257

