### PR TITLE
[Core] Fix concession exchange log message word order

### DIFF
--- a/lib/engine/share_pool.rb
+++ b/lib/engine/share_pool.rb
@@ -81,9 +81,9 @@ module Engine
           unless silent
             @log << if exchange_price
                       "#{name} exchanges #{exchange.name} and #{@game.format_currency(price)}"\
-                        " from #{from} for #{share_str}"
+                        " for #{share_str} from #{from}"
                     else
-                      "#{name} exchanges #{exchange.name} from #{from} for #{share_str}"
+                      "#{name} exchanges #{exchange.name} for #{share_str} from #{from}"
                     end
           end
         end


### PR DESCRIPTION
Fixes #11327

Small change in the message based on reported bug. 

Move `#{from}` to the end of the exchange log message so it clearly describes where the received share comes from, not where the exchanged company/cash comes from.

Before: `Player exchanges Concession and $100 from the Treasury for a 10% share of Major`
After: `Player exchanges Concession and $100 for a 10% share of Major from the Treasury`

this also fits to the message when buying shares:

`Player buys a 10% share of Major from the Treasury for $100`



## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Remark regarding the reported bug #11327: `#{from}` in 1822 is filled with `ipo_name` which is defined in 1822 as "treasury" (fits to rulebook). But changing the word order makes it clearer.

Reference to rule book e.g. 1822CA

<img width="773" height="76" alt="image" src="https://github.com/user-attachments/assets/c4b0fe8d-46b2-4513-ad2e-d972d0fc05c7" />

### Screenshots

<img width="904" height="307" alt="image" src="https://github.com/user-attachments/assets/33b26423-3c76-4752-b80d-37cb40ce5d81" />

<br>

<img width="301" height="182" alt="image" src="https://github.com/user-attachments/assets/d23295fe-35f7-48b3-b060-b5c460b87842" />


### Any Assumptions / Hacks
