### PR TITLE
[1849] reorder corps after sell action, instead of at end of SR turn

### DIFF
--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -595,7 +595,8 @@ module Engine
 
         def reorder_corps
           just_moved = @moved_this_turn.uniq
-          @moved_this_turn = []
+          return unless just_moved.size > 1
+
           same_spot =
             @corporations
               .select(&:floated?)

--- a/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1849/step/buy_sell_par_shares.rb
@@ -15,7 +15,6 @@ module Engine
           def process_par(action)
             super
 
-            @game.moved_this_turn << action.corporation
             @log << "#{action.entity.name} may buy up to two additional shares."
           end
 
@@ -25,7 +24,7 @@ module Engine
             return unless price_before != action.bundle.shares.first.price
 
             @game.moved_this_turn << action.bundle.corporation
-            @moved_any = true
+            @game.reorder_corps
           end
 
           def pass!
@@ -34,12 +33,10 @@ module Engine
               @round.pass_order |= [current_entity]
               current_entity.pass!
             else
-              @game.reorder_corps if @moved_any
               @round.pass_order.delete(current_entity)
               current_entity.unpass!
             end
             @game.old_operating_order = @game.corporations.sort
-            @moved_any = false
           end
 
           def get_par_prices(entity, _corp)

--- a/lib/engine/game/g_1849/step/buy_train.rb
+++ b/lib/engine/game/g_1849/step/buy_train.rb
@@ -12,19 +12,13 @@ module Engine
             super
           end
 
-          def pass!
-            super
-            @game.reorder_corps if @moved_any
-            @moved_any = false
-          end
-
           def process_sell_shares(action)
             price_before = action.bundle.shares.first.price
             super
             return unless price_before != action.bundle.shares.first.price
 
             @game.moved_this_turn << action.bundle.corporation
-            @moved_any = true
+            @game.reorder_corps
           end
 
           def can_sell?(entity, bundle)


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

* `@moved_this_turn` is set to `[]` at the start of each player's SR turn, so it does not need to be set in `reorder_corps`
* if 3 or more corporations have shares sold and end on the same spot, `reorder_corps` will be called and possibly show up in the game log multiple times, keeping the order correct after each action
* Fixes #12421 - with tokens in the right order at the end of the sale action, floating a new corporation naturally puts its token in the right spot
