### PR TITLE
[18OE] - Trains updated to match physical components

### DIFF
--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -107,16 +107,16 @@ module Engine
         ].freeze
 
         TRAINS = [
-          # Level 2 — local only; rusts when first Level 4 train is bought
+          # Level 2 — yellow; rusts when first Level 4 train is bought
           {
             name: '2+2',
             distance: [{ 'nodes' => ['town'], 'pay' => 2, 'visit' => 99 },
                        { 'nodes' => %w[city offboard town], 'pay' => 2, 'visit' => 2 }],
             price: 100,
             rusts_on: '4',
-            num: 30,
+            num: 35,
           },
-          # Level 3 — express (3) triggers Phase 3; local variant (3+3); rust at Level 6
+          # Level 3 — green double-sided (3 / 3+3); rust at Level 6
           {
             name: '3',
             distance: [{ 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 },
@@ -130,23 +130,25 @@ module Engine
               price: 225,
               rusts_on: '6',
             }],
-            num: 20,
+            num: 24,
           },
-          # Level 4 — express (4) triggers Phase 4; local variant (4+4)
+          # Level 4 — green double-sided (4 / 4+4); rust at Level 8
           {
             name: '4',
             distance: [{ 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 },
                        { 'nodes' => %w[city offboard town], 'pay' => 4, 'visit' => 4 }],
             price: 300,
+            rusts_on: '8+8',
             variants: [{
               name: '4+4',
               distance: [{ 'nodes' => ['town'], 'pay' => 4, 'visit' => 99 },
                          { 'nodes' => %w[city offboard town], 'pay' => 4, 'visit' => 4 }],
               price: 350,
+              rusts_on: '8+8',
             }],
-            num: 10,
+            num: 14,
           },
-          # Level 5 — express (5) triggers Phase 5; local variant (5+5)
+          # Level 5 — brown double-sided (5 / 5+5); permanent
           {
             name: '5',
             distance: [{ 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 },
@@ -158,10 +160,10 @@ module Engine
                          { 'nodes' => %w[city offboard town], 'pay' => 5, 'visit' => 5 }],
               price: 475,
             }],
-            num: 8,
+            num: 11,
             events: [{ 'type' => 'consolidation_triggered' }],
           },
-          # Level 6 — express (6) triggers Phase 6; local variant (6+6)
+          # Level 6 — brown double-sided (6 / 6+6); permanent
           {
             name: '6',
             distance: [{ 'nodes' => ['town'], 'pay' => 0, 'visit' => 99 },
@@ -173,9 +175,9 @@ module Engine
                          { 'nodes' => %w[city offboard town], 'pay' => 6, 'visit' => 6 }],
               price: 600,
             }],
-            num: 6,
+            num: 9,
           },
-          # Level 7 — local (7+7) triggers Phase 7; diesel variant (4D)
+          # Level 7 — gray double-sided (7+7 / 4D); permanent
           # NOTE: Level 8 trains become available only after the 4th Level 7 purchase
           {
             name: '7+7',
@@ -188,9 +190,9 @@ module Engine
                          { 'nodes' => %w[city offboard], 'pay' => 4, 'visit' => 99 }],
               price: 850,
             }],
-            num: 14,
+            num: 17,
           },
-          # Level 8 — local (8+8) triggers Phase 8; diesel variant (5D)
+          # Level 8 — gray double-sided (8+8 / 5D); permanent
           {
             name: '8+8',
             distance: [{ 'nodes' => ['town'], 'pay' => 8, 'visit' => 99 },
@@ -202,7 +204,7 @@ module Engine
                          { 'nodes' => %w[city offboard], 'pay' => 5, 'visit' => 99 }],
               price: 1000,
             }],
-            num: 8,
+            num: 11,
           },
         ].freeze
 


### PR DESCRIPTION
                                                                                                                                                       
  Corrected train quantities and added missing rust trigger for level-4 trains and actual train prices:                                                                                 
                                                                                                                                                                
  | Train | Old qty | New qty |                                                                                                                                 
  |---|---|---|                                                                                                                                                 
  | 2+2 | 30 | 35 |                                                                                                                                             
  | 3 / 3+3 | 20 | 24 |
  | 4 / 4+4 | 10 | 14 |                                                                                                                                         
  | 5 / 5+5 | 8 | 11 |
  | 6 / 6+6 | 9 | 9 |                                                                                                                                           
  | 7+7 / 4D | 14 | 17 |                                                                                                                                        
  | 8+8 / 5D | 8 | 11 |
                                                                                                                                                                
  Each double-sided card entry shares a single `num`, correctly enforcing the physical                                                                          
  constraint that buying either side of a card consumes one card from the supply.                                                                               
                                                                                                                                                                
  Level-4 trains (`4` and `4+4`) were also missing `rusts_on: '8+8'`; this is now set.               