### PR TITLE
[18OE] Map update - everything - only Ports and hex-crossing-province-borders missing

### DIFF
--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -243,12 +243,12 @@ module Engine
 
         NATIONAL_REGION_HEXES = {
           # United Kingdom / Ireland
-          'UK' => %w[E24 E26 E28 F23 F25 F27 F29 G16 G18 G20 G24 G26 G28
+          'UK' => %w[D25 E24 E26 E28 F23 F25 F27 F29 G16 G18 G20 G24 G26 G28
                      H15 H17 H19 H21 H25 H27 H29 I14 I16 I18 I20 I26 I28
                      J13 J15 J17 J19 J23 J25 J27 J29 K22 K24 K26 K28 K30
                      L23 L25 L27 L29 L31 M22 M24 M26 M28 M30],
           # Scandinavia (Sweden / Norway / Denmark)
-          'SC' => %w[A42 A44 A46 A48 A50 A52 B43 B45 B47 B49 B51 B53 B55 B57
+          'SC' => %w[A42 A44 A46 A48 A50 A52 A54 A56 B41 B43 B45 B47 B49 B51 B53 B55 B57
                      C42 C44 C46 C48 C50 C52 C54 C56 C58 D41 D43 D45 D47 D49 D51 D53 D55 D57
                      E42 E44 E48 E50 E52 E54 E56 E58 F49 F51 F53 F55
                      G44 G46 G50 G52 G54 G56 H43 H45 H47 H51 H53 H55 I44 I46 I48 I50 I52],
@@ -261,7 +261,7 @@ module Engine
                      U22 U24 U26 U28 U30 U32 U34 U36 U38
                      V21 V23 V25 V27 V29 V31 V33 V35 V37
                      W22 W24 W26 W28 W30 W32 W34 W36 W38
-                     X25 X27 X29 X33 X35 X37 Y28 Z41],
+                     X25 X27 X29 X33 X35 X37 Y28 Z41 AF25],
           # Prussia / Holland / Switzerland
           'PHS' => %w[I64 J45 J47 J49 J63 J65 K40 K42 K44 K46 K48 K50 K54 K56 K58 K60 K62 K64
                       L37 L39 L41 L43 L45 L47 L49 L51 L53 L55 L57 L59 L61
@@ -285,33 +285,33 @@ module Engine
                      W38 W40 W42 W44 W46 W48 X43 X45 X47 X49 Y44 Y46 Y48 Y50
                      Z45 Z47 Z49 Z51 AA48 AA50 AA52 AA54
                      AB39 AB41 AB51 AB53 AB55 AB57 AC38 AC40 AC54 AC56 AC58
-                     AD39 AD55 AE52 AF49 AF51 AF53 AG50 AG52],
+                     AD39 AD55 AE52 AF49 AF51 AF53 AG40 AG50 AG52],
           # Spain / Portugal
           'SP' => %w[U6 U8 U10 U12 V5 V7 V9 V11 V13 V15 V17 V19
                      W6 W8 W10 W12 W14 W16 W18 W20 W22
                      X5 X7 X9 X11 X13 X15 X17 X19 X21 X23 X25
                      Y2 Y4 Y6 Y8 Y10 Y12 Y14 Y16 Y18 Y20 Y22 Y24 Y26 Y28
-                     Z3 Z5 Z7 Z9 Z11 Z13 Z15 Z17 Z19 Z21 Z23 Z25 Z27
+                     Z1 Z3 Z5 Z7 Z9 Z11 Z13 Z15 Z17 Z19 Z21 Z23 Z25 Z27
                      AA2 AA4 AA6 AA8 AA10 AA12 AA14 AA16 AA18 AA20 AA22
                      AB1 AB3 AB5 AB7 AB9 AB11 AB13 AB15 AB17 AB19
                      AC6 AC8 AC10 AC12 AC14 AC16 AC18 AC20
-                     AD5 AD7 AD9 AD11 AD13 AD15 AD17],
+                     AD1 AD5 AD7 AD9 AD11 AD13 AD15 AD17 AF5 AF11],
           # Russia
-          'RU' => %w[A66 A68 A70 A72 A74 B63 B65 B67 B69 B71 B73 B75 B77 B79 B81
+          'RU' => %w[A64 A66 A68 A70 A72 A74 B63 B65 B67 B69 B71 B73 B75 B77 B79 B81 B83
                      C64 C66 C72 C74 C76 C78 C80 C82 D67 D69 D71 D73 D75 D77 D79 D81 D83 D85
                      E66 E68 E70 E72 E74 E76 E78 E80 E82 E84 E86
-                     F69 F71 F73 F75 F77 F79 F81 F83 F85
-                     G64 G66 G68 G70 G72 G74 G76 G78 G80 G82 G84 G86
+                     F69 F71 F73 F75 F77 F79 F81 F83 F85 F87
+                     G64 G66 G68 G70 G72 G74 G76 G78 G80 G82 G84 G86 G88
                      H63 H65 H67 H69 H71 H73 H75 H77 H79 H81 H83 H85 H87
                      I64 I66 I68 I70 I72 I74 I76 I78 I80 I82 I84 I86
                      J67 J69 J71 J73 J75 J77 J79 J81 J83 J85 J87
                      K64 K66 K68 K70 K72 K74 K76 K78 K80 K82 K84 K86
                      L61 L63 L65 L67 L69 L71 L73 L75 L77 L79 L81 L83 L85 L87
                      M58 M60 M62 M64 M66 M68 M70 M72 M74 M76 M78 M80 M82 M84 M86
-                     N59 N61 N63 N65 N67 N69 N71 N73 N75 N77 N79 N81 N83 N85
+                     N59 N61 N63 N65 N67 N69 N71 N73 N75 N77 N79 N81 N83 N85 N87
                      O58 O60 O62 O64 O66 O68 O70 O72 O74 O76 O78 O80 O82 O84 O86
                      P73 P75 P77 P79 P81 P83 P85 P87 Q74 Q76 Q78 Q80 Q82 Q84 Q86
-                     R75 R77 R79 R81 R83 R85 R87 S76 S78 S80 S82 S84 S86 T79 T81 U80],
+                     R75 R77 R79 R81 R83 R85 R87 S76 S78 S80 S82 S84 S86 S88 T79 T81 T87 U80],
         }.freeze
 
         # Cities that sit on a national-zone border hex (hex listed in two zones).
@@ -672,7 +672,7 @@ module Engine
         end
 
         def metropolis_hex?(hex)
-          %w[A56 B41 C74 F87 K26 M28 M50 Q30 R55 Y14 AA82 BB51].include?(hex.name.to_s)
+          %w[A56 B41 C74 F87 K26 M28 M50 Q30 R55 Y14 AA82 AB51].include?(hex.name.to_s)
         end
 
         def metropolis_tile?(tile)
@@ -730,6 +730,8 @@ module Engine
             to.label.to_s.include?('B')
           when 'AA82'
             to.label.to_s.include?('C')
+          when 'AB51'
+            to.label.to_s.include?('N')
           when 'Q30'
             to.label.to_s.include?('P')
           when 'C74'

--- a/lib/engine/game/g_18_oe/map.rb
+++ b/lib/engine/game/g_18_oe/map.rb
@@ -258,18 +258,14 @@ module Engine
           # Constantinople
           'AA82' => 'Constantinople',
           # Red Offboard Locations
-          'A40' => 'Norwegian Coast (to Narvik)',
-          'A54' => 'North Sweden',
           'A56' => 'North Sweden',
+          'A64' => 'Finland',
           'B41' => 'Bergen',
           'B83' => 'Arkhangelsk',
           'D25' => 'Scottish Highlands',
-          'E88' => 'Moskva',
           'F87' => 'Moskva',
-          'G88' => 'Moskva',
           'N1' => 'New York',
           'N87' => 'Kharkov',
-          'S88' => 'Sevastopol',
           'T87' => 'Sevastopol',
           'AB87' => 'Levant',
           'AD1' => 'North Africa & The Americas',
@@ -278,7 +274,6 @@ module Engine
           'AF25' => 'Alger',
           'AG40' => 'Tunis',
           'AG88' => 'Alexandria & Suez',
-          'AH87' => 'Alexandria & Suez',
         }.freeze
 
         HEXES = {
@@ -290,31 +285,85 @@ module Engine
               F55 F69 F71 F75 F81 F83 F85 G16 G18 G20 G50 G52
               G54 G56 G70 G72 G76 G78 G80 G82 G86 H15 H19 H25
               H27 H43 H45 H53 H65 H67 H69 H75 H77 H79 H81 I14
-              I18 I28 I44 I64 I68 I74 I78 I82 J13 J19 J45 J67
-              J75 J79 J81 J83 J85 J87 K22 K24 K28 K30 K54 K56
-              K58 K70 K74 K76 K80 K82 K84 L27 L41 L45 L47 L49
-              L51 L55 L57 L59 L61 L63 L65 L67 L73 L81 L83 L85
-              M22 M24 M40 M42 M46 M52 M54 M58 M60 M64 M66 M70
-              M82 M84 M86 N37 N43 N47 N51 N53 N55 N57 N61 N63
-              N67 N85 O30 O32 O34 O36 O38 O48 O58 O60 O64 O66
-              O70 O72 O74 O76 O78 O84 O86 P21 P23 P25 P27 P31
-              P35 P39 P47 P49 P51 P59 P63 P65 P67 P71 P73 P75
-              P79 P81 Q22 Q24 Q28 Q32 Q34 Q36 Q42 Q44 Q48 Q54
-              Q58 Q66 Q74 Q76 Q78 Q80 Q82 Q86 R25 R27 R31 R33
-              R35 R37 R41 R43 R45 R49 R57 R63 R65 R73 R75 R77
-              R79 R81 R83 R85 S24 S26 S28 S30 S32 S36 S56 S58
-              S64 S66 S74 S80 S82 T25 T29 T31 T35 T55 T57 T59
-              T63 T65 U8 U22 U26 U28 U48 U50 U54 U58 U60 V7
-              V23 V25 V33 V43 V53 V57 V59 V61 V63 V71 V75 W10
-              W12 W14 W16 W26 W28 W30 W34 W48 W56 W58 W60 W62
-              W72 W78 X5 X9 X17 X21 X29 X43 X49 X75 X77 Y2
-              Y4 Y16 Y18 Y22 Y24 Y26 Y46 Y50 Y56 Y58 Y72 Y74
-              Y76 Z5 Z7 Z9 Z11 Z15 Z17 Z19 Z45 Z51 Z79 AA2
-              AA6 AA8 AA14 AA16 AA22 AA48 AA54 AA70 AA74 AA76 AA78 AA80
-              AB1 AB5 AB11 AB17 AB41 AB63 AC18 AC38 AC78 AC80 AC82 AC86
-              AD5 AD11 AD39 AD67 AD69 AD85 AD87 AE86 AF67 AF81 AF85 AG52
+              I18 I28 I64 I68 I74 I78 I82 J13 J19 J75 J79 J81
+              J83 J85 J87 K22 K24 K28 K30 K54 K56 K58 K70 K74
+              K76 K80 K82 K84 L27 L41 L45 L47 L49 L51 L55 L57
+              L61 L65 L67 L73 L81 L83 L85 M22 M24 M40 M42 M46
+              M52 M54 M58 M64 M66 M70 M82 M84 M86 N37 N43 N47
+              N51 N53 N55 N61 N63 N67 N85 O30 O32 O34 O36 O38
+              O48 O58 O74 O76 O78 O84 O86 P21 P23 P25 P27 P31
+              P35 P47 P49 P73 P75 P79 P81 Q22 Q24 Q28 Q32 Q34
+              Q36 Q42 Q44 Q48 Q54 Q58 Q66 Q74 Q76 Q78 Q80 Q82
+              Q86 R25 R27 R31 R33 R35 R37 R41 R43 R45 R57 R63
+              R65 R77 R79 R81 R83 R85 S24 S26 S28 S30 S32 S36
+              S56 S58 S64 S66 S80 S82 T25 T29 T31 T35 T55 T57
+              T59 T63 T65 U8 U22 U26 U28 U54 U58 U60 V7 V23
+              V25 V33 V43 V53 V57 V59 V61 V63 V71 V75 W10 W12
+              W14 W16 W26 W28 W30 W34 W48 W56 W58 W60 W62 W72
+              W78 X5 X9 X17 X21 X29 X43 X49 X75 X77 Y2 Y4
+              Y16 Y18 Y22 Y24 Y46 Y50 Y56 Y58 Y72 Y74 Y76 Z5
+              Z7 Z9 Z11 Z15 Z17 Z19 Z45 Z51 Z79 AA2 AA6 AA8
+              AA14 AA16 AA22 AA48 AA54 AA70 AA74 AA76 AA78 AA80 AB1 AB5
+              AB11 AB17 AB41 AB63 AC18 AC38 AC78 AC80 AC82 AC86 AD5 AD11
+              AD39 AD67 AD69 AD85 AD87 AE86 AF67 AF81 AF85 AG52
             ] => '',
 
+            # National zone province borders
+            ['I44'] => 'border=edge:5,type:province',
+            ['I66'] => 'town=revenue:0;border=edge:0,type:province',
+            ['J45'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['J65'] => 'upgrade=cost:30,terrain:water;border=edge:3,type:province;' \
+                       'border=edge:4,type:province;border=edge:5,type:province',
+            ['J67'] => 'border=edge:1,type:province',
+            ['K62'] => 'town=revenue:0;border=edge:5,type:province',
+            ['K66'] => 'upgrade=cost:30,terrain:water;border=edge:2,type:province',
+            ['L59'] => 'border=edge:5,type:province',
+            ['L63'] => 'border=edge:2,type:province',
+            ['M34'] => 'upgrade=cost:60,terrain:water;border=edge:0,type:province;border=edge:5,type:province',
+            ['M60'] => 'border=edge:2,type:province',
+            ['N33'] => 'town=revenue:0;border=edge:3,type:province',
+            ['N57'] => 'border=edge:4,type:province',
+            ['N59'] => 'town=revenue:0;border=edge:1,type:province',
+            ['O50'] => 'upgrade=cost:30,terrain:mountain;border=edge:5,type:province',
+            ['O56'] => 'city=revenue:0;border=edge:0,type:province;border=edge:5,type:province',
+            ['O60'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['O62'] => 'upgrade=cost:45,terrain:mountain;border=edge:0,type:province;border=edge:5,type:province',
+            ['O64'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['O66'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['O68'] => 'upgrade=cost:30,terrain:mountain;border=edge:0,type:province;border=edge:5,type:province',
+            ['O70'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['O72'] => 'border=edge:0,type:province',
+
+            ['P37'] => 'town=revenue:0;border=edge:4,type:province',
+            ['P39'] => 'border=edge:1,type:province',
+            ['P51'] => 'border=edge:2,type:province',
+            ['P55'] => 'upgrade=cost:45,terrain:mountain;border=edge:3,type:province',
+            ['P57'] => 'upgrade=cost:30,terrain:mountain;border=edge:2,type:province',
+            ['P59'] => 'border=edge:3,type:province',
+            ['P61'] => 'town=revenue:0;border=edge:2,type:province;border=edge:3,type:province',
+            ['P63'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['P65'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['P67'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['P69'] => 'city=revenue:0;border=edge:2,type:province;border=edge:3,type:province',
+            ['P71'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['R49'] => 'border=edge:5,type:province',
+            ['R73'] => 'border=edge:4,type:province',
+            ['R75'] => 'border=edge:0,type:province;border=edge:1,type:province',
+            ['S74'] => 'border=edge:3,type:province;border=edge:4,type:province',
+            ['S76'] => 'city=revenue:0;border=edge:0,type:province;border=edge:1,type:province',
+            ['T43'] => 'upgrade=cost:120,terrain:mountain;border=edge:4,type:province;border=edge:5,type:province',
+            ['T45'] => 'upgrade=cost:120,terrain:mountain;border=edge:0,type:province;' \
+                       'border=edge:1,type:province;border=edge:5,type:province',
+            ['T47'] => 'upgrade=cost:120,terrain:mountain;border=edge:0,type:province;border=edge:5,type:province',
+            ['T49'] => 'upgrade=cost:60,terrain:mountain;border=edge:0,type:province',
+            ['T75'] => 'upgrade=cost:45,terrain:water;border=edge:3,type:province',
+            ['U44'] => 'upgrade=cost:120,terrain:mountain;border=edge:2,type:province;border=edge:3,type:province',
+            ['U46'] => 'upgrade=cost:60,terrain:mountain;border=edge:2,type:province;border=edge:3,type:province',
+            ['U48'] => 'border=edge:2,type:province;border=edge:3,type:province;border=edge:4,type:province',
+            ['U50'] => 'border=edge:1,type:province',
+            ['W20'] => 'upgrade=cost:45,terrain:mountain;border=edge:3,type:province',
+            ['X23'] => 'upgrade=cost:120,terrain:mountain;border=edge:3,type:province',
+            ['Y26'] => 'border=edge:3,type:province',
             # Impassable borders (landtiles_with_borders.csv)
             # Scotland — Highlands barrier
             ['F27'] => 'town=revenue:0;border=edge:0,type:impassable;border=edge:5,type:impassable',
@@ -324,12 +373,17 @@ module Engine
             # England — coastal/estuary
             ['L31'] => 'border=edge:0,type:impassable',
             # Channel Islands
-            ['M30'] => 'border=edge:3,type:impassable;border=edge:5,type:impassable;upgrade=cost:45,terrain:water',
+            ['M30'] => 'border=edge:3,type:impassable;border=edge:5,type:impassable;' \
+                       'upgrade=cost:45,terrain:water',
             # Franco-Belgian border
-            ['N31'] => 'city=revenue:20;label=Y;path=a:1,b:_0;border=edge:2,type:impassable',
+            ['N31'] => 'city=revenue:0;label=Y;border=edge:2,type:impassable;path=a:1,b:_0',
             # Pyrenees
             ['V19'] => 'border=edge:4,type:impassable;upgrade=cost:30,terrain:mountain',
-            ['V21'] => 'town=revenue:0;border=edge:1,type:impassable',
+            ['V21'] => 'town=revenue:0;border=edge:1,type:impassable;border=edge:0,type:province',
+            ['W22'] => 'upgrade=cost:120,terrain:mountain',
+            ['W24'] => 'upgrade=cost:60,terrain:mountain;border=edge:0,type:province',
+            ['X27'] => 'upgrade=cost:60,terrain:mountain;border=edge:0,type:province',
+            ['Y28'] => 'upgrade=cost:45,terrain:mountain',
             # Kattegat / Danish straits
             ['K40'] => 'border=edge:4,type:impassable;upgrade=cost:60,terrain:water',
             ['K42'] => 'border=edge:1,type:impassable;upgrade=cost:30,terrain:water',
@@ -337,19 +391,19 @@ module Engine
             ['AC56'] => 'border=edge:4,type:impassable',
             ['AC58'] => 'border=edge:1,type:impassable',
             # Skagerrak / Norwegian coast
-            ['I46'] => 'town=revenue:0;town=revenue:0;border=edge:5,type:impassable',
-            ['I48'] => 'border=edge:0,type:impassable;upgrade=cost:45,terrain:water',
+            ['I46'] => 'town=revenue:0;border=edge:5,type:impassable;border=edge:0,type:province',
             ['J47'] => 'border=edge:2,type:impassable;border=edge:3,type:impassable;' \
                        'border=edge:4,type:impassable;border=edge:5,type:impassable;upgrade=cost:60,terrain:water',
             ['J49'] => 'border=edge:0,type:impassable;border=edge:1,type:impassable;' \
+                       'border=edge:2,type:province;border=edge:3,type:province;' \
                        'border=edge:5,type:impassable;upgrade=cost:60,terrain:water',
             ['K48'] => 'border=edge:2,type:impassable;border=edge:3,type:impassable',
             ['K50'] => 'border=edge:2,type:impassable',
             # North Sea — Danish coast
-            ['D47'] => 'town=revenue:0;town=revenue:0;border=edge:4,type:impassable;border=edge:5,type:impassable',
+            ['D47'] => 'town=revenue:0;border=edge:4,type:impassable;border=edge:5,type:impassable',
             ['D49'] => 'border=edge:1,type:impassable',
-            ['D51'] => 'town=revenue:0;town=revenue:0;border=edge:5,type:impassable;upgrade=cost:30,terrain:water',
-            ['D53'] => 'town=revenue:0;town=revenue:0;border=edge:0,type:impassable;upgrade=cost:30,terrain:water',
+            ['D51'] => 'town=revenue:0;border=edge:5,type:impassable;upgrade=cost:30,terrain:water',
+            ['D53'] => 'town=revenue:0;border=edge:0,type:impassable;upgrade=cost:30,terrain:water',
             ['E52'] => 'border=edge:2,type:impassable;border=edge:3,type:impassable;upgrade=cost:45,terrain:water',
             # Baltic — Gulf of Bothnia entry
             ['C66'] => 'border=edge:5,type:impassable',
@@ -362,14 +416,15 @@ module Engine
             ['C72'] => 'border=edge:2,type:impassable;border=edge:3,type:impassable;upgrade=cost:30,terrain:water',
 
             # Towns — no terrain
-            %w[H17 H29 J17 L29 N33 O24 P19 P29 P33 P37 R29 S34 T27 X35 X37 Z41
-               V5 W18 X11 Z3 Z13 Z25 AA4 AB3 AC10 AC12 AC20 AD15
-               K60 K62 L43 M48 M56 P43 P61 Q56 Q72
-               R53 R59 R67 S40 S68 T61 U56 U62 X55
-               V45 V47 Y44 AA52 AB39 AB55
-               C64 D69 D75 D83 E70 F73 G84 H71 H85
-               I66 I80 K68 L79 L87 N59 N65 N83 Q84
-               V73 W70 AA84 AC68 AC84 AG68 AF87] => 'town=revenue:0',
+            %w[
+              E44 F53 H17 H29 J17 L29 O24 P19 P29 P33 R29 S34
+              T27 X35 X37 Z41 V5 W18 X11 Z3 Z13 Z25 AA4 AB3
+              AC10 AC12 AC20 AD15 K60 L43 M48 M56 P43 Q56 Q72 R53
+              R59 R67 S40 S68 T61 U56 U62 X55 V45 V47 Y44 AA52
+              AB39 AB55 C64 D69 D75 D83 E70 F73 G84 H71 H85 I80
+              K68 L79 L87 N65 N83 Q84 V73 W70 AA84 AC68 AC84 AG68
+              AF87 G46 H51 H55
+            ] => 'town=revenue:0',
             # Towns — mountain terrain
             %w[G24 I16 I26 U12 V15 AD13] => 'town=revenue:0;upgrade=cost:30,terrain:mountain',
             %w[E26 E28 J23] => 'town=revenue:0;upgrade=cost:45,terrain:mountain',
@@ -378,25 +433,28 @@ module Engine
             %w[L23 AD7] => 'town=revenue:0;upgrade=cost:45,terrain:water',
             # Double towns
             %w[J29 M26 W32
-               C58 E44 F53 G46 H51 H55
+               C58
                N41 Q46 U64 W46 AF53
                J77 P77
                AC6 U6] => 'town=revenue:0;town=revenue:0',
             ['T37'] => 'town=revenue:0;town=revenue:0;upgrade=cost:45,terrain:mountain',
             # Cities — no label, no terrain
-            %w[ H21 J15 L25 Q26 Q38 R23 V27
-                C48 F49 L53 N49 J73 AD17
-                V17 W6 X13 Y20 AA20 AC8 AC16 AB27] => 'city=revenue:0',
+            %w[
+              F25 H21 J15 L25 Q26 Q38 R23 V27 F49 L53 N49
+              J73 AD17 V17 W6 X13 Y20 AA20 AC8 AC16 AB27
+            ] => 'city=revenue:0',
+            ['C48'] => 'city=revenue:10',
             # Cities — no terrain (added station geometry)
-            %w[ AA62 AB57 AB69 AC40 AD79
-                AE72 AF49 B67 D77 E56 G68 H47 H63 H87 I76 J69 K78
-                K86 M44 M68
-                O56 P69 S76 S78 T53 T81
-                V39 V51 V55 W40 W64
-                Y70] => 'city=revenue:0',
+            %w[
+              AA62 AB57 AB69 AC40 AD79 AF49 B67 D77 E56 G68 H47 H63
+              H87 I76 J69 K78 K86 M44 M68 S78 T53 T81 V51
+              V55 W40 W64 Y70
+            ] => 'city=revenue:0',
+            ['V39'] => 'city=revenue:30',
             # Cities — label Y
             ['U34'] => 'city=revenue:0;label=Y',
-            ['N35'] => 'city=revenue:0;label=Y;upgrade=cost:30,terrain:water',
+            ['N35'] => 'city=revenue:0;label=Y;upgrade=cost:30,terrain:water;' \
+                       'border=edge:2,type:province;border=edge:3,type:province',
             # Cities — other labels
             ['K26'] => 'city=revenue:0;label=A',
             ['Q30'] => 'city=revenue:0;label=P',
@@ -405,18 +463,15 @@ module Engine
             ['U32'] => 'city=revenue:0;upgrade=cost:30,terrain:mountain',
             ['AD9'] => 'city=revenue:0;upgrade=cost:30,terrain:mountain',
             ['D57'] => 'city=revenue:0;upgrade=cost:30,terrain:water',
-            ['I50'] => 'city=revenue:0;label=Y;upgrade=cost:45,terrain:water',
-            ['AA82'] => 'city=revenue:20;city=revenue:20;upgrade=cost:45,terrain:water;label=C',
-            # Cities — pre-printed revenue
+            ['AA82'] => 'city=revenue:20;city=revenue:20;upgrade=cost:45,terrain:water;label=C;path=a:2,b:_0',
             ['U24'] => 'city=revenue:10',
             ['I20'] => 'city=revenue:10;path=a:4,b:_0',
-            ['O28'] => 'city=revenue:10;path=a:_0,b:1',
+            ['O28'] => 'city=revenue:0;path=a:1,b:_0',
             ['M28'] => 'city=revenue:30;label=L;upgrade=cost:30,terrain:water;path=a:5,b:_0',
-            ['X33'] => 'city=revenue:20;label=Y;path=a:_0,b:5',
+            ['X33'] => 'city=revenue:20;label=Y;path=a:5,b:_0',
 
-            ['F25'] => 'city=revenue:0;label=Y',
-            ['Z27'] => 'city=revenue:0;label=Y',
-            ['K46'] => 'city=revenue:0;label=Y',
+            ['Z27'] => 'city=revenue:20;label=Y',
+            ['K46'] => 'city=revenue:20;label=Y',
             ['M50'] => 'city=revenue:0;label=B',
             ['R47'] => 'city=revenue:0;label=Y',
             ['R55'] => 'city=revenue:0;label=A',
@@ -424,19 +479,18 @@ module Engine
             ['P53'] => 'city=revenue:0;label=Y',
             ['V41'] => 'city=revenue:0;label=Y',
             ['Z47'] => 'city=revenue:0;label=Y',
-            ['AB51'] => 'city=revenue:0;label=N',
-            ['C74'] => 'city=revenue:0;label=S',
+            ['AB51'] => 'city=revenue:20;label=N',
+            ['C74'] => 'city=revenue:20;label=S',
             ['M62'] => 'city=revenue:0;label=Y',
             ['O80'] => 'city=revenue:0;label=Y',
             # Cities — water terrain
             ['AE68'] => 'town=revenue:0;upgrade=cost:30,terrain:water',
-            ['D41'] => 'town=revenue:0;town=revenue:0;upgrade=cost:45,terrain:water',
+            ['D41'] => 'town=revenue:0;upgrade=cost:45,terrain:water',
             ['D81'] => 'town=revenue:0;upgrade=cost:30,terrain:water',
             ['I52'] => 'city=revenue:0;upgrade=cost:45,terrain:water',
             ['J63'] => 'city=revenue:0;label=Y;upgrade=cost:30,terrain:water',
-            ['L37'] => 'city=revenue:0;label=Y;upgrade=cost:45,terrain:water',
             ['L39'] => 'town=revenue:0;town=revenue:0;upgrade=cost:30,terrain:water',
-            ['M36'] => 'city=revenue:0;upgrade=cost:30,terrain:water',
+            ['M36'] => 'city=revenue:0;upgrade=cost:30,terrain:water;border=edge:0,type:province',
             ['M38'] => 'town=revenue:0;upgrade=cost:30,terrain:water',
             ['M72'] => 'town=revenue:0;upgrade=cost:30,terrain:water',
             ['O40'] => 'city=revenue:0;label=Y;upgrade=cost:30,terrain:water',
@@ -455,7 +509,7 @@ module Engine
             ['Q52'] => 'town=revenue:0;upgrade=cost:45,terrain:mountain',
             ['S42'] => 'city=revenue:0;upgrade=cost:30,terrain:mountain',
             ['S46'] => 'town=revenue:0;upgrade=cost:60,terrain:mountain',
-            ['S50'] => 'city=revenue:0;upgrade=cost:30,terrain:mountain',
+            ['S50'] => 'city=revenue:0;upgrade=cost:30,terrain:mountain;border=edge:2,type:province',
             ['T39'] => 'town=revenue:0;upgrade=cost:120,terrain:mountain',
             ['T69'] => 'city=revenue:0;upgrade=cost:30,terrain:mountain',
             ['U52'] => 'town=revenue:0;upgrade=cost:45,terrain:mountain',
@@ -468,130 +522,420 @@ module Engine
 
             # Terrain — water
             ['E78'] => 'upgrade=cost:5,terrain:water',
-            %w[C50 C52 E82 F77 F79 G64 G66 G74 H73 I70 I72 J65 K64 K66 L69 L71 L75 L77 M74 M76 M78 M80
-               N39 N69 N71 N73 N75 N77 N79 P41 P83 P87 Q50 R87
-               V77 W76 X69 X71 X73 Y78 Z77 Z23 AE70] => 'upgrade=cost:30,terrain:water',
-            %w[A72 A74 C42 C76 E50 E54 E72 G44
-               K44 N81 O82 Q20
-               T75 T77 T79 U76 V79
-               AB71 AE52] => 'upgrade=cost:45,terrain:water',
-            %w[B81 C82 M34 T23 AB77 AC76 AD71 AG70] => 'upgrade=cost:60,terrain:water',
+            %w[
+              C50 C52 E82 F77 F79 G64 G66 G74 H73 I70 I72 K64
+              L69 L71 L75 L77 M74 M76 M78 M80 N39 N69 N71 N73
+              N75 N77 N79 P41 P83 P87 Q50 R87 V77 W76 X69 X71
+              X73 Y78 Z77 Z23 AE70
+            ] => 'upgrade=cost:30,terrain:water',
+            %w[
+              A72 A74 C42 C76 E50 E54 E72 G44 K44 N81 O82 Q20
+              T77 T79 U76 V79 AB71 AE52
+            ] => 'upgrade=cost:45,terrain:water',
+            %w[
+              B81 C82 T23 AB77 AC76 AD71 AG70
+            ] => 'upgrade=cost:60,terrain:water',
 
             # Terrain — mountain
-            %w[B51 B53 H83 I84 I86 J71 K72
-               O46 O50 O68 P45 P57
-               Q70 R39 S62 S70
-               T33 U10
-               W54 X65
-               Z63 Z69 Z75 AA68
-               AB13 AB53 AC66 AD65 AF69 AG50] => 'upgrade=cost:30,terrain:mountain',
-            %w[A48 A50 A52 N45 O42 O44 O62 P55 Q60 Q62 Q64 Q68 R51 R61 R69
-               S38 S44 S48 T67 T71 T73
-               U30 U66 U74
-               V9 V13 V29 V35 V65 V69
-               W20 W36 W42 W44 W68 X7 X15 X47 X57 X61 X63 X67
-               Y6 Y28 Y48 Y62 Y68
-               Z21 Z49 Z61 Z65 Z71
-               AA10 AA12 AA18 AA50 AA64 AA72
-               AB7 AB9 AB19 AB65 AB67 AC14 AC54 AD55 AD81 AD83 AE80 AF83] => 'upgrade=cost:45,terrain:mountain',
-            %w[A44 A46 C44 D43
-               O54 R71 S52 S54 S72
-               T49 T51 U36 U40 U42 U46
-               U68 U70 V11 V31 V37 V67
-               W8 W24 W38 W66
-               X19 X27 Y8 Y10 Y12 Y60 Z67
-               AA66 AA86
-               AB15 AB85 AE82 AE84 AF51] => 'upgrade=cost:60,terrain:mountain',
-            %w[B45 T41 T43 T45 T47 U38 U44 W22 X23] => 'upgrade=cost:120,terrain:mountain',
+            %w[
+              B51 B53 H83 I84 I86 J71 K72 O46 P45 Q70 R39 S62
+              S70 T33 U10 W54 X65 Z63 Z69 Z75 AA68 AB13 AB53 AC66
+              AD65 AF69 AG50
+            ] => 'upgrade=cost:30,terrain:mountain',
+            %w[
+              A48 A50 A52 N45 O42 O44 Q60 Q62 Q64 Q68 R51 R61
+              R69 S38 S44 S48 T67 T71 T73 U30 U66 U74 V9 V13
+              V29 V35 V65 V69 W36 W42 W44 W68 X7 X15 X47 X57
+              X61 X63 X67 Y6 Y48 Y62 Y68 Z21 Z49 Z61 Z65 Z71
+              AA10 AA12 AA18 AA50 AA64 AA72 AB7 AB9 AB19 AB65 AB67 AC14
+              AC54 AD55 AD81 AD83 AE80 AF83
+            ] => 'upgrade=cost:45,terrain:mountain',
+            %w[
+              A44 A46 C44 D43 O54 R71 S52 S54 S72 T51 U36 U40
+              U42 U68 U70 V11 V31 V37 V67 W8 W38 W66 X19 Y8
+              Y10 Y12 Y60 Z67 AA66 AA86 AB15 AB85 AE82 AE84 AF51
+            ] => 'upgrade=cost:60,terrain:mountain',
+            %w[
+              B45 T41 U38
+            ] => 'upgrade=cost:120,terrain:mountain',
           },
           yellow: {
+            ['L37'] => 'city=revenue:30;label=Y;upgrade=cost:45,terrain:water;path=a:0,b:_0;path=a:_0,b:5',
+            ['I48'] => 'border=edge:0,type:impassable;upgrade=cost:45,terrain:water;path=a:2,b:4;' \
+                       'border=edge:5,type:province',
+            ['I50'] => 'city=revenue:30;label=Y;upgrade=cost:45,terrain:water;path=a:1,b:_0;' \
+                       'path=a:_0,b:3;border=edge:0,type:province',
             ['J25'] => 'city=revenue:30;label=Y;path=a:2,b:_0;path=a:_0,b:4',
             ['J27'] => 'city=revenue:20;upgrade=cost:30,terrain:mountain;path=a:1,b:_0;path=a:_0,b:4',
+            ['AE72'] => 'city=revenue:20;path=a:1,b:_0;path=a:5,b:_0',
+          },
+          gray: {
+            # North Sweden approach
+            ['A54'] => 'path=a:1,b:4',
+            # Moskva approach
+            ['G88'] => 'path=a:0,b:2',
+            # Sevastopol approach
+            ['S88'] => 'path=a:0,b:1',
           },
           red: {
-            ['D25'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Scottish Highlands
-            ['A40'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Norwegian Coast (to Narvik)
-            ['B41'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Bergen
-            ['A54'] => 'offboard=revenue:0;path=a:0,b:_0',                          # North Sweden
-            ['A56'] => 'offboard=revenue:0;path=a:0,b:_0',                          # North Sweden
-            ['B83'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Arkhangelsk
-            ['E88'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Moskva
-            ['F87'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Moskva
-            ['G88'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Moskva
-            ['N1'] => 'offboard=revenue:0;path=a:0,b:_0', # New York
-            ['N87'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Kharkov
-            ['S88'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Sevastopol
-            ['T87'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Sevastopol
-            ['Z1'] => 'offboard=revenue:0;city=revenue:0;city=revenue:0;path=a:0,b:_0', # Lisboa (2 station slots; RCP home)
-            ['AB87'] => 'offboard=revenue:0;path=a:0,b:_0', # Levant
-            ['AD1'] => 'offboard=revenue:0;path=a:0,b:_0',                          # North Africa & The Americas
-            ['AF5'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Casablanca
-            ['AF11'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Melilla
-            ['AF25'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Alger
-            ['AG40'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Tunis
-            ['AG88'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Alexandria & Suez
-            ['AH87'] => 'offboard=revenue:0;path=a:0,b:_0',                          # Alexandria & Suez
+            ['D25'] => 'offboard=revenue:yellow_20|green_40|brown_50|gray_50;path=a:0,b:_0;path=a:5,b:_0', # Scottish Highlands
+            # North Sweden
+            ['A56'] => 'offboard=revenue:yellow_30|green_50|brown_80|gray_100;' \
+                       'city=revenue:0,slots:2;path=a:1,b:_0;path=a:_0,b:0;path=a:_0,b:4;path=a:_0,b:5',
+            # Finland
+            ['A64'] => 'offboard=revenue:yellow_30|green_40|brown_60|gray_80;' \
+                       'city=revenue:0,slots:2;path=a:0,b:_0;path=a:_0,b:1;path=a:_0,b:4',
+            # Bergen
+            ['B41'] => 'offboard=revenue:yellow_30|green_60|brown_80|gray_120;' \
+                       'city=revenue:0,slots:2;path=a:1,b:_0;path=a:_0,b:3;path=a:_0,b:4',
+            ['B83'] => 'offboard=revenue:yellow_30|green_50|brown_60|gray_60', # Arkhangelsk — no path defined
+            # Moskva
+            ['F87'] => 'offboard=revenue:yellow_30|green_50|brown_80|gray_100;' \
+                       'city=revenue:0,slots:3;path=a:0,b:_0;path=a:_0,b:1;path=a:_0,b:2;path=a:_0,b:5',
+            ['N1'] => 'offboard=revenue:green_60|brown_100|gray_160;path=a:5,b:_0', # New York
+            # Kharkov
+            ['N87'] => 'offboard=revenue:yellow_30|green_40|brown_60|gray_80;' \
+                       'city=revenue:0,slots:2;path=a:0,b:_0;path=a:_0,b:1;path=a:_0,b:2',
+            # Sevastopol
+            ['T87'] => 'offboard=revenue:yellow_30|green_40|brown_60|gray_80;' \
+                       'city=revenue:0,slots:2;path=a:0,b:_0;path=a:_0,b:3;border=edge:5,type:province',
+            # Lisboa (2 station slots; RCP home)
+            ['Z1'] => 'offboard=revenue:yellow_30|green_40|brown_60|gray_80;' \
+                      'city=revenue:0,slots:2;path=a:3,b:_0;path=a:_0,b:4',
+            ['AB87'] => 'offboard=revenue:yellow_30|green_50|brown_80|gray_120;path=a:1,b:_0;path=a:2,b:_0', # Levant
+            ['AD1'] => 'offboard=revenue:green_40|brown_80|gray_120;path=a:4,b:_0', # North Africa & The Americas
+            ['AF5'] => 'offboard=revenue:yellow_30|green_40|brown_60|gray_80;path=a:3,b:_0', # Casablanca
+            ['AF11'] => 'offboard=revenue:yellow_30|green_40|brown_40|gray_40;path=a:4,b:_0', # Melilla
+            ['AF25'] => 'offboard=revenue:yellow_30|green_40|brown_60|gray_100;path=a:2,b:_0;path=a:3,b:_0;' \
+                        'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province', # Alger
+            ['AG40'] => 'offboard=revenue:yellow_30|green_40|brown_50|gray_80;path=a:3,b:_0;path=a:4,b:_0;' \
+                        'border=edge:0,type:province;border=edge:1,type:province', # Tunis
+            ['AG88'] => 'offboard=revenue:green_50|brown_80|gray_120;path=a:1,b:_0', # Alexandria & Suez
           },
           blue: {
             %w[
-              A0 A2 A4 A6 A8 A10 A12 A14 A16 A18 A20 A22
-              A24 A26 A28 A30 A32 A34 A36 A38 A58 A60 A62 A64
-              B1 B3 B5 B7 B9
-              B11 B13 B15 B17 B19 B21 B23 B25 B27 B29 B31 B33
-              B35 B37 B39 B59 B61 C0 C2 C4 C6 C8
-              C10 C12 C14 C16 C18 C20 C22 C24 C26 C28 C30 C32
-              C34 C36 C38 C40 C60 C62 C68 C70 D1
-              D3 D5 D7 D9 D11 D13 D15 D17 D19 D21 D23 D27
-              D29 D31 D33 D35 D37 D39 D59 D61 D63 D65 E0
-              E2 E4 E6 E8 E10 E12 E14 E16 E18 E20 E22 E30
-              E32 E34 E36 E38 E40 E46 E60 E62 E64 F1 F3 F5
-              F7 F9 F11 F13 F15 F17 F19 F21 F31 F33 F35 F37
-              F39 F41 F43 F45 F47 F57 F59 F61 F63 F65 F67 G0
-              G2 G4 G6 G8 G10 G12 G14 G22 G30 G32 G34 G36
-              G38 G40 G42 G48 G58 G60 G62 H1 H3 H5 H7 H9
-              H11 H13 H23 H31 H33 H35 H37 H39 H41 H49 H57 H59
-              H61 I0 I2 I4 I6 I8 I10 I12 I22 I24 I30 I32
-              I34 I36 I38 I40 I42 I54 I56 I58 I60 I62 J1
-              J3 J5 J7 J9 J11 J21 J31 J33 J35 J37 J39 J41
-              J43 J51 J53 J55 J57 J59 J61 K0 K2 K4 K6 K8
-              K10 K12 K14 K16 K18 K20 K32 K34 K36 K38 K52
-              L1 L3 L5 L7 L9 L11 L13 L15 L17 L19 L21 L33
-              L35 M0 M2 M4 M6 M8 M10 M12 M14 M16 M18 M20
-              M32 N3 N5 N7 N9 N11 N13 N15 N17 N19 N21
-              N23 N25 N27 N29 O0 O2 O4 O6 O8 O10 O12 O14
-              O16 O18 O20 O22 O26 P1 P3 P5 P7 P9 P11
-              P13 P15 P17 Q0 Q2 Q4 Q6 Q8 Q10 Q12 Q14 Q16
-              Q18 R1 R3 R5 R7 R9 R11 R13 R15 R17 R19
-              R21 S0 S2 S4 S6 S8 S10 S12 S14 S16 S18 S20
-              S22 T1 T3 T5 T7 T9 T11 T13 T15 T17 T19 T21
-              T83 T85 U0 U2 U4 U14 U16 U18 U20 U82 U84 U86
-              U88 V1 V3 V49 V81 V83 V85 V87 W0 W2 W4 W50
-              W52 W80 W82 W84 W86 W88 X1 X3 X31 X39 X41 X51
-              X53 X79 X81 X83 X85 X87 Y0 Y30 Y32 Y34 Y36 Y38
-              Y40 Y42 Y52 Y54 Y80 Y82 Y84 Y86 Y88 Z29 Z31 Z33
-              Z35 Z37 Z39 Z43 Z53 Z55 Z57 Z59 Z81 Z83 Z85 Z87
-              AA0 AA24 AA26 AA28 AA30 AA32 AA34 AA36 AA38 AA40 AA42 AA44
-              AA46 AA56 AA58 AA60 AA88 AB21 AB23 AB25 AB29 AB31 AB33 AB35
+              A0 A2 A4 A6 A8 A10 A12 A14 A16 A22 A24 A26
+              A28 A30 A32 A34 A40 A58 A60 A62 B1 B3 B5 B7
+              B9 B11 B13 B15 B17 B23 B25 B27 B29 B31 B33 B39
+              B59 B61 C0 C2 C4 C6 C8 C10 C12 C14 C16 C22
+              C24 C26 C28 C30 C32 C34 C40 C60 C62 C68 C70 D1
+              D3 D5 D7 D9 D11 D13 D15 D17 D23 D27 D29 D31
+              D33 D39 D63 D65 E0 E2 E4 E6 E8 E10 E12 E14
+              E16 E22 E30 E32 E34 E40 E46 E64 F1 F3 F5 F7
+              F9 F11 F13 F15 F17 F31 F33 F39 F41 F43 F45 F47
+              F57 F65 F67 G0 G2 G4 G6 G8 G10 G12 G14
+              G30 G32 G34 G48 G58 H1 H3 H5 H7 H9 H11 H13
+              H23 H31 H33 H49 H57 H59 H61 I0 I2 I4 I6 I8
+              I10 I12 I30 I32 I38 I40 I42 I54 I56 I58 I60 I62
+              J5 J7 J9 J11 J21 J31 J37 J39 J41 J43 J51 J53
+              J55 J57 J59 J61 K6 K8 K10 K12 K14 K16 K18 K20
+              K38 K52 L1 L7 L9 L11 L13 L15 L17 L19 L21 M0
+              M2 M8 M10 M12 M14 M16 M32 N7 N9 N11 N13 N15
+              N23 N27 O0 O2 O20 O22 O26 P1 Q0 Q8 Q10 Q12
+              Q14 Q16 Q18 R7 R9 R11 R13 R15 R17 R19 R21 S0
+              S2 S8 S10 S12 S14 S16 S18 S20 S22 T1 T3 T9
+              T11 T13 T15 T17 T19 T21 T83 T85 U0 U2 U4 U14
+              U16 U18 U20 V1 V3 V49 W0 W2 W4 W50 W52 W80
+              W82 W84 W86 W88 X1 X3 X31 X39 X51 X53 X79 X81
+              X83 X85 X87 Y0 Y30 Y32 Y34 Y36 Y38 Y52 Y54 Y80
+              Y82 Y84 Y86 Y88 Z29 Z31 Z33 Z35 Z37 Z39 Z43 Z53
+              Z55 Z57 Z59 Z81 Z83 Z85 Z87 AA0 AA24 AA30 AA32 AA34
+              AA36 AA38 AA44 AA46 AA56 AA58 AA60 AA88 AB29 AB31 AB33 AB35
               AB37 AB43 AB45 AB47 AB49 AB59 AB61 AB73 AB75 AB79 AB81 AC0
-              AC2 AC4 AC22 AC24 AC26 AC28 AC30 AC32 AC34 AC36 AC42 AC44
-              AC46 AC48 AC50 AC52 AC60 AC62 AC70 AC72 AC74 AD3 AD19
-              AD21 AD23 AD25 AD27 AD29 AD31 AD33 AD35 AD37 AD41 AD43 AD45
-              AD47 AD49 AD51 AD53 AD57 AD59 AD61 AD63 AD73 AD75 AD77 AE0
-              AE2 AE4 AE6 AE8 AE10 AE12 AE14 AE16 AE18 AE20 AE22 AE24
-              AE26 AE28 AE30 AE32 AE34 AE36 AE38 AE40 AE42 AE44 AE46 AE48
-              AE50 AE54 AE56 AE58 AE60 AE62 AE64 AE66 AE74 AE76 AE78
-              AF1 AF3 AF7 AF9 AF13 AF15 AF17 AF19 AF21 AF23 AF27 AF29
-              AF31 AF33 AF35 AF37 AF39 AF41 AF43 AF45 AF47 AF55 AF57 AF59
-              AF61 AF63 AF65 AF71 AF73 AF75 AF77 AF79 AG0 AG2 AG4 AG6
-              AG8 AG10 AG12 AG14 AG16 AG18 AG20 AG22 AG24 AG26 AG28 AG30
-              AG32 AG34 AG36 AG38 AG42 AG44 AG46 AG48 AG54 AG56 AG58 AG60
-              AG62 AG64 AG66 AG72 AG74 AG76 AG78 AG80 AG82 AG84 AG86 AH1
-              AH3 AH5 AH7 AH9 AH11 AH13 AH15 AH17 AH19 AH21 AH23 AH25
-              AH27 AH29 AH31 AH33 AH35 AH37 AH39 AH41 AH43 AH45 AH47 AH49
-              AH51 AH53 AH55 AH57 AH59 AH61 AH63 AH65 AH67 AH69 AH71 AH73
-              AH75 AH77 AH79 AH81 AH83 AH85
+              AC2 AC4 AC22 AC28 AC30 AC32 AC34 AC36 AC42 AC44 AC46 AC48
+              AC50 AC52 AC62 AC70 AC72 AC74 AD3 AD19 AD21 AD23 AD29 AD31
+              AD33 AD35 AD41 AD43 AD45 AD47 AD49 AD51 AD53 AD57 AD73 AD75
+              AD77 AE0 AE2 AE4 AE8 AE14 AE16 AE18 AE20 AE22 AE28 AE30
+              AE32 AE34 AE40 AE42 AE44 AE46 AE48 AE50 AE54 AE56 AE66
+              AE74 AE76 AF1 AF3 AF7 AF9 AF15 AF17 AF19 AF21 AF23 AF29
+              AF31 AF33 AF41 AF43 AF45 AF47 AF55 AF57 AF63 AF65 AF71 AF73
+              AF75 AG0 AG2 AG4 AG6 AG8 AG14 AG16 AG18 AG20 AG22 AG28
+              AG30 AG32 AG34 AG42 AG44 AG46 AG48 AG54 AG56 AG62 AG64
+              AG66 AG72 AG74 AG80 AG82 AG84 AG86 AH1 AH3 AH5 AH7 AH13
+              AH15 AH17 AH19 AH21 AH23 AH29 AH31 AH33 AH35 AH37 AH43 AH45
+              AH47 AH49 AH51 AH53 AH55 AH57 AH63 AH65 AH67 AH69 AH71 AH73
+              AH79 AH81 AH83 AH85 AH87
+
               ] => '',
+            # Ferry routes (pre-printed track through sea hexes)
+            ['N29'] => 'path=a:4,b:2',
+            ['G22'] => 'path=a:0,b:4;border=edge:2,type:province',
+            ['I22'] => 'path=a:1,b:5;path=a:1,b:4',
+            ['I24'] => 'path=a:1,b:5;path=a:1,b:4',
+            ['N25'] => 'path=a:0,b:3',
+            ['AE6'] => 'town=revenue:20;path=a:0,b:3',
+            ['AE12'] => 'path=a:3,b:0;border=edge:1,type:province',
+            ['AF13'] => 'path=a:2,b:1',
+            ['AB21'] => 'path=a:2,b:4',
+            ['AB23'] => 'path=a:1,b:4',
+            ['AB25'] => 'path=a:1,b:4;border=edge:5,type:province',
+            # Sea zone province borders
+            ['AD25'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
+            ['AE58'] => 'border=edge:4,type:province',
+            ['AG58'] => 'border=edge:4,type:province',
+            ['AE60'] => 'border=edge:0,type:province;border=edge:1,type:province;' \
+                        'border=edge:2,type:province;border=edge:3,type:province',
+            ['AG60'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['F63'] => 'border=edge:0,type:province',
+            ['G62'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['A18'] => 'border=edge:4,type:province',
+            ['A20'] => 'border=edge:0,type:province;border=edge:1,type:province',
+            ['A36'] => 'border=edge:4,type:province;border=edge:5,type:province',
+            ['A38'] => 'border=edge:1,type:province',
+            ['AA26'] => 'border=edge:4,type:province',
+            ['AA28'] => 'border=edge:1,type:province',
+            ['AA40'] => 'border=edge:4,type:province',
+            ['AA42'] => 'border=edge:1,type:province',
+            ['AC24'] => 'border=edge:4,type:province',
+            ['AC26'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['AC60'] => 'border=edge:0,type:province',
+            ['AD27'] => 'border=edge:1,type:province',
+            ['AD37'] => 'border=edge:5,type:province',
+            ['AD59'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
+            ['AD61'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:5,type:province',
+            ['AD63'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['AE10'] => 'border=edge:4,type:province',
+            ['AE24'] => 'border=edge:4,type:province',
+            ['AE26'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['AE36'] => 'border=edge:4,type:province;border=edge:5,type:province',
+            ['AE38'] => 'border=edge:1,type:province;border=edge:2,type:province',
+            ['AE62'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['AE64'] => 'border=edge:2,type:province',
+            ['AE78'] => 'border=edge:5,type:province',
+            ['AF27'] => 'border=edge:1,type:province',
+            ['AF35'] => 'border=edge:4,type:province',
+            ['AF37'] => 'border=edge:0,type:province;border=edge:1,type:province;' \
+                        'border=edge:2,type:province;border=edge:5,type:province',
+            ['AF39'] => 'border=edge:0,type:province',
+            ['AF59'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
+            ['AF61'] => 'border=edge:1,type:province',
+            ['AF77'] => 'border=edge:4,type:province;border=edge:5,type:province',
+            ['AF79'] => 'border=edge:1,type:province;border=edge:2,type:province',
+            ['AG10'] => 'border=edge:4,type:province;border=edge:5,type:province',
+            ['AG12'] => 'border=edge:1,type:province',
+            ['AG24'] => 'border=edge:4,type:province',
+            ['AG26'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['AG36'] => 'border=edge:3,type:province',
+            ['AG38'] => 'border=edge:2,type:province;border=edge:3,type:province;border=edge:4,type:province',
+            ['AG76'] => 'border=edge:4,type:province;border=edge:5,type:province',
+            ['AG78'] => 'border=edge:1,type:province;border=edge:2,type:province',
+            ['AH11'] => 'border=edge:1,type:province;border=edge:2,type:province',
+            ['AH25'] => 'border=edge:3,type:province;border=edge:4,type:province',
+            ['AH27'] => 'border=edge:1,type:province',
+            ['AH39'] => 'border=edge:3,type:province;border=edge:4,type:province',
+            ['AH41'] => 'border=edge:1,type:province',
+            ['AH59'] => 'border=edge:3,type:province;border=edge:4,type:province',
+            ['AH61'] => 'border=edge:1,type:province',
+            ['AH75'] => 'border=edge:4,type:province',
+            ['AH77'] => 'border=edge:1,type:province;border=edge:2,type:province',
+            ['AH9'] => 'border=edge:4,type:province',
+            ['B19'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
+            ['B21'] => 'border=edge:1,type:province',
+            ['B35'] => 'border=edge:4,type:province',
+            ['B37'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['C18'] => 'border=edge:4,type:province',
+            ['C20'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['C36'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
+            ['C38'] => 'border=edge:1,type:province',
+            ['D19'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
+            ['D21'] => 'border=edge:1,type:province',
+            ['D35'] => 'border=edge:4,type:province',
+            ['D37'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['D59'] => 'border=edge:5,type:province',
+            ['D61'] => 'border=edge:0,type:province',
+            ['E18'] => 'border=edge:4,type:province',
+            ['E20'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['E36'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
+            ['E38'] => 'border=edge:1,type:province',
+            ['E60'] => 'border=edge:2,type:province;border=edge:3,type:province;' \
+                       'border=edge:4,type:province;border=edge:5,type:province',
+            ['E62'] => 'border=edge:1,type:province',
+            ['F19'] => 'border=edge:3,type:province;border=edge:4,type:province',
+            ['F21'] => 'border=edge:1,type:province;border=edge:5,type:province',
+            ['F35'] => 'border=edge:4,type:province',
+            ['F37'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['F59'] => 'border=edge:4,type:province',
+            ['F61'] => 'border=edge:0,type:province;border=edge:1,type:province;' \
+                       'border=edge:2,type:province;border=edge:5,type:province',
+            ['G36'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
+            ['G38'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:5,type:province',
+            ['G40'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['G42'] => 'border=edge:0,type:province',
+            ['G60'] => 'border=edge:3,type:province',
+            ['H35'] => 'border=edge:4,type:province;border=edge:5,type:province',
+            ['H37'] => 'border=edge:1,type:province;border=edge:2,type:province;border=edge:3,type:province',
+            ['H39'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['H41'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['I34'] => 'border=edge:4,type:province;border=edge:5,type:province',
+            ['I36'] => 'border=edge:1,type:province;border=edge:2,type:province',
+            ['J1'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['K0'] => 'border=edge:3,type:province',
+            ['J3'] => 'border=edge:0,type:province',
+            ['J33'] => 'border=edge:4,type:province;border=edge:5,type:province',
+            ['J35'] => 'border=edge:1,type:province;border=edge:2,type:province',
+            ['K2'] => 'border=edge:2,type:province;border=edge:3,type:province;border=edge:4,type:province',
+            ['K32'] => 'border=edge:4,type:province;border=edge:5,type:province',
+            ['K34'] => 'border=edge:0,type:province;border=edge:1,type:province;' \
+                       'border=edge:2,type:province;border=edge:5,type:province',
+            ['K36'] => 'border=edge:0,type:province',
+            ['K4'] => 'border=edge:0,type:province;border=edge:1,type:province',
+            ['L3'] => 'border=edge:3,type:province;border=edge:4,type:province',
+            ['L33'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['L35'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['L5'] => 'border=edge:0,type:province;border=edge:1,type:province',
+            ['M18'] => 'border=edge:5,type:province',
+            ['M20'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['M4'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
+            ['M6'] => 'border=edge:1,type:province',
+            ['N17'] => 'border=edge:4,type:province;border=edge:5,type:province',
+            ['N19'] => 'border=edge:1,type:province;border=edge:2,type:province;border=edge:3,type:province',
+            ['N21'] => 'border=edge:2,type:province',
+            ['N3'] => 'border=edge:4,type:province',
+            ['N5'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['O10'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['O12'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['O14'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['O16'] => 'border=edge:0,type:province;border=edge:4,type:province;border=edge:5,type:province',
+            ['O18'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['O4'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
+            ['O6'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:5,type:province',
+            ['O8'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['P11'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['P13'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['P15'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['P17'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['P3'] => 'border=edge:4,type:province',
+            ['P5'] => 'border=edge:0,type:province;border=edge:1,type:province;' \
+                      'border=edge:2,type:province;border=edge:3,type:province',
+            ['P7'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['P9'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['Q2'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['Q4'] => 'border=edge:0,type:province;border=edge:3,type:province;' \
+                      'border=edge:4,type:province;border=edge:5,type:province',
+            ['Q6'] => 'border=edge:1,type:province',
+            ['R1'] => 'border=edge:3,type:province',
+            ['R3'] => 'border=edge:2,type:province;border=edge:3,type:province;border=edge:4,type:province',
+            ['R5'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['S4'] => 'border=edge:3,type:province;border=edge:4,type:province',
+            ['S6'] => 'border=edge:0,type:province;border=edge:1,type:province',
+            ['T5'] => 'border=edge:3,type:province;border=edge:4,type:province',
+            ['T7'] => 'border=edge:1,type:province',
+            ['U82'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['U84'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['U86'] => 'border=edge:0,type:province;border=edge:4,type:province;border=edge:5,type:province',
+            ['V81'] => 'border=edge:3,type:province',
+            ['V83'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['V85'] => 'border=edge:2,type:province;border=edge:3,type:province',
+            ['U88'] => 'border=edge:1,type:province;border=edge:2,type:province',
+            ['V87'] => 'border=edge:2,type:province',
+            ['X41'] => 'border=edge:5,type:province',
+            ['Y40'] => 'border=edge:4,type:province',
+            ['Y42'] => 'border=edge:1,type:province;border=edge:2,type:province',
           },
+        }.freeze
+
+        SEA_ZONES = {
+          'Celtic Sea' => %w[
+            A2 A4 A6 A8 A10 A12 A14 A16 A18 B1 B3 B5
+            B7 B9 B11 B13 B15 B17 B19 C2 C4 C6 C8 C10
+            C12 C14 C16 C18 D1 D3 D5 D7 D9 D11 D13 D15
+            D17 D19 E2 E4 E6 E8 E10 E12 E14 E16 E18 F1
+            F3 F5 F7 F9 F11 F13 F15 F17 F19 G2 G4 G6
+            G8 G10 G12 G14 G22 H1 H3 H5 H7 H9 H11 H13
+            H23 I2 I4 I6 I8 I10 I12 I22 I24 J1 J3 J5
+            J7 J9 J11 J21 K4 K6 K8 K10 K12 K14 K16 K18
+            K20 L5 L7 L9 L11 L13 L15 L17 L19 L21 M6 M8
+            M10 M12 M14 M16 M18 M20 N5 N7 N9 N11 N13 N15
+            N17 O6 O8 O10 O12 O14 O16
+          ].freeze,
+          'North Atlantic Ocean' => %w[
+            K2 L1 L3 M2 M4 N1 N3 O2 O4 P1 P3 Q2 Q4
+          ].freeze,
+          'North Atlantic (Silver Coast)' => %w[
+            R1 R3 S2 S4 T1 T3 T5 U2 U4 V1 V3 W2
+            W4 X1 X3
+          ].freeze,
+          'Bay of Biscay' => %w[
+            P5 P7 P9 P11 P13 P15 P17 Q6 Q8 Q10 Q12 Q14
+            Q16 Q18 R5 R7 R9 R11 R13 R15 R17 R19 R21 S6
+            S8 S10 S12 S14 S16 S18 S20 S22 T7 T9 T11 T13
+            T15 T17 T19 T21 U14 U16 U18 U20
+          ].freeze,
+          'English Channel' => %w[
+            L33 L35 M32 N19 N21 N23 N25 N27 N29 O18 O20 O22
+            O26
+          ].freeze,
+          'North Sea' => %w[
+            A20 A22 A24 A26 A28 A30 A32 A34 A36 B21 B23 B25
+            B27 B29 B31 B33 B35 C20 C22 C24 C26 C28 C30 C32
+            C34 C36 D21 D23 D27 D29 D31 D33 D35 E20 E22 E30
+            E32 E34 E36 F21 F31 F33 F35 G30 G32 G34 G36 H31
+            H33 H35 I30 I32 I34 J31 J33 K32
+          ].freeze,
+          'Skagerrak' => %w[
+            A38 A40 B37 B39 B43 C38 C40 D37 D39 E38 E40 E46 F37 F39
+            F41 F43 F45 F47 G38 G40 G42 G48 H49
+          ].freeze,
+          'German Bight' => %w[
+            H37 H39 H41 I36 I38 I40 I42 J35 J37 J39 J41 J43
+            K34 K36 K38
+          ].freeze,
+          'Baltic Sea' => %w[
+            E60 F57 F59 G58 G60 G62 H57 H59 H61 I54 I56 I58 I60
+            I62 J51 J53 J55 J57 J59 J61 K52
+          ].freeze,
+          'Gulf of Finland' => %w[
+            A58 A60 A62 B59 B61 C60 C62 C68 C70 D59 D61 D63
+            D65 E62 E64 F61 F63 F65 F67
+          ].freeze,
+          'Strait of Gibraltar' => %w[
+            AC2 AC4 AD1 AD3 AE2 AE4 AE6 AE8 AE10 AF1 AF3 AF7 AF9
+            AG2 AG4 AG6 AG8 AG10 AH1 AH3 AH5 AH7 AH9
+          ].freeze,
+          'Balearic Sea' => %w[
+            AA24 AA26 AB21 AB23 AB25 AC22 AC24 AD19 AD21 AD23 AD25 AE12
+            AE14 AE16 AE18 AE20 AE22 AE24 AF13 AF15 AF17 AF19 AF21 AF23
+            AG12 AG14 AG16 AG18 AG20 AG22 AG24 AH11 AH13 AH15 AH17 AH19
+            AH21 AH23 AH25 AF25
+          ].freeze,
+          'Sea of Sardinia' => %w[
+            X31 X39 Y30 Y32 Y34 Y36 Y38 Y40 Z29 Z31 Z33 Z35
+            Z37 Z39 AA28 AA30 AA32 AA34 AA36 AA38 AA40 AB29 AB31 AB33
+            AB35 AB37 AC26 AC28 AC30 AC32 AC34 AC36 AD27 AD29 AD31
+            AD33 AD35 AD37 AE26 AE28 AE30 AE32 AE34 AE36 AF27 AF29 AF31
+            AF33 AF35 AG26 AG28 AG30 AG32 AG34 AG36 AG38 AH27 AH29 AH31
+            AH33 AH35 AH37 AH39
+            X41
+          ].freeze,
+          'Tyrrhenian Sea' => %w[
+            Y42 Z43 AA42 AA44 AA46 AB43 AB45 AB47 AB49 AC42 AC44
+            AC46 AC48 AC50 AC52 AD41 AD43 AD45 AD47 AD49 AD51 AD53 AD57
+            AD59 AE38 AE40 AE42 AE44 AE46 AE48 AE50 AE54 AE56 AE58 AF37
+            AF39 AF41 AF43 AF45 AF47 AF55 AF57 AF59 AG42 AG44 AG46 AG48
+            AG40 AG54 AG56 AG58 AH41 AH43 AH45 AH47 AH49 AH51 AH53 AH55 AH57
+            AH59
+          ].freeze,
+          'Adriatic Sea' => %w[
+            V49 W50 W52 X51 X53 Y52 Y54 Z53 Z55 Z57 Z59 AA56
+            AA58 AA60 AB59 AB61 AC60 AC62 AD61 AD63
+          ].freeze,
+          'Aegean Sea' => %w[
+            AB73 AB75 AB79 AB81 AC70 AC72 AC74 AD73 AD75 AD77 AE60 AE62 AE64
+            AE66 AE74 AE76 AE78 AF61 AF63 AF65 AF71 AF73 AF75 AF77 AG60 AG62
+            AG64 AG66 AG72 AG74 AG76 AH61 AH63 AH65 AH67 AH69 AH71 AH73
+            AH75
+          ].freeze,
+          'Levantine Sea' => %w[
+            AF79 AG78 AG80 AG82 AG84 AG88 AH77 AH79 AH81 AH83 AH85
+          ].freeze,
+          'Black Sea' => %w[
+            V81 V83 V85 V87 W80 W82 W84 W86 X79 X81 X83 X85
+            X87 Y80 Y82 Y84 Y86 Z81 Z83 Z85 Z87
+            U88
+          ].freeze,
+          'Karkinitsky Bay' => %w[
+            T83 T85 T87 U82 U84 U86
+          ].freeze,
         }.freeze
       end
     end

--- a/lib/engine/game/g_18_oe/map.rb
+++ b/lib/engine/game/g_18_oe/map.rb
@@ -616,8 +616,8 @@ module Engine
           blue: {
             %w[
               A0 A2 A4 A6 A8 A10 A12 A14 A16 A22 A24 A26
-              A28 A30 A32 A34 A40 A58 A60 A62 B1 B3 B5 B7
-              B9 B11 B13 B15 B17 B23 B25 B27 B29 B31 B33 B39
+              A28 A30 A32 A34 A40 B1 B3 B5 B7
+              B9 B11 B13 B15 B17 B23 B25 B27 B29 B31 B33
               B59 B61 C0 C2 C4 C6 C8 C10 C12 C14 C16 C22
               C24 C26 C28 C30 C32 C34 C40 C60 C62 C68 C70 D1
               D3 D5 D7 D9 D11 D13 D15 D17 D23 D27 D29 D31
@@ -625,11 +625,11 @@ module Engine
               E16 E22 E30 E32 E34 E40 E46 E64 F1 F3 F5 F7
               F9 F11 F13 F15 F17 F31 F33 F39 F41 F43 F45 F47
               F57 F65 F67 G0 G2 G4 G6 G8 G10 G12 G14
-              G30 G32 G34 G48 G58 H1 H3 H5 H7 H9 H11 H13
-              H23 H31 H33 H49 H57 H59 H61 I0 I2 I4 I6 I8
-              I10 I12 I30 I32 I38 I40 I42 I54 I56 I58 I60 I62
+              G48 G58 H1 H3 H5 H7 H9 H11 H13
+              H23 H31 H33 H49 H59 H61 I0 I2 I4 I6 I8
+              I10 I12 I30 I32 I38 I40 I42 I54 I56 I60 I62
               J5 J7 J9 J11 J21 J31 J37 J39 J41 J43 J51 J53
-              J55 J57 J59 J61 K6 K8 K10 K12 K14 K16 K18 K20
+              J55 J57 J61 K6 K8 K10 K12 K14 K16 K18 K20
               K38 K52 L1 L7 L9 L11 L13 L15 L17 L19 L21 M0
               M2 M8 M10 M12 M14 M16 M32 N7 N9 N11 N13 N15
               N23 N27 O0 O2 O20 O22 O26 P1 Q0 Q8 Q10 Q12
@@ -689,6 +689,16 @@ module Engine
             ['Z81'] => 'path=a:5,b:2',
             ['Y80'] => 'path=a:5,b:2',
             ['X79'] => 'town=revenue:20;path=a:5,b:_0;path=a:1,b:_0',
+            ['G30'] => 'junction;path=a:4,b:_0',
+            ['G32'] => 'path=a:1,b:4',
+            ['G34'] => 'path=a:1,b:3',
+            ['B39'] => 'path=a:0,b:4',
+            ['J59'] => 'path=a:5,b:2',
+            ['I58'] => 'path=a:5,b:2',
+            ['H57'] => 'path=a:5,b:1',
+            ['A58'] => 'path=a:1,b:4',
+            ['A60'] => 'path=a:1,b:4',
+            ['A62'] => 'path=a:1,b:4',
             # Sea zone province borders
             ['AD25'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
             ['AE58'] => 'border=edge:4,type:province',
@@ -709,7 +719,7 @@ module Engine
             ['AC24'] => 'border=edge:4,type:province',
             ['AC26'] => 'path=a:3,b:5;border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
             ['AC60'] => 'border=edge:0,type:province',
-            ['AD27'] => 'path=a:3,b:1;border=edge:1,type:province',
+            ['AD27'] => 'path=a:0,b:2;border=edge:1,type:province',
             ['AD37'] => 'border=edge:5,type:province',
             ['AD59'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
             ['AD61'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:5,type:province',
@@ -756,23 +766,23 @@ module Engine
             ['C18'] => 'border=edge:4,type:province',
             ['C20'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
             ['C36'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
-            ['C38'] => 'border=edge:1,type:province',
+            ['C38'] => 'path=a:0,b:3;border=edge:1,type:province',
             ['D19'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
             ['D21'] => 'border=edge:1,type:province',
             ['D35'] => 'border=edge:4,type:province',
-            ['D37'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['D37'] => 'path=a:0,b:3;border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
             ['D59'] => 'border=edge:5,type:province',
             ['D61'] => 'border=edge:0,type:province',
             ['E18'] => 'border=edge:4,type:province',
             ['E20'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
-            ['E36'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
+            ['E36'] => 'path=a:0,b:3;border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
             ['E38'] => 'border=edge:1,type:province',
             ['E60'] => 'border=edge:2,type:province;border=edge:3,type:province;' \
                        'border=edge:4,type:province;border=edge:5,type:province',
             ['E62'] => 'border=edge:1,type:province',
             ['F19'] => 'border=edge:3,type:province;border=edge:4,type:province',
             ['F21'] => 'border=edge:1,type:province;border=edge:5,type:province',
-            ['F35'] => 'border=edge:4,type:province',
+            ['F35'] => 'path=a:0,b:3;border=edge:4,type:province',
             ['F37'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
             ['F59'] => 'border=edge:4,type:province',
             ['F61'] => 'border=edge:0,type:province;border=edge:1,type:province;' \

--- a/lib/engine/game/g_18_oe/map.rb
+++ b/lib/engine/game/g_18_oe/map.rb
@@ -619,7 +619,7 @@ module Engine
               A28 A30 A32 A34 A40 B1 B3 B5 B7
               B9 B11 B13 B15 B17 B23 B25 B27 B29 B31 B33
               B59 B61 C0 C2 C4 C6 C8 C10 C12 C14 C16 C22
-              C24 C26 C28 C30 C32 C34 C40 C60 C62 C68 C70 D1
+              C24 C26 C28 C30 C32 C34 C40 C60 C68 C70 D1
               D3 D5 D7 D9 D11 D13 D15 D17 D23 D27 D29 D31
               D33 D39 D63 D65 E0 E2 E4 E6 E8 E10 E12 E14
               E16 E22 E30 E32 E34 E40 E46 E64 F1 F3 F5 F7
@@ -699,6 +699,7 @@ module Engine
             ['A58'] => 'path=a:1,b:4',
             ['A60'] => 'path=a:1,b:4',
             ['A62'] => 'path=a:1,b:4',
+            ['C62'] => 'path=a:0,b:4',
             # Sea zone province borders
             ['AD25'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
             ['AE58'] => 'border=edge:4,type:province',
@@ -771,8 +772,8 @@ module Engine
             ['D21'] => 'border=edge:1,type:province',
             ['D35'] => 'border=edge:4,type:province',
             ['D37'] => 'path=a:0,b:3;border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
-            ['D59'] => 'border=edge:5,type:province',
-            ['D61'] => 'border=edge:0,type:province',
+            ['D59'] => 'path=a:1,b:4;border=edge:5,type:province',
+            ['D61'] => 'path=a:1,b:3;border=edge:0,type:province',
             ['E18'] => 'border=edge:4,type:province',
             ['E20'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
             ['E36'] => 'path=a:0,b:3;border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',

--- a/lib/engine/game/g_18_oe/map.rb
+++ b/lib/engine/game/g_18_oe/map.rb
@@ -446,7 +446,7 @@ module Engine
             ['C48'] => 'city=revenue:10',
             # Cities — no terrain (added station geometry)
             %w[
-              AA62 AB57 AB69 AC40 AD79 AF49 B67 D77 E56 G68 H47 H63
+              AA62 AB57 AB69 AC40 AF49 B67 D77 E56 G68 H47 H63
               H87 I76 J69 K78 K86 M44 M68 S78 T53 T81 V51
               V55 W40 W64 Y70
             ] => 'city=revenue:0',
@@ -467,10 +467,11 @@ module Engine
             ['U24'] => 'city=revenue:10',
             ['I20'] => 'city=revenue:10;path=a:4,b:_0',
             ['O28'] => 'city=revenue:0;path=a:1,b:_0',
+            ['AD79'] => 'city=revenue:0;path=a:1,b:_0',
             ['M28'] => 'city=revenue:30;label=L;upgrade=cost:30,terrain:water;path=a:5,b:_0',
             ['X33'] => 'city=revenue:20;label=Y;path=a:5,b:_0',
 
-            ['Z27'] => 'city=revenue:20;label=Y',
+            ['Z27'] => 'city=revenue:20;label=Y;path=a:0,b:_0',
             ['K46'] => 'city=revenue:20;label=Y',
             ['M50'] => 'city=revenue:0;label=B',
             ['R47'] => 'city=revenue:0;label=Y',
@@ -636,21 +637,21 @@ module Engine
               S2 S8 S10 S12 S14 S16 S18 S20 S22 T1 T3 T9
               T11 T13 T15 T17 T19 T21 T83 T85 U0 U2 U4 U14
               U16 U18 U20 V1 V3 V49 W0 W2 W4 W50 W52 W80
-              W82 W84 W86 W88 X1 X3 X31 X39 X51 X53 X79 X81
-              X83 X85 X87 Y0 Y30 Y32 Y34 Y36 Y38 Y52 Y54 Y80
+              W82 W84 W86 W88 X1 X3 X31 X39 X51 X53 X81
+              X83 X85 X87 Y0 Y30 Y32 Y34 Y36 Y52 Y54
               Y82 Y84 Y86 Y88 Z29 Z31 Z33 Z35 Z37 Z39 Z43 Z53
-              Z55 Z57 Z59 Z81 Z83 Z85 Z87 AA0 AA24 AA30 AA32 AA34
-              AA36 AA38 AA44 AA46 AA56 AA58 AA60 AA88 AB29 AB31 AB33 AB35
-              AB37 AB43 AB45 AB47 AB49 AB59 AB61 AB73 AB75 AB79 AB81 AC0
+              Z55 Z57 Z59 Z83 Z85 Z87 AA0 AA24 AA30 AA32 AA34
+              AA36 AA38 AA56 AA58 AA60 AA88 AB29 AB31 AB33 AB35
+              AB37 AB43 AB45 AB47 AB49 AB73 AB75 AB79 AB81 AC0
               AC2 AC4 AC22 AC28 AC30 AC32 AC34 AC36 AC42 AC44 AC46 AC48
-              AC50 AC52 AC62 AC70 AC72 AC74 AD3 AD19 AD21 AD23 AD29 AD31
-              AD33 AD35 AD41 AD43 AD45 AD47 AD49 AD51 AD53 AD57 AD73 AD75
-              AD77 AE0 AE2 AE4 AE8 AE14 AE16 AE18 AE20 AE22 AE28 AE30
-              AE32 AE34 AE40 AE42 AE44 AE46 AE48 AE50 AE54 AE56 AE66
-              AE74 AE76 AF1 AF3 AF7 AF9 AF15 AF17 AF19 AF21 AF23 AF29
-              AF31 AF33 AF41 AF43 AF45 AF47 AF55 AF57 AF63 AF65 AF71 AF73
+              AC50 AC52 AC70 AC72 AC74 AD3 AD19 AD21 AD23 AD29 AD31
+              AD33 AD35 AD41 AD43 AD45 AD47 AD49 AD51 AD53 AD57 AD73
+              AE0 AE2 AE4 AE8 AE14 AE16 AE18 AE20 AE22 AE28 AE30
+              AE32 AE34 AE40 AE42 AE44 AE46 AE48 AE50 AE56
+              AE76 AF1 AF3 AF7 AF9 AF15 AF17 AF19 AF21 AF23 AF29
+              AF31 AF33 AF41 AF43 AF45 AF47 AF55 AF57 AF63 AF65 AF71
               AF75 AG0 AG2 AG4 AG6 AG8 AG14 AG16 AG18 AG20 AG22 AG28
-              AG30 AG32 AG34 AG42 AG44 AG46 AG48 AG54 AG56 AG62 AG64
+              AG30 AG32 AG34 AG54 AG56 AG62 AG64
               AG66 AG72 AG74 AG80 AG82 AG84 AG86 AH1 AH3 AH5 AH7 AH13
               AH15 AH17 AH19 AH21 AH23 AH29 AH31 AH33 AH35 AH37 AH43 AH45
               AH47 AH49 AH51 AH53 AH55 AH57 AH63 AH65 AH67 AH69 AH71 AH73
@@ -664,11 +665,30 @@ module Engine
             ['I24'] => 'path=a:1,b:5;path=a:1,b:4',
             ['N25'] => 'path=a:0,b:3',
             ['AE6'] => 'town=revenue:20;path=a:0,b:3',
-            ['AE12'] => 'path=a:3,b:0;border=edge:1,type:province',
+            ['AE12'] => 'path=a:3,b:5;border=edge:1,type:province',
             ['AF13'] => 'path=a:2,b:1',
             ['AB21'] => 'path=a:2,b:4',
             ['AB23'] => 'path=a:1,b:4',
             ['AB25'] => 'path=a:1,b:4;border=edge:5,type:province',
+            ['Y38'] => 'path=a:4,b:2',
+            ['AA44'] => 'path=a:1,b:4',
+            ['AA46'] => 'path=a:1,b:3',
+            ['AE54'] => 'path=a:3,b:0',
+            ['AG42'] => 'path=a:4,b:1',
+            ['AG44'] => 'path=a:4,b:1',
+            ['AG46'] => 'path=a:4,b:1',
+            ['AG48'] => 'path=a:4,b:1;path=a:3,b:1',
+            ['AB59'] => 'path=a:1,b:4',
+            ['AB61'] => 'path=a:1,b:5',
+            ['AC62'] => 'path=a:2,b:5',
+            ['AE66'] => 'path=a:1,b:4',
+            ['AF73'] => 'path=a:2,b:3',
+            ['AE74'] => 'town=revenue:20;path=a:0,b:_0;path=a:3,b:_0',
+            ['AD75'] => 'path=a:0,b:4',
+            ['AD77'] => 'path=a:1,b:4',
+            ['Z81'] => 'path=a:5,b:2',
+            ['Y80'] => 'path=a:5,b:2',
+            ['X79'] => 'town=revenue:20;path=a:5,b:_0;path=a:1,b:_0',
             # Sea zone province borders
             ['AD25'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
             ['AE58'] => 'border=edge:4,type:province',
@@ -682,25 +702,25 @@ module Engine
             ['A20'] => 'border=edge:0,type:province;border=edge:1,type:province',
             ['A36'] => 'border=edge:4,type:province;border=edge:5,type:province',
             ['A38'] => 'border=edge:1,type:province',
-            ['AA26'] => 'border=edge:4,type:province',
+            ['AA26'] => 'path=a:3,b:5;border=edge:4,type:province',
             ['AA28'] => 'border=edge:1,type:province',
-            ['AA40'] => 'border=edge:4,type:province',
-            ['AA42'] => 'border=edge:1,type:province',
+            ['AA40'] => 'path=a:3,b:0;border=edge:4,type:province',
+            ['AA42'] => 'path=a:0,b:4;border=edge:1,type:province',
             ['AC24'] => 'border=edge:4,type:province',
-            ['AC26'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['AC26'] => 'path=a:3,b:5;border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
             ['AC60'] => 'border=edge:0,type:province',
-            ['AD27'] => 'border=edge:1,type:province',
+            ['AD27'] => 'path=a:3,b:1;border=edge:1,type:province',
             ['AD37'] => 'border=edge:5,type:province',
             ['AD59'] => 'border=edge:3,type:province;border=edge:4,type:province;border=edge:5,type:province',
             ['AD61'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:5,type:province',
-            ['AD63'] => 'border=edge:0,type:province;border=edge:5,type:province',
+            ['AD63'] => 'path=a:2,b:5;border=edge:0,type:province;border=edge:5,type:province',
             ['AE10'] => 'border=edge:4,type:province',
             ['AE24'] => 'border=edge:4,type:province',
-            ['AE26'] => 'border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
+            ['AE26'] => 'path=a:3,b:0;border=edge:0,type:province;border=edge:1,type:province;border=edge:2,type:province',
             ['AE36'] => 'border=edge:4,type:province;border=edge:5,type:province',
             ['AE38'] => 'border=edge:1,type:province;border=edge:2,type:province',
             ['AE62'] => 'border=edge:2,type:province;border=edge:3,type:province',
-            ['AE64'] => 'border=edge:2,type:province',
+            ['AE64'] => 'path=a:2,b:4;border=edge:2,type:province',
             ['AE78'] => 'border=edge:5,type:province',
             ['AF27'] => 'border=edge:1,type:province',
             ['AF35'] => 'border=edge:4,type:province',
@@ -829,7 +849,7 @@ module Engine
             ['U88'] => 'border=edge:1,type:province;border=edge:2,type:province',
             ['V87'] => 'border=edge:2,type:province',
             ['X41'] => 'border=edge:5,type:province',
-            ['Y40'] => 'border=edge:4,type:province',
+            ['Y40'] => 'path=a:5,b:1;border=edge:4,type:province',
             ['Y42'] => 'border=edge:1,type:province;border=edge:2,type:province',
           },
         }.freeze


### PR DESCRIPTION
  ### Overview

  This PR adds a 95% `map.rb` for 18OE and corrects the `NATIONAL_REGION_HEXES` zone hex lists and a handful of map-data methods in `game.rb`. No game logic is changed.

  ---
<img width="1508" height="1021" alt="grafik" src="https://github.com/user-attachments/assets/dac71d81-c19b-4504-b042-69e1e5720130" />

  ### `map.rb` (599 → 943 lines)

  #### Hex grid and terrain
  - Full land grid coverage with all terrain costs already present from the initial map commit; this PR restructures and extends that data with the items below.

  #### Province borders on national zone boundaries
  231 `border=edge:N,type:province` entries added to draw dashed orange lines along the boundaries between the eight national track-rights zones (UK / PHS / FR / AH / IT / SP / RU / SC). Each border is encoded on both sides of the zone boundary.

  #### Sea zone borders
  8 `border=edge:N,type:impassable` entries on coastal hexes marking the edges where land meets the named sea zones, covering the North Sweden approach, Finland coast, Bergen, Moskva, Kharkov, and Sevastopol approaches.

  ####Ferry routes (pre-printed track through sea hexes)                                                                                             
  Sea crossing hexes now carry pre-printed paths. G30 is intended to end in warter - Port to be added later with port update.                                          
                                                            
  #### Pre-printed city paths                                                                                                                         
  First White cities with pre-printed ferry exits now carry the correct path entries:
  - N31 Lille (→ edge 1), M28 London (← edge 5), AA82 Constantinople (→ edge 2), I20 Dublin (→ edge 4), O28 Le Havre (→ edge 1), X33 Marseille (→ edge 5)                                                                                                                                                 
                                                                                                                                                      
  #### Lisboa (Z1)                                                                                                                                    
  Z1 now defined as a two-slot city (`city=revenue:0;city=revenue:0`) — home city for RCP.
                                                                                                                                                      
  #### `SEA_ZONES` constant                                 
  18 named sea zones defined with complete hex lists:                                                                                                 
  Celtic Sea, North Atlantic Ocean, Bay of Biscay, English Channel, North Sea, Skagerrak, German Bight, Baltic Sea, Gulf of Finland, Strait of Gibraltar, Balearic Sea, Sea of Sardinia, Tyrrhenian Sea, Adriatic Sea, Aegean Sea, Levantine Sea, Black Sea, Karkinitsky Bay.                      
                                                                                                                                                      
  ---                                                                                                                                                 
                                                            
  ### `game.rb` — map data corrections

  #### `NATIONAL_REGION_HEXES` hex list additions
  Hexes missing from the initial submission, added after cross-checking against the physical map:                                                     
                                                                                                                                                      
  | Zone | Added hexes |                                                                                                                              
  |---|---|                                                                                                                                           
  | UK | D25 |                                              
  | SC | A54, A56, B41 |                                                                                                                              
  | FR | AF25 (Ajaccio / Corsica red offboard) |                                                                                                      
  | IT | AG40 |                                                                                                                                       
  | SP | Z1, AD1, AF5, AF11 |                                                                                                                         
  | RU | A64, B83, F87, G88, N87, S88, T87 |                                                                                                          
                                                                                                                                                      
  #### `metropolis_hex?` — typo fix                                                                                                                   
  `BB51` corrected to `AB51` (Napoli). The wrong coordinate caused Napoli to not be treated as a metropolis.                                          
                                                                                                                                                      
  #### `upgrades_to_correct_label?` — Napoli label rule                                                                                               
  Added `when 'AB51'` → label must include `'N'`, consistent with the existing rules for the other labelled metropolises (Berlin `B`, Constantinople  
  `C`, Paris `P`, Sankt-Peterburg `S`).                                                                                                               
                                                            
  ---                                                                                                                                                 
                                                            
  ### What is NOT in this PR
  - connect to ferry routes. Engine override for tile placement toward sea/ferry hexes (open point §2.7)
  - Sea zone crossing costs
  - province borders for hexes assigned to multiple zones
  - Ports