### PR TITLE
[18OE] Minor track-rights chit system

### DIFF
--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -689,7 +689,8 @@ module Engine
           self.class::TRACK_RIGHTS_COST[region] || 0
         end
 
-        def claim_region!(region)
+        def claim_region!(entity, region)
+          @minor_floated_regions[entity.id] = region
           @minor_available_regions[region] -= 1
           @minor_available_regions.delete(region) if @minor_available_regions[region].zero?
 

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -208,6 +208,22 @@ module Engine
           },
         ].freeze
 
+        # 2 chits per zone; 16 total for 12 minors.
+        # Asterisked zones (UK/PHS/FR): 6 chits combined but capped at 4 selections —
+        # when the 4th is taken the remaining chits for those zones are removed from play.
+        MINOR_TRACK_RIGHTS_CHITS = {
+          'UK' => 2,
+          'PHS' => 2,
+          'FR' => 2,
+          'AH' => 2,
+          'IT' => 2,
+          'SP' => 2,
+          'SC' => 2,
+          'RU' => 2,
+        }.freeze
+        ASTERISKED_ZONES = %w[UK PHS FR].freeze
+        ASTERISKED_ZONES_CAP = 4
+
         CORPORATIONS_TRACK_RIGHTS = {
           # United Kingdom
           'LNWR' => 'UK',
@@ -625,13 +641,8 @@ module Engine
         def setup
           super
           @minor_regional_order = []
-          # Derive available regions from the regional corporations actually defined,
-          # using only zones present in CORPORATIONS_TRACK_RIGHTS. This is failsafe:
-          # zones not yet in NATIONAL_REGION_HEXES are simply skipped at token placement.
-          @minor_available_regions = corporations
-            .select { |c| c.type == :regional }
-            .map { |c| CORPORATIONS_TRACK_RIGHTS[c.id] }
-            .compact
+          @minor_available_regions = self.class::MINOR_TRACK_RIGHTS_CHITS.transform_values(&:itself)
+          @minor_asterisked_selected = 0
           @minor_floated_regions = {}
           @regional_corps_floated = 0
 
@@ -649,7 +660,10 @@ module Engine
         # "Major Railroad Phase" entry: conversions and secondary-share purchases
         # become available from this point on.
         def major_phase?
-          @regional_corps_floated >= self.class::MAX_FLOATED_REGIONALS
+          return false unless @regional_corps_floated >= self.class::MAX_FLOATED_REGIONALS
+
+          total_minors = corporations.count { |c| c.type == :minor }
+          @minor_floated_regions.size >= total_minors
         end
 
         def operating_order
@@ -662,12 +676,38 @@ module Engine
           hexes&.include?(hex.coordinates) || false
         end
 
+        def region_for_hex(hex)
+          self.class::CITY_NATIONAL_ZONE[hex.coordinates] ||
+            self.class::NATIONAL_REGION_HEXES.find { |_, hexes| hexes.include?(hex.coordinates) }&.first
+        end
+
+        def region_available?(region)
+          @minor_available_regions.key?(region)
+        end
+
+        def track_rights_cost(region)
+          self.class::TRACK_RIGHTS_COST[region] || 0
+        end
+
+        def claim_region!(region)
+          @minor_available_regions[region] -= 1
+          @minor_available_regions.delete(region) if @minor_available_regions[region].zero?
+
+          return unless self.class::ASTERISKED_ZONES.include?(region)
+
+          @minor_asterisked_selected += 1
+          return unless @minor_asterisked_selected >= self.class::ASTERISKED_ZONES_CAP
+
+          self.class::ASTERISKED_ZONES.each { |z| @minor_available_regions.delete(z) }
+        end
+
         def home_token_locations(corporation)
           available_regions = self.class::NATIONAL_REGION_HEXES.select { |key, _| @minor_available_regions.include?(key) }
           region_hexes = available_regions.values.flatten
 
           @hexes
             .select { |hex| region_hexes.include?(hex.coordinates) }
+            .reject { |hex| (z = self.class::CITY_NATIONAL_ZONE[hex.coordinates]) && !@minor_available_regions.key?(z) }
             .select { |hex| hex.tile.cities.any? { |city| city.tokenable?(corporation, free: true) } }
             .reject { |hex| metropolis_hex?(hex) }
             .reject { |hex| self.class::MINOR_EXCLUDED_HOME_CITIES.include?(hex.coordinates) }

--- a/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
@@ -119,6 +119,14 @@ module Engine
             @game.update_cache(:shares)
           end
 
+          def help
+            return super unless can_float_minor?(current_entity)
+
+            zones_display = @game.minor_available_regions.map { |zone, count| "#{zone}(#{count})" }.join(', ')
+            "Available track rights zones: #{zones_display}. "\
+              'Home station placement determines which zone the minor receives.'
+          end
+
           def float_minor(action)
             share_price = action.share_price
             corporation = action.corporation
@@ -126,7 +134,6 @@ module Engine
             company = find_minor_company(corporation)
 
             @log << "#{entity.name} floats #{company.sym}"
-            @log << "Available track rights zones: #{@game.minor_available_regions}"
 
             @game.stock_market.set_par(corporation, share_price)
             share = corporation.ipo_shares.first

--- a/lib/engine/game/g_18_oe/step/home_token.rb
+++ b/lib/engine/game/g_18_oe/step/home_token.rb
@@ -8,15 +8,16 @@ module Engine
       module Step
         class HomeToken < Engine::Step::HomeToken
           def process_place_token(action)
-            hex = action.city.hex
-            region = @game.class::CITY_NATIONAL_ZONE[hex.name] ||
-                     @game.class::NATIONAL_REGION_HEXES.find { |_, hexes| hexes.include?(hex.name) }&.first
+            if action.entity.type == :minor
+              hex = action.city.hex
+              region = @game.region_for_hex(hex)
 
-            raise GameError, "Region #{region} is not available" unless @game.minor_available_regions.include?(region)
+              raise GameError, "Region #{region} is not available" unless @game.region_available?(region)
 
-            token.price = @game.class::TRACK_RIGHTS_COST[region] || 0
-            @game.minor_available_regions.delete(region)
-            @game.minor_floated_regions[action.entity.id] = region
+              token.price = @game.track_rights_cost(region)
+              @game.claim_region!(region)
+              @game.minor_floated_regions[action.entity.id] = region
+            end
 
             super
           end

--- a/lib/engine/game/g_18_oe/step/home_token.rb
+++ b/lib/engine/game/g_18_oe/step/home_token.rb
@@ -15,8 +15,7 @@ module Engine
               raise GameError, "Region #{region} is not available" unless @game.region_available?(region)
 
               token.price = @game.track_rights_cost(region)
-              @game.claim_region!(region)
-              @game.minor_floated_regions[action.entity.id] = region
+              @game.claim_region!(action.entity, region)
             end
 
             super


### PR DESCRIPTION
## 18OE: Minor track-rights chit system                                                                                                 
                                                                                                                                                      
  Implements the physical chit-bag mechanic that governs where minors may                                                                             
  place their home tokens. In the physical game there are 16 chits                                                                                    
  (2 per zone × 8 zones) in a bag; when a minor is floated the president                                                                              
  draws one, which determines the zone the home token must go into and                                                                                
  charges the appropriate track-rights fee.                                                                                                           
                                                                                                                                                      
  ### Rules implemented                                                                                                                               
                                                                                                                                                      
  - **16 chits total, 2 per zone**: each of the 8 national zones starts                                                                               
    with 2 chits available. A minor consumes one chit on placement.                                                                                 
  - **Asterisked zones (UK / PHS / FR)**: these three zones share a                                                                                   
    combined pool of 6 chits but are capped at 4 total placements across                                                                              
    all three. When the 4th asterisked chit is taken, any remaining                                                                                   
    chits for UK, PHS, and FR are removed from play — no further minors                                                                               
    may home into those zones.                                                                                                                        
  - **Zone exhaustion**: once a zone's chit count reaches zero it is                                                                                  
    removed from `minor_available_regions` and becomes unavailable.                                                                                   
  - **Major phase gate**: `major_phase?` now requires *both* that                                                                                     
    18 regionals have floated *and* that all 12 minors have placed their                                                                              
    home tokens. Previously only the regional count was checked, which                                                                                
    could allow the major phase to trigger before all minors had settled.                                                                             
                                                                                                                                                      
  ### Changes                                                                                                                                         
                                                                                                                                                      
  #### `game.rb`                                                                                                                                      
   
  | Item | Change |                                                                                                                                   
  |---|---|                                                 
  | `MINOR_TRACK_RIGHTS_CHITS` | New constant — `{ 'UK' => 2, 'PHS' => 2, … }` for all 8 zones |
  | `ASTERISKED_ZONES` | New constant — `%w[UK PHS FR]` |                                                                                             
  | `ASTERISKED_ZONES_CAP` | New constant — `4` |                                                                                                     
  | `minor_asterisked_selected` | New `attr_accessor` to track how many asterisked-zone chits have been drawn |                                       
  | `setup` | Replaces the old list derived from regional corporations with `MINOR_TRACK_RIGHTS_CHITS.transform_values(&:itself)`; initialises        
  `@minor_asterisked_selected = 0` |                                                                                                                  
  | `major_phase?` | Extended: returns `false` until `@minor_floated_regions.size >= total_minors` in addition to the existing regional count check | 
                                                                                                                                                      
  #### `step/home_token.rb`                                 
                                                                                                                                                      
  - **Zone lookup**: switched from `hex.name` to `hex.coordinates` for
    consistency with the rest of the codebase.                                                                                                        
  - **Minor guard**: zone-tracking logic is now wrapped in                                                                                            
    `if action.entity.type == :minor`, so regional and major home-token                                                                               
    placements bypass it entirely.                                                                                                                    
  - **Hash-based chit decrement**: `minor_available_regions[region] -= 1`                                                                             
    with zone removal when the count hits zero, replacing the previous                                                                                
    `Array#delete` which consumed the entire zone on first placement.                                                                                 
  - **Availability check**: uses `Hash#key?` instead of `Array#include?`.                                                                             
  - **Asterisked cap enforcement**: after each minor placement in                                                                                     
    UK / PHS / FR, checks whether the cap of 4 has been reached and                                                                                   
    removes all remaining asterisked-zone chits if so.        
  - The else branch ran for any non-minor placing a home token, incorrectly calling minor_available_regions.delete(region) (wiping out a whole zone's chit slots) and adding the regional's ID to minor_floated_regions. Once enough regionals placed tokens, all minor chit slots would be gone and minors would get a GameError on token placement. The else branch is removed — non-minors fall straight through to super.                                                                                        
                                                                                                                                                      
  #### `step/buy_sell_par_shares.rb`                                                                                                                  
                                                                                                                                                      
  - `float_minor` log line: available zones now displayed as                                                                                          
    `"UK(2), FR(1), AH(2), …"` instead of dumping the raw hash.