### PR TITLE
[18Cuba] Tile upgrading and sugar cane fields

### DIFF
--- a/lib/engine/game/g_18_cuba/game.rb
+++ b/lib/engine/game/g_18_cuba/game.rb
@@ -18,14 +18,6 @@ module Engine
 
         include DoubleSidedTiles
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
         def sugar_cane_open_for_majors?
           @sugar_cane_open_for_majors
         end

--- a/lib/engine/game/g_18_cuba/game.rb
+++ b/lib/engine/game/g_18_cuba/game.rb
@@ -301,7 +301,7 @@ module Engine
           if corp.type == :minor
             minor_tile_blocked?(tile, corp.tokens.first.hex, hex, for_selector: for_selector)
           else
-            major_tile_blocked?(tile)
+            major_tile_blocked?(tile, hex, for_selector: for_selector)
           end
         end
 
@@ -312,30 +312,40 @@ module Engine
         end
 
         def tile_has_only_track_type?(tile, track_type)
-          # Returns true if all paths on the tile are of the given track type
           tile.paths.all? { |path| path.track == track_type }
+        end
+
+        def mixed_gauge_city_tile?(tile)
+          tile && !tile.cities.empty? && tile.paths.any? { |p| p.track == :narrow }
         end
 
         def minor_tile_blocked?(tile, home_hex, current_hex, for_selector: false)
           # Determines if a tile is illegal for a minor:
           # - Tiles with only broad tracks are always illegal
           # - City tiles are illegal except on the minor's home hex
-          # - When `for_selector` is true, the home/city rule is ignored because the hex is unknown
+          # - On sugar cane hexes, only tiles with hidden towns are legal (no plain track)
+          # - When `for_selector` is true, the rules which require current_hex is ignored because the hex is unknown
           pure_broad = tile_has_only_track_type?(tile, :broad)
 
           return pure_broad if for_selector
-
           return pure_broad if current_hex == home_hex
+          return true if sugar_cane_hex?(current_hex) && tile.towns.empty?
 
           !tile.cities.empty? || pure_broad
         end
 
-        def major_tile_blocked?(tile)
+        def major_tile_blocked?(tile, hex = nil, for_selector: false)
           # Pure narrow tiles cannot be part of a major's route
           return true if tile_has_only_track_type?(tile, :narrow)
 
-          # Mixed gauge city tiles (sugar mill, e.g. L66, L77) are only for minor home cities
-          return true if !tile.cities.empty? && tile.paths.any? { |p| p.track == :narrow }
+          # Mixed gauge city tiles (sugar mill) are minor-only in yellow.
+          # In green/brown they are only allowed as upgrades from an existing sugar mill
+          # (e.g. L53 → L67, L67 → brown sugar mill); majors cannot place them on plain hexes.
+          if mixed_gauge_city_tile?(tile)
+            return true if tile.color == :yellow
+            return false if for_selector
+            return true unless mixed_gauge_city_tile?(hex&.tile)
+          end
 
           # Yellow tiles must be pure broad for majors
           tile.color == :yellow && !tile_has_only_track_type?(tile, :broad)

--- a/lib/engine/game/g_18_cuba/game.rb
+++ b/lib/engine/game/g_18_cuba/game.rb
@@ -18,6 +18,16 @@ module Engine
 
         include DoubleSidedTiles
 
+        register_colors(red: '#d1232a',
+                        orange: '#f58121',
+                        black: '#110a0c',
+                        blue: '#025aaa',
+                        lightBlue: '#8dd7f6',
+                        yellow: '#ffe600',
+                        green: '#32763f',
+                        brightGreen: '#6ec037')
+        attr_reader :sugar_cane_open_for_majors
+
         TRACK_RESTRICTION = :permissive
         CURRENCY_FORMAT_STR = '$%s'
         HOME_TOKEN_TIMING = :operate
@@ -268,6 +278,23 @@ module Engine
           end
         end
 
+        def upgrades_to_correct_city_town?(from, to)
+          return true if sugar_cane_tile?(from) && @sugar_cane_open_for_majors && to.city_towns.empty?
+
+          super
+        end
+
+        def sugar_cane_hex?(hex)
+          SUGAR_CANE_HEXES.include?(hex.id)
+        end
+
+        def upgrade_cost(tile, hex, entity, spender)
+          # Minors lay on sugar cane hexes at no cost
+          return 0 if entity&.type == :minor && sugar_cane_hex?(hex)
+
+          super
+        end
+
         def tile_blocked_for_corp?(tile, corp, hex, for_selector: false)
           return false unless corp
 
@@ -279,6 +306,10 @@ module Engine
         end
 
         private
+
+        def sugar_cane_tile?(tile)
+          tile.towns.any?(&:hidden?)
+        end
 
         def tile_has_only_track_type?(tile, track_type)
           # Returns true if all paths on the tile are of the given track type
@@ -300,7 +331,13 @@ module Engine
         end
 
         def major_tile_blocked?(tile)
-          # Returns true if a yellow tile is illegal for a major: only pure broad tracks allowed on yellow
+          # Pure narrow tiles cannot be part of a major's route
+          return true if tile_has_only_track_type?(tile, :narrow)
+
+          # Mixed gauge city tiles (sugar mill, e.g. L66, L77) are only for minor home cities
+          return true if !tile.cities.empty? && tile.paths.any? { |p| p.track == :narrow }
+
+          # Yellow tiles must be pure broad for majors
           tile.color == :yellow && !tile_has_only_track_type?(tile, :broad)
         end
       end

--- a/lib/engine/game/g_18_cuba/game.rb
+++ b/lib/engine/game/g_18_cuba/game.rb
@@ -26,7 +26,9 @@ module Engine
                         yellow: '#ffe600',
                         green: '#32763f',
                         brightGreen: '#6ec037')
-        attr_reader :sugar_cane_open_for_majors
+        def sugar_cane_open_for_majors?
+          @sugar_cane_open_for_majors
+        end
 
         TRACK_RESTRICTION = :permissive
         CURRENCY_FORMAT_STR = '$%s'
@@ -279,7 +281,7 @@ module Engine
         end
 
         def upgrades_to_correct_city_town?(from, to)
-          return true if sugar_cane_tile?(from) && @sugar_cane_open_for_majors && to.city_towns.empty?
+          return true if sugar_cane_tile?(from) && sugar_cane_open_for_majors? && to.city_towns.empty?
 
           super
         end

--- a/lib/engine/game/g_18_cuba/map.rb
+++ b/lib/engine/game/g_18_cuba/map.rb
@@ -422,6 +422,8 @@ module Engine
         }.freeze
 
         FC_HEX = %w[B9 B11 C14 D15 D19 E22 G24].freeze
+        SUGAR_CANE_HEXES = %w[D1 C2 E2 D5 D11 B13 C16 C18 E16 E18 G22 H21 D21 F29 G28
+                              D9 G20 F27 F19 E26].freeze
 
         LAYOUT = :pointy
       end

--- a/lib/engine/game/g_18_cuba/step/track.rb
+++ b/lib/engine/game/g_18_cuba/step/track.rb
@@ -34,6 +34,8 @@ module Engine
           end
 
           def check_track_restrictions!(entity, old_tile, new_tile)
+            return if @game.loading || !entity.operator?
+
             # City tiles: "It is not necessary that any of the new track is usable by the company."
             return unless old_tile.cities.empty?
 
@@ -41,9 +43,18 @@ module Engine
             # Majors are already blocked from pure narrow upgrades via major_tile_blocked?.
             return unless old_tile.towns.empty?
 
-            # Plain track tiles: must extend the entity's route.
-            # graph_for_entity filters by gauge (narrow for minors, broad for majors).
-            super
+            # Plain track: "may upgrade only if the [narrow/standard] gauge track is extended."
+            graph = @game.graph_for_entity(entity)
+            old_paths = old_tile.paths
+            used_new_track = old_paths.empty?
+
+            new_tile.paths.each do |np|
+              next unless graph.connected_paths(entity)[np]
+
+              used_new_track = true unless old_paths.find { |path| np <= path }
+            end
+
+            raise GameError, 'Must use new track' unless used_new_track
           end
         end
       end

--- a/lib/engine/game/g_18_cuba/step/track.rb
+++ b/lib/engine/game/g_18_cuba/step/track.rb
@@ -47,8 +47,8 @@ module Engine
             # ("it is not necessary that any of the new track is usable by the company").
             # Hex reachability is already enforced by tracker_available_hex.
             old_paths = old_tile.paths
-            raise GameError, 'Must use new track' unless old_paths.empty? ||
-                                                         new_tile.paths.any? { |np| old_paths.none? { |op| np <= op } }
+            raise GameError, 'Must use new track' if !old_paths.empty? &&
+                                                      new_tile.paths.none? { |np| old_paths.none? { |op| np <= op } }
           end
         end
       end

--- a/lib/engine/game/g_18_cuba/step/track.rb
+++ b/lib/engine/game/g_18_cuba/step/track.rb
@@ -48,7 +48,7 @@ module Engine
             # Hex reachability is already enforced by tracker_available_hex.
             old_paths = old_tile.paths
             raise GameError, 'Must use new track' if !old_paths.empty? &&
-                                                      new_tile.paths.none? { |np| old_paths.none? { |op| np <= op } }
+                                                      new_tile.paths.all? { |np| old_paths.any? { |op| np <= op } }
           end
         end
       end

--- a/lib/engine/game/g_18_cuba/step/track.rb
+++ b/lib/engine/game/g_18_cuba/step/track.rb
@@ -43,18 +43,12 @@ module Engine
             # Majors are already blocked from pure narrow upgrades via major_tile_blocked?.
             return unless old_tile.towns.empty?
 
-            # Plain track: "may upgrade only if the [narrow/standard] gauge track is extended."
-            graph = @game.graph_for_entity(entity)
+            # Plain track: the gauge track must be extended, but new track need not be reachable
+            # ("it is not necessary that any of the new track is usable by the company").
+            # Hex reachability is already enforced by tracker_available_hex.
             old_paths = old_tile.paths
-            used_new_track = old_paths.empty?
-
-            new_tile.paths.each do |np|
-              next unless graph.connected_paths(entity)[np]
-
-              used_new_track = true unless old_paths.any? { |path| np <= path }
-            end
-
-            raise GameError, 'Must use new track' unless used_new_track
+            raise GameError, 'Must use new track' unless old_paths.empty? ||
+                                                         new_tile.paths.any? { |np| old_paths.none? { |op| np <= op } }
           end
         end
       end

--- a/lib/engine/game/g_18_cuba/step/track.rb
+++ b/lib/engine/game/g_18_cuba/step/track.rb
@@ -10,13 +10,17 @@ module Engine
         class Track < Engine::Step::Track
           def tracker_available_hex(entity, hex)
             # TODO: FC logic with fee payments
-            # TODO: upgrade logic ensure narrow track connect to narrow track and broad to broad
             corp = entity.corporation? ? entity : @game.current_entity
 
             # 18Cuba: minors cannot build cities except on their home hex
             return nil if corp.type == :minor &&
                           !hex.tile.cities.empty? &&
                           hex != corp.tokens.first.hex
+
+            # Majors may only lay on sugar cane hexes after the sugar_cane_open_for_majors event
+            return nil if corp.type == :major &&
+                          @game.sugar_cane_hex?(hex) &&
+                          !@game.sugar_cane_open_for_majors
 
             super
           end
@@ -27,6 +31,19 @@ module Engine
             super.reject do |tile|
               @game.tile_blocked_for_corp?(tile, corp, hex)
             end
+          end
+
+          def check_track_restrictions!(entity, old_tile, new_tile)
+            # City tiles: "It is not necessary that any of the new track is usable by the company."
+            return unless old_tile.cities.empty?
+
+            # Sugar cane (town) tiles: "A minor company may upgrade any sugar cane field tile."
+            # Majors are already blocked from pure narrow upgrades via major_tile_blocked?.
+            return unless old_tile.towns.empty?
+
+            # Plain track tiles: must extend the entity's route.
+            # graph_for_entity filters by gauge (narrow for minors, broad for majors).
+            super
           end
         end
       end

--- a/lib/engine/game/g_18_cuba/step/track.rb
+++ b/lib/engine/game/g_18_cuba/step/track.rb
@@ -43,12 +43,20 @@ module Engine
             # Majors are already blocked from pure narrow upgrades via major_tile_blocked?.
             return unless old_tile.towns.empty?
 
-            # Plain track: the gauge track must be extended, but new track need not be reachable
-            # ("it is not necessary that any of the new track is usable by the company").
-            # Hex reachability is already enforced by tracker_available_hex.
+            # Gauge-appropriate track must be extended.
             old_paths = old_tile.paths
-            raise GameError, 'Must use new track' if !old_paths.empty? &&
-                                                      new_tile.paths.all? { |np| old_paths.any? { |op| np <= op } }
+            corp = entity.corporation? ? entity : @game.current_entity
+
+            case corp.type
+            when :major
+              raise GameError, 'Standard gauge track must be extended' unless new_tile.paths.any? do |np|
+                np.track != :narrow && old_paths.none? { |op| np <= op }
+              end
+            else
+              raise GameError, 'Narrow gauge track must be extended' unless new_tile.paths.any? do |np|
+                np.track != :broad && old_paths.none? { |op| np <= op }
+              end
+            end
           end
         end
       end

--- a/lib/engine/game/g_18_cuba/step/track.rb
+++ b/lib/engine/game/g_18_cuba/step/track.rb
@@ -20,7 +20,7 @@ module Engine
             # Majors may only lay on sugar cane hexes after the sugar_cane_open_for_majors event
             return nil if corp.type == :major &&
                           @game.sugar_cane_hex?(hex) &&
-                          !@game.sugar_cane_open_for_majors
+                          !@game.sugar_cane_open_for_majors?
 
             super
           end
@@ -51,7 +51,7 @@ module Engine
             new_tile.paths.each do |np|
               next unless graph.connected_paths(entity)[np]
 
-              used_new_track = true unless old_paths.find { |path| np <= path }
+              used_new_track = true unless old_paths.any? { |path| np <= path }
             end
 
             raise GameError, 'Must use new track' unless used_new_track

--- a/lib/engine/game/g_18_cuba/step/track.rb
+++ b/lib/engine/game/g_18_cuba/step/track.rb
@@ -46,16 +46,12 @@ module Engine
             # Gauge-appropriate track must be extended.
             old_paths = old_tile.paths
             corp = entity.corporation? ? entity : @game.current_entity
+            added_paths = new_tile.paths.reject { |np| old_paths.any? { |op| np <= op } }
 
-            case corp.type
-            when :major
-              raise GameError, 'Standard gauge track must be extended' unless new_tile.paths.any? do |np|
-                np.track != :narrow && old_paths.none? { |op| np <= op }
-              end
+            if corp.type == :major
+              raise GameError, 'Standard gauge track must be extended' unless added_paths.any? { |np| np.track != :narrow }
             else
-              raise GameError, 'Narrow gauge track must be extended' unless new_tile.paths.any? do |np|
-                np.track != :broad && old_paths.none? { |op| np <= op }
-              end
+              raise GameError, 'Narrow gauge track must be extended' unless added_paths.any? { |np| np.track != :broad }
             end
           end
         end

--- a/lib/engine/game/g_18_cuba/trains.rb
+++ b/lib/engine/game/g_18_cuba/trains.rb
@@ -36,6 +36,7 @@ module Engine
                 price: 230,
               },
             ],
+            events: [{ 'type' => 'sugar_cane_open_for_majors' }],
           },
           {
             name: '4',
@@ -139,6 +140,11 @@ module Engine
             discount: { '4n' => 130, '4-1n' => 65 },
           },
           ].freeze
+
+        def event_sugar_cane_open_for_majors!
+          @sugar_cane_open_for_majors = true
+          @log << '-- Event: Major corporations may now lay plain track on sugar cane hexes --'
+        end
 
         def event_downgrade_4n_trains!
           @log << '-- Event: 4n trains downgrade to 4-1n trains --'


### PR DESCRIPTION
This PR enfores rules for tile upgrading. Additionally it adds sugar_cane_open_for_majors event triggered by the first 3-train


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

Thanks for reviewing this PR. 

## Implementation Notes

### Explanation of Change

The rules say "It is not necessary that any of the new track is usable by the company" (VII.7), so `:permissive` is correct for city and sugar cane upgrades. The plain track restriction ("may upgrade only if gauge track is extended") is enforced explicitly in `check_track_restrictions!`.

**Tile blocking**

- Minors: pure broad tiles blocked everywhere; on sugar cane hexes only tiles with towns are legal (plain track has no towns); city tiles only allowed on home hex
- Majors: pure narrow tiles blocked; yellow mixed-gauge city tiles (sugar mills) blocked — green/brown only allowed as upgrades from an existing sugar mill on that hex; other yellow non-broad tiles blocked

**Sugar Cane**

Minors build on sugar cane hexes for free; majors only from phase 3 (`sugar_cane_open_for_majors`)
`upgrades_to_correct_city_town?` override allows upgrading a sugar cane hex (hidden town) to plain track

### Screenshots

### Any Assumptions / Hacks
