### PR TITLE
[Core] Implement game log indentation groups

### DIFF
--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -22,9 +22,9 @@ module View
       needs :show_log, default: true, store: true
 
       def render
-        children = [render_log_choices, render_log]
-
         @player = @game.player_by_id(@user['id']) if @user
+
+        children = [render_log_choices, render_log]
 
         key_event = lambda do |event|
           event = Native(event)
@@ -102,6 +102,10 @@ module View
         blank_action.created_at = @game.actions[0]&.created_at || Time.now
 
         last_action = nil
+        @last_entity = nil
+        @in_or_operation = false
+        @eft_corps = nil
+        @eft_companies = nil
 
         actions = @game.actions.to_h { |a| [a.id, a] }
 
@@ -164,14 +168,145 @@ module View
         h('div#chatlog', props, the_log)
       end
 
-      def render_log_for_action(log, action)
-        timestamp_props = {
-          style: {
-            fontSize: 'smaller',
-          },
-        }
-        message_props = { style: { margin: '0 0.2rem' } }
+      def ensure_eft_built
+        return if @eft_corps
 
+        historical = @game.actions.map(&:entity).uniq
+          .reject { |e| @game.players.include?(e) }
+          .select { |e| e.respond_to?(:id) }
+        @eft_corps = (@game.corporations + @game.minors + historical)
+          .uniq
+          .sort_by { |e| -[e.name.size, e.id.size].max }
+        @eft_companies = @game.companies
+          .sort_by { |e| -[e.name.size, e.id.size].max }
+      end
+
+      def entity_for_line(line, auctioning_lot = nil)
+        return nil unless line.is_a?(String)
+        return nil if line.start_with?('--')
+
+        # Build the corps list once per render (memoized). Include historical
+        # acting corps from actions so that entities removed mid-game
+        # (e.g. nationalized minors in 1861) are still recognised in the log.
+        ensure_eft_built
+
+        # Sort longest-first so e.g. "P10" is checked before "P1"
+        corps = @eft_corps
+        companies = @eft_companies
+
+        # When an auction lot is active, derive the canonical entity key for it
+        # so all log lines during that auction group together.
+        lot_key = lot_entity_key(auctioning_lot) if auctioning_lot
+
+        corp_in_line = lambda do |text|
+          corps.each do |e|
+            # Corporation#name == #id == sym; guard short IDs to avoid matching
+            # every line that contains the letter, e.g. corp 'E' in "Exemplar1..."
+            return e.id if e.id.size >= 2 && text.include?(e.id)
+            # Also match by full name for corps whose log text uses the long name
+            # rather than the short ID (e.g. 1866 minor nationals: "Sardinia Minor
+            # National" in bid lines, while the ID is just "SAR").
+            return e.id if e.name.size >= 4 && e.name != e.id && text.include?(e.name)
+          end
+          nil
+        end
+
+        # Like corp_in_line but also searches private companies — for player lines
+        # so "Player 1 bids on Tsarskoye Selo Railway" groups with other TSR auction lines
+        entity_in_line = lambda do |text|
+          result = corp_in_line.call(text)
+          return result if result
+
+          companies.each do |e|
+            return e.id if text.include?(e.name) || (e.id.size >= 2 && text.include?(e.id))
+          end
+          nil
+        end
+
+        # Corporation/minor at start of line.
+        # Require the next character to be a space (or end of string) so corp "1"
+        # does not match "1822CA is currently..." and corp "E" does not match
+        # "Exemplar1 receives...". Lines like "3's share price..." fall through
+        # to the catch-all which handles them via @last_entity.
+        corps.each do |e|
+          id = e.id
+          next unless line.start_with?(id)
+
+          next_char = line[id.size]
+          next if next_char && next_char != ' '
+
+          return id
+        end
+
+        # Player starts line.
+        # Without an active auction lot (subject-centric): group by the acting
+        # player. With an active lot (object-centric): all bids/passes group
+        # under the lot's canonical entity key.
+        @game.players.each do |player|
+          next unless line.start_with?(player.name)
+
+          unless auctioning_lot
+            # During an OR operation, player lines like "X receives $Y" are
+            # consequences of the corp's turn — keep them grouped under the corp.
+            return @last_entity if @in_or_operation && @last_entity && @game.players.none? { |p| p.name == @last_entity }
+
+            return player.name
+          end
+
+          return lot_key || entity_in_line.call(line) || @last_entity || player.name
+        end
+
+        # Private company starts line.
+        # With an active auction lot: company is the lot (or acting for the lot),
+        # so anchor to lot_key. Without a lot: company acts on behalf of the
+        # current entity — stay grouped rather than starting a new group.
+        companies.each do |e|
+          next if !line.start_with?(e.name) && !line.start_with?(e.id)
+
+          return @last_entity if @last_entity && !auctioning_lot
+
+          return lot_key || corp_in_line.call(line) || e.id
+        end
+
+        # Catch-all: unrecognised lines without an active lot stay grouped under
+        # the current entity rather than breaking the chain.
+        return @last_entity if @last_entity && !auctioning_lot
+
+        nil
+      end
+
+      def lot_entity_key(lot)
+        # Map an auctioning lot (Company or Corporation) to the canonical entity
+        # key used by the log grouping — the id of the matching corp/minor, or
+        # the company id as fallback. Lists must already be initialised.
+        @eft_corps.each do |e|
+          return e.id if e.name == lot.name || e.id == lot.id
+        end
+        @eft_companies.each do |e|
+          return e.id if e.name == lot.name || e.id == lot.id
+        end
+        lot.id
+      end
+
+      def player_for(entity)
+        return nil unless entity
+        return entity if @game.players.include?(entity)
+
+        if entity.respond_to?(:player)
+          found = entity.player
+          return found if @game.players.include?(found)
+        end
+
+        if entity.respond_to?(:owner)
+          owner = entity.owner
+          return owner if @game.players.include?(owner)
+          return player_for(owner) if owner && owner != entity
+        end
+
+        nil
+      end
+
+      def render_log_for_action(log, action)
         timestamp = "[#{Time.at(action.created_at || Time.now).strftime('%R')}] "
 
         click = lambda do
@@ -192,20 +327,45 @@ module View
             },
             on: { click: click },
           }
-          line_props[:style][:fontWeight] = 'bold' if line.is_a?(String) && line.start_with?('--')
+          is_banner = line.is_a?(String) && line.start_with?('--')
+          line_props[:style][:fontWeight] = 'bold' if is_banner
+
+          indent = false
 
           if line.is_a?(Engine::Action::Message)
             next [] if line.message.empty?
 
             line_props[:style][:fontWeight] = 'bold'
             line_props[:style][:marginTop] = '0.5em'
-
             sender = line.entity.name || 'Owner'
             line = "#{sender}: #{line.message}"
+          elsif is_banner
+            # Only reset grouping for round/entity changes; let phase changes,
+            # train rusts, and other mid-sequence events pass through silently.
+            if line.include?(' Round ')
+              @last_entity = nil
+              @in_or_operation = false
+            elsif line.include?(' operates ')
+              ensure_eft_built
+              operating_name = line.delete_prefix('-- ').delete_suffix(' --').split(' operates ').last
+              match = @eft_corps.find { |e| e.name == operating_name || e.id == operating_name }
+              @last_entity = match ? match.id : nil
+              @in_or_operation = true
+            end
+          else
+            line_entity = entity_for_line(line, entry.auctioning_lot)
+            indent = line_entity && line_entity == @last_entity
+            @last_entity = line_entity if line_entity
           end
 
-          h('div.chatline', line_props,
-            [h('span.timestamp', timestamp_props, timestamp), h('span.message', message_props, line)])
+          ts_props = { style: { fontSize: 'smaller' } }
+          msg_props = { style: { margin: '0 0.2rem' } }
+          msg_props[:style][:marginLeft] = '1.5rem' if indent
+
+          h('div.chatline', line_props, [
+            h('span.timestamp', ts_props, timestamp),
+            h('span.message', msg_props, line),
+          ])
         end
 
         if !action.is_a?(Engine::Action::Message) &&
@@ -214,7 +374,16 @@ module View
           action_log << render_action_buttons(action.id)
         end
 
-        h(:div, action_log)
+        h(:div, { attrs: { id: "action-#{action.id}" } }, action_log)
+      end
+
+      def last_player_action_id
+        return nil unless @player
+
+        @game.actions.reverse_each do |action|
+          return action.id if player_for(action.entity) == @player
+        end
+        nil
       end
 
       def render_action_buttons(action_id)
@@ -252,15 +421,30 @@ module View
       end
 
       def render_log_choices
+        left_buttons = [
+          h(:button,
+            {
+              style: { marginTop: '0' },
+              on: { click: -> { copy_log_transcript } },
+            },
+            'Copy Transcript 📋'),
+        ]
+
+        if @player && (last_id = last_player_action_id)
+          jump = lambda do
+            store(:selected_action_id, last_id)
+            `document.getElementById('action-' + #{last_id}).scrollIntoView({block: 'nearest'})`
+          end
+          left_buttons << h(:button,
+                            {
+                              style: { marginTop: '0' },
+                              on: { click: jump },
+                            },
+                            'My Last Move ↑')
+        end
+
         h(:div, { style: { marginBottom: '0.3rem', display: 'flex', justifyContent: 'space-between' } }, [
-          h(:div, { style: { textAlign: 'left' } }, [
-            h(:button,
-              {
-                style: { marginTop: '0' },
-                on: { click: -> { copy_log_transcript } },
-              },
-              'Copy Transcript 📋'),
-          ]),
+          h(:div, { style: { textAlign: 'left' } }, left_buttons),
           h(:div, { style: { textAlign: 'right' } }, [
             h(:button,
               {

--- a/lib/engine/game/g_1825/round/operating.rb
+++ b/lib/engine/game/g_1825/round/operating.rb
@@ -14,9 +14,9 @@ module Engine
             entity.trains.each { |train| train.operated = false }
             actor = @game.acting_for_entity(entity)
             if actor == entity.owner
-              @log << "#{actor.name} operates #{entity.name}" unless finished?
+              @log << "-- #{actor.name} operates #{entity.name} --" unless finished?
             else
-              @log << "#{actor.name} selected to operate #{entity.name} (in Receivership)" unless finished?
+              @log << "-- #{actor.name} selected to operate #{entity.name} (in Receivership) --" unless finished?
             end
             @game.place_home_token(entity) if @home_token_timing == :operate || @game.minor_deferred_token?(entity)
             skip_steps

--- a/lib/engine/game/g_1858/step/exchange.rb
+++ b/lib/engine/game/g_1858/step/exchange.rb
@@ -47,7 +47,10 @@ module Engine
           def exchange_for_presidency(bundle, corporation, minor, player)
             raise GameError, "#{corporation.name} cannot be parred" unless @game.can_par?(corporation, player)
 
-            acquire_private(corporation, minor)
+            # Close the minor early so its home hex is free for token placement,
+            # but suppress the log message until after after_par so the log order is:
+            # player exchanges → becomes president → corp floats → corp acquires.
+            acquire_log = acquire_private(corporation, minor, silent: true)
             share_price = @game.par_price(minor)
             @game.stock_market.set_par(corporation, share_price)
             @round.players_bought[player][corporation] += bundle.percent
@@ -60,6 +63,7 @@ module Engine
                        exchange_price: share_price.price,
                        silent: true)
             @game.after_par(corporation)
+            @log << acquire_log
           end
         end
       end

--- a/lib/engine/game/g_1858/step/private_exchange.rb
+++ b/lib/engine/game/g_1858/step/private_exchange.rb
@@ -6,7 +6,7 @@ module Engine
       module Step
         # Code shared by both the Exchange and PrivateClosure steps.
         module PrivateExchange
-          def acquire_private(corporation, entity)
+          def acquire_private(corporation, entity, silent: false)
             player = entity.owner
 
             company = @game.private_company(entity)
@@ -18,7 +18,8 @@ module Engine
             player.companies.delete(company)
             company.owner = corporation
             corporation.companies << company
-            @log << "#{corporation.name} acquires #{company.name} from #{player.name}"
+            @log << "#{corporation.name} acquires #{company.name} from #{player.name}" unless silent
+            "#{corporation.name} acquires #{company.name} from #{player.name}"
           end
 
           def transfer_abilities(minor, company)

--- a/lib/engine/game/g_1860/round/operating.rb
+++ b/lib/engine/game/g_1860/round/operating.rb
@@ -48,7 +48,7 @@ module Engine
             @current_operator = entity
             @current_operator_acted = false
             entity.trains.each { |train| train.operated = false }
-            @log << "#{@game.acting_for_entity(entity).name} operates #{entity.name}" unless finished?
+            @log << "-- #{@game.acting_for_entity(entity).name} operates #{entity.name} --" unless finished?
             @game.place_home_token(entity) if @home_token_timing == :operate
             @game.update_crowded(entity)
             clear_cache!

--- a/lib/engine/game/g_1866/game.rb
+++ b/lib/engine/game/g_1866/game.rb
@@ -1390,6 +1390,9 @@ module Engine
           @game_end_three_rounds = nil
           @game_end_triggered_corporation = nil
           @game_end_triggered_round = nil
+
+          auction_step = @round.steps.find { |s| s.is_a?(G1866::Step::SingleItemAuction) }
+          auction_step&.auction_log(auction_step.companies[0]) unless auction_step&.companies&.empty?
         end
 
         def setup_preround

--- a/lib/engine/game/g_1866/step/single_item_auction.rb
+++ b/lib/engine/game/g_1866/step/single_item_auction.rb
@@ -67,8 +67,9 @@ module Engine
                               .join(', ')
             privates_left_str = "In alphabetical order, the following items remain to be auctioned: #{privates_left}."
             privates_left_str = 'Last one.' if privates_left.empty?
-            @game.log << "#{entity.name} is up for auction. #{privates_left_str}"
             @auction_start_entity = entities[entity_index]
+            @auctioning = entity
+            @game.log << "#{entity.name} is up for auction. #{privates_left_str}"
             auction_entity(entity)
           end
 
@@ -252,8 +253,6 @@ module Engine
           def setup
             setup_auction
             @companies = @game.companies.reject { |c| @game.stock_turn_token_company?(c) }
-
-            auction_log(@companies[0]) unless @companies.empty?
           end
 
           def show_stock_market?
@@ -301,6 +300,9 @@ module Engine
               player = winner.entity
               company = winner.company
               price = winner.price
+              @log << "#{player.name} wins the auction for #{company.name} with a bid of #{@game.format_currency(price)}"
+              player.spend(price, @game.bank) if price.positive?
+              @companies.delete(company)
               if @game.class::NATIONAL_COMPANIES.include?(company.id)
                 company.owner = player
                 player.companies << company
@@ -327,9 +329,6 @@ module Engine
                                             exchange: :free,
                                             exchange_price: share.price_per_share)
               end
-              player.spend(price, @game.bank) if price.positive?
-              @companies.delete(company)
-              @log << "#{player.name} wins the auction for #{company.name} with a bid of #{@game.format_currency(price)}"
             else
               remove_company(company)
             end

--- a/lib/engine/game/g_1867/step/single_item_auction.rb
+++ b/lib/engine/game/g_1867/step/single_item_auction.rb
@@ -88,6 +88,7 @@ module Engine
           def auction_entity_log(entity)
             @dutch_mode = false
             @declined_bids = []
+            @auctioning = entity
             @game.log << "#{entity.name} is up for auction, minimum bid is #{@game.format_currency(min_bid(entity))}"
             auction_entity(entity)
           end

--- a/lib/engine/game/g_18_hiawatha/round/operating.rb
+++ b/lib/engine/game/g_18_hiawatha/round/operating.rb
@@ -17,7 +17,7 @@ module Engine
             @payable_loans = @current_operator.loans.size
             @current_operator_acted = false
             entity.trains.each { |train| train.operated = false }
-            @log << "#{@game.acting_for_entity(entity).name} operates #{entity.name}" unless finished?
+            @log << "-- #{@game.acting_for_entity(entity).name} operates #{entity.name} --" unless finished?
             @game.place_home_token(entity) if @home_token_timing == :operate
             skip_steps
             return unless finished?

--- a/lib/engine/game/g_18_royal_gorge/step/single_item_auction.rb
+++ b/lib/engine/game/g_18_royal_gorge/step/single_item_auction.rb
@@ -95,6 +95,7 @@ module Engine
 
           def auction_entity_log(entity)
             @declined_bids = []
+            @auctioning = entity
             @game.log << "#{entity.name} is up for auction, minimum bid is #{@game.format_currency(min_bid(entity))}"
             auction_entity(entity)
           end

--- a/lib/engine/game_log.rb
+++ b/lib/engine/game_log.rb
@@ -8,12 +8,18 @@ module Engine
     end
 
     def <<(message)
-      message = Entry.new(message, @game.current_action_id) unless message.is_a?(Entry)
-      super(message)
+      entry = message.is_a?(Entry) ? message : Entry.new(message, @game.current_action_id)
+      begin
+        step = @game.active_step
+        entry.auctioning_lot = step.auctioning_lot if step.respond_to?(:auctioning_lot)
+      rescue StandardError
+        # active_step may raise during game initialization before a round exists
+      end
+      super(entry)
     end
 
     class Entry
-      attr_accessor :message, :action_id
+      attr_accessor :message, :action_id, :auctioning_lot
 
       def initialize(message, action_id)
         @message = message

--- a/lib/engine/game_log.rb
+++ b/lib/engine/game_log.rb
@@ -10,8 +10,8 @@ module Engine
     def <<(message)
       entry = message.is_a?(Entry) ? message : Entry.new(message, @game.current_action_id)
       begin
-        step = @game.round&.steps&.find { |s| s.active? && s.blocking? }
-        entry.auctioning_lot = step.auctioning_lot if step.respond_to?(:auctioning_lot)
+        step = @game.round&.steps&.find { |s| s.respond_to?(:auctioning_lot) && s.auctioning_lot }
+        entry.auctioning_lot = step.auctioning_lot if step
       rescue StandardError
         # may raise during game initialization before a round exists
       end

--- a/lib/engine/game_log.rb
+++ b/lib/engine/game_log.rb
@@ -10,10 +10,10 @@ module Engine
     def <<(message)
       entry = message.is_a?(Entry) ? message : Entry.new(message, @game.current_action_id)
       begin
-        step = @game.active_step
+        step = @game.round&.steps&.find { |s| s.active? && s.blocking? }
         entry.auctioning_lot = step.auctioning_lot if step.respond_to?(:auctioning_lot)
       rescue StandardError
-        # active_step may raise during game initialization before a round exists
+        # may raise during game initialization before a round exists
       end
       super(entry)
     end

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -85,7 +85,7 @@ module Engine
 
         @current_operator = entity
         @current_operator_acted = false
-        @log << "#{@game.acting_for_entity(entity).name} operates #{entity.name}" unless finished?
+        @log << "-- #{@game.acting_for_entity(entity).name} operates #{entity.name} --" unless finished?
         @game.place_home_token(entity) if @home_token_timing == :operate
         skip_steps
         return unless finished?

--- a/lib/engine/step/auctioner.rb
+++ b/lib/engine/step/auctioner.rb
@@ -99,6 +99,10 @@ module Engine
         active_auction { |company, _| company }
       end
 
+      def auctioning_lot
+        @auctioning
+      end
+
       def highest_bid(company)
         @bids[company].max_by(&:price)
       end

--- a/lib/engine/step/buy_sell_par_shares_via_bid.rb
+++ b/lib/engine/step/buy_sell_par_shares_via_bid.rb
@@ -20,6 +20,10 @@ module Engine
         actions
       end
 
+      def auctioning_lot
+        @lot_for_log || @auctioning
+      end
+
       def auctioning_company
         @auctioning
       end
@@ -69,8 +73,10 @@ module Engine
         if @auctioning
           @log << "#{player.name} bids #{@game.format_currency(price)} for #{entity.name}"
         else
+          @lot_for_log = entity
           @log << "#{player.name} auctions #{entity.name} for #{@game.format_currency(price)}"
           @game.place_home_token(entity) if (@game.class::HOME_TOKEN_TIMING == :par) && !entity.company?
+          @lot_for_log = nil
         end
         super(action)
 

--- a/lib/engine/step/waterfall_auction.rb
+++ b/lib/engine/step/waterfall_auction.rb
@@ -22,6 +22,7 @@ module Engine
       end
 
       def process_pass(action)
+        flush_pending_auction_announcement
         entity = action.entity
 
         if auctioning
@@ -75,6 +76,7 @@ module Engine
       def round_state
         {
           companies_pending_par: [],
+          pending_auction_announcement: nil,
         }
       end
 
@@ -110,15 +112,24 @@ module Engine
       def resolve_bids_for_company(company)
         resolved = false
         is_new_auction = company != @auctioning
-        @auctioning = nil
         bids = @bids[company]
 
         if bids.one?
+          @auctioning = company
           accept_bid(bids.first)
+          @auctioning = nil
           resolved = true
         elsif can_auction?(company)
           @auctioning = company
-          @log << "#{@auctioning.name} goes up for auction" if is_new_auction
+          if is_new_auction
+            if @round.companies_pending_par.any?
+              @round.pending_auction_announcement = "#{company.name} goes up for auction"
+            else
+              @log << "#{company.name} goes up for auction"
+            end
+          end
+        else
+          @auctioning = nil
         end
 
         resolved
@@ -210,6 +221,7 @@ module Engine
       end
 
       def add_bid(bid)
+        flush_pending_auction_announcement
         super
         company = bid.company
         price = bid.price
@@ -218,6 +230,13 @@ module Engine
         @bidders[company] |= [entity]
 
         @log << "#{entity.name} bids #{@game.format_currency(price)} for #{bid.company.name}"
+      end
+
+      def flush_pending_auction_announcement
+        return unless @round.pending_auction_announcement
+
+        @log << @round.pending_auction_announcement
+        @round.pending_auction_announcement = nil
       end
     end
   end


### PR DESCRIPTION
Implements an indentation function for the game logs.  Log entries are now indented to visually indicate a group of related log entries (e.g. multiple actions in an OR by the same company, or multiple bids in an auction on the same entity, or multiple actions related to the same player's actions in an SR (buy/sell/float).

Two types of grouping are used:

    Subject-centric (SR/OR): lines group under the acting player or the
  operating corporation; player lines during an OR stay grouped under
  the corp.

Object-centric (auction): all bid/pass/win lines indent under the lot
  being auctioned, regardless of which player acts.

Infrastructure (See attached summary file for more fulsome description of each change):
- lib/engine/game_log.rb: Entry now carries auctioning_lot; GameLog#<< captures it from active_step at write time.
- lib/engine/step/auctioner.rb: adds auctioning_lot returning @auctioning as the base implementation for all auctioning steps.
- lib/engine/round/operating.rb and game-specific overrides (1825, 1860, 18Hiawatha): operation banner changed to "-- X operates Y --" format so the view can detect it as a banner and set @in_or_operation.

Game log view (assets/app/view/game/game_log.rb):
- entity_for_line now accepts auctioning_lot and applies object-centric grouping when a lot is active.
- Corp-at-start guard requires next char to be a space, preventing single-char corp IDs from matching mid-word (fixes 1822CA SR1).
- @in_or_operation gates the "player line stays under corp" rule so it only applies during OR operations, not SR turns.
- Operates banner sets @last_entity and @in_or_operation; Round banner resets both.

Per-game fixes:
- 1867 / 18RoyalGorge single_item_auction: set @auctioning before logging "is up for auction" so the line is tagged to the lot.
- 1866 single_item_auction / game: moved first auction announcement out of setup and into game#setup so it follows stock-turn-token messages.
- buy_sell_par_shares_via_bid: @lot_for_log pattern tags "auctions X for" and home-token lines to the lot without disturbing @auctioning.
- waterfall_auction: defers "goes up for auction" announcement until after pending par actions complete (fixes 1870 MKT/SLSF ordering).
- 1858 private_exchange / exchange: acquire_private silent: option lets exchange_for_presidency log in correct order (exchange → par → acquires).

Fixes #12400, #10369

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

### Explanation of Change

[game-log-indenter-changes.txt](https://github.com/user-attachments/files/27111312/game-log-indenter-changes.txt)

### Screenshots

<img width="1046" height="784" alt="image" src="https://github.com/user-attachments/assets/812a2623-5264-49ca-ab80-a9eb0f4b13f6" />

<img width="1148" height="826" alt="image" src="https://github.com/user-attachments/assets/a7ab9b36-c88a-4559-9216-188c9e407959" />

<img width="1344" height="972" alt="image" src="https://github.com/user-attachments/assets/1383148f-8abe-4e4f-8424-a163c7d8210d" />
