### PR TITLE
[Core/various] Remove `register_colors` method

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -531,14 +531,6 @@ module Engine
       # use to modify tiles based on optional rules
       def optional_tiles; end
 
-      def self.register_colors(colors)
-        colors.default_proc = proc do |_, key|
-          key
-        end
-
-        const_set(:COLORS, colors)
-      end
-
       def self.include_meta(meta_module)
         include meta_module
 

--- a/lib/engine/game/g_1804/game.rb
+++ b/lib/engine/game/g_1804/game.rb
@@ -13,14 +13,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
         TRACK_RESTRICTION = :permissive
         SELL_BUY_ORDER = :sell_buy_sell
         TILE_RESERVATION_BLOCKS_OTHERS = :always

--- a/lib/engine/game/g_1812/game.rb
+++ b/lib/engine/game/g_1812/game.rb
@@ -19,14 +19,6 @@ module Engine
         include CompanyPriceUpToFace
         include InterestOnLoans
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
         TRACK_RESTRICTION = :semi_restrictive
         CURRENCY_FORMAT_STR = '£%s'
 

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -15,27 +15,6 @@ module Engine
         include G1817::Entities
         include G1817::Map
 
-        register_colors(black: '#16190e',
-                        blue: '#165633',
-                        brightGreen: '#0a884b',
-                        brown: '#984573',
-                        gold: '#904098',
-                        gray: '#984d2d',
-                        green: '#bedb86',
-                        lavender: '#e96f2c',
-                        lightBlue: '#bedef3',
-                        lightBrown: '#bec8cc',
-                        lime: '#00afad',
-                        navy: '#003d84',
-                        natural: '#e31f21',
-                        orange: '#f2a847',
-                        pink: '#ee3e80',
-                        red: '#ef4223',
-                        turquoise: '#0095da',
-                        violet: '#e48329',
-                        white: '#fff36b',
-                        yellow: '#ffdea8')
-
         CURRENCY_FORMAT_STR = '$%s'
 
         BANK_CASH = 99_999

--- a/lib/engine/game/g_1822/game.rb
+++ b/lib/engine/game/g_1822/game.rb
@@ -14,18 +14,6 @@ module Engine
         include G1822::Entities
         include G1822::Map
 
-        register_colors(lnwrBlack: '#000',
-                        gwrGreen: '#165016',
-                        lbscrYellow: '#cccc00',
-                        secrOrange: '#ff7f2a',
-                        crBlue: '#5555ff',
-                        mrRed: '#ff2a2a',
-                        lyrPurple: '#5a2ca0',
-                        nbrBrown: '#a05a2c',
-                        swrGray: '#999999',
-                        nerGreen: '#aade87',
-                        black: '#000',
-                        white: '#ffffff')
         PRIVATE_RED = '#FF7276'
         PRIVATE_GREEN = '#90EE90'
         PRIVATE_BLUE = '#89CFF0'

--- a/lib/engine/game/g_1825/game.rb
+++ b/lib/engine/game/g_1825/game.rb
@@ -17,21 +17,6 @@ module Engine
 
         attr_reader :units, :node_distance_graph, :city_distance_graph
 
-        register_colors(black: '#37383a',
-                        seRed: '#f72d2d',
-                        bePurple: '#2d0047',
-                        peBlack: '#000',
-                        beBlue: '#c3deeb',
-                        heGreen: '#78c292',
-                        oegray: '#6e6966',
-                        weYellow: '#ebff45',
-                        beBrown: '#54230e',
-                        gray: '#6e6966',
-                        red: '#d81e3e',
-                        turquoise: '#00a993',
-                        blue: '#0189d1',
-                        brown: '#7b352a')
-
         SMALL_MARKET = [
           %w[0c
              5y

--- a/lib/engine/game/g_1826/game.rb
+++ b/lib/engine/game/g_1826/game.rb
@@ -15,17 +15,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        lightishBlue: '#0097df',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037',
-                        violet: '#601d39',
-                        sand: '#c89432')
         TRACK_RESTRICTION = :semi_restrictive
         SELL_BUY_ORDER = :sell_buy
         SELL_AFTER = :operate

--- a/lib/engine/game/g_1828/game.rb
+++ b/lib/engine/game/g_1828/game.rb
@@ -18,24 +18,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(hanBlue: '#446CCF',
-                        steelBlue: '#4682B4',
-                        brick: '#9C661F',
-                        powderBlue: '#B0E0E6',
-                        khaki: '#F0E68C',
-                        darkGoldenrod: '#B8860B',
-                        yellowGreen: '#9ACD32',
-                        gray70: '#B3B3B3',
-                        khakiDark: '#BDB76B',
-                        thistle: '#D8BFD8',
-                        lightCoral: '#F08080',
-                        tan: '#D2B48C',
-                        gray50: '#7F7F7F',
-                        cinnabarGreen: '#61B329',
-                        tomato: '#FF6347',
-                        plum: '#DDA0DD',
-                        lightGoldenrod: '#EEDD82')
-
         CURRENCY_FORMAT_STR = '$%s'
 
         BANK_CASH = 99_999

--- a/lib/engine/game/g_1829/game.rb
+++ b/lib/engine/game/g_1829/game.rb
@@ -13,14 +13,6 @@ module Engine
         include G1829::Entities
         include G1829::Map
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
         TRACK_RESTRICTION = :permissive
         SELL_BUY_ORDER = :sell_buy_sell
         CURRENCY_FORMAT_STR = '$%sP'

--- a/lib/engine/game/g_1830/game.rb
+++ b/lib/engine/game/g_1830/game.rb
@@ -13,14 +13,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
         TRACK_RESTRICTION = :permissive
         SELL_BUY_ORDER = :sell_buy_sell
         TILE_RESERVATION_BLOCKS_OTHERS = :always

--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -14,21 +14,6 @@ module Engine
         include G1835::Entities
         include G1835::Map
 
-        register_colors(black: '#37383a',
-                        seRed: '#f72d2d',
-                        bePurple: '#2d0047',
-                        peBlack: '#000',
-                        beBlue: '#c3deeb',
-                        heGreen: '#78c292',
-                        oegray: '#6e6966',
-                        weYellow: '#ebff45',
-                        beBrown: '#54230e',
-                        gray: '#6e6966',
-                        red: '#d81e3e',
-                        turquoise: '#00a993',
-                        blue: '#0189d1',
-                        brown: '#7b352a')
-
         CURRENCY_FORMAT_STR = '%sM'
         # game end current or, when the bank is empty
         GAME_END_CHECK = { bank: :current_or }.freeze

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -15,16 +15,6 @@ module Engine
         include Entities
         include CompanyPriceUpToFace
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        purple: '#A79ECD',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
-
         TRACK_RESTRICTION = :permissive
         SELL_BUY_ORDER = :sell_buy
         CURRENCY_FORMAT_STR = '%s'

--- a/lib/engine/game/g_1841/game.rb
+++ b/lib/engine/game/g_1841/game.rb
@@ -18,27 +18,6 @@ module Engine
 
         attr_reader :corporation_info, :done_this_round, :transform_state
 
-        register_colors(black: '#16190e',
-                        blue: '#0189d1',
-                        brown: '#7b352a',
-                        gray: '#7c7b8c',
-                        green: '#3c7b5c',
-                        olive: '#808000',
-                        lightGreen: '#009a54ff',
-                        lightBlue: '#4cb5d2',
-                        lightishBlue: '#0097df',
-                        teal: '#009595',
-                        orange: '#d75500',
-                        magenta: '#d30869',
-                        purple: '#772282',
-                        red: '#ef4223',
-                        rose: '#b7274c',
-                        coral: '#f3716d',
-                        white: '#fff36b',
-                        navy: '#000080',
-                        cream: '#fffdd0',
-                        yellow: '#ffdea8')
-
         CURRENCY_FORMAT_STR = 'L.%s'
 
         BANK_CASH_NORMAL = 14_400

--- a/lib/engine/game/g_1846/game.rb
+++ b/lib/engine/game/g_1846/game.rb
@@ -19,14 +19,6 @@ module Engine
 
         attr_accessor :second_tokens_in_green
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f')
-
         CURRENCY_FORMAT_STR = '$%s'
 
         BANK_CASH = { 2 => 7000, 3 => 6500, 4 => 7500, 5 => 9000 }.freeze

--- a/lib/engine/game/g_1849/game.rb
+++ b/lib/engine/game/g_1849/game.rb
@@ -18,14 +18,6 @@ module Engine
         include Entities
         include Map
         include InterestOnLoans
-        register_colors(black: '#000000',
-                        orange: '#f48221',
-                        brightGreen: '#76a042',
-                        red: '#ff0000',
-                        turquoise: '#00a993',
-                        blue: '#0189d1',
-                        brown: '#7b352a',
-                        goldenrod: '#f9b231')
 
         CURRENCY_FORMAT_STR = 'L.%s'
 

--- a/lib/engine/game/g_1850_jr/game.rb
+++ b/lib/engine/game/g_1850_jr/game.rb
@@ -13,11 +13,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        yellow: '#ffe600',
-                        green: '#32763f')
         TRACK_RESTRICTION = :permissive
         SELL_BUY_ORDER = :sell_buy_sell
         TILE_RESERVATION_BLOCKS_OTHERS = :always

--- a/lib/engine/game/g_1856/game.rb
+++ b/lib/engine/game/g_1856/game.rb
@@ -15,28 +15,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(black: '#37383a',
-                        orange: '#f48221',
-                        brightGreen: '#76a042',
-
-                        bbgPink: '#ffd9eb',
-                        caRed: '#f72d2d',
-                        cprPink: '#c474bc',
-                        cvPurple: '#2d0047',
-                        cgrBlack: '#000',
-                        lpsBlue: '#c3deeb',
-                        gtGreen: '#78c292',
-                        gwGray: '#6e6966',
-                        tgbOrange: '#c94d00',
-                        thbYellow: '#ebff45',
-                        wgbBlue: '#494d99',
-                        wrBrown: '#54230e',
-
-                        red: '#d81e3e',
-                        turquoise: '#00a993',
-                        blue: '#0189d1',
-                        brown: '#7b352a')
-
         CURRENCY_FORMAT_STR = '$%s'
 
         BANK_CASH = 12_000

--- a/lib/engine/game/g_1860/game.rb
+++ b/lib/engine/game/g_1860/game.rb
@@ -18,14 +18,6 @@ module Engine
 
         attr_reader :nationalization, :sr_after_southern, :distance_graph
 
-        register_colors(black: '#000000',
-                        orange: '#f48221',
-                        brightGreen: '#76a042',
-                        red: '#ff0000',
-                        turquoise: '#00a993',
-                        blue: '#0189d1',
-                        brown: '#7b352a')
-
         CURRENCY_FORMAT_STR = '£%s'
 
         BANK_CASH = 10_000

--- a/lib/engine/game/g_1862/game.rb
+++ b/lib/engine/game/g_1862/game.rb
@@ -33,14 +33,6 @@ module Engine
 
         attr_accessor :chartered, :base_tiles, :deferred_rust, :skip_round, :permits, :lner, :london_nodes
 
-        register_colors(black: '#000000',
-                        orange: '#f48221',
-                        brightGreen: '#76a042',
-                        red: '#ff0000',
-                        turquoise: '#00a993',
-                        blue: '#0189d1',
-                        brown: '#7b352a')
-
         CURRENCY_FORMAT_STR = '£%s'
 
         BANK_CASH = 15_000

--- a/lib/engine/game/g_1867/game.rb
+++ b/lib/engine/game/g_1867/game.rb
@@ -20,27 +20,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(black: '#16190e',
-                        blue: '#0189d1',
-                        brown: '#7b352a',
-                        gray: '#7c7b8c',
-                        green: '#3c7b5c',
-                        olive: '#808000',
-                        lightGreen: '#009a54ff',
-                        lightBlue: '#4cb5d2',
-                        lightishBlue: '#0097df',
-                        teal: '#009595',
-                        orange: '#d75500',
-                        magenta: '#d30869',
-                        purple: '#772282',
-                        red: '#ef4223',
-                        rose: '#b7274c',
-                        coral: '#f3716d',
-                        white: '#fff36b',
-                        navy: '#000080',
-                        cream: '#fffdd0',
-                        yellow: '#ffdea8')
-
         CURRENCY_FORMAT_STR = '$%s'
 
         BANK_CASH = 15_000

--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -16,14 +16,6 @@ module Engine
 
         attr_accessor :sell_queue, :connection_run, :reissued
 
-        register_colors(black: '#37383a',
-                        orange: '#f48221',
-                        brightGreen: '#76a042',
-                        red: '#d81e3e',
-                        turquoise: '#00a993',
-                        blue: '#0189d1',
-                        brown: '#7b352a')
-
         CURRENCY_FORMAT_STR = '$%s'
 
         BANK_CASH = 12_000

--- a/lib/engine/game/g_1877_stockholm_tramways/game.rb
+++ b/lib/engine/game/g_1877_stockholm_tramways/game.rb
@@ -24,8 +24,6 @@ module Engine
 
         attr_accessor :sl
 
-        register_colors(black: '#000000')
-
         CURRENCY_FORMAT_STR = '%skr'
 
         BANK_CASH = 99_999

--- a/lib/engine/game/g_1882/game.rb
+++ b/lib/engine/game/g_1882/game.rb
@@ -13,13 +13,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(green: '#237333',
-                        gray: '#9a9a9d',
-                        red: '#d81e3e',
-                        blue: '#0189d1',
-                        yellow: '#FFF500',
-                        brown: '#7b352a')
-
         CORPORATIONS_WITHOUT_NEUTRAL = %w[CPR CN].freeze
 
         CURRENCY_FORMAT_STR = '$%s'

--- a/lib/engine/game/g_1888/game.rb
+++ b/lib/engine/game/g_1888/game.rb
@@ -15,14 +15,6 @@ module Engine
         include Map
         include CompanyPrice50To150Percent
 
-        register_colors(green: '#237333',
-                        red: '#d81e3e',
-                        blue: '#0189d1',
-                        lightBlue: '#a2dced',
-                        yellow: '#FFF500',
-                        orange: '#f48221',
-                        brown: '#7b352a')
-
         CURRENCY_FORMAT_STR = '¥%s'
 
         PROTOTYPE_BANK_CASH = 10_000

--- a/lib/engine/game/g_1889/game.rb
+++ b/lib/engine/game/g_1889/game.rb
@@ -14,14 +14,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(black: '#37383a',
-                        orange: '#f48221',
-                        brightGreen: '#76a042',
-                        red: '#d81e3e',
-                        turquoise: '#00a993',
-                        blue: '#0189d1',
-                        brown: '#7b352a')
-
         CURRENCY_FORMAT_STR = '¥%s'
 
         BANK_CASH = 7000

--- a/lib/engine/game/g_1893/game.rb
+++ b/lib/engine/game/g_1893/game.rb
@@ -13,11 +13,6 @@ module Engine
         attr_accessor :passers_first_stock_round, :agv_mergable, :agv_auto_found, :hgk_mergable, :hgk_auto_found,
                       :potential_discard_trains, :fdsd_to_close
 
-        register_colors(
-          gray70: '#B3B3B3',
-          gray50: '#7F7F7F'
-        )
-
         CURRENCY_FORMAT_STR = '%sM'
 
         BANK_CASH = 7200

--- a/lib/engine/game/g_18_carolinas/game.rb
+++ b/lib/engine/game/g_18_carolinas/game.rb
@@ -19,14 +19,6 @@ module Engine
         attr_reader :corporation_power, :final_gauge, :north_hexes, :power_progress, :south_hexes,
                     :tile_groups
 
-        register_colors(green: '#237333',
-                        red: '#d81e3e',
-                        blue: '#0189d1',
-                        lightBlue: '#a2dced',
-                        yellow: '#FFF500',
-                        orange: '#f48221',
-                        brown: '#7b352a')
-
         CERT_LIMIT = {
           2 => 24,
           3 => 20,

--- a/lib/engine/game/g_18_chesapeake/game.rb
+++ b/lib/engine/game/g_18_chesapeake/game.rb
@@ -15,14 +15,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(green: '#237333',
-                        red: '#d81e3e',
-                        blue: '#0189d1',
-                        lightBlue: '#a2dced',
-                        yellow: '#FFF500',
-                        orange: '#f48221',
-                        brown: '#7b352a')
-
         CURRENCY_FORMAT_STR = '$%s'
 
         BANK_CASH = 8000

--- a/lib/engine/game/g_18_co/game.rb
+++ b/lib/engine/game/g_18_co/game.rb
@@ -16,17 +16,6 @@ module Engine
 
         attr_accessor :presidents_choice
 
-        register_colors(green: '#237333',
-                        red: '#d81e3e',
-                        blue: '#0189d1',
-                        lightBlue: '#a2dced',
-                        yellow: '#FFF500',
-                        orange: '#f48221',
-                        brown: '#7b352a',
-                        black: '#000000',
-                        pink: '#FF0099',
-                        purple: '#9900FF',
-                        white: '#FFFFFF')
         CURRENCY_FORMAT_STR = '$%s'
 
         BANK_CASH = 10_000

--- a/lib/engine/game/g_18_cuba/game.rb
+++ b/lib/engine/game/g_18_cuba/game.rb
@@ -18,14 +18,6 @@ module Engine
 
         include DoubleSidedTiles
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
         TRACK_RESTRICTION = :permissive
         CURRENCY_FORMAT_STR = '$%s'
         HOME_TOKEN_TIMING = :operate

--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -15,13 +15,6 @@ module Engine
         include Map
         include Entities
 
-        register_colors(brightGreen: '#c2ce33',
-                        beige: '#e5d19e',
-                        lightBlue: '#1EA2D6',
-                        mintGreen: '#B1CEC7',
-                        yellow: '#ffe600',
-                        lightRed: '#F3B1B3')
-
         CURRENCY_FORMAT_STR = '%s K'
 
         BANK_CASH = 99_999

--- a/lib/engine/game/g_18_dixie/game.rb
+++ b/lib/engine/game/g_18_dixie/game.rb
@@ -26,16 +26,6 @@ module Engine
         include G18Dixie::Companies
         include G18Dixie::Minors
         include G18Dixie::Corporations
-
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
-
         include CitiesPlusTownsRouteDistanceStr
 
         # General Constants

--- a/lib/engine/game/g_18_fl/game.rb
+++ b/lib/engine/game/g_18_fl/game.rb
@@ -16,14 +16,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(black: '#37383a',
-                        orange: '#f48221',
-                        brightGreen: '#76a042',
-                        red: '#d81e3e',
-                        turquoise: '#00a993',
-                        blue: '#0189d1',
-                        brown: '#7b352a')
-
         CURRENCY_FORMAT_STR = '$%s'
 
         BANK_CASH = 8000

--- a/lib/engine/game/g_18_india/game.rb
+++ b/lib/engine/game/g_18_india/game.rb
@@ -19,10 +19,6 @@ module Engine
         attr_accessor :draft_deck, :ipo_pool, :unclaimed_commodities, :gauge_change_markers, :jewlery_hex
         attr_reader :ipo_rows
 
-        register_colors(brown: '#a05a2c',
-                        white: '#000000',
-                        purple: '#5a2ca0')
-
         BANKRUPTCY_ALLOWED = false
         BANK_CASH = 9_000
         CURRENCY_FORMAT_STR = '₹%s'

--- a/lib/engine/game/g_18_jpt/game.rb
+++ b/lib/engine/game/g_18_jpt/game.rb
@@ -13,18 +13,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(lightGreen: '#84BF48',
-                        darkgreen: '#00984C',
-                        grey: '#949595',
-                        red: '#D72A33',
-                        lightBlue: '#00A1D8',
-                        darkBlue: '#292A74',
-                        yellow: '#FFF234',
-                        orange: '#EA8D3B',
-                        pink: '#E591B4',
-                        brown: '#5E4E35',
-                        purple: '#572979')
-
         TRACK_RESTRICTION = :permissive
         SELL_BUY_ORDER = :sell_buy_sell
         TILE_RESERVATION_BLOCKS_OTHERS = :always

--- a/lib/engine/game/g_18_los_angeles/game.rb
+++ b/lib/engine/game/g_18_los_angeles/game.rb
@@ -18,16 +18,6 @@ module Engine
         include Map
         include StubsAreRestricted
 
-        register_colors(red: '#ff0000',
-                        pink: '#ff7fed',
-                        orange: '#ff6a00',
-                        green: '#00830e',
-                        blue: '#0026ff',
-                        black: '#727272',
-                        lightBlue: '#b8ffff',
-                        brown: '#644c00',
-                        purple: '#832e9a')
-
         attr_reader :drafted_companies, :parred_corporations
         attr_accessor :dump_token, :rj_token, :use_che_discount
 

--- a/lib/engine/game/g_18_mt/game.rb
+++ b/lib/engine/game/g_18_mt/game.rb
@@ -26,17 +26,6 @@ module Engine
         include G18MT::Companies
         include G18MT::Corporations
 
-        register_colors(green: '#237333',
-                        red: '#d81e3e',
-                        blue: '#0189d1',
-                        lightBlue: '#a2dced',
-                        yellow: '#FFF500',
-                        orange: '#f48221',
-                        brown: '#7b352a',
-                        black: '#000000',
-                        pink: '#FF0099',
-                        purple: '#9900FF',
-                        white: '#FFFFFF')
         CURRENCY_FORMAT_STR = '$%s'
 
         BANK_CASH = 8000

--- a/lib/engine/game/g_18_new_england/game.rb
+++ b/lib/engine/game/g_18_new_england/game.rb
@@ -13,27 +13,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(black: '#16190e',
-                        blue: '#0189d1',
-                        brown: '#7b352a',
-                        gray: '#7c7b8c',
-                        green: '#3c7b5c',
-                        olive: '#808000',
-                        lightGreen: '#009a54ff',
-                        lightBlue: '#4cb5d2',
-                        lightishBlue: '#0097df',
-                        teal: '#009595',
-                        orange: '#d75500',
-                        magenta: '#d30869',
-                        purple: '#772282',
-                        red: '#ef4223',
-                        rose: '#b7274c',
-                        coral: '#f3716d',
-                        white: '#fff36b',
-                        navy: '#000080',
-                        cream: '#fffdd0',
-                        yellow: '#ffdea8')
-
         CURRENCY_FORMAT_STR = '$%s'
         BANK_CASH = 12_000
         CERT_LIMIT = { 3 => 20, 4 => 16, 5 => 13 }.freeze

--- a/lib/engine/game/g_18_norway/game.rb
+++ b/lib/engine/game/g_18_norway/game.rb
@@ -21,15 +21,6 @@ module Engine
         include Trains
         include Phases
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
-
         TRACK_RESTRICTION = :permissive
         SELL_BUY_ORDER = :sell_buy
         TILE_RESERVATION_BLOCKS_OTHERS = :always

--- a/lib/engine/game/g_18_pa/game.rb
+++ b/lib/engine/game/g_18_pa/game.rb
@@ -13,14 +13,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
         TRACK_RESTRICTION = :semi_restrictive
         SELL_BUY_ORDER = :sell_buy
         TILE_RESERVATION_BLOCKS_OTHERS = :always

--- a/lib/engine/game/g_18_sj/game.rb
+++ b/lib/engine/game/g_18_sj/game.rb
@@ -16,20 +16,6 @@ module Engine
         attr_reader :edelsward
         attr_accessor :requisition_turn
 
-        register_colors(
-          black: '#0a0a0a', # STJ
-          brightGreen: '#7bb137', # UGJ
-          brown: '#7b352a', # BJ
-          green: '#237333', # SWB
-          lavender: '#baa4cb', # SNJ
-          olive: '#808000', # TGOJ (not right)
-          orange: '#f48221', # MOJ
-          red: '#d81e3e', # OSJ
-          violet: '#4d2674', # OKJ
-          white: '#ffffff', # KFJr
-          yellow: '#FFF500' # MYJ
-        )
-
         CURRENCY_FORMAT_STR = '%s kr'
 
         BANK_CASH = 10_000

--- a/lib/engine/game/g_18_tokaido/game.rb
+++ b/lib/engine/game/g_18_tokaido/game.rb
@@ -23,13 +23,6 @@ module Engine
 
         include CompanyPriceUpToFace
 
-        register_colors(green: '#237333',
-                        red: '#d81e3e',
-                        blue: '#0189d1',
-                        yellow: '#FFF500',
-                        orange: '#f48221',
-                        brown: '#7b352a')
-
         attr_reader :drafted_companies
 
         CURRENCY_FORMAT_STR = '¥%s'

--- a/lib/engine/game/g_18_uruguay/game.rb
+++ b/lib/engine/game/g_18_uruguay/game.rb
@@ -45,16 +45,6 @@ module Engine
         EBUY_SELL_MORE_THAN_NEEDED = true
         EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false
 
-        register_colors(darkred: '#ff131a',
-                        red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
-
         TRACK_RESTRICTION = :permissive
         SELL_BUY_ORDER = :sell_buy
         SELL_AFTER = :p_any_operate

--- a/lib/engine/game/g_18_va/game.rb
+++ b/lib/engine/game/g_18_va/game.rb
@@ -13,14 +13,6 @@ module Engine
         include Entities
         include Map
 
-        register_colors(black: '#37383a',
-                        orange: '#f48221',
-                        brightGreen: '#76a042',
-                        red: '#d81e3e',
-                        turquoise: '#00a993',
-                        blue: '#0189d1',
-                        brown: '#7b352a')
-
         CURRENCY_FORMAT_STR = '$%s'
 
         BANK_CASH = 8000

--- a/lib/engine/game/g_2038/game.rb
+++ b/lib/engine/game/g_2038/game.rb
@@ -13,14 +13,6 @@ module Engine
         include Map
         include Entities
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#ccdeee',
-                        lightBlue: '#e0ebf4',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
         TRACK_RESTRICTION = :permissive
         SELL_BUY_ORDER = :sell_buy
         SELL_AFTER = :p_any_operate

--- a/lib/engine/game/g_21_moon/game.rb
+++ b/lib/engine/game/g_21_moon/game.rb
@@ -15,27 +15,6 @@ module Engine
 
         attr_reader :lb_graph, :sp_graph, :train_base
 
-        register_colors(black: '#16190e',
-                        blue: '#0189d1',
-                        brown: '#7b352a',
-                        gray: '#7c7b8c',
-                        green: '#3c7b5c',
-                        olive: '#808000',
-                        lightGreen: '#009a54ff',
-                        lightBlue: '#4cb5d2',
-                        lightishBlue: '#0097df',
-                        teal: '#009595',
-                        orange: '#d75500',
-                        magenta: '#d30869',
-                        purple: '#772282',
-                        red: '#ef4223',
-                        rose: '#b7274c',
-                        coral: '#f3716d',
-                        white: '#fff36b',
-                        navy: '#000080',
-                        cream: '#fffdd0',
-                        yellow: '#ffdea8')
-
         CURRENCY_FORMAT_STR = '₡%s'
         BANK_CASH = 12_000
         CERT_LIMIT = { 2 => 18, 3 => 15, 4 => 12, 5 => 10 }.freeze

--- a/lib/engine/game/g_rolling_stock/game.rb
+++ b/lib/engine/game/g_rolling_stock/game.rb
@@ -14,27 +14,6 @@ module Engine
         attr_reader :foreign_investor, :company_deck, :company_highlight, :company_level, :company_synergies,
                     :cost_level, :cost_table, :offering
 
-        register_colors(black: '#16190e',
-                        blue: '#0189d1',
-                        brown: '#7b352a',
-                        gray: '#7c7b8c',
-                        green: '#3c7b5c',
-                        olive: '#808000',
-                        lightGreen: '#009a54ff',
-                        lightBlue: '#4cb5d2',
-                        lightishBlue: '#0097df',
-                        teal: '#009595',
-                        orange: '#d75500',
-                        magenta: '#d30869',
-                        purple: '#772282',
-                        red: '#ef4223',
-                        rose: '#b7274c',
-                        coral: '#f3716d',
-                        white: '#fff36b',
-                        navy: '#000080',
-                        cream: '#fffdd0',
-                        yellow: '#ffdea8')
-
         CURRENCY_FORMAT_STR = '$%s'
         BANK_CASH = 10_000
         STARTING_CASH = { 2 => 30, 3 => 30, 4 => 30, 5 => 30, 6 => 25 }.freeze

--- a/lib/engine/game/g_steam_over_holland/game.rb
+++ b/lib/engine/game/g_steam_over_holland/game.rb
@@ -15,14 +15,6 @@ module Engine
         include Map
         include CompanyPriceUpToFace
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
         TRACK_RESTRICTION = :semi_restrictive
         SELL_BUY_ORDER = :sell_buy
         CURRENCY_FORMAT_STR = 'fl. %s'

--- a/lib/engine/game/g_system18/game.rb
+++ b/lib/engine/game/g_system18/game.rb
@@ -44,15 +44,6 @@ module Engine
 
         include MapGotlandCustomization
 
-        register_colors(red: '#d1232a',
-                        orange: '#f58121',
-                        black: '#110a0c',
-                        blue: '#025aaa',
-                        lightBlue: '#8dd7f6',
-                        yellow: '#ffe600',
-                        green: '#32763f',
-                        brightGreen: '#6ec037')
-
         MARKET_2D = [
           %w[75
              80


### PR DESCRIPTION
The `register_colors` method was added in PR tobymao#471 to give a way of assigning custom colours to corporations. This was done by creating a `COLORS` hash. The code that used this hash to assign the colours to the corporations was removed in PR tobymao#4167 but the `register_colors` method was left in place and it is still called from lots of games, even though it now has no effects.

This commit purges this method from the code base.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`