### PR TITLE
[1835] forbid routes including the yellow Berlin tile twice

### DIFF
--- a/lib/engine/game/g_1835/map.rb
+++ b/lib/engine/game/g_1835/map.rb
@@ -194,7 +194,8 @@ module Engine
           },
           yellow: {
             ['E19'] =>
-                     'city=revenue:30,loc:1;city=revenue:30,loc:3;path=a:1,b:_0;path=a:2,b:_1;future_label=label:B,color:green',
+            'city=revenue:30,loc:1,groups:Berlin;city=revenue:30,loc:3,groups:Berlin;path=a:1,b:_0;path=a:2,b:_1;'\
+            'future_label=label:B,color:green',
             ['G3'] =>
             'city=revenue:0,loc:0;city=revenue:0,loc:4.5;label=XX;upgrade=cost:50',
             ['J6'] => 'city=revenue:0;city=revenue:0;label=XX;upgrade=cost:50',


### PR DESCRIPTION
Refers to  #3059

## Implementation Notes

### Explanation of Change

Running trains from Berlin to Berlin is forbidden by the rules.

### Screenshots
<img width="1279" height="454" alt="image" src="https://github.com/user-attachments/assets/58a4b83a-ae35-4bbf-8181-664c2e51e46a" />

