### PR TITLE
[1858 India] Fix typo in city name: Bhagalpur not Bhagaipur

### DIFF
--- a/lib/engine/game/g_1858_india/map.rb
+++ b/lib/engine/game/g_1858_india/map.rb
@@ -37,7 +37,7 @@ module Engine
           'G16' => 'Allahabad',
           'G18' => 'Benares',
           'G20' => 'Patna',
-          'G22' => 'Bhagaipur',
+          'G22' => 'Bhagalpur',
           'H7' => 'Ahmadabad',
           'H11' => 'Bhopal',
           'H13' => 'Jubbulpore',


### PR DESCRIPTION
Corrected spelling for hex G22: Bhagalpur, not Bhagipur.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`