### PR TITLE
[18OE] Adjustment of Dividend Options for Minor, Major, and National

### DIFF
--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -761,6 +761,23 @@ module Engine
           corporation.spend(cost, @bank) if cost&.positive?
         end
 
+        # Override stock price movement according to 18OE rules
+        # - Minors & Regionals: no movement
+        # - Majors & Nationals:
+        #   * revenue >= share price -> move right
+        #   * revenue between 0 and share price -> no move
+        #   * revenue = 0 -> move left
+        def change_share_price(entity, revenue)
+          return if entity.type == :minor || entity.type == :regional
+
+          share_price = entity.share_price.price
+          if revenue >= share_price
+            @stock_market.move_right(entity)
+          elsif revenue.zero?
+            @stock_market.move_left(entity)
+          end
+        end
+
         def issuable_shares(entity)
           return [] if !entity.corporation? || entity.type != :major
 

--- a/lib/engine/game/g_18_oe/step/dividend.rb
+++ b/lib/engine/game/g_18_oe/step/dividend.rb
@@ -1,37 +1,23 @@
 # frozen_string_literal: true
 
 require_relative '../../../step/dividend'
-require_relative '../../../step/minor_half_pay'
+require_relative '../../../step/half_pay'
 
 module Engine
   module Game
     module G18OE
       module Step
         class Dividend < Engine::Step::Dividend
-          DIVIDEND_TYPES = %i[payout half withhold].freeze
-          include Engine::Step::MinorHalfPay
+          include Engine::Step::HalfPay
 
-          def half(entity, revenue)
-            withheld = half_pay_withhold_amount(entity, revenue)
-            { corporation: withheld, per_share: payout_per_share(entity, revenue - withheld) }
-          end
-
-          def half_pay_withhold_amount(entity, revenue)
-            (revenue / 2 / entity.total_shares) * entity.total_shares
-          end
-
-          def share_price_change(entity, revenue = 0)
-            return {} if @game.minor_regional_order.include?(entity)
-
-            price = entity.share_price.price
-            return { share_direction: :left, share_times: 1 } if revenue < 1
-
-            times = 0
-            times = 1 if revenue >= price
-            if times.positive?
-              { share_direction: :right, share_times: times }
+          def dividend_types(entity = current_entity)
+            case entity&.type
+            when :minor
+              [:half]
+            when :national
+              [:payout]
             else
-              {}
+              %i[withhold half payout]
             end
           end
         end

--- a/lib/engine/game/g_18_oe/step/dividend.rb
+++ b/lib/engine/game/g_18_oe/step/dividend.rb
@@ -10,12 +10,30 @@ module Engine
         class Dividend < Engine::Step::Dividend
           include Engine::Step::HalfPay
 
+          def actions(entity)
+            return [] if %i[minor national].include?(entity.type)
+
+            super
+          end
+
+          def skip!
+            case current_entity.type
+            when :minor
+              kind = total_revenue.zero? ? 'withhold' : 'half'
+            when :national
+              kind = total_revenue.zero? ? 'withhold' : 'payout'
+            else
+              return super
+            end
+            process_dividend(Action::Dividend.new(current_entity, kind: kind))
+          end
+
           def dividend_types
             case current_entity.type
             when :minor
-              [:half]
+              %i[half withhold]
             when :national
-              [:payout]
+              %i[payout withhold]
             else
               %i[withhold half payout]
             end

--- a/lib/engine/game/g_18_oe/step/dividend.rb
+++ b/lib/engine/game/g_18_oe/step/dividend.rb
@@ -10,8 +10,8 @@ module Engine
         class Dividend < Engine::Step::Dividend
           include Engine::Step::HalfPay
 
-          def dividend_types(entity = current_entity)
-            case entity&.type
+          def dividend_types
+            case current_entity.type
             when :minor
               [:half]
             when :national


### PR DESCRIPTION
Switched from old 18oeUKFR custom code to engine defaults based on 18OE rules:

Dividend Options:

    Minors: half pay only
    Nationals: payout only
    Majors: payout, half pay, withhold

Stock Movement: G18OE adaptation as described.

    majors & nationals move_right if Revenue >= Share price

Files:

    lib/engine/game/g_18_oe/step/dividend.rb
    lib/engine/game/g_18_oe/game.rb
