### PR TITLE
[18India] Display hand size on Info tab and Entities player card

### DIFF
--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -177,6 +177,11 @@ module View
           h(:td, 'Shares'),
           h('td.right', td_cert_props, (@game.all_corporations.sum { |c| c.minor? ? 0 : num_shares_of(@player, c) }).to_s),
         ])
+        if @game.respond_to?(:player_card_rows)
+          @game.player_card_rows(@player).each do |label, value|
+            trs << h(:tr, [h(:td, label), h('td.right', value)])
+          end
+        end
 
         priority_props = {
           attrs: { colspan: '2' },

--- a/assets/app/view/game/player.rb
+++ b/assets/app/view/game/player.rb
@@ -178,9 +178,8 @@ module View
           h('td.right', td_cert_props, (@game.all_corporations.sum { |c| c.minor? ? 0 : num_shares_of(@player, c) }).to_s),
         ])
         if @game.respond_to?(:player_card_rows)
-          @game.player_card_rows(@player).each do |label, value|
-            trs << h(:tr, [h(:td, label), h('td.right', value)])
-          end
+          label, value = @game.player_card_rows(@player)
+          trs << h(:tr, [h(:td, label), h('td.right', value)])
         end
 
         priority_props = {

--- a/lib/engine/game/g_18_india/game.rb
+++ b/lib/engine/game/g_18_india/game.rb
@@ -679,7 +679,7 @@ module Engine
         end
 
         def player_card_rows(player)
-          [['Shares in hand', player.hand.size.to_s]]
+          { 'Hand size' => player.hand.size.to_s }
         end
 
         def hand_companies_for_stock_round

--- a/lib/engine/game/g_18_india/game.rb
+++ b/lib/engine/game/g_18_india/game.rb
@@ -625,7 +625,8 @@ module Engine
 
           timeline << 'Player Draft History'
           @players.each do |p|
-            timeline << "#{p.name} (#{p.hand.size} cards in hand): #{p.draft_history.join(', ')}"
+            hand_size = "#{p.hand.size} card#{p.hand.one? ? '' : 's'} in hand"
+            timeline << "#{p.name} (#{hand_size}): #{p.draft_history.join(', ')}"
           end
 
           timeline
@@ -679,7 +680,7 @@ module Engine
         end
 
         def player_card_rows(player)
-          { 'Hand size' => player.hand.size.to_s }
+          ['Hand size', player.hand.size.to_s]
         end
 
         def hand_companies_for_stock_round

--- a/lib/engine/game/g_18_india/game.rb
+++ b/lib/engine/game/g_18_india/game.rb
@@ -625,7 +625,7 @@ module Engine
 
           timeline << 'Player Draft History'
           @players.each do |p|
-            timeline << "#{p.name}: #{p.draft_history.join(', ')}"
+            timeline << "#{p.name} (#{p.hand.size} cards in hand): #{p.draft_history.join(', ')}"
           end
 
           timeline
@@ -676,6 +676,10 @@ module Engine
 
         def show_hidden_hand?
           true
+        end
+
+        def player_card_rows(player)
+          [['Shares in hand', player.hand.size.to_s]]
         end
 
         def hand_companies_for_stock_round


### PR DESCRIPTION
Fixes #12519

## Before clicking "Create"

- [ x] Branch is derived from the latest `master`
- [ x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [ x] Code passes linter with `docker compose exec rack rubocop -a`
- [x ] Tests pass cleanly with `docker compose exec rack rake`

### Explanation of Change

This is a split off of PR #12533 to isolate the hand size issue from the OO city fix.

Adds the number of shares a player currently holds in their hand to two places in the UI:

Player card (Entities tab): A new "Shares in hand" row appears on each player's card, below the share count row. This is implemented via a new player_card_rows hook in View::Game::Player — any game can implement player_card_rows(player) to inject additional labeled rows into the player card table.

Info tab (Timeline): Each player's draft history entry now includes their current hand size, e.g. Alice (3 cards in hand): CompanyA, CompanyB, CompanyC.

### Screenshots

<img width="668" height="440" alt="image" src="https://github.com/user-attachments/assets/25cbe3ca-f732-4083-ad28-a79329093265" />

<img width="696" height="292" alt="image" src="https://github.com/user-attachments/assets/73c73f6e-993d-4b70-81d7-d706007741cc" />


