### PR TITLE
18India: use theme font color in map legend tables

### DIFF
--- a/lib/engine/game/g_18_india/game.rb
+++ b/lib/engine/game/g_18_india/game.rb
@@ -1222,10 +1222,10 @@ module Engine
           %i[commodity_legend connection_legend]
         end
 
-        def connection_legend(_font_color, _yellow, green, _brown, _gray, _red, action_processor: nil)
+        def connection_legend(font_color, _yellow, green, _brown, _gray, _red, action_processor: nil)
           cell_style = {
             border: '1px solid',
-            color: 'black',
+            color: font_color,
             'font-weight': 'bold',
             'text-align': 'center',
             'vertical-align': 'middle',
@@ -1263,10 +1263,10 @@ module Engine
           ]
         end
 
-        def commodity_legend(_font_color, yellow, green, _brown, _gray, _red, action_processor: nil)
+        def commodity_legend(font_color, yellow, green, _brown, _gray, _red, action_processor: nil)
           cell_style = {
             border: '1px solid',
-            color: 'black',
+            color: font_color,
             'font-weight': 'bold',
             'text-align': 'center',
             'vertical-align': 'middle',
@@ -1281,7 +1281,7 @@ module Engine
                 margin: '0.5rem 0 0.5rem 0',
                 border: '1px solid',
                 borderCollapse: 'collapse',
-                color: 'black',
+                color: font_color,
                 'font-weight': 'bold',
                 'text-align': 'center',
                 'vertical-align': 'middle',

--- a/lib/engine/game/g_18_india/game.rb
+++ b/lib/engine/game/g_18_india/game.rb
@@ -1242,7 +1242,10 @@ module Engine
               },
             },
             [
-              { text: 'Connection Bonus', props: { attrs: { colspan: 10 }, style: { **cell_style, backgroundColor: green } } },
+              {
+                text: 'Connection Bonus',
+                props: { attrs: { colspan: 10 }, style: { **cell_style, backgroundColor: green, color: 'black' } },
+              },
             ],
             [
               { text: 'Delhi (G8) ⟷ Kocchi (G36)', props: { style: cell_style } },
@@ -1273,6 +1276,7 @@ module Engine
             width: '35px',
             height: '25px',
           }
+          yellow_cell_style = { **cell_style, backgroundColor: yellow, color: 'black' }
 
           [
             # table-wide props
@@ -1291,21 +1295,21 @@ module Engine
             [
               {
                 text: 'Commodity Delivery Bonus',
-                props: { style: { backgroundColor: green }, attrs: { colspan: 11 } },
+                props: { style: { backgroundColor: green, color: 'black' }, attrs: { colspan: 11 } },
               },
             ],
             [
-              { text: 'Destination', props: { style: { **cell_style, backgroundColor: yellow } } },
-              { text: 'Hex', props: { style: { **cell_style, backgroundColor: yellow } } },
-              { image: '/icons/18_india/cotton.svg', props: { style: { **cell_style, backgroundColor: yellow } } },
-              { image: '/icons/18_india/gold.svg', props: { style: { **cell_style, backgroundColor: yellow } } },
-              { image: '/icons/18_india/jewlery.svg', props: { style: { **cell_style, backgroundColor: yellow } } },
-              { image: '/icons/18_india/oil.svg', props: { style: { **cell_style, backgroundColor: yellow } } },
-              { image: '/icons/18_india/opium.svg', props: { style: { **cell_style, backgroundColor: yellow } } },
-              { image: '/icons/18_india/ore.svg', props: { style: { **cell_style, backgroundColor: yellow } } },
-              { image: '/icons/18_india/rice.svg', props: { style: { **cell_style, backgroundColor: yellow } } },
-              { image: '/icons/18_india/spices.svg', props: { style: { **cell_style, backgroundColor: yellow } } },
-              { image: '/icons/18_india/tea.svg', props: { style: { **cell_style, backgroundColor: yellow } } },
+              { text: 'Destination', props: { style: yellow_cell_style } },
+              { text: 'Hex', props: { style: yellow_cell_style } },
+              { image: '/icons/18_india/cotton.svg', props: { style: yellow_cell_style } },
+              { image: '/icons/18_india/gold.svg', props: { style: yellow_cell_style } },
+              { image: '/icons/18_india/jewlery.svg', props: { style: yellow_cell_style } },
+              { image: '/icons/18_india/oil.svg', props: { style: yellow_cell_style } },
+              { image: '/icons/18_india/opium.svg', props: { style: yellow_cell_style } },
+              { image: '/icons/18_india/ore.svg', props: { style: yellow_cell_style } },
+              { image: '/icons/18_india/rice.svg', props: { style: yellow_cell_style } },
+              { image: '/icons/18_india/spices.svg', props: { style: yellow_cell_style } },
+              { image: '/icons/18_india/tea.svg', props: { style: yellow_cell_style } },
             ],
             [
               { text: 'Chennai', props: { style: cell_style } },


### PR DESCRIPTION
In 18 India, the commodity tables use hardcoded colors in certain places.  Specifically, commodity_legend and connection_legend both accepted a font_color parameter but ignored it, hardcoding 'black' instead. This makes the legend text invisible for users with dark background themes.


## Before clicking "Create"

- [ x] Branch is derived from the latest `master`
- [ x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [ x] Code passes linter with `docker compose exec rack rubocop -a`
- [ x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Updated both sections of code to use the main font color for these legends, instead of hardcoded black.

### Screenshots

<img width="1194" height="902" alt="image" src="https://github.com/user-attachments/assets/3368e2a9-ef04-4832-9e4f-514a463137e5" />

### Any Assumptions / Hacks
