### PR TITLE
[Core] Implement game log indentation

### DIFF
--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -102,6 +102,7 @@ module View
         blank_action.created_at = @game.actions[0]&.created_at || Time.now
 
         last_action = nil
+        @last_indent_group = nil
 
         actions = @game.actions.to_h { |a| [a.id, a] }
 
@@ -165,13 +166,6 @@ module View
       end
 
       def render_log_for_action(log, action)
-        timestamp_props = {
-          style: {
-            fontSize: 'smaller',
-          },
-        }
-        message_props = { style: { margin: '0 0.2rem' } }
-
         timestamp = "[#{Time.at(action.created_at || Time.now).strftime('%R')}] "
 
         click = lambda do
@@ -192,20 +186,31 @@ module View
             },
             on: { click: click },
           }
-          line_props[:style][:fontWeight] = 'bold' if line.is_a?(String) && line.start_with?('--')
+          is_banner = line.is_a?(String) && line.start_with?('--')
+          line_props[:style][:fontWeight] = 'bold' if is_banner
+
+          indent = false
 
           if line.is_a?(Engine::Action::Message)
             next [] if line.message.empty?
 
             line_props[:style][:fontWeight] = 'bold'
             line_props[:style][:marginTop] = '0.5em'
-
             sender = line.entity.name || 'Owner'
             line = "#{sender}: #{line.message}"
+          elsif entry.indent_group && !is_banner
+            indent = entry.indent_group == @last_indent_group
+            @last_indent_group = entry.indent_group
           end
 
-          h('div.chatline', line_props,
-            [h('span.timestamp', timestamp_props, timestamp), h('span.message', message_props, line)])
+          ts_props = { style: { fontSize: 'smaller' } }
+          msg_props = { style: { margin: '0 0.2rem' } }
+          msg_props[:style][:marginLeft] = '1.5rem' if indent
+
+          h('div.chatline', line_props, [
+            h('span.timestamp', ts_props, timestamp),
+            h('span.message', msg_props, line),
+          ])
         end
 
         if !action.is_a?(Engine::Action::Message) &&

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -911,6 +911,7 @@ module Engine
 
       def transition_to_next_round!
         store_player_info
+        @log.indent_group = nil
         next_round!
         return if @finished
 

--- a/lib/engine/game_log.rb
+++ b/lib/engine/game_log.rb
@@ -2,18 +2,31 @@
 
 module Engine
   class GameLog < Array
+    attr_writer :indent_group
+
     def initialize(game)
       super()
       @game = game
+      @indent_group = nil
     end
 
     def <<(message)
-      message = Entry.new(message, @game.current_action_id) unless message.is_a?(Entry)
-      super(message)
+      entry = message.is_a?(Entry) ? message : Entry.new(message, @game.current_action_id)
+      begin
+        step = @game.round&.steps&.find { |s| s.respond_to?(:auctioning_lot) && s.auctioning_lot }
+        entry.indent_group = if step
+                               step.auctioning_lot.id.to_s
+                             else
+                               @indent_group
+                             end
+      rescue StandardError
+        # may raise during game initialization before a round exists
+      end
+      super(entry)
     end
 
     class Entry
-      attr_accessor :message, :action_id
+      attr_accessor :message, :action_id, :indent_group
 
       def initialize(message, action_id)
         @message = message

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -22,6 +22,7 @@ module Engine
       def initialize(game, steps, **opts)
         @game = game
         @log = game.log
+        @game.log.indent_group = nil
         @entity_index = 0
         @round_num = opts[:round_num] || 1
         @entities = select_entities
@@ -92,11 +93,13 @@ module Engine
         raise GameError, "No step found for action #{type} at #{action.id}: #{action.to_h}" unless step
 
         step.acted = true
+        @game.log.indent_group = indent_group_for_action(action)
         step.send("process_#{action.type}", action)
 
         @at_start = false
 
         after_process_before_skip(action)
+        @game.log.indent_group = @entities[@entity_index]&.id&.to_s
         skip_steps
         clear_cache!
         after_process(action)
@@ -216,6 +219,11 @@ module Engine
       end
 
       def highest_bid(_entity); end
+
+      def indent_group_for_action(action)
+        act = action.entity
+        (act&.company? ? act.owner : act)&.id&.to_s
+      end
 
       private
 

--- a/lib/engine/round/operating.rb
+++ b/lib/engine/round/operating.rb
@@ -85,7 +85,8 @@ module Engine
 
         @current_operator = entity
         @current_operator_acted = false
-        @log << "#{@game.acting_for_entity(entity).name} operates #{entity.name}" unless finished?
+        @game.log.indent_group = entity&.id&.to_s
+        @log << "-- #{@game.acting_for_entity(entity).name} operates #{entity.name} --" unless finished?
         @game.place_home_token(entity) if @home_token_timing == :operate
         skip_steps
         return unless finished?
@@ -97,6 +98,10 @@ module Engine
       def recalculate_order
         unsorted_corps = @entities.pop(@entities.size - @entity_index - 1)
         @entities.concat(@game.operating_order.select { |e| unsorted_corps.include?(e) })
+      end
+
+      def indent_group_for_action(_action)
+        @current_operator&.id&.to_s || super
       end
 
       def operating?

--- a/lib/engine/round/stock.rb
+++ b/lib/engine/round/stock.rb
@@ -37,6 +37,7 @@ module Engine
           # Need to move entity round once more to be back to the priority deal player
           next_entity_index!
 
+          @game.log.indent_group = nil
           finish_round
           return
         end
@@ -49,6 +50,7 @@ module Engine
         @steps.each(&:unpass!)
         @steps.each(&:setup)
 
+        @game.log.indent_group = @entities[@entity_index]&.id&.to_s
         skip_steps
         next_entity! unless active_step
       end


### PR DESCRIPTION
Fixes #12400

## Before clicking "Create"

- [ x] Branch is derived from the latest `master`
- [ x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x ] Code passes linter with `docker compose exec rack rubocop -a`
- [x ] Tests pass cleanly with `docker compose exec rack rake`

Summary
This PR creates an indenter for the game log, to visually group all related actions for the currently operating entity (corporation, player or in auctions the entity being auctioned).  The standard behavior is to write the first action for a given group without indent, and to indent all subsequent actions related to the operating entity.  

Provides an explicit indent_group field stamped on each GameLog::Entry at write time. The round machinery maintains @log.indent_group and sets it at well-defined moments, making indentation deterministic and game-rule-driven.

Changes to the GameLog#<< (shovel) operator
Before: The Entry stored only message and action_id. Indentation was not recorded at write time.

Added in this PR: Each Entry now also stores indent_group — a string (typically an entity id) stamped at write time from @log.indent_group as maintained by the round machinery. One special case is handled directly in <<: if an auction step with an auctioning_lot is active, the lot's id is used regardless of what the round machinery has set. This allows for grouping by the entity (private, minor or corporation) being auctioned when an auction is underway.  

This is expected to be the first module which extends the information saved with log entries.  Future development can add additional information to the log shovel def, to allow for retention of additional information in the log entries.  

Available at write time for future PRs: The full @game object is accessible in <<, including @game.round, @game.turn, @game.phase, @game.current_entity, and @game.players. Any of these could be stamped onto entries to support features like per-phase coloring, turn-number display in the log, or player-color highlighting without requiring a second pass over the log.  Additional information could be provided as needed, with the addition of further fields in the shovel, and updating of those fields at write time.  For example, recording the track objects laid in tile-lays.

How indentation works:

Round::Base#initialize clears @log.indent_group = nil at round creation
Round::Base#process_action sets indent_group to the acting entity's id via the overridable indent_group_for_action hook, then resets to the current entity after the action completes
Round::Operating overrides indent_group_for_action to always use @current_operator.id, so private-company actions taken during a corporation's OR turn are correctly grouped under that corporation
Round::Stock#start_entity sets the indent_group to the current player; next_entity! clears it at round end
game/base.rb#transition_to_next_round! clears indent_group before starting the next round so round-opening banners are never indented

Test plan
 Verified indentation behavior visually across 18NY (auction round, OR), 1871 (SR with private conversion + share buy, OR with PEIR), 1861 (merger round), 18 India (OR with private company track action), and 18Ireland.
 bundle exec rspec spec/lib/engine/game/fixtures_spec.rb — 7429 examples, 0 failures
 rubocop — no offenses on all 7 modified files

### Screenshots

<img width="1478" height="522" alt="image" src="https://github.com/user-attachments/assets/4df11da2-914b-4cb8-b2b0-89978c31b152" />

<img width="1248" height="734" alt="image" src="https://github.com/user-attachments/assets/713b59bb-8694-438e-99dc-d6c3982db011" />

<img width="1214" height="470" alt="image" src="https://github.com/user-attachments/assets/41fd604a-5bec-40d9-b0b6-5b2a4fc88bbb" />

