### PR TITLE
[Core] Add My Last Move button to game log

### DIFF
--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -22,9 +22,9 @@ module View
       needs :show_log, default: true, store: true
 
       def render
-        children = [render_log_choices, render_log]
-
         @player = @game.player_by_id(@user['id']) if @user
+
+        children = [render_log_choices, render_log]
 
         key_event = lambda do |event|
           event = Native(event)
@@ -164,6 +164,24 @@ module View
         h('div#chatlog', props, the_log)
       end
 
+      def player_for(entity)
+        return nil unless entity
+        return entity if @game.players.include?(entity)
+
+        if entity.respond_to?(:player)
+          found = entity.player
+          return found if @game.players.include?(found)
+        end
+
+        if entity.respond_to?(:owner)
+          owner = entity.owner
+          return owner if @game.players.include?(owner)
+          return player_for(owner) if owner && owner != entity
+        end
+
+        nil
+      end
+
       def render_log_for_action(log, action)
         timestamp_props = {
           style: {
@@ -214,7 +232,16 @@ module View
           action_log << render_action_buttons(action.id)
         end
 
-        h(:div, action_log)
+        h(:div, { attrs: { id: "action-#{action.id}" } }, action_log)
+      end
+
+      def last_player_action_id
+        return nil unless @player
+
+        @game.actions.reverse_each do |action|
+          return action.id if player_for(action.entity) == @player
+        end
+        nil
       end
 
       def render_action_buttons(action_id)
@@ -252,15 +279,30 @@ module View
       end
 
       def render_log_choices
+        left_buttons = [
+          h(:button,
+            {
+              style: { marginTop: '0' },
+              on: { click: -> { copy_log_transcript } },
+            },
+            'Copy Transcript 📋'),
+        ]
+
+        if @player && (last_id = last_player_action_id)
+          jump = lambda do
+            store(:selected_action_id, last_id)
+            `document.getElementById('action-' + #{last_id}).scrollIntoView({block: 'nearest'})`
+          end
+          left_buttons << h(:button,
+                            {
+                              style: { marginTop: '0' },
+                              on: { click: jump },
+                            },
+                            'My Last Move ↑')
+        end
+
         h(:div, { style: { marginBottom: '0.3rem', display: 'flex', justifyContent: 'space-between' } }, [
-          h(:div, { style: { textAlign: 'left' } }, [
-            h(:button,
-              {
-                style: { marginTop: '0' },
-                on: { click: -> { copy_log_transcript } },
-              },
-              'Copy Transcript 📋'),
-          ]),
+          h(:div, { style: { textAlign: 'left' } }, left_buttons),
           h(:div, { style: { textAlign: 'right' } }, [
             h(:button,
               {

--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -165,21 +165,11 @@ module View
       end
 
       def player_for(entity)
-        return nil unless entity
-        return entity if @game.players.include?(entity)
-
-        if entity.respond_to?(:player)
-          found = entity.player
-          return found if @game.players.include?(found)
+        if entity&.player?
+          entity
+        elsif (owner = entity&.owner)
+          owner.player? ? owner : player_for(owner)
         end
-
-        if entity.respond_to?(:owner)
-          owner = entity.owner
-          return owner if @game.players.include?(owner)
-          return player_for(owner) if owner && owner != entity
-        end
-
-        nil
       end
 
       def render_log_for_action(log, action)
@@ -235,13 +225,10 @@ module View
         h(:div, { attrs: { id: "action-#{action.id}" } }, action_log)
       end
 
-      def last_player_action_id
-        return nil unless @player
+      def player_action_ids
+        return [] unless @player
 
-        @game.actions.reverse_each do |action|
-          return action.id if player_for(action.entity) == @player
-        end
-        nil
+        @game.actions.filter_map { |action| action.id if player_for(action.entity) == @player }
       end
 
       def render_action_buttons(action_id)
@@ -288,13 +275,19 @@ module View
             'Copy Transcript 📋'),
         ]
 
-        if @player && (last_id = last_player_action_id)
+        if @player && !(ids = player_action_ids).empty?
           jump = lambda do
-            store(:selected_action_id, last_id)
-            `document.getElementById('action-' + #{last_id}).scrollIntoView({block: 'nearest'})`
+            target_id = if @selected_action_id && (idx = ids.index(@selected_action_id))
+                          ids[(idx - 1) % ids.size]
+                        else
+                          ids.last
+                        end
+            store(:selected_action_id, target_id)
+            `document.getElementById('action-' + #{target_id}).scrollIntoView({block: 'nearest'})`
           end
-          left_buttons << h(:button,
+          left_buttons << h('button#last_move',
                             {
+                              attrs: { title: 'hotkey: p' },
                               style: { marginTop: '0' },
                               on: { click: jump },
                             },

--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -164,14 +164,6 @@ module View
         h('div#chatlog', props, the_log)
       end
 
-      def player_for(entity)
-        if entity&.player?
-          entity
-        elsif (owner = entity&.owner)
-          owner.player? ? owner : player_for(owner)
-        end
-      end
-
       def render_log_for_action(log, action)
         timestamp_props = {
           style: {
@@ -225,12 +217,6 @@ module View
         h(:div, { attrs: { id: "action-#{action.id}" } }, action_log)
       end
 
-      def player_action_ids
-        return [] unless @player
-
-        @game.actions.filter_map { |action| action.id if player_for(action.entity) == @player }
-      end
-
       def render_action_buttons(action_id)
         rewind_action = lambda do
           process_action(Engine::Action::Undo.new(@game.current_entity, action_id: action_id))
@@ -274,25 +260,6 @@ module View
             },
             'Copy Transcript 📋'),
         ]
-
-        if @player && !(ids = player_action_ids).empty?
-          jump = lambda do
-            target_id = if @selected_action_id && (idx = ids.index(@selected_action_id))
-                          ids[(idx - 1) % ids.size]
-                        else
-                          ids.last
-                        end
-            store(:selected_action_id, target_id)
-            `document.getElementById('action-' + #{target_id}).scrollIntoView({block: 'nearest'})`
-          end
-          left_buttons << h('button#last_move',
-                            {
-                              attrs: { title: 'hotkey: p' },
-                              style: { marginTop: '0' },
-                              on: { click: jump },
-                            },
-                            ['My ', h(:u, 'P'), 'revious Move'])
-        end
 
         h(:div, { style: { marginBottom: '0.3rem', display: 'flex', justifyContent: 'space-between' } }, [
           h(:div, { style: { textAlign: 'left' } }, left_buttons),

--- a/assets/app/view/game/game_log.rb
+++ b/assets/app/view/game/game_log.rb
@@ -291,7 +291,7 @@ module View
                               style: { marginTop: '0' },
                               on: { click: jump },
                             },
-                            'My Last Move ↑')
+                            ['My ', h(:u, 'P'), 'revious Move'])
         end
 
         h(:div, { style: { marginBottom: '0.3rem', display: 'flex', justifyContent: 'space-between' } }, [

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -52,37 +52,31 @@ module View
         end
 
         if (ids = player_action_ids) && !ids.empty?
+          cur_idx = @selected_action_id && ids.index(@selected_action_id)
+          prev_id = cur_idx ? ids[(cur_idx - 1) % ids.size] : ids.last
+          next_id = cur_idx ? ids[(cur_idx + 1) % ids.size] : ids.first
+
           prev_jump = lambda do
-            target_id = if @selected_action_id && (idx = ids.index(@selected_action_id))
-                          ids[(idx - 1) % ids.size]
-                        else
-                          ids.last
-                        end
-            store(:selected_action_id, target_id)
-            `document.getElementById('action-' + #{target_id}).scrollIntoView({block: 'nearest'})`
+            store(:selected_action_id, prev_id)
+            `document.getElementById('action-' + #{prev_id}).scrollIntoView({block: 'nearest'})`
           end
 
           next_jump = lambda do
-            target_id = if @selected_action_id && (idx = ids.index(@selected_action_id))
-                          ids[(idx + 1) % ids.size]
-                        else
-                          ids.first
-                        end
-            store(:selected_action_id, target_id)
-            `document.getElementById('action-' + #{target_id}).scrollIntoView({block: 'nearest'})`
+            store(:selected_action_id, next_id)
+            `document.getElementById('action-' + #{next_id}).scrollIntoView({block: 'nearest'})`
           end
 
           btn_style = { margin: '0', padding: '0.2rem 0.5rem', width: '100%' }
           divs << h(:button,
                     {
-                      attrs: { id: 'my_prev', title: 'My previous action – hotkey: Shift+←' },
+                      attrs: { id: 'my_prev', title: "My previous action: ##{prev_id} – hotkey: Shift+←" },
                       style: { gridColumnStart: '8', **btn_style },
                       on: { click: prev_jump },
                     },
                     'My <')
           divs << h(:button,
                     {
-                      attrs: { id: 'my_next', title: 'My next action – hotkey: Shift+→' },
+                      attrs: { id: 'my_next', title: "My next action: ##{next_id} – hotkey: Shift+→" },
                       style: { gridColumnStart: '9', **btn_style },
                       on: { click: next_jump },
                     },

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -100,29 +100,23 @@ module View
         h(:div, props, divs)
       end
 
-      def player_for(entity)
-        if entity&.player?
-          entity
-        elsif (owner = entity&.owner)
-          owner.player? ? owner : player_for(owner)
-        end
-      end
-
       def player_action_ids
         return [] unless @user
 
         player = @game.player_by_id(@user['id'])
         return [] unless player
 
-        controlled_ids = @game.corporations
-                              .select { |c| player_for(c) == player }
-                              .map(&:id)
-                              .to_set
-        controlled_ids << player.id
+        player_corp_ids = @game.corporations
+                               .select { |c| c.owner&.id == player.id }
+                               .map(&:id)
 
         @game_data['actions'].filter_map do |action|
           next if action['type'] == 'message'
-          action['id'] if controlled_ids.include?(action['entity'])
+          if action['entity_type'] == 'player'
+            action['id'] if action['entity'] == player.id
+          elsif action['entity_type'] == 'corporation'
+            action['id'] if player_corp_ids.include?(action['entity'])
+          end
         end
       end
     end

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# backtick_javascript: true
-
 require 'lib/params'
 require 'view/link'
 require 'view/game/actionable'
@@ -52,35 +50,42 @@ module View
         end
 
         if (ids = player_action_ids) && !ids.empty?
-          cur_idx = @selected_action_id && ids.index(@selected_action_id)
-          prev_id = cur_idx ? ids[(cur_idx - 1) % ids.size] : ids.last
-          next_id = cur_idx ? ids[(cur_idx + 1) % ids.size] : ids.first
+          current_pos = cursor || @game.last_game_action_id
+          prev_id = ids.select { |id| id < current_pos }.last
+          next_id = ids.find { |id| id > current_pos }
+          link_style = { margin: '0', textDecoration: 'none', **style_extra }
 
-          prev_jump = lambda do
-            store(:selected_action_id, prev_id)
-            `document.getElementById('action-' + #{prev_id}).scrollIntoView({block: 'nearest'})`
+          if prev_id
+            prev_route = Lib::Params.add(@app_route, 'action', prev_id)
+            divs << h(Link, {
+              href: prev_route,
+              click: lambda {
+                store(:round_history, @game.round_history, skip: true) unless @round_history
+                store(:app_route, prev_route)
+                clear_ui_state
+              },
+              title: 'My previous action – hotkey: Shift+←',
+              children: 'My <',
+              style: { gridColumnStart: '8', **link_style },
+              class: '#my_prev.button_link',
+            })
           end
 
-          next_jump = lambda do
-            store(:selected_action_id, next_id)
-            `document.getElementById('action-' + #{next_id}).scrollIntoView({block: 'nearest'})`
+          if next_id
+            next_route = Lib::Params.add(@app_route, 'action', next_id)
+            divs << h(Link, {
+              href: next_route,
+              click: lambda {
+                store(:round_history, @game.round_history, skip: true) unless @round_history
+                store(:app_route, next_route)
+                clear_ui_state
+              },
+              title: 'My next action – hotkey: Shift+→',
+              children: 'My >',
+              style: { gridColumnStart: '9', **link_style },
+              class: '#my_next.button_link',
+            })
           end
-
-          btn_style = { margin: '0', padding: '0.2rem 0.5rem', width: '100%' }
-          divs << h(:button,
-                    {
-                      attrs: { id: 'my_prev', title: "My previous action: ##{prev_id} – hotkey: Shift+←" },
-                      style: { gridColumnStart: '8', **btn_style },
-                      on: { click: prev_jump },
-                    },
-                    'My <')
-          divs << h(:button,
-                    {
-                      attrs: { id: 'my_next', title: "My next action: ##{next_id} – hotkey: Shift+→" },
-                      style: { gridColumnStart: '9', **btn_style },
-                      on: { click: next_jump },
-                    },
-                    'My >')
         end
 
         props = {

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -103,9 +103,11 @@ module View
       def player_action_ids
         return [] unless @user
 
-        user_id = @user['id']
+        player = @game.player_by_id(@user['id'])
+        return [] unless player
+
         @game_data['actions'].filter_map do |action|
-          action['id'] if action['user'] == user_id && action['type'] != 'message'
+          action['id'] if action['entity_type'] == 'player' && action['entity'] == player.id
         end
       end
     end

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -11,6 +11,7 @@ module View
       needs :last_action_id, default: 0
       needs :game, store: true
       needs :round_history, default: nil, store: true
+      needs :history_player_id, default: nil, store: true
 
       def render
         return h(:div) if @last_action_id.zero?
@@ -36,56 +37,56 @@ module View
                                { gridColumnStart: '4', **style_extra }, true, 'ArrowLeft')
         end
 
-        if cursor && !@game.exception
-          next_action_id = @game.next_action_id_from(cursor)
-          next_action_id = nil if @last_action_id == next_action_id
-          divs << history_link('>', 'Next Action', next_action_id,
-                               { gridColumnStart: '5', **style_extra }, true, 'ArrowRight')
-          store(:round_history, @game.round_history, skip: true) unless @round_history
-          if (next_round = @round_history.find { |rh| rh > cursor })
-            divs << history_link('>>', 'Next Round', next_round,
-                                 { gridColumnStart: '6', **style_extra }, true, 'ArrowDown')
-          end
-          divs << history_link('>|', 'Current Action', nil, { gridColumnStart: '7', **style_extra }, true, 'End')
-        end
-
         if (ids = player_action_ids) && !ids.empty?
           current_pos = cursor || @game.last_game_action_id
-          prev_id = ids.select { |id| id < current_pos }.last
+          prev_id = ids.reverse.find { |id| id < current_pos }
           next_id = ids.find { |id| id > current_pos }
           link_style = { margin: '0', textDecoration: 'none', **style_extra }
 
           if prev_id
             prev_route = Lib::Params.add(@app_route, 'action', prev_id)
             divs << h(Link, {
-              href: prev_route,
-              click: lambda {
-                store(:round_history, @game.round_history, skip: true) unless @round_history
-                store(:app_route, prev_route)
-                clear_ui_state
-              },
-              title: 'My previous action – hotkey: Shift+←',
-              children: 'My <',
-              style: { gridColumnStart: '8', **link_style },
-              class: '#my_prev.button_link',
-            })
+                        href: prev_route,
+                        click: lambda {
+                                 store(:round_history, @game.round_history, skip: true) unless @round_history
+                                 store(:app_route, prev_route)
+                                 clear_ui_state
+                               },
+                        title: 'My previous action – hotkey: Shift+←',
+                        children: 'My <',
+                        style: { gridColumnStart: '5', **link_style },
+                        class: '#my_prev.button_link',
+                      })
           end
 
           if next_id
             next_route = Lib::Params.add(@app_route, 'action', next_id)
             divs << h(Link, {
-              href: next_route,
-              click: lambda {
-                store(:round_history, @game.round_history, skip: true) unless @round_history
-                store(:app_route, next_route)
-                clear_ui_state
-              },
-              title: 'My next action – hotkey: Shift+→',
-              children: 'My >',
-              style: { gridColumnStart: '9', **link_style },
-              class: '#my_next.button_link',
-            })
+                        href: next_route,
+                        click: lambda {
+                                 store(:round_history, @game.round_history, skip: true) unless @round_history
+                                 store(:app_route, next_route)
+                                 clear_ui_state
+                               },
+                        title: 'My next action – hotkey: Shift+→',
+                        children: 'My >',
+                        style: { gridColumnStart: '6', **link_style },
+                        class: '#my_next.button_link',
+                      })
           end
+        end
+
+        if cursor && !@game.exception
+          next_action_id = @game.next_action_id_from(cursor)
+          next_action_id = nil if @last_action_id == next_action_id
+          divs << history_link('>', 'Next Action', next_action_id,
+                               { gridColumnStart: '7', **style_extra }, true, 'ArrowRight')
+          store(:round_history, @game.round_history, skip: true) unless @round_history
+          if (next_round = @round_history.find { |rh| rh > cursor })
+            divs << history_link('>>', 'Next Round', next_round,
+                                 { gridColumnStart: '8', **style_extra }, true, 'ArrowDown')
+          end
+          divs << history_link('>|', 'Current Action', nil, { gridColumnStart: '9', **style_extra }, true, 'End')
         end
 
         props = {
@@ -101,20 +102,30 @@ module View
       end
 
       def player_action_ids
-        return [] unless @user
+        cursor = Lib::Params['action']&.to_i
 
-        player = @game.player_by_id(@user['id'])
-        return [] unless player
+        player = if hotseat?
+                   if @history_player_id && cursor
+                     @game.player_by_id(@history_player_id)
+                   else
+                     p = @game.acting_for_entity(@game.current_entity)
+                     store(:history_player_id, p&.player? ? p.id : nil, skip: true) if cursor.nil?
+                     p
+                   end
+                 elsif @user
+                   @game.player_by_id(@user['id'])
+                 end
+        return [] unless player&.player?
 
-        player_corp_ids = @game.corporations
-                               .select { |c| c.owner&.id == player.id }
-                               .map(&:id)
+        player_corp_ids = player.presidencies.map(&:id)
 
         @game_data['actions'].filter_map do |action|
           next if action['type'] == 'message'
-          if action['entity_type'] == 'player'
+
+          case action['entity_type']
+          when 'player'
             action['id'] if action['entity'] == player.id
-          elsif action['entity_type'] == 'corporation'
+          when 'corporation'
             action['id'] if player_corp_ids.include?(action['entity'])
           end
         end

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -100,20 +100,13 @@ module View
         h(:div, props, divs)
       end
 
-      def player_for(entity)
-        if entity&.player?
-          entity
-        elsif (owner = entity&.owner)
-          owner.player? ? owner : player_for(owner)
-        end
-      end
-
       def player_action_ids
         return [] unless @user
-        player = @game.player_by_id(@user['id'])
-        return [] unless player
 
-        @game.actions.filter_map { |action| action.id if player_for(action.entity) == player }
+        user_id = @user['id']
+        @game_data['actions'].filter_map do |action|
+          action['id'] if action['user'] == user_id && action['type'] != 'message'
+        end
       end
     end
   end

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# backtick_javascript: true
+
 require 'lib/params'
 require 'view/link'
 require 'view/game/actionable'
@@ -49,16 +51,70 @@ module View
           divs << history_link('>|', 'Current Action', nil, { gridColumnStart: '7', **style_extra }, true, 'End')
         end
 
+        if (ids = player_action_ids) && !ids.empty?
+          prev_jump = lambda do
+            target_id = if @selected_action_id && (idx = ids.index(@selected_action_id))
+                          ids[(idx - 1) % ids.size]
+                        else
+                          ids.last
+                        end
+            store(:selected_action_id, target_id)
+            `document.getElementById('action-' + #{target_id}).scrollIntoView({block: 'nearest'})`
+          end
+
+          next_jump = lambda do
+            target_id = if @selected_action_id && (idx = ids.index(@selected_action_id))
+                          ids[(idx + 1) % ids.size]
+                        else
+                          ids.first
+                        end
+            store(:selected_action_id, target_id)
+            `document.getElementById('action-' + #{target_id}).scrollIntoView({block: 'nearest'})`
+          end
+
+          btn_style = { padding: '0.2rem 0.5rem', width: '100%' }
+          divs << h(:button,
+                    {
+                      attrs: { id: 'my_prev', title: 'My previous action – hotkey: Shift+←' },
+                      style: { gridColumnStart: '8', **btn_style },
+                      on: { click: prev_jump },
+                    },
+                    'My <')
+          divs << h(:button,
+                    {
+                      attrs: { id: 'my_next', title: 'My next action – hotkey: Shift+→' },
+                      style: { gridColumnStart: '9', **btn_style },
+                      on: { click: next_jump },
+                    },
+                    'My >')
+        end
+
         props = {
           style: {
             display: 'grid',
-            grid: '1fr / 4.2rem repeat(6, minmax(2rem, 2.5rem))',
+            grid: '1fr / 4.2rem repeat(8, minmax(2rem, 2.5rem))',
             justifyItems: 'center',
             gap: '0 0.5rem',
           },
         }
 
         h(:div, props, divs)
+      end
+
+      def player_for(entity)
+        if entity&.player?
+          entity
+        elsif (owner = entity&.owner)
+          owner.player? ? owner : player_for(owner)
+        end
+      end
+
+      def player_action_ids
+        return [] unless @user
+        player = @game.player_by_id(@user['id'])
+        return [] unless player
+
+        @game.actions.filter_map { |action| action.id if player_for(action.entity) == player }
       end
     end
   end

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -72,7 +72,7 @@ module View
             `document.getElementById('action-' + #{target_id}).scrollIntoView({block: 'nearest'})`
           end
 
-          btn_style = { padding: '0.2rem 0.5rem', width: '100%' }
+          btn_style = { margin: '0', padding: '0.2rem 0.5rem', width: '100%' }
           divs << h(:button,
                     {
                       attrs: { id: 'my_prev', title: 'My previous action – hotkey: Shift+←' },

--- a/assets/app/view/game/history_controls.rb
+++ b/assets/app/view/game/history_controls.rb
@@ -100,14 +100,29 @@ module View
         h(:div, props, divs)
       end
 
+      def player_for(entity)
+        if entity&.player?
+          entity
+        elsif (owner = entity&.owner)
+          owner.player? ? owner : player_for(owner)
+        end
+      end
+
       def player_action_ids
         return [] unless @user
 
         player = @game.player_by_id(@user['id'])
         return [] unless player
 
+        controlled_ids = @game.corporations
+                              .select { |c| player_for(c) == player }
+                              .map(&:id)
+                              .to_set
+        controlled_ids << player.id
+
         @game_data['actions'].filter_map do |action|
-          action['id'] if action['entity_type'] == 'player' && action['entity'] == player.id
+          next if action['type'] == 'message'
+          action['id'] if controlled_ids.include?(action['entity'])
         end
       end
     end

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -252,6 +252,13 @@ module View
         end
       elsif event.getModifierState('Shift')
         button_click('zoom+') if key == '+' # + on qwerty
+        if key == 'ArrowLeft'
+          button_click('my_prev')
+          event.preventDefault
+        elsif key == 'ArrowRight'
+          button_click('my_next')
+          event.preventDefault
+        end
       else
         case key
         when 'g'
@@ -287,8 +294,6 @@ module View
             chatbar.selectionStart = chatbar.value.length
             event.preventDefault
           end
-        when 'p'
-          button_click('last_move')
         when '-', '0', '+' # + on qwertz
           button_click('zoom' + key)
         when 'Home', 'End', 'ArrowLeft', 'ArrowRight'

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -287,6 +287,8 @@ module View
             chatbar.selectionStart = chatbar.value.length
             event.preventDefault
           end
+        when 'p'
+          button_click('last_move')
         when '-', '0', '+' # + on qwertz
           button_click('zoom' + key)
         when 'Home', 'End', 'ArrowLeft', 'ArrowRight'

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -252,10 +252,11 @@ module View
         end
       elsif event.getModifierState('Shift')
         button_click('zoom+') if key == '+' # + on qwerty
-        if key == 'ArrowLeft'
+        case key
+        when 'ArrowLeft'
           button_click('my_prev')
           event.preventDefault
-        elsif key == 'ArrowRight'
+        when 'ArrowRight'
           button_click('my_next')
           event.preventDefault
         end


### PR DESCRIPTION
Adds a button to the log toolbar that scrolls to and highlights the current player's most recent action, making it easy to find where you left off in a long game.

Fixes #10369

## Before clicking "Create"

- [x ] Branch is derived from the latest `master`
- [ x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [ x] Code passes linter with `docker compose exec rack rubocop -a`
- [ x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

Before:
<img width="1064" height="940" alt="image" src="https://github.com/user-attachments/assets/023a175f-496e-4004-b68f-8b53f374c549" />

After:
<img width="1074" height="1022" alt="image" src="https://github.com/user-attachments/assets/8bfce827-ef0e-4327-a659-7c7e85d24ae6" />

