### PR TITLE
18USA: log subsidies removed from pool at game start

### DIFF
--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -372,13 +372,15 @@ module Engine
             'Placing a track and the resource token from the Resource Subsidy is a free extra ' \
             'track lay in addition to the normal track placements.'
 
-          @log << "Resource subsidy includes #{resources.join(', ')}"
+          @resource_subsidy_resources = resources.join(', ')
         end
 
         def randomize_subsidies
-          randomized_subsidies = @subsidies.sort_by { rand }.take(SUBSIDIZED_HEXES.size)
-          excluded = @subsidies - randomized_subsidies
-          @log << "Removing: #{excluded.map { |s| s['name'] }.join(', ')}" if excluded.any?
+          shuffled = @subsidies.sort_by { rand }
+          randomized_subsidies = shuffled.take(SUBSIDIZED_HEXES.size)
+          excluded = shuffled.drop(SUBSIDIZED_HEXES.size)
+          @log << "Resource subsidy includes #{@resource_subsidy_resources}" unless excluded.any? { |s| s[:id] == 'S16' }
+          @log << "Removing: #{excluded.map { |s| s[:name] }.join(', ')}" unless excluded.empty?
           @subsidies_by_hex = {}
           SUBSIDIZED_HEXES.zip(randomized_subsidies).each do |hex_id, subsidy|
             hex = hex_by_id(hex_id)

--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -377,6 +377,8 @@ module Engine
 
         def randomize_subsidies
           randomized_subsidies = @subsidies.sort_by { rand }.take(SUBSIDIZED_HEXES.size)
+          excluded = @subsidies - randomized_subsidies
+          @log << "Removing: #{excluded.map { |s| s['name'] }.join(', ')}" if excluded.any?
           @subsidies_by_hex = {}
           SUBSIDIZED_HEXES.zip(randomized_subsidies).each do |hex_id, subsidy|
             hex = hex_by_id(hex_id)


### PR DESCRIPTION
During setup, 18USA randomly selects 14 of 16 subsidies to place on the map. Previously the 2 excluded subsidies were silently discarded with no log entry.

This change logs those excluded subsidies at game start so all players can see what didn't make it onto the map.

Example log entry:

Removing: No Subsidy, $50 Subsidy

Closes #12536

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots
<img width="1606" height="434" alt="image" src="https://github.com/user-attachments/assets/691c7816-69b1-40bb-b6d3-1d0c94ce46e5" />

### Any Assumptions / Hacks
