### PR TITLE
18FL: fix double-capitalization of unfloated corps on forced conversion

### DIFF
--- a/lib/engine/game/g_18_fl/game.rb
+++ b/lib/engine/game/g_18_fl/game.rb
@@ -312,7 +312,7 @@ module Engine
         # 5 => 10 share conversion logic
         def event_forced_conversions!
           @log << '-- Event: All 5 share corporations must convert to 10 share corporations immediately --'
-          @corporations.select { |c| c.type == :five_share }.each { |c| convert(c, funding: c.share_price) }
+          @corporations.select { |c| c.type == :five_share }.each { |c| convert(c, funding: c.floated?) }
         end
 
         def process_convert(action)


### PR DESCRIPTION
Fixes #12529

## Bug

When the `forced_conversions` event fires (on purchase of the first 5-train),
`event_forced_conversions!` called `convert(c, funding: c.share_price)` for
every remaining 5-share corporation. Because `c.share_price` is a truthy
object, this gave **all** converting corporations — including ones not yet
floated — an immediate cash injection of `5 × share_price` for the five new
treasury shares.

When an unfloated corporation later received enough share purchases to float,
`float_corporation` then paid out the full `10 × par_price` as normal full
capitalization. The result was **150% capitalization** instead of 100%
(e.g. $400 conversion funding + $800 float = $1200 at par $80).

## Fix

Change `funding: c.share_price` to `funding: c.floated?`:

- **Already-floated corps:** `funding: true` — correctly receive `5 × share_price`
  for the five new shares (they already received their original 5-share cap
  when they first floated).
- **Unfloated corps:** `funding: false` — no premature cash; they receive the
  correct full `10 × par_price` via the normal float mechanism when they
  eventually float.

## Pinning note

Any in-progress games where this bug was triggered (e.g. game #250224) will
need to be pinned to a pre-fix version before this is deployed, as their
recorded action logs reflect the incorrect capitalization.
## Before clicking "Create"

- [ x] Branch is derived from the latest `master`
- [ x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [ x] Code passes linter with `docker compose exec rack rubocop -a`
- [ x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
