### PR TITLE
[1880 Romania Regatul] Add 2-3 player variant on alternate map for 1880 Romania

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1748,9 +1748,11 @@ module Engine
         end
 
         discount = abilities.sum { |a| a.discounts_tile?(tile) ? a.discount : 0 }
+        sum_cost = tile.upgrades.sum(&:cost)
+        discount = [sum_cost, discount].min # In case discount exceeds total cost
         log_cost_discount(spender, abilities, discount)
 
-        tile.upgrades.sum(&:cost) - discount
+        sum_cost - discount
       end
 
       def tile_cost_with_discount(_tile, hex, entity, spender, cost)

--- a/lib/engine/game/g_1880_romania/meta.rb
+++ b/lib/engine/game/g_1880_romania/meta.rb
@@ -19,6 +19,15 @@ module Engine
         GAME_TITLE = '1880 Romania'
 
         PLAYER_RANGE = [3, 6].freeze
+
+        GAME_VARIANTS = [
+          {
+            sym: :regatul,
+            name: 'Regatul României',
+            title: '1880 Regatul României (Kingdom of Romania)',
+            desc: 'Alternate map for 2-3 players',
+          },
+        ].freeze
       end
     end
   end

--- a/lib/engine/game/g_1880_romania_regatul.rb
+++ b/lib/engine/game/g_1880_romania_regatul.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1880RomaniaRegatul
+    end
+  end
+end

--- a/lib/engine/game/g_1880_romania_regatul/game.rb
+++ b/lib/engine/game/g_1880_romania_regatul/game.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require_relative 'meta'
+require_relative '../g_1880_romania/game'
+require_relative 'map'
+require_relative '../g_1880_romania/entities'
+
+module Engine
+  module Game
+    module G1880RomaniaRegatul
+      class Game < G1880Romania::Game
+        include_meta(G1880RomaniaRegatul::Meta)
+        include Map
+
+        attr_reader :vaclav
+
+        CERT_LIMIT = { 2 => 22, 3 => 18 }.freeze
+
+        STARTING_CASH = { 2 => 700, 3 => 500 }.freeze
+
+        def optional_hexes
+          map_optional_hexes
+        end
+
+        def game_companies
+          companies = COMPANIES.map(&:dup)
+          kept_companies = %w[P1 P4 P5 P6 P7]
+          companies.select { |c| kept_companies.include?(c[:sym]) }
+        end
+
+        def game_minors
+          minors = MINORS.map(&:dup)
+
+          kept_minors = %w[1 2 3 6]
+          coordinates = {
+            '1' => 'I7',
+            '2' => 'V2',
+            '3' => 'Z10',
+            '6' => 'N8',
+          }.freeze
+          minors
+          .select { |m| kept_minors.include?(m[:sym]) }
+          .each { |m| m[:coordinates] = coordinates[m[:sym]] }
+        end
+
+        def game_corporations
+          corporations = CORPORATIONS.map(&:dup)
+          kept_corporations = %w[LCR MR Bess VRL CFR GWR LWR DR]
+          coordinates = {
+            'LCR' => 'Q1',
+            'MR' => 'U3',
+            'Bess' => 'X4',
+            'VRL' => 'P8',
+            'CFR' => 'Q9',
+            'GWR' => 'Q9',
+            'LWR' => 'J10',
+            'DR' => 'X10',
+            'TR' => 'L6',
+          }.freeze
+          corporations
+          .select { |c| kept_corporations.include?(c[:sym]) }
+          .each { |m| m[:coordinates] = coordinates[m[:sym]] }
+        end
+
+        def game_trains
+          unless @train_games
+            @train_games = super.map(&:dup)
+            t_2, t_2p2, t_3, t_3p3, t_4, t_4p4, t_6, t_6e, t_8, t_8e, t_2r = @train_games
+            t_2[:num] = 8
+            t_2p2[:num] = 4
+            t_3[:num] = 4
+            t_3p3[:num] = 4
+            t_3p3[:events] = [{ 'type' => 'communist_takeover' }]
+            t_4[:num] = 4
+            t_4p4[:num] = 4
+            t_6[:num] = 2
+            t_6e[:num] = 1
+            t_6e[:events] = [{ 'type' => 'signal_end_game', 'when' => 1 }]
+            t_8[:num] = 1
+            t_8e[:num] = 'unlimited'
+            t_2r[:num] = t_2[:num]
+          end
+          @train_games
+        end
+
+        def par_chart
+          @par_chart ||=
+            share_prices.sort_by { |sp| -sp.price }.to_h { |sp| [sp, [nil, nil, nil]] }
+        end
+
+        def setup
+          super
+
+          @dummy ||= Company.new(
+            name: 'Dummy Company',
+            sym: 'DUMMY',
+            value: 0,
+          )
+          @dummy.close!
+        end
+
+        # P2 not used in this variant
+        def consortiu
+          @dummy
+        end
+
+        def upgrades_to_correct_label?(from, to)
+          return from.label == to.label if from.color == :white && from.cities.size == 2 && to.label&.to_s == 'B'
+
+          super
+        end
+
+        # Modified compared to 1880 as no BCR, and potential Amira corporation has only one tile lay
+        def tile_lays(entity)
+          return [] unless can_build_track?(entity)
+
+          tile_lays = [{ lay: true, upgrade: true }]
+          return tile_lays if entity.minor? || !@phase.tiles.include?(:green)
+
+          tile_lays << { lay: :not_if_upgraded, upgrade: false }
+          tile_lays
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880_romania_regatul/map.rb
+++ b/lib/engine/game/g_1880_romania_regatul/map.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require_relative '../g_1880_romania/map'
+
+module Engine
+  module Game
+    module G1880RomaniaRegatul
+      module Map
+        include G1880Romania::Map
+
+        LAYOUT = :pointy
+        AXES = { x: :letter, y: :number }.freeze
+
+        LOCATION_NAMES = {
+          'Q1' => 'Czernowitz',
+          'P2' => 'Cluj-Napoca',
+          'R2' => 'Suceava / Botoșani',
+          'V2' => 'Moskova',
+          'Q3' => 'Iași',
+          'T4' => 'Bacău',
+          'V4' => 'Vaslui',
+          'X4' => 'Chișinău',
+          'Q5' => 'Miercurea Ciuc / Targu Oena',
+          'S5' => 'Onesti',
+          'U5' => 'Birlad',
+          'T6' => 'Focșani',
+          'I7' => 'Vienna Budapesta',
+          'O7' => 'Campulun',
+          'W7' => 'Braila / Galati',
+          'Y7' => 'Tulcea',
+          'H8' => 'Petrosani / Târgu Jiu',
+          'L8' => 'Râmnicu Vâlcea',
+          'N8' => 'Pitești',
+          'P8' => 'Tîrgoviște / Ploiești',
+          'T8' => 'Buzău',
+          'Z8' => 'Odesa',
+          'G9' => 'Drobeta-Turnu Severin',
+          'Q9' => 'Burcurești',
+          'U9' => 'Slobozia / Fetesti',
+          'Y9' => 'Năvodari',
+          'J10' => 'Craiova',
+          'L10' => 'Slatina',
+          'T10' => 'Calarasi',
+          'X10' => 'Constanta',
+          'Z10' => 'Marea Neagră',
+          'G11' => 'Sofia',
+          'I11' => 'Băilești',
+          'K11' => 'Dunărea',
+          'O11' => 'Alexandria',
+          'Q11' => 'Girgiu',
+          'S11' => 'Instanbul',
+          'W11' => 'Varna',
+        }.freeze
+
+        def map_optional_hexes
+          white = {
+            # no cities or towns
+            %w[S1 T2 S3 W5 V6 U7 J8 R8 X8 I9 K9 M9 O9 S9 H10 N10 P10 R10 K11 M11] => '',
+            %w[P4 R4 R6] => 'upgrade=cost:40,terrain:mountain',
+            ['Q7'] => 'upgrade=cost:30,terrain:mountain',
+            %w[K7 M7 S7] => 'upgrade=cost:20,terrain:mountain',
+            %w[V8 W9] => 'upgrade=cost:20,terrain:water',
+            ['V10'] => 'upgrade=cost:10,terrain:water',
+
+            # town
+            %w[V4 U5 Y9 L10 O11] => 'town=revenue:0',
+            %w[I11 Q11] => 'town=revenue:0;icon=image:port',
+            ['S5'] => 'town=revenue:0;upgrade=cost:40,terrain:mountain',
+            ['O7'] => 'town=revenue:0;upgrade=cost:20,terrain:mountain',
+            ['G9'] => 'town=revenue:0;upgrade=cost:20,terrain:mountain;icon=image:port',
+
+            # double towns
+            ['U9'] => 'town=revenue:0;town=revenue:0',
+            ['Q5'] => 'town=revenue:0;town=revenue:0;upgrade=cost:40,terrain:mountain',
+
+            # city
+            %w[U3 T4 N8 T8 J10 X10] => 'city=revenue:0',
+            ['Q1'] => 'city=revenue:0;label=T',
+            ['Y7'] => 'city=revenue:0;label=T;icon=image:port',
+            ['Q3'] => 'city=revenue:0;upgrade=cost:40,terrain:mountain',
+
+            # town and city
+            ['L8'] => 'town=revenue:0;city=revenue:0',
+            ['T10'] => 'town=revenue:0;city=revenue:0;icon=image:port',
+            ['T6'] => 'town=revenue:0;city=revenue:0;upgrade=cost:30,terrain:mountain',
+
+            # double city
+            ['P8'] => 'city=revenue:0;city=revenue:0',
+            ['W7'] => 'city=revenue:0;city=revenue:0;upgrade=cost:10,terrain:water;icon=image:port',
+            ['Q9'] => 'city=revenue:20;city=revenue:20;path=a:1,b:_0;path=a:4,b:_1;label=B',
+
+            # double town and city
+            %w[R2 H8] => 'town=revenue:0;city=revenue:0;town=revenue:0;city=revenue:0',
+          }
+          blue = {
+            ['Z8'] => 'offboard=revenue:yellow_20|green_30|brown_40|gray_40;path=a:1,b:_0;path=a:2,b:_0',
+            ['Z10'] => 'city=revenue:yellow_20|green_30|brown_40|gray_40;path=a:1,b:_0,terminal:1;path=a:2,b:_0,terminal:1',
+          }
+          red = {
+            ['P2'] => 'offboard=revenue:yellow_20|green_30|brown_40|gray_50;path=a:3,b:_0;path=a:4,b:_0',
+            ['V2'] => 'city=revenue:yellow_20|green_30|brown_50|gray_60;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1',
+            ['X4'] => 'city=revenue:yellow_20|green_60|brown_30|gray_40;path=a:0,b:_0,terminal:1;path=a:1,b:_0,terminal:1',
+            ['I7'] => 'city=revenue:yellow_20|green_30|brown_50|gray_70;path=a:0,b:_0,terminal:1;path=a:4,b:_0,terminal:1;'\
+                      'path=a:5,b:_0,terminal:1',
+            ['G11'] => 'city=revenue:yellow_20|green_30|brown_40|gray_50;path=a:3,b:_0,terminal:1;path=a:4,b:_0,terminal:1',
+            ['S11'] => 'offboard=revenue:yellow_10|green_20|brown_40|gray_50;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0',
+            ['W11'] => 'offboard=revenue:yellow_10|green_20|brown_30|gray_40;path=a:2,b:_0;path=a:3,b:_0',
+          }
+          {
+            white: white,
+            blue: blue,
+            red: red,
+          }.freeze
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1880_romania_regatul/meta.rb
+++ b/lib/engine/game/g_1880_romania_regatul/meta.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../meta'
+require_relative '../g_1880_romania/meta'
+
+module Engine
+  module Game
+    module G1880RomaniaRegatul
+      module Meta
+        include Game::Meta
+        include G1880Romania::Meta
+
+        DEPENDS_ON = '1880 Romania'
+
+        DEV_STAGE = :prealpha
+
+        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/1880-Romania-Regatul-map'.freeze
+        GAME_TITLE = '1880 Regatul României'.freeze
+        GAME_SUBTITLE = '1880 Kingdom of Romania'
+
+        PLAYER_RANGE = [2, 3].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -240,6 +240,11 @@ module Engine
       end
 
       def pay_tile_cost!(entity_or_entities, tile, rotation, hex, spender, cost, _extra_cost)
+        if cost.negative?
+          cost = 0
+          @log << "Discounts exceed cost for tile lay, so cost reduced to zero for #{spender.name}."
+        end
+
         # entity_or_entities is an array when combining private company abilities
         entities = Array(entity_or_entities)
         entity, *_combo_entities = entities

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -240,11 +240,6 @@ module Engine
       end
 
       def pay_tile_cost!(entity_or_entities, tile, rotation, hex, spender, cost, _extra_cost)
-        if cost.negative?
-          cost = 0
-          @log << "Discounts exceed cost for tile lay, so cost reduced to zero for #{spender.name}."
-        end
-
         # entity_or_entities is an array when combining private company abilities
         entities = Array(entity_or_entities)
         entity, *_combo_entities = entities


### PR DESCRIPTION
2-3 player variant of 1880 Romania. Uses an alternative map.

## Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

This is based on the PR for Transilvania. That one should be merged first.

## Implementation Notes

Amira optional rule is not included in this implementation.

### Explanation of Change

Long variant for 1880 Romania.

### Screenshots

N/A

### Any Assumptions / Hacks

N/A