### PR TITLE
Add constant to allow games to always show par price on charter

### DIFF
--- a/assets/app/view/game/corporation.rb
+++ b/assets/app/view/game/corporation.rb
@@ -462,7 +462,10 @@ module View
         num_treasury_shares = share_number_str(@corporation.num_treasury_shares)
 
         pool_rows = []
-        if !num_ipo_shares.empty? || num_dc_avail.positive? || !%i[full none].include?(@corporation.capitalization)
+        if !num_ipo_shares.empty? ||
+           num_dc_avail.positive? ||
+           !%i[full none].include?(@corporation.capitalization) ||
+           @game.class::ALWAYS_SHOW_PAR_PRICE
           pool_rows << h('tr.ipo', [
             h('td.left', @game.ipo_name(@corporation)),
             h('td.right', shares_props, ('d' * num_dc_avail) + num_ipo_shares),

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -188,6 +188,9 @@ module Engine
 
       CAPITALIZATION = :full
 
+      # In some games, it's relevant to know the par price of a corporation even after the IPO sells out
+      ALWAYS_SHOW_PAR_PRICE = false
+
       # Must sell all shares of a company in one action per turn
       MUST_SELL_IN_BLOCKS = false
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -188,7 +188,9 @@ module Engine
 
       CAPITALIZATION = :full
 
-      # In some games, it's relevant to know the par price of a corporation even after the IPO sells out
+      # In some games, it's relevant to know the par price of a corporation even after the IPO sells out.
+      # Setting this to true will make the IPO row always appear on the corporation charter.
+      # If false then this row will be omitted when there are no IPO shares remaining.
       ALWAYS_SHOW_PAR_PRICE = false
 
       # Must sell all shares of a company in one action per turn

--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -27,6 +27,7 @@ module Engine
         MULTIPLE_BUY_ONLY_FROM_MARKET = true
         MUST_SELL_IN_BLOCKS = true
         EBUY_FROM_OTHERS = :never
+        ALWAYS_SHOW_PAR_PRICE = true
 
         CLOSED_CORP_TRAINS_REMOVED = false
 

--- a/lib/engine/game/g_1850/game.rb
+++ b/lib/engine/game/g_1850/game.rb
@@ -21,6 +21,7 @@ module Engine
         CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT = true
         MULTIPLE_BUY_ONLY_FROM_MARKET = true
         EBUY_FROM_OTHERS = :never
+        ALWAYS_SHOW_PAR_PRICE = true
 
         CERT_LIMIT = {
           2 => { 9 => 24, 8 => 21 },

--- a/lib/engine/game/g_1870/game.rb
+++ b/lib/engine/game/g_1870/game.rb
@@ -20,6 +20,8 @@ module Engine
 
         BANK_CASH = 12_000
 
+        ALWAYS_SHOW_PAR_PRICE = true
+
         CERT_LIMIT = {
           2 => { 10 => 28, 9 => 24 },
           3 => { 10 => 20, 9 => 17 },

--- a/lib/engine/game/g_18_esp/game.rb
+++ b/lib/engine/game/g_18_esp/game.rb
@@ -31,6 +31,8 @@ module Engine
 
         STARTING_CASH = { 3 => 860, 4 => 650, 5 => 520, 6 => 440 }.freeze
 
+        ALWAYS_SHOW_PAR_PRICE = true
+
         NORTH_CORPS = %w[FdSB FdLR CFEA CFLG SFVA FdC].freeze
 
         TRACK_RESTRICTION = :permissive


### PR DESCRIPTION
Fixes #10406
Fixes #10645

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Some games require players to know the par price of a corporation even after the initial IPO has sold out. For example, 1870, 1850, (and 1832) all allow corporations to re-par at new prices based on the initial par price. 

I've implemented a constant, ALWAYS_SHOW_PAR_PRICE, that is checked against the code that hides that row once the IPO is empty. By default it's set to false, and games that need it can be set to true. 

### Screenshots

Before change: 
<img width="337" height="293" alt="image" src="https://github.com/user-attachments/assets/7eead3bf-fd26-4342-b3a9-9bcb7842c59d" />

After change: 
<img width="328" height="285" alt="image" src="https://github.com/user-attachments/assets/59ba281e-8c41-4942-bbca-9548b009eb28" />


### Any Assumptions / Hacks
