### PR TITLE
[18Chesapeake] set diesels to unlimited

### DIFF
--- a/lib/engine/game/g_18_chesapeake/game.rb
+++ b/lib/engine/game/g_18_chesapeake/game.rb
@@ -118,7 +118,7 @@ module Engine
             name: 'D',
             distance: 999,
             price: 900,
-            num: 20,
+            num: 'unlimited',
             available_on: '6',
             discount: { '4' => 200, '5' => 200, '6' => 200 },
           },

--- a/lib/engine/game/g_18_chesapeake_off_the_rails/game.rb
+++ b/lib/engine/game/g_18_chesapeake_off_the_rails/game.rb
@@ -64,7 +64,7 @@ module Engine
             name: 'D',
             distance: 999,
             price: 1100,
-            num: 20,
+            num: 'unlimited',
             available_on: '6',
             discount: { '4' => 300, '5' => 300, '6' => 300 },
           },


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Sets 18Chesapeake's diesel trains to unlimited.
also made the change here for the 18Chesapeake Off The Rails variant 

### Screenshots

### Any Assumptions / Hacks
