### PR TITLE
 [18CZ] set last rank of trains to unlimited

### DIFF
--- a/lib/engine/game/g_18_cz/entities.rb
+++ b/lib/engine/game/g_18_cz/entities.rb
@@ -307,7 +307,7 @@ module Engine
               name: '5j',
               distance: 5,
               price: 350,
-              num: 30,
+              num: 'unlimited',
               variants: [
                 {
                   name: '5+5j',


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

sets last rank of trains to unlimited

### Screenshots

### Any Assumptions / Hacks
