### PR TITLE
[18ChristmasEve] set last rank of trains to unlimited

### DIFF
--- a/lib/engine/game/g_18_christmas_eve/game.rb
+++ b/lib/engine/game/g_18_christmas_eve/game.rb
@@ -80,7 +80,7 @@ module Engine
             name: 'D',
             distance: 999,
             price: 900,
-            num: 20,
+            num: 'unlimited',
             available_on: '6',
             discount: { '4' => 200, '5' => 200, '6' => 200 },
             events: [{ 'type' => 'd_trigger' }],


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

 sets last rank of trains to unlimited

### Screenshots

### Any Assumptions / Hacks
