### PR TITLE
[18ESP] set last rank of trains to unlimited

### DIFF
--- a/lib/engine/game/g_18_esp/game.rb
+++ b/lib/engine/game/g_18_esp/game.rb
@@ -256,7 +256,7 @@ module Engine
             name: '8',
             distance: 8,
             price: 800,
-            num: 30,
+            num: 'unlimited',
             variants: [
                       {
                         name: '6+8',


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

 sets last rank of trains to unlimited

### Screenshots

### Any Assumptions / Hacks
