### PR TITLE
[18EU] set last rank of trains to unlimited

### DIFF
--- a/lib/engine/game/g_18_eu/trains.rb
+++ b/lib/engine/game/g_18_eu/trains.rb
@@ -99,7 +99,7 @@ module Engine
             distance: [{ 'nodes' => %w[city offboard], 'pay' => 8, 'visit' => 8 },
                        { 'nodes' => ['town'], 'pay' => 99, 'visit' => 99 }],
             price: 800,
-            num: 99,
+            num: 'unlimited',
           },
           {
             name: 'P',


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

 sets last rank of trains to unlimited

### Screenshots

### Any Assumptions / Hacks
