### PR TITLE
[18FL] set last rank of trains to unlimited

### DIFF
--- a/lib/engine/game/g_18_fl/game.rb
+++ b/lib/engine/game/g_18_fl/game.rb
@@ -150,7 +150,7 @@ module Engine
                 price: 600,
               },
             ],
-            num: 7,
+            num: 'unlimited',
             events: [{ 'type' => 'hurricane' }],
           },
         ].freeze


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

 sets last rank of trains to unlimited

### Screenshots

### Any Assumptions / Hacks
