### PR TITLE
[18Ireland] set last rank of trains to unlimited

### DIFF
--- a/lib/engine/game/g_18_ireland/game.rb
+++ b/lib/engine/game/g_18_ireland/game.rb
@@ -185,7 +185,7 @@ module Engine
           },
           {
             name: 'D',
-            num: 29, # 7 majors @ 2, 15 minors @ 1
+            num: 'unlimited',
             distance: 99,
             price: 770,
             discount: {


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

 sets last rank of trains to unlimited

### Screenshots

### Any Assumptions / Hacks
