### PR TITLE
[18ESP] Graph processing

### DIFF
--- a/lib/engine/game/g_18_esp/game.rb
+++ b/lib/engine/game/g_18_esp/game.rb
@@ -720,9 +720,12 @@ module Engine
           return false unless entity&.corporation?
           return true if entity.destination_connected?
 
-          graph = Graph.new(self, no_blocking: true)
-          graph.compute(entity)
-          graph.reachable_hexes(entity).include?(hex_by_id(entity.destination))
+          @no_blocking_graph ||= Graph.new(self, no_blocking: true)
+          @no_blocking_graph.reachable_hexes(entity).include?(hex_by_id(entity.destination))
+        end
+
+        def clear_no_blocking_graph
+          @no_blocking_graph = nil
         end
 
         def check_offboard_goal(entity, routes)
@@ -895,6 +898,7 @@ module Engine
             super
           end
           clear_graph_for_entity(corporation)
+          clear_no_blocking_graph
           corporation.goal_reached!(:destination) if check_for_destination_connection(corporation)
         end
 
@@ -1073,7 +1077,7 @@ module Engine
         def opening_new_mountain_pass(entity, p4_ability = false)
           return {} unless entity
 
-          @graph.clear
+          @graph.clear unless @loading
           openable_passes = @graph.connected_hexes(entity).keys.select do |hex|
             mountain_pass_token_hex?(hex)
           end

--- a/lib/engine/game/g_18_esp/game.rb
+++ b/lib/engine/game/g_18_esp/game.rb
@@ -724,8 +724,9 @@ module Engine
           @no_blocking_graph.reachable_hexes(entity).include?(hex_by_id(entity.destination))
         end
 
-        def clear_no_blocking_graph
-          @no_blocking_graph = nil
+        def clear_graph_for_entity(entity)
+          super
+          @no_blocking_graph&.clear
         end
 
         def check_offboard_goal(entity, routes)
@@ -898,7 +899,6 @@ module Engine
             super
           end
           clear_graph_for_entity(corporation)
-          clear_no_blocking_graph
           corporation.goal_reached!(:destination) if check_for_destination_connection(corporation)
         end
 

--- a/lib/engine/game/g_18_esp/step/track.rb
+++ b/lib/engine/game/g_18_esp/step/track.rb
@@ -40,7 +40,7 @@ module Engine
 
           def process_place_token(action)
             super
-            @game.graph.clear
+            @game.clear_no_blocking_graph
           end
 
           def pay_token_cost(entity, cost, city)

--- a/lib/engine/game/g_18_esp/step/track.rb
+++ b/lib/engine/game/g_18_esp/step/track.rb
@@ -38,11 +38,6 @@ module Engine
             @round.opened_mountain_pass = false
           end
 
-          def process_place_token(action)
-            super
-            @game.clear_no_blocking_graph
-          end
-
           def pay_token_cost(entity, cost, city)
             return super if !@game.mountain_pass_token_hex?(city.hex) || city.tokens.compact.size == 1
 

--- a/lib/engine/game/g_18_esp/step/tracker.rb
+++ b/lib/engine/game/g_18_esp/step/tracker.rb
@@ -34,9 +34,6 @@ module Engine
             hex.tile.cities.first.delete_token!(mz_token)
             hex.tile.cities.first.exchange_token(mz_token, extra_slot: true)
           end
-          # clear graphs
-          @game.clear_no_blocking_graph
-
           action.entity.goal_reached!(:destination) if @game.check_for_destination_connection(action.entity)
         end
 

--- a/lib/engine/game/g_18_esp/step/tracker.rb
+++ b/lib/engine/game/g_18_esp/step/tracker.rb
@@ -35,7 +35,7 @@ module Engine
             hex.tile.cities.first.exchange_token(mz_token, extra_slot: true)
           end
           # clear graphs
-          @game.graph.clear
+          @game.clear_no_blocking_graph
 
           action.entity.goal_reached!(:destination) if @game.check_for_destination_connection(action.entity)
         end


### PR DESCRIPTION
Relates to #12571 
Relates to #12579

Had the issue in my games and wanted to understand the topic a bit better based also on @ollybh's anaylsis. This PR is a **suggested fix** — I'm not an expert on the graph calculation system and I don't want to step on @bentziaxl's toes. Please treat this as a proposal rather than a definitive solution, happy to adjust or close in favour of a better approach.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

- `check_for_destination_connection`: caches `@no_blocking_graph` instead of creating a new `Graph` instance on every call.
- `clear_graph_for_entity`: overridden to also call `@no_blocking_graph&.clear`, so the cache is invalidated automatically whenever tile lays or token placements occur — no explicit calls needed at the call sites.
- `opening_new_mountain_pass`: skips `@graph.clear` during loading — the graph is still computed lazily on first access, but is no longer force-cleared and recomputed on every step evaluation.
- `tracker.rb`: removed the now-redundant explicit graph clear (the base class `clear_graph_for_entity` already handles this).
- `track.rb`: removed `process_place_token` override which only called `super` + `@game.graph.clear` — both are now handled automatically.

`check_for_destination_connection` cannot simply be skipped during loading because reaching the destination goal has immediate side effects (cash and token grants) that subsequent actions may depend on — caching the graph object is used here instead of a `@game.loading` guard.

Here's a profile after the fix, loading the same `18ESP_game_end_second_eight.json` fixture:


```
==================================
  Mode: cpu(10)
  Samples: 1274 (0.00% miss rate)
  GC: 192 (15.07%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       583  (45.8%)         180  (14.1%)     Engine::Part::Path#walk
       127  (10.0%)         127  (10.0%)     (marking)
       658  (51.6%)          80   (6.3%)     Engine::Graph#compute
       577  (45.3%)          73   (5.7%)     Engine::Part::Node#walk
      1059  (83.1%)          69   (5.4%)     Array#each
        65   (5.1%)          65   (5.1%)     (sweeping)
       137  (10.8%)          61   (4.8%)     Engine::Hex#paths
        36   (2.8%)          36   (2.8%)     Hash#initialize
        21   (1.6%)          21   (1.6%)     Array#flatten
        26   (2.0%)          19   (1.5%)     Engine::Part::City#tokened_by?


```
`Engine::Graph#compute` dropped from **834 total samples (64.1%)** to **658 (51.6%)** — an ~18% reduction. `Path#walk` and `Node#walk` follow the same trend as both are called from within `compute`. `Kernel#hash` (60 samples / 4.6% before) is no longer in the top 30 at all, which reflects the reduction in `Graph.new` allocations.

The remaining `Graph#compute` cost is largely unavoidable: `check_for_destination_connection` must still run during loading because reaching a destination goal has immediate side effects (cash and token grants) that subsequent actions may depend on.


### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
