### PR TITLE
[18OE] fix get_par_prices for regional companies

### DIFF
--- a/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
@@ -220,10 +220,14 @@ module Engine
 
           def get_par_prices(entity, corp)
             prices = @game.stock_market.par_prices
-            return prices if corp.type == :minor
-            return prices.select { |p| p.price * 2 <= available_cash(entity) } if corp.type == :regional
-
-            super
+            case corp.type
+            when :minor
+              prices
+            when :regional
+              prices.select { |p| p.price * 2 <= available_cash(entity) }
+            else
+              super
+            end
           end
 
           def check_legal_buy(entity, shares, exchange: nil, swap: nil, allow_president_change: true)

--- a/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
@@ -219,9 +219,11 @@ module Engine
           end
 
           def get_par_prices(entity, corp)
-            return super unless corp.type == :minor
+            prices = @game.stock_market.par_prices
+            return prices if corp.type == :minor
+            return prices.select { |p| p.price * 2 <= available_cash(entity) } if corp.type == :regional
 
-            @game.stock_market.par_prices
+            super
           end
 
           def check_legal_buy(entity, shares, exchange: nil, swap: nil, allow_president_change: true)


### PR DESCRIPTION
## Explanation of Change

Minors use exchange-based float (no player cash), so all par prices are
valid regardless of entity cash. Regionals cost 2× par to treasury, so
filter by `price * 2 <= available_cash`. Previously calling `super` for
regionals used the same path as majors and returned empty in SR2/SR3.

