### PR TITLE
[18OE] implement §4.4 three-way OR share price movement

### DIFF
--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -822,17 +822,6 @@ module Engine
           corporation.spend(cost, @bank) if cost&.positive?
         end
 
-        def change_share_price(entity, revenue)
-          return if entity.type == :minor || entity.type == :regional
-
-          share_price = entity.share_price.price
-          if revenue >= share_price
-            @stock_market.move_right(entity)
-          elsif revenue.zero?
-            @stock_market.move_left(entity)
-          end
-        end
-
         def add_new_share(share)
           owner = share.owner
           corporation = share.corporation

--- a/lib/engine/game/g_18_oe/step/dividend.rb
+++ b/lib/engine/game/g_18_oe/step/dividend.rb
@@ -28,6 +28,13 @@ module Engine
             process_dividend(Action::Dividend.new(current_entity, kind: kind))
           end
 
+          def share_price_change(entity, revenue)
+            return {} if entity.type == :minor || entity.type == :regional
+            return { share_direction: :left, share_times: 1 } if revenue.zero?
+            return {} if revenue < entity.share_price.price
+
+            { share_direction: :right, share_times: 1 }
+          end
           def dividend_types
             case current_entity.type
             when :minor

--- a/lib/engine/game/g_18_oe/step/dividend.rb
+++ b/lib/engine/game/g_18_oe/step/dividend.rb
@@ -35,6 +35,7 @@ module Engine
 
             { share_direction: :right, share_times: 1 }
           end
+
           def dividend_types
             case current_entity.type
             when :minor

--- a/lib/engine/game/g_18_oe/step/dividend.rb
+++ b/lib/engine/game/g_18_oe/step/dividend.rb
@@ -29,7 +29,7 @@ module Engine
           end
 
           def share_price_change(entity, revenue)
-            return {} if entity.type == :minor || entity.type == :regional
+            return {} if %i[minor regional].include?(entity.type)
             return { share_direction: :left, share_times: 1 } if revenue.zero?
             return {} if revenue < entity.share_price.price
 


### PR DESCRIPTION
## Explanation of Change

Previously `share_price_change` called `super` for majors and nationals,
which returns `:right` for any positive revenue — ignoring whether the
dividend met the share-price threshold. A major at £150 paying £100
would incorrectly move RIGHT instead of staying put.

Replace the `super` call with the correct three-way rule (§4.4):
- revenue = 0          → move LEFT  (withhold)
- 0 < revenue < price  → no move    (partial dividend)
- revenue ≥ price      → move RIGHT (full dividend meets threshold)

Also remove `game.rb#change_share_price` 
this method contained the correct three-way logic but was never called — OR movement
is driven by `Step::Dividend#share_price_change` returning a direction
hash, not by an imperative game-level method. Keeping it was a
misleading dead code path.

Rule ref: §4.4 p.14
