### PR TITLE
[18OE] president pool purchase above 60% at 2× price

### DIFF
--- a/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
@@ -57,21 +57,23 @@ module Engine
               return false if bought_corporation == bundle.corporation
             end
 
-            # §10.2: president may buy own pool shares above 60% cap at 2× price.
-            # Bypass holding_ok? check but still enforce bought?, cash, and cert limit.
-            if president_pool_overcap_buy?(entity, bundle)
+            super
+          end
+
+          def can_gain?(entity, bundle, exchange: false)
+            # §10.2: president buying own pool shares is allowed above the holding cap.
+            # Bypass holding_ok?; all other checks (bought?, cash, cert limit) run via super.
+            if bundle&.owner&.share_pool? && bundle.corporation.president?(entity)
               corp = bundle.corporation
-              return !bought? &&
-                     available_cash(entity) >= modify_purchase_price(bundle) &&
-                     (!corp.counts_for_limit || @game.num_certs(entity) < @game.cert_limit(entity))
+              return !corp.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit(entity)
             end
 
             super
           end
 
           def modify_purchase_price(bundle)
-            # bundle.share_price is set when replaying an action that already carries the
-            # adjusted price — skip doubling to avoid charging 4×.
+            # On replay, bundle.share_price is set to the already-adjusted price from the
+            # stored action — returning bundle.price * 2 here would charge 4×.
             return bundle.price if bundle.share_price
             return bundle.price * 2 if president_pool_overcap_buy?(current_entity, bundle)
 

--- a/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
@@ -62,23 +62,20 @@ module Engine
             if president_pool_overcap_buy?(entity, bundle)
               corp = bundle.corporation
               return !bought? &&
-                     available_cash(entity) >= bundle.price * 2 &&
+                     available_cash(entity) >= modify_purchase_price(bundle) &&
                      (!corp.counts_for_limit || @game.num_certs(entity) < @game.cert_limit(entity))
             end
 
             super
           end
 
-          def process_buy_shares(action)
-            if president_pool_overcap_buy?(action.entity, action.bundle)
-              price = action.bundle.price * 2
-              @log << "#{action.entity.name} pays #{@game.format_currency(price)} "\
-                      "(2× market) for #{action.bundle.corporation.name} pool share above 60%"
-              buy_shares(action.entity, action.bundle, exchange_price: price)
-              track_action(action, action.bundle.corporation)
-            else
-              super
-            end
+          def modify_purchase_price(bundle)
+            # bundle.share_price is set when replaying an action that already carries the
+            # adjusted price — skip doubling to avoid charging 4×.
+            return bundle.price if bundle.share_price
+            return bundle.price * 2 if president_pool_overcap_buy?(current_entity, bundle)
+
+            super
           end
 
           def can_sell?(entity, bundle)

--- a/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
@@ -72,10 +72,7 @@ module Engine
           end
 
           def modify_purchase_price(bundle)
-            # On replay, bundle.share_price is set to the already-adjusted price from the
-            # stored action — returning bundle.price * 2 here would charge 4×.
-            return bundle.price if bundle.share_price
-            return bundle.price * 2 if president_pool_overcap_buy?(current_entity, bundle)
+            return bundle.corporation.share_price.price * 2 if president_pool_overcap_buy?(current_entity, bundle)
 
             super
           end

--- a/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
@@ -57,7 +57,28 @@ module Engine
               return false if bought_corporation == bundle.corporation
             end
 
+            # §10.2: president may buy own pool shares above 60% cap at 2× price.
+            # Bypass holding_ok? check but still enforce bought?, cash, and cert limit.
+            if president_pool_overcap_buy?(entity, bundle)
+              corp = bundle.corporation
+              return !bought? &&
+                     available_cash(entity) >= bundle.price * 2 &&
+                     (!corp.counts_for_limit || @game.num_certs(entity) < @game.cert_limit(entity))
+            end
+
             super
+          end
+
+          def process_buy_shares(action)
+            if president_pool_overcap_buy?(action.entity, action.bundle)
+              price = action.bundle.price * 2
+              @log << "#{action.entity.name} pays #{@game.format_currency(price)} "\
+                      "(2× market) for #{action.bundle.corporation.name} pool share above 60%"
+              buy_shares(action.entity, action.bundle, exchange_price: price)
+              track_action(action, action.bundle.corporation)
+            else
+              super
+            end
           end
 
           def can_sell?(entity, bundle)
@@ -280,6 +301,16 @@ module Engine
 
           def bought_corporation
             @round.current_actions.find { |x| x.is_a?(Action::BuyShares) }&.bundle&.corporation
+          end
+
+          def president_pool_overcap_buy?(entity, bundle)
+            return false unless bundle&.owner&.share_pool?
+
+            corp = bundle.corporation
+            return false unless %i[major national].include?(corp.type)
+            return false unless corp.president?(entity)
+
+            entity.common_percent_of(corp) >= 60
           end
 
           def complete_conversion

--- a/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_18_oe/step/buy_sell_par_shares.rb
@@ -64,8 +64,7 @@ module Engine
             # §10.2: president buying own pool shares is allowed above the holding cap.
             # Bypass holding_ok?; all other checks (bought?, cash, cert limit) run via super.
             if bundle&.owner&.share_pool? && bundle.corporation.president?(entity)
-              corp = bundle.corporation
-              return !corp.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit(entity)
+              return !bundle.corporation.counts_for_limit || exchange || @game.num_certs(entity) < @game.cert_limit(entity)
             end
 
             super


### PR DESCRIPTION
## Explanation of Change

§10.2 — "The president of a major or national may purchase shares of that
RR from the Open Market (not from the treasury!), paying the bank double
the current share value per share." This is the only way to voluntarily
exceed 60% ownership.

Implementation in `G18OE::Step::BuySellParShares`:

- `president_pool_overcap_buy?`: returns true when bundle is from the
  pool, corp type is `:major` or `:national`, entity is the corp's
  president, and entity already holds ≥60%.
- `can_buy?` short-circuits before `super`, bypassing `holding_ok?`
  while still enforcing one-buy-per-turn, 2× cash requirement, and cert
  limit.
- `process_buy_shares` logs the 2× price and passes
  `exchange_price: bundle.price * 2` to `buy_shares`.

Non-presidents remain blocked above 60%; treasury share purchases also
blocked (bundle.owner is not the pool).

Rule ref: §10.2
