### PR TITLE
[18OE] level-8 train gate + game-end timing + remainder cash

### DIFF
--- a/lib/engine/bank.rb
+++ b/lib/engine/bank.rb
@@ -30,6 +30,10 @@ module Engine
       break!
     end
 
+    def receive(cash)
+      @cash += cash
+    end
+
     def break!
       @log << '-- The bank has broken --' unless @broken
       @broken = true

--- a/lib/engine/bank.rb
+++ b/lib/engine/bank.rb
@@ -30,7 +30,7 @@ module Engine
       break!
     end
 
-    def receive(cash)
+    def add_cash(cash)
       @cash += cash
     end
 

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -37,6 +37,8 @@ module Engine
         MUST_SELL_IN_BLOCKS = false
         HOME_TOKEN_TIMING = :float
         TILE_UPGRADES_MUST_USE_MAX_EXITS = [:cities].freeze
+        # §11.6.4/11.6.5: no player-bankruptcy game-end; force-buy converts major or suspends minor
+        GAME_END_CHECK = { bank: :full_or }.freeze
 
         STOCKMARKET_COLORS = {
           par: :blue,

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -37,8 +37,10 @@ module Engine
         MUST_SELL_IN_BLOCKS = false
         HOME_TOKEN_TIMING = :float
         TILE_UPGRADES_MUST_USE_MAX_EXITS = [:cities].freeze
-        # §11.6.4/11.6.5: no player-bankruptcy game-end; force-buy converts major or suspends minor
-        GAME_END_CHECK = { bank: :full_or }.freeze
+        # §13: bank-break ends at current OR; level-8 purchase ends at one_more_full_or_set
+        GAME_END_CHECK = { bank: :current_or, final_phase: :one_more_full_or_set }.freeze
+        # Physical game includes 20×£5,000 notes set aside at setup; injected when first level-8 bought
+        REMAINDER_CASH = 100_000
 
         STOCKMARKET_COLORS = {
           par: :blue,
@@ -195,6 +197,7 @@ module Engine
             num: 17,
           },
           # Level 8 — gray double-sided (8+8 / 5D); permanent
+          # NOTE: purchase of the FIRST level-8 triggers game end (§13)
           {
             name: '8+8',
             distance: [{ 'nodes' => ['town'], 'pay' => 8, 'visit' => 99 },
@@ -207,6 +210,7 @@ module Engine
               price: 1000,
             }],
             num: 11,
+            events: [{ 'type' => 'level8_train_purchased' }],
           },
         ].freeze
 
@@ -775,6 +779,20 @@ module Engine
             @log << "#{spender.name} receives a #{label} discount of #{format_currency(discount)}"
           end
           cost
+        end
+
+        def game_end_check_final_phase?
+          @level8_train_purchased
+        end
+
+        def event_level8_train_purchased!
+          return if @level8_train_purchased
+
+          @level8_train_purchased = true
+          remainder = self.class::REMAINDER_CASH
+          @bank.instance_variable_set(:@cash, @bank.cash + remainder)
+          @log << "-- Event: First level 8 train purchased --"
+          @log << "#{format_currency(remainder)} remainder cash added to bank (§13)"
         end
 
         # UP movement at end of SR: only for majors and nationals that are fully player-held

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -210,6 +210,7 @@ module Engine
               price: 1000,
             }],
             num: 11,
+            available_on: '7+7',
             events: [{ 'type' => 'level8_train_purchased' }],
           },
         ].freeze
@@ -785,10 +786,6 @@ module Engine
           level7_remaining = depot.upcoming.count { |t| t.name == '7+7' }
           level7_total = depot.trains.count { |t| %w[7+7 4D].include?(t.name) }
           level7_total - level7_remaining >= 4
-        end
-
-        def game_end_check_final_phase?
-          @level8_train_purchased
         end
 
         def event_level8_train_purchased!

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -803,7 +803,7 @@ module Engine
           @remainder_cash_added = true
           remainder = self.class::REMAINDER_CASH
           @bank.receive(remainder)
-          @log << "-- Event: #{format_currency(remainder)} remainder cash added to bank; game ends after one more full OR set --"
+          @log << "-- Event: #{format_currency(remainder)} remainder cash added to bank; game ends after one more full OR set (sooner if bank breaks) --"
         end
 
         # UP movement at end of SR: only for majors and nationals that are fully player-held

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -37,7 +37,7 @@ module Engine
         MUST_SELL_IN_BLOCKS = false
         HOME_TOKEN_TIMING = :float
         TILE_UPGRADES_MUST_USE_MAX_EXITS = [:cities].freeze
-        # §13: bank-break ends at current OR; level-8 purchase ends at one_more_full_or_set
+        # bank-break ends current OR; first level-8 purchase ends after one more full OR set
         GAME_END_CHECK = { bank: :current_or, final_phase: :one_more_full_or_set }.freeze
         # Physical game includes 20×£5,000 notes set aside at setup; injected when first level-8 bought
         REMAINDER_CASH = 100_000
@@ -50,7 +50,7 @@ module Engine
         EVENTS_TEXT = Base::EVENTS_TEXT.merge(
           'remainder_cash_added' => [
             'Remainder Cash Added',
-            '£100,000 remainder cash injected into bank; game ends after one more full OR set (§13)',
+            '£100,000 remainder cash injected into bank; game ends after one more full OR set',
           ]
         ).freeze
 

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -802,7 +802,7 @@ module Engine
 
           @remainder_cash_added = true
           remainder = self.class::REMAINDER_CASH
-          @bank.receive(remainder)
+          @bank.add_cash(remainder)
           @log << "-- Event: #{format_currency(remainder)} remainder cash added to bank; game ends after one more full OR set (sooner if bank breaks) --"
         end
 

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -204,7 +204,7 @@ module Engine
             num: 17,
           },
           # Level 8 — gray double-sided (8+8 / 5D); permanent
-          # NOTE: purchase of the FIRST level-8 triggers game end (§13)
+          # NOTE: purchase of the FIRST level-8 triggers game end
           {
             name: '8+8',
             distance: [{ 'nodes' => ['town'], 'pay' => 8, 'visit' => 99 },
@@ -803,7 +803,7 @@ module Engine
           @remainder_cash_added = true
           remainder = self.class::REMAINDER_CASH
           @bank.receive(remainder)
-          @log << "-- Event: #{format_currency(remainder)} remainder cash added to bank (§13) --"
+          @log << "-- Event: #{format_currency(remainder)} remainder cash added to bank; game ends after one more full OR set --"
         end
 
         # UP movement at end of SR: only for majors and nationals that are fully player-held

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -803,7 +803,8 @@ module Engine
           @remainder_cash_added = true
           remainder = self.class::REMAINDER_CASH
           @bank.add_cash(remainder)
-          @log << "-- Event: #{format_currency(remainder)} remainder cash added to bank; game ends after one more full OR set (sooner if bank breaks) --"
+          @log << "-- Event: #{format_currency(remainder)} remainder cash added to bank;" \
+                  ' game ends after one more full OR set (sooner if bank breaks) --'
         end
 
         # UP movement at end of SR: only for majors and nationals that are fully player-held

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -47,6 +47,13 @@ module Engine
           convert_range: :red,
         }.freeze
 
+        EVENTS_TEXT = Base::EVENTS_TEXT.merge(
+          'remainder_cash_added' => [
+            'Remainder Cash Added',
+            '£100,000 remainder cash injected into bank; game ends after one more full OR set (§13)',
+          ]
+        ).freeze
+
         MARKET_TEXT = {
           par: 'Regional par values',
           convert_range: 'Major par values',
@@ -211,7 +218,7 @@ module Engine
             }],
             num: 11,
             available_on: '7+7',
-            events: [{ 'type' => 'level8_train_purchased' }],
+            events: [{ 'type' => 'remainder_cash_added' }],
           },
         ].freeze
 
@@ -783,18 +790,20 @@ module Engine
         end
 
         def level8_train_available?
-          level7_remaining = depot.upcoming.count { |t| t.name == '7+7' }
-          level7_total = depot.trains.count { |t| %w[7+7 4D].include?(t.name) }
-          level7_total - level7_remaining >= 4
+          return false if phase.name.to_i < 7
+          return true if phase.name.to_i == 8
+
+          next_train = @depot.upcoming.first
+          next_train.index >= 4 || next_train.name != '7+7'
         end
 
-        def event_level8_train_purchased!
-          return if @level8_train_purchased
+        def event_remainder_cash_added!
+          return if @remainder_cash_added
 
-          @level8_train_purchased = true
+          @remainder_cash_added = true
           remainder = self.class::REMAINDER_CASH
-          @bank.instance_variable_set(:@cash, @bank.cash + remainder)
-          @log << "-- Event: First level 8 train purchased; #{format_currency(remainder)} remainder cash added to bank (§13) --"
+          @bank.receive(remainder)
+          @log << "-- Event: #{format_currency(remainder)} remainder cash added to bank (§13) --"
         end
 
         # UP movement at end of SR: only for majors and nationals that are fully player-held

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -781,6 +781,12 @@ module Engine
           cost
         end
 
+        def level8_train_available?
+          level7_remaining = depot.upcoming.count { |t| t.name == '7+7' }
+          level7_total = depot.trains.count { |t| %w[7+7 4D].include?(t.name) }
+          level7_total - level7_remaining >= 4
+        end
+
         def game_end_check_final_phase?
           @level8_train_purchased
         end
@@ -791,8 +797,7 @@ module Engine
           @level8_train_purchased = true
           remainder = self.class::REMAINDER_CASH
           @bank.instance_variable_set(:@cash, @bank.cash + remainder)
-          @log << "-- Event: First level 8 train purchased --"
-          @log << "#{format_currency(remainder)} remainder cash added to bank (§13)"
+          @log << "-- Event: First level 8 train purchased; #{format_currency(remainder)} remainder cash added to bank (§13) --"
         end
 
         # UP movement at end of SR: only for majors and nationals that are fully player-held

--- a/lib/engine/game/g_18_oe/step/buy_train.rb
+++ b/lib/engine/game/g_18_oe/step/buy_train.rb
@@ -15,8 +15,8 @@ module Engine
             trains = super
 
             # Level 8 trains only available after 4th level-7 purchase (§11.6)
-            if level8_available?
-              if trains.none? { |t| t.name == '8+8' }
+            if @game.level8_train_available?
+              unless trains.any? { |t| t.name == '8+8' }
                 lvl8 = @game.depot.upcoming.find { |t| t.name == '8+8' }
                 trains = trains + [lvl8] if lvl8
               end
@@ -41,14 +41,6 @@ module Engine
           end
 
           # TODO: Nationals claiming rusted trains for free (openpoints §1.9, §3.7) — deferred
-
-          private
-
-          def level8_available?
-            level7_remaining = @game.depot.upcoming.count { |t| t.name == '7+7' }
-            level7_total = @game.depot.trains.count { |t| %w[7+7 4D].include?(t.name) }
-            level7_total - level7_remaining >= 4
-          end
         end
       end
     end

--- a/lib/engine/game/g_18_oe/step/buy_train.rb
+++ b/lib/engine/game/g_18_oe/step/buy_train.rb
@@ -13,6 +13,17 @@ module Engine
 
           def buyable_trains(entity)
             trains = super
+
+            # Level 8 trains only available after 4th level-7 purchase (§11.6)
+            if level8_available?
+              if trains.none? { |t| t.name == '8+8' }
+                lvl8 = @game.depot.upcoming.find { |t| t.name == '8+8' }
+                trains = trains + [lvl8] if lvl8
+              end
+            else
+              trains = trains.reject { |t| t.name == '8+8' }
+            end
+
             return trains unless @game.train_obligation_active?
 
             if @game.fulfilled_train_obligation?(entity)
@@ -30,6 +41,14 @@ module Engine
           end
 
           # TODO: Nationals claiming rusted trains for free (openpoints §1.9, §3.7) — deferred
+
+          private
+
+          def level8_available?
+            level7_remaining = @game.depot.upcoming.count { |t| t.name == '7+7' }
+            level7_total = @game.depot.trains.count { |t| %w[7+7 4D].include?(t.name) }
+            level7_total - level7_remaining >= 4
+          end
         end
       end
     end

--- a/lib/engine/game/g_18_oe/step/buy_train.rb
+++ b/lib/engine/game/g_18_oe/step/buy_train.rb
@@ -18,7 +18,7 @@ module Engine
             if @game.level8_train_available?
               unless trains.any? { |t| t.name == '8+8' }
                 lvl8 = @game.depot.upcoming.find { |t| t.name == '8+8' }
-                trains = trains + [lvl8] if lvl8
+                trains += [lvl8] if lvl8
               end
             else
               trains = trains.reject { |t| t.name == '8+8' }

--- a/lib/engine/game/g_18_oe/step/buy_train.rb
+++ b/lib/engine/game/g_18_oe/step/buy_train.rb
@@ -14,15 +14,8 @@ module Engine
           def buyable_trains(entity)
             trains = super
 
-            # Level 8 trains only available after 4th level-7 purchase (§11.6)
-            if @game.level8_train_available?
-              unless trains.any? { |t| t.name == '8+8' }
-                lvl8 = @game.depot.upcoming.find { |t| t.name == '8+8' }
-                trains += [lvl8] if lvl8
-              end
-            else
-              trains = trains.reject { |t| t.name == '8+8' }
-            end
+            # Level 8 trains visible via available_on:'7+7' but gated until 4th L7 purchase (§11.6)
+            trains = trains.reject { |t| t.name == '8+8' } unless @game.level8_train_available?
 
             return trains unless @game.train_obligation_active?
 


### PR DESCRIPTION
## Explanation of Change

Four bugs grouped: BUG-027 sets the initial `GAME_END_CHECK` override;
BUG-024/025 modifies it further — coupled on the same constant, all
relate to game-end rules and level-8 trains.

### BUG-027 — Remove bankrupt: :immediate game-end trigger

18OE has no bankruptcy game-end (§11.6.4: force-buy → president
contribution or national conversion; §11.6.5: minor insolvency →
suspend + Open Market). Override `GAME_END_CHECK` to drop
`bankrupt: :immediate`, retaining only `bank: :full_or`.

Rule ref: §11.6.4, §11.6.5

### BUG-018 — Gate level-8 trains behind 4th level-7 purchase

§11.6: level-8 trains available only after the 4th level-7 purchase
(not after all 17). `G18OE::Step::BuyTrain#buyable_trains` injects the
first 8+8 from `depot.upcoming` once `game.level8_train_available?`
returns true (counts sold level-7s via depot diff).

Rule ref: §11.6

### BUG-024/025 — Bank-break timing + level-8 game-end + remainder cash

§13: bank-break → `:current_or` timing (not `:full_or`). First level-8
purchase → `:one_more_full_or_set` end, triggers injection of
`REMAINDER_CASH` (20×£5,000 = £100,000) into bank. Bank-break wins if
both fire (priority ordering).

Also refactors `level8_train_available?` from step to `game.rb` per
coding guidelines.
