### PR TITLE
[18OE] D-train city/offboard revenue doubling + Krasnaya Strela exception

### DIFF
--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -648,10 +648,33 @@ module Engine
           @regional_corps_floated = 0
           @fulfilled_train_obligation = Set.new
           @first_or_done = false
+          @krasnaya_strela_train = nil
 
           corporations.each do |corp|
             corp.par_via_exchange = companies.find { |c| c.sym == corp.id } if corp.type == :minor
           end
+        end
+
+        def revenue_for(route, stops)
+          base = super
+          return base unless d_train?(route.train)
+
+          # §11.6 — D-trains double all city and red-zone (offboard) revenue
+          doublers = stops.select { |s| s.city? || s.offboard? }
+          doubling_bonus = doublers.sum { |s| s.route_revenue(route.phase, route.train) }
+
+          # §15.7 — Krasnaya Strela: the extra city on a D-train does not double;
+          # player may choose any city — optimal choice is always the lowest-value stop
+          if @krasnaya_strela_train == route.train
+            min_rev = doublers.map { |s| s.route_revenue(route.phase, route.train) }.min || 0
+            doubling_bonus -= min_rev
+          end
+
+          base + doubling_bonus
+        end
+
+        def d_train?(train)
+          %w[4D 5D].include?(train.name)
         end
 
         def ipo_name(_entity = nil)


### PR DESCRIPTION
## Explanation of Change

### BUG-031 — D-train revenue doubling + Krasnaya Strela exception

**§11.6** — 4D and 5D trains double the revenue of all city and red-zone
(offboard) stops on their route. Non-D trains (7+7, 8+8, etc.) are
unaffected. Towns are never doubled.

Implemented via `revenue_for` override in `game.rb`: adds each city/offboard
stop's `route_revenue` a second time on top of `super`. Helper predicate
`d_train?(train)` returns true for `4D` / `5D` only.

**§15.7** — When Minor L (Krasnaya Strela) assigns its +1+1 marker to a D-train,
the player may select any one city on the extended route to not double.
Since the optimal choice is always the lowest-value stop, the implementation
automatically subtracts the minimum city/offboard revenue from the doubling
bonus — no extra UI action required.

`@krasnaya_strela_train` is initialised to `nil` in `setup`. The Minor L
abilities implementation (pending separate PR) sets it via
`assign_krasnaya_strela!`; the exception activates automatically once
that branch merges.

## Checklist

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake`