### PR TITLE
[1862] add 1862 Golden Spike — stub and meta

### DIFF
--- a/lib/engine/game/g_1862_usa_canada.rb
+++ b/lib/engine/game/g_1862_usa_canada.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1862UsaCanada
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/meta.rb
+++ b/lib/engine/game/g_1862_usa_canada/meta.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../meta'
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      module Meta
+        include Game::Meta
+
+        DEV_STAGE = :prealpha
+
+        GAME_TITLE = '1862 USA Canada'
+        GAME_SUBTITLE = 'The First Transcontinental Railroad'
+        GAME_DESIGNER = 'Helmut Ohley'
+        GAME_LOCATION = 'North America'
+        GAME_PUBLISHER = nil
+        GAME_RULES_URL = nil
+        GAME_INFO_URL = nil
+
+        PLAYER_RANGE = [3, 7].freeze
+        OPTIONAL_RULES = [].freeze
+
+        # fs_name must match the actual directory so asset bundling resolves correctly
+        def self.fs_name
+          'g_1862_usa_canada'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
PR 2 — map + entities
Title: [1862] add map and entities
Base: neutronc:1862_gs_pr1


N/A — new game implementation

## Before clicking "Create"
- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
`map.rb` — pointy-top hex layout covering the continental USA and southern
Canada. Includes the full tile supply with standard tiles plus 25 custom
Sonderteile (GS_ prefix) for all labeled cities:

- M (Montreal): GS_MTL_Y → GS_MTL_G → GS_MTL_B → GS_MTL_GR
- NY (New York): GS_NY_G → GS_NY_B → GS_MTL_GR (shared gray with M)
- SLC (Salt Lake City): GS_SLC_Y → GS_SLC_G → GS_SLC_B
- C (Chicago): GS_C_G → GS_C_B → GS_C_GR
- NO (New Orleans): GS_NO_G → GS_NO_B → 899
- V/P/L/S (Vancouver/Portland/L.A./Sacramento): individual yellow/green
  tiles converging to shared GS_VSPL_B (brown) and GS_VSPL_G (gray)
- T (Toronto): GS_TOR gray (placed by TOR private company ability)

All 26 upgrade chains verified via IRB.

`entities.rb` — 13 corporations across 3 unlock groups:
- Group 1 (NYH, NYC, CP): 30% director share, unlocked at game start
- Group 2 (CPR, UP, ATS, SP): 20% director share, unlocks when Group 1 all floated
- Group 3 (NP, CN, TP, ORN, WP, GMO): mixed 20%/30% director, unlocks when Group 2 all floated

8 private companies with abilities and close triggers:
- P1 BOM: closes SOC when CPR or UP floats; SOC reduces SLC bonus while open
- P2 TOR: places GS_TOR gray tile on Toronto hex (one-use)
- P3 GHU Bahnhoflizenz: $80 station token discount
- P4 RMC: bonus markers (Bonusplättchen) for CP, ATS, CN
- P5 PSC: closes when WP pays first dividend
- P6 FNY: closes when NYC pays first dividend
- P7 SOC: closes when CPR or UP floats; reduces SLC route bonus to $15 while open
- P8 NHSC: forces NYH par at exactly $100; closes when NYH floats

### Screenshots
<img width="2263" height="1659" alt="image" src="https://github.com/user-attachments/assets/8c1043e5-8f91-4709-ac19-3bb85a0489cb" />
### Any Assumptions / Hacks