### PR TITLE
[1862] add 1862 Golden Spike — stub and meta

### DIFF
--- a/lib/engine/game/g_1862_usa_canada.rb
+++ b/lib/engine/game/g_1862_usa_canada.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1862UsaCanada
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/meta.rb
+++ b/lib/engine/game/g_1862_usa_canada/meta.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../meta'
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      module Meta
+        include Game::Meta
+
+        DEV_STAGE = :prealpha
+
+        GAME_TITLE = '1862 USA Canada'
+        GAME_SUBTITLE = 'The First Transcontinental Railroad'
+        GAME_DESIGNER = 'Helmut Ohley'
+        GAME_LOCATION = 'North America'
+        GAME_PUBLISHER = nil
+        GAME_RULES_URL = nil
+        GAME_INFO_URL = nil
+
+        PLAYER_RANGE = [3, 7].freeze
+        OPTIONAL_RULES = [].freeze
+
+        # fs_name must match the actual directory so asset bundling resolves correctly
+        def self.fs_name
+          'g_1862_usa_canada'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
PR 1 — stub + meta
Title: [1862] add 1862 Golden Spike — stub and meta
Base: tobymao/18xx:master


N/A — new game implementation

## Before clicking "Create"
- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
Registers the 1862 Golden Spike game module with the engine.

`g_1862_usa_canada.rb` — empty namespace stub so the engine can resolve
the module before the full game files load.

`meta.rb` — declares title ("1862 USA Canada"), subtitle ("The First
Transcontinental Railroad"), designer (Helmut Ohley), location (North
America), player range 3–7, and dev stage `:prealpha`.

This is part 1 of 9 — further files follow in subsequent PRs.

### Screenshots
N/A — no UI changes.

### Any Assumptions / Hacks
- Dev stage is `:prealpha`; the game is not yet playable end-to-end.
- `GAME_RULES_URL` and `GAME_INFO_URL` are `nil` pending a public rules link.