### PR TITLE
1862 gs pr3

### DIFF
--- a/lib/engine/game/g_1862_usa_canada.rb
+++ b/lib/engine/game/g_1862_usa_canada.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1862UsaCanada
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/entities.rb
+++ b/lib/engine/game/g_1862_usa_canada/entities.rb
@@ -1,0 +1,343 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      module Entities
+        # ---------------------------------------------------------------------------
+        # Private Companies (P1–P8)
+        # Auctioned in first stock round only; unsellable to corporations; no end value.
+        # ---------------------------------------------------------------------------
+        COMPANIES = [
+          {
+            name: 'Butterfield Overland Mail',
+            sym: 'BOM',
+            value: 20,
+            revenue: 5,
+            desc: 'No special abilities. Income only.',
+            color: nil,
+          },
+          {
+            name: 'Toronto Steamship Company',
+            sym: 'TOR',
+            value: 50,
+            revenue: 10,
+            desc: 'Blocks the Toronto hex while owned by a player. The owning corporation '\
+                  'may place the special Toronto gray tile on the Toronto hex at any time '\
+                  'when acting (free, no connection required). Closes when placed.',
+            abilities: [
+              { type: 'blocks_hexes', owner_type: 'player', hexes: ['E25'] },
+              {
+                type: 'tile_lay',
+                owner_type: 'corporation',
+                hexes: ['E25'],
+                tiles: ['GS_TOR'],
+                when: 'any',
+                count: 1,
+                free: true,
+                closed_when_used_up: true,
+              },
+            ],
+            color: nil,
+          },
+          {
+            name: 'Bahnhoflizenz',
+            sym: 'GHU',
+            value: 75,
+            revenue: 15,
+            desc: 'The owning corporation\'s director may place a station token for $80 '\
+                  'less than the normal cost (minimum $0).',
+            abilities: [
+              {
+                type: 'tile_discount',
+                discount: 80,
+                terrain: 'station',
+                owner_type: 'corporation',
+              },
+            ],
+            color: nil,
+          },
+          {
+            name: 'Rocky Mountain Company',
+            sym: 'RMC',
+            value: 100,
+            revenue: 20,
+            desc: 'The owning corporation may lay one additional yellow tile during its '\
+                  'operating turn. This ability is one-time use and closes the company.',
+            abilities: [
+              {
+                type: 'tile_lay',
+                owner_type: 'corporation',
+                hexes: [],
+                tiles: [],
+                when: 'owning_corp_or_turn',
+                count: 1,
+                closed_when_used_up: true,
+                special: false,
+                free: false,
+              },
+            ],
+            color: nil,
+          },
+          {
+            name: 'Pacific Steamship Company',
+            sym: 'PSC',
+            value: 140,
+            revenue: 25,
+            desc: 'The initial purchaser immediately receives a 10% share of WP. '\
+                  'Closes when WP first pays a dividend.',
+            abilities: [
+              { type: 'shares', shares: 'WP_1' },
+              # Custom close trigger: when WP pays first dividend — handled in game.rb
+            ],
+            color: nil,
+          },
+          {
+            name: 'First New York Steamship Co.',
+            sym: 'FNY',
+            value: 180,
+            revenue: 30,
+            desc: 'The initial purchaser immediately receives a 10% share of NYC. '\
+                  'Closes when NYC first pays a dividend.',
+            abilities: [
+              { type: 'shares', shares: 'NYC_1' },
+              # Custom close trigger: when NYC pays first dividend — handled in game.rb
+            ],
+            color: nil,
+          },
+          {
+            name: 'Sacramento-Omaha Company',
+            sym: 'SOC',
+            value: 220,
+            revenue: 35,
+            desc: 'The initial purchaser immediately receives a 10% share of CPR and '\
+                  'a 10% share of UP. Closes when either CPR or UP floats. '\
+                  'While open, reduces the UP/CPR Salt Lake City route bonus payout to $15.',
+            abilities: [
+              { type: 'shares', shares: %w[CPR_1 UP_1] },
+              # Custom close trigger: when CPR or UP floats — handled in game.rb
+            ],
+            color: nil,
+          },
+          {
+            name: 'New Haven Steamship Company',
+            sym: 'NHSC',
+            value: 270,
+            revenue: 40,
+            desc: "The initial purchaser immediately receives the 30% Director's "\
+                  'certificate of NYH. NYH must be parred at exactly $100. '\
+                  'Closes when NYH floats.',
+            abilities: [
+              { type: 'shares', shares: 'NYH_0' },
+              { type: 'no_buy' },
+              # Custom close trigger: when NYH floats — handled in game.rb
+              # Custom par restriction: NYH par locked to $100 — handled in game.rb
+            ],
+            color: nil,
+          },
+        ].freeze
+
+        # ---------------------------------------------------------------------------
+        # Corporations — 3 groups, unlocked progressively:
+        #   Group 1 (NYH, NYC, CP)  : available from game start
+        #   Group 2 (CPR, UP, ATS, SP) : unlocked when ALL Group 1 companies float
+        #   Group 3 (NP, CN, TP, ORN, WP, GMO) : unlocked when ALL Group 2 companies float
+        #
+        # Share structures:
+        #   Group 1: 30% Director cert + 7 × 10% = 100%  (float at 60%)
+        #   Group 2/3: 20% Director cert + 8 × 10% = 100% (float at 60%)
+        #
+        # FIXME: All hex coordinates are placeholders — update when map.rb is complete.
+        # ---------------------------------------------------------------------------
+        CORPORATIONS = [
+          # -------------------------------------------------------------------------
+          # Group 1 — 30% Director, float at 60%
+          # -------------------------------------------------------------------------
+          {
+            sym: 'NYH',
+            name: 'New York New Haven',
+            logo: '1862_usa_canada/NYH',
+            simple_logo: '1862_usa_canada/NYH.alt',
+            float_percent: 60,
+            shares: [30, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 100, 100],
+            coordinates: 'F28',
+            city: 1,
+            color: '#d1232a',
+            text_color: 'white',
+          },
+          {
+            sym: 'NYC',
+            name: 'New York Central',
+            logo: '1862_usa_canada/NYC',
+            simple_logo: '1862_usa_canada/NYC.alt',
+            float_percent: 60,
+            shares: [30, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 100, 100],
+            coordinates: 'F28',
+            city: 0,
+            color: '#110a0c',
+            text_color: 'white',
+          },
+          {
+            sym: 'CP',
+            name: 'Canadian Pacific',
+            logo: '1862_usa_canada/CP',
+            simple_logo: '1862_usa_canada/CP.alt',
+            float_percent: 60,
+            shares: [30, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 100, 100],
+            coordinates: 'D28',
+            color: '#d88e39',
+            text_color: 'black',
+          },
+
+          # -------------------------------------------------------------------------
+          # Group 2 — 20% Director, float at 60%
+          # -------------------------------------------------------------------------
+          {
+            sym: 'CPR',
+            name: 'Central Pacific Railroad',
+            logo: '1862_usa_canada/CPR',
+            simple_logo: '1862_usa_canada/CPR.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 100],
+            coordinates: 'G3',
+            city: 0,
+            color: '#f48221',
+            text_color: 'black',
+          },
+          {
+            sym: 'UP',
+            name: 'Union Pacific',
+            logo: '1862_usa_canada/UP',
+            simple_logo: '1862_usa_canada/UP.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 100],
+            coordinates: 'F14',
+            color: '#025aaa',
+            text_color: 'white',
+          },
+          {
+            sym: 'ATS',
+            name: 'Atchison Topeka & Santa Fe',
+            logo: '1862_usa_canada/ATS',
+            simple_logo: '1862_usa_canada/ATS.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 100],
+            coordinates: 'F20',
+            color: '#32763f',
+            text_color: 'white',
+          },
+          {
+            sym: 'SP',
+            name: 'Southern Pacific',
+            logo: '1862_usa_canada/SP',
+            simple_logo: '1862_usa_canada/SP.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 100],
+            coordinates: 'K19',
+            color: '#76a042',
+            text_color: 'black',
+          },
+
+          # -------------------------------------------------------------------------
+          # Group 3 — 20% Director, float at 60%
+          # -------------------------------------------------------------------------
+          {
+            sym: 'NP',
+            name: 'Northern Pacific',
+            logo: '1862_usa_canada/NP',
+            simple_logo: '1862_usa_canada/NP.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40],
+            coordinates: 'D16',
+            color: '#95c054',
+            text_color: 'black',
+          },
+          {
+            sym: 'CN',
+            name: 'Canadian National',
+            logo: '1862_usa_canada/CN',
+            simple_logo: '1862_usa_canada/CN.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40],
+            coordinates: 'B14',
+            color: '#ADD8E6',
+            text_color: 'black',
+          },
+          {
+            sym: 'TP',
+            name: 'Texas Pacific',
+            logo: '1862_usa_canada/TP',
+            simple_logo: '1862_usa_canada/TP.alt',
+            float_percent: 60,
+            shares: [30, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40],
+            coordinates: 'J16',
+            color: '#7b352a',
+            text_color: 'white',
+          },
+          {
+            sym: 'ORN',
+            name: 'Oregon Railroad & Navigation',
+            logo: '1862_usa_canada/ORN',
+            simple_logo: '1862_usa_canada/ORN.alt',
+            float_percent: 60,
+            shares: [30, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40],
+            coordinates: 'C3',
+            color: '#FFF500',
+            text_color: 'black',
+          },
+          {
+            # WP co-homes in Sacramento (slot 1) alongside CPR (slot 0).
+            # Both transcontinental roads originate from the Sacramento terminus.
+            sym: 'WP',
+            name: 'Western Pacific',
+            logo: '1862_usa_canada/WP',
+            simple_logo: '1862_usa_canada/WP.alt',
+            float_percent: 60,
+            shares: [30, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40],
+            coordinates: 'G3',
+            city: 1,
+            color: '#8dd7f6',
+            text_color: 'black',
+          },
+          {
+            sym: 'GMO',
+            name: 'Gulf Mobile & Ohio',
+            logo: '1862_usa_canada/GMO',
+            simple_logo: '1862_usa_canada/GMO.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40],
+            coordinates: 'J20',
+            color: '#6ec037',
+            text_color: 'black',
+          },
+        ].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -1,0 +1,636 @@
+# frozen_string_literal: true
+
+# Developed with Claude (Anthropic) AI assistance — claude.ai/code
+
+require_relative 'meta'
+require_relative 'entities'
+require_relative 'map'
+require_relative 'step/buy_sell_par_shares'
+require_relative 'step/company_pending_par'
+require_relative 'step/dividend'
+require_relative 'step/repay_bond'
+require_relative 'step/token'
+require_relative '../base'
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      class Game < Game::Base
+        include_meta(G1862UsaCanada::Meta)
+        include Entities
+        include Map
+
+        # ---------------------------------------------------------------------------
+        # Corporation groups — unlocked progressively
+        # Group 1 available from game start.
+        # Group 2 unlocks when ALL Group 1 companies have floated.
+        # Group 3 unlocks when ALL Group 2 companies have floated.
+        #
+        # Director share sizes by group (from rulebook):
+        #   Group 1 (NYH, NYC, CP):       30% Director + 7×10%
+        #   Group 2 (CPR, UP, ATS, SP):   20% Director + 8×10%
+        #   Group 3 (NP, CN, GMO):        20% Director + 8×10%
+        #   Group 3 (TP, ORN, WP):        30% Director + 7×10%  ← mixed within group
+        # ---------------------------------------------------------------------------
+        CORP_GROUPS = {
+          1 => %w[NYH NYC CP],
+          2 => %w[CPR UP ATS SP],
+          3 => %w[NP CN TP ORN WP GMO],
+        }.freeze
+
+        # ---------------------------------------------------------------------------
+        # Bonus markers (Bonusplättchen) — 8 corporations, pre-placed on cities.
+        # Activation: corporation's route passes through BOTH its home hex AND the
+        # bonus hex. Director then chooses: take cash immediately (marker removed)
+        # OR keep as permanent +N revenue bonus each OR the route visits that city.
+        # Each bonus is counted at most once per OR.
+        #
+        # FIXME: V/P/S/L (Vancouver/Portland/Sacramento/Los Angeles) and El Paso
+        # hex groups need confirmation against physical map before activation works.
+        # ---------------------------------------------------------------------------
+        CORP_BONUSES = {
+          'CP' => [
+            { hexes: %w[E25],          cash: 100, route_bonus: 30,  name: 'Toronto'     },
+            { hexes: %w[B20],          cash: 200, route_bonus: 60,  name: 'Thunder Bay' },
+            { hexes: %w[B2 C1 G3 I5], cash: 300, route_bonus: 100, name: 'V/P/S/L' },
+          ],
+          'NYH' => [
+            { hexes: %w[F20],          cash: 100, route_bonus: 30,  name: 'Chicago'     },
+            { hexes: %w[K19],          cash: 200, route_bonus: 60,  name: 'New Orleans' },
+          ],
+          'CPR' => [
+            { hexes: %w[F14],          cash: 100, route_bonus: 30,  name: 'Omaha'       },
+          ],
+          'UP' => [
+            { hexes: %w[K19],          cash: 100, route_bonus: 30,  name: 'New Orleans' },
+            { hexes: %w[J10],          cash: 200, route_bonus: 60,  name: 'El Paso'     },
+          ],
+          'ATS' => [
+            { hexes: %w[B2 C1 G3 I5], cash: 200, route_bonus: 60, name: 'V/P/S/L' },
+          ],
+          'NP' => [
+            { hexes: %w[F20], cash: 100, route_bonus: 30, name: 'Chicago' },
+          ],
+          'CN' => [
+            { hexes: %w[B2 C1 G3 I5], cash: 100, route_bonus: 30, name: 'V/P/S/L' },
+            { hexes: %w[B10], cash: 200, route_bonus: 60, name: 'Regina' },
+          ],
+          # FIXME: TP El Paso bonus omitted until bonus amount confirmed from rulebook
+        }.freeze
+
+        # ---------------------------------------------------------------------------
+        # SLC (Salt Lake City / Promontory Summit) transcontinental bonus
+        # CPR and UP each earn a per-OR route bonus when their route passes through SLC.
+        # When BOTH have connected through SLC for the first time the "Golden Spike"
+        # fires: a one-time shareholder bonus is paid from the bank and both stock
+        # prices advance one step.
+        #
+        # FIXME: SLC hex coordinate unconfirmed — placeholder until map verified.
+        # FIXME: GOLDEN_SPIKE_SHAREHOLDER_BONUS amount unconfirmed from rulebook.
+        # ---------------------------------------------------------------------------
+        SLC_HEX                        = 'G9'.freeze
+        SLC_CORPS                      = %w[CPR UP].freeze
+        SLC_ROUTE_BONUS                = 30   # per OR while route passes through SLC
+        SLC_ROUTE_BONUS_SOC            = 15   # reduced while SOC (P7) is open
+        GOLDEN_SPIKE_SHAREHOLDER_BONUS = 50   # FIXME: per 10% share, paid from bank on completion
+
+        CURRENCY_FORMAT_STR = '$%s'
+
+        BANK_CASH = 12_000
+
+        CERT_LIMIT = { 3 => 27, 4 => 22, 5 => 18, 6 => 15, 7 => 13 }.freeze
+
+        STARTING_CASH = { 3 => 750, 4 => 600, 5 => 500, 6 => 440, 7 => 400 }.freeze
+
+        TRACK_RESTRICTION = :permissive
+        SELL_BUY_ORDER    = :sell_buy_sell
+
+        # Players can hold up to 100% of a company; monopoly fees apply above 60%
+        MARKET_SHARE_LIMIT = 100
+
+        # Selling drops stock price; buying into pool does not raise it
+        SELL_MOVEMENT = :down_per_10
+        POOL_SHARE_DROP = :down_block
+
+        # Companies are never required to buy a train to operate
+        MUST_BUY_TRAIN = :never
+
+        # Place all home tokens at OR start so the graph is populated before any
+        # entity queries connected_hexes — avoids stale-cache bug on shared home hexes.
+        HOME_TOKEN_TIMING = :operating_round
+
+        # 60% of par price paid into company on float; remainder drips in as shares sell
+        CAPITALIZATION = :incremental
+
+        # ---------------------------------------------------------------------------
+        # Stock market — 2D ledge layout, Kurstabelle 1863
+        # p = valid par/IPO cell
+        # e = end-game zone (any marker reaching these cells ends the game after
+        #     the current OR set)
+        # Rows read top (row 0) to bottom (row 9); columns left to right.
+        # ---------------------------------------------------------------------------
+        MARKET = [
+          %w['' 85 92 100p 110 120 132 146 162 180 200 225 250 280 310 340e 370e],
+          %w['' 70 80 85 92p 100 110 120 132 146 162 180 200 225 250 280 315e 350e],
+          %w[55 65 75 80 85p 92 100 110 120 132 146 162 180 200 225 250],
+          %w[50 60 70 75 80p 85 92 100 110 120 132 146 162 180],
+          %w[45 55 65 70 75p 80 85 92 100 110 120 132],
+          %w[40 50 60 65 70p 75 80 85 92 100],
+          %w[35 45 55 62 68 72 75 80],
+          %w[30 40 50 60 65 70],
+          %w[25 35 45 55],
+          %w[20 30],
+        ].freeze
+
+        MARKET_TEXT = Base::MARKET_TEXT.merge(
+          'par' => 'Valid par price',
+          'end_game' => 'Stock price reaches this cell; game ends after current OR set'
+        ).freeze
+
+        STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(
+          par: :yellow,
+          end_game: :orange
+        ).freeze
+
+        # ---------------------------------------------------------------------------
+        # Phases
+        # Phase name = first train type purchased that triggers it.
+        # FIXME: verify exact operating_rounds count per phase from rulebook.
+        # ---------------------------------------------------------------------------
+        PHASES = [
+          {
+            name: '2',
+            train_limit: 4,
+            tiles: [:yellow],
+            operating_rounds: 1,
+          },
+          {
+            name: '3',
+            on: '3',
+            train_limit: 4,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+          },
+          {
+            name: '4',
+            on: '4',
+            train_limit: 3,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+          },
+          {
+            name: '5',
+            on: '5',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+          },
+          {
+            name: '6',
+            on: '6',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+          },
+          {
+            name: '7',
+            on: '7',
+            train_limit: 2,
+            tiles: %i[yellow green brown gray],
+            operating_rounds: 3,
+          },
+          {
+            name: '8',
+            on: '8',
+            train_limit: 2,
+            tiles: %i[yellow green brown gray],
+            operating_rounds: 3,
+          },
+        ].freeze
+
+        # ---------------------------------------------------------------------------
+        # Trains
+        #
+        # Each base type (2–7) has an E-variant (Express).
+        # E-trains use the distance-array format: pay: N stops, visit: 999.
+        # This allows them to traverse unlimited intermediate cities/towns while
+        # only collecting revenue at N chosen stops (true express behaviour).
+        #
+        # Rusting (confirmed from rulebook summary card):
+        #   2/2E  → rusts on first 4/4E purchase
+        #   3/3E  → rusts on first 6/6E purchase
+        #   4/4E  → rusts on first 8 purchase
+        #   5/5E, 6/6E, 7/7E, 8 → never rust
+        # ---------------------------------------------------------------------------
+        TRAINS = [
+          {
+            name: '2',
+            distance: 2,
+            price: 100,
+            rusts_on: '4',
+            num: 7,
+            variants: [
+              { name: '2E', distance: [{ nodes: %w[city offboard town], pay: 2, visit: 999 }], price: 150 },
+            ],
+          },
+          {
+            name: '3',
+            distance: 3,
+            price: 200,
+            rusts_on: '6',
+            num: 6,
+            variants: [
+              { name: '3E', distance: [{ nodes: %w[city offboard town], pay: 3, visit: 999 }], price: 300 },
+            ],
+          },
+          {
+            name: '4',
+            distance: 4,
+            price: 300,
+            rusts_on: '8',
+            num: 5,
+            variants: [
+              { name: '4E', distance: [{ nodes: %w[city offboard town], pay: 4, visit: 999 }], price: 400 },
+            ],
+          },
+          {
+            name: '5',
+            distance: 5,
+            price: 550,
+            num: 4,
+            variants: [
+              { name: '5E', distance: [{ nodes: %w[city offboard town], pay: 5, visit: 999 }], price: 700 },
+            ],
+          },
+          {
+            name: '6',
+            distance: 6,
+            price: 650,
+            num: 3,
+            variants: [
+              { name: '6E', distance: [{ nodes: %w[city offboard town], pay: 6, visit: 999 }], price: 800 },
+            ],
+          },
+          {
+            name: '7',
+            distance: 7,
+            price: 750,
+            num: 2,
+            variants: [
+              { name: '7E', distance: [{ nodes: %w[city offboard town], pay: 7, visit: 999 }], price: 900 },
+            ],
+          },
+          {
+            name: '8',
+            distance: 999,
+            price: 900,
+            num: 20,
+          },
+        ].freeze
+
+        # ---------------------------------------------------------------------------
+        # Game end
+        # Triggers: bank empty OR any stock price marker reaches a cell > 310.
+        # After trigger: finish current OR set, then end.
+        # ---------------------------------------------------------------------------
+        GAME_END_CHECK = { bank: :current_round, stock_market: :current_round }.freeze
+
+        # ---------------------------------------------------------------------------
+        # Setup
+        # ---------------------------------------------------------------------------
+        def setup
+          @available_par_groups = [1]
+          @slc_bonus_paid = false
+          @slc_connected  = {}       # { corp_sym => true } when first route through SLC
+          @first_dividend_paid = {}  # { corp_sym => true } for P5/P6 close triggers
+          @corp_bonds = {} # { corp_sym => Integer } outstanding Schuldschein per corp
+          # Bonus state: [corp_sym, bonus_index] => :unactivated / :permanent / :cash
+          @bonus_state = {}
+          CORP_BONUSES.each do |sym, bonuses|
+            bonuses.each_index { |i| @bonus_state[[sym, i]] = :unactivated }
+          end
+        end
+
+        # ---------------------------------------------------------------------------
+        # Bond (Schuldschein) helpers
+        # One bond per corporation; amount is face value rounded up to nearest $100.
+        # Available from phase 3 (first 3/3E purchase).
+        # Director cannot sell the corp's shares while a bond is outstanding.
+        # Outstanding bonds at game end: Director is personally liable.
+        # FIXME: actual share-halving (50% buyback action) not yet implemented.
+        # ---------------------------------------------------------------------------
+        def corp_bond(corporation)
+          @corp_bonds[corporation.id] || 0
+        end
+
+        def bond?(corporation)
+          corp_bond(corporation).positive?
+        end
+
+        def issue_bond!(corporation, amount)
+          @corp_bonds[corporation.id] = amount
+          @log << "#{corporation.name} issues a $#{amount} bond (Schuldschein)"
+        end
+
+        def repay_bond!(corporation)
+          owed = corp_bond(corporation)
+          return if owed.zero?
+
+          paid = [owed, corporation.cash].min
+          @corp_bonds[corporation.id] = owed - paid
+          corporation.spend(paid, @bank)
+          msg = "#{corporation.name} repays $#{paid} bond"
+          msg += " ($#{@corp_bonds[corporation.id]} remaining)" if @corp_bonds[corporation.id].positive?
+          @log << msg
+        end
+
+        def buyback_available?
+          @phase.name.to_i >= 3
+        end
+
+        # ---------------------------------------------------------------------------
+        # Bonus markers (Bonusplättchen)
+        # ---------------------------------------------------------------------------
+
+        # Called from routes_revenue to include permanent bonus revenue in totals.
+        # Pure calculation — no side effects.
+        def corp_bonus_revenue(corporation, routes)
+          return 0 unless (bonuses = CORP_BONUSES[corporation.id])
+
+          home_hex = corporation.coordinates
+          bonuses.each_with_index.sum do |bonus, i|
+            state = @bonus_state[[corporation.id, i]]
+            case state
+            when :unactivated
+              # Would this bonus activate? Include its value in the display.
+              would_activate?(bonus, routes, home_hex) ? bonus[:route_bonus] : 0
+            when :permanent
+              bonus_on_route?(bonus, routes) ? bonus[:route_bonus] : 0
+            else
+              0
+            end
+          end
+        end
+
+        # Called from our Dividend step before super to permanently record activations.
+        # FIXME: should offer cash-vs-permanent choice; auto-chooses permanent for now.
+        def activate_new_bonuses!(corporation, routes)
+          return unless (bonuses = CORP_BONUSES[corporation.id])
+
+          home_hex = corporation.coordinates
+          bonuses.each_with_index do |bonus, i|
+            next unless @bonus_state[[corporation.id, i]] == :unactivated
+            next unless would_activate?(bonus, routes, home_hex)
+
+            @bonus_state[[corporation.id, i]] = :permanent
+            @log << "#{corporation.name} activates #{bonus[:name]} bonus " \
+                    "(permanent +#{format_currency(bonus[:route_bonus])} per route)"
+          end
+        end
+
+        def routes_revenue(routes)
+          return 0 if routes.empty?
+
+          base = super
+          corp = routes.first.train.owner
+          base + corp_bonus_revenue(corp, routes) + slc_route_bonus(corp, routes)
+        end
+
+        # Called from dividend step (before super) each time a corporation runs routes.
+        # Marks first-time SLC connections and fires the Golden Spike event when both
+        # CPR and UP have connected.
+        def check_golden_spike!(corporation, routes)
+          return unless SLC_CORPS.include?(corporation.id)
+          return if @slc_connected[corporation.id]
+          return unless routes.any? { |r| r.visited_stops.any? { |s| s.hex.id == SLC_HEX } }
+
+          @slc_connected[corporation.id] = true
+          @log << "#{corporation.name} reaches Salt Lake City — transcontinental route active"
+
+          return unless SLC_CORPS.all? { |sym| @slc_connected[sym] }
+          return if @slc_bonus_paid
+
+          @slc_bonus_paid = true
+          golden_spike_event!
+        end
+
+        private
+
+        def golden_spike_event!
+          @log << '-- GOLDEN SPIKE! Transcontinental railroad complete --'
+          SLC_CORPS.each do |sym|
+            corp = corporation_by_id(sym)
+            next unless corp&.floated?
+
+            corp.share_holders.each do |entity, percent|
+              next unless entity.player?
+
+              bonus = (percent / 10) * GOLDEN_SPIKE_SHAREHOLDER_BONUS
+              @bank.spend(bonus, entity)
+              @log << "#{entity.name} receives #{format_currency(bonus)} Golden Spike bonus " \
+                      "(#{percent}% #{corp.name})"
+            end
+
+            @stock_market.move_up(corp)
+            @log << "#{corp.name} stock advances to #{format_currency(corp.share_price.price)}"
+          end
+        end
+
+        def slc_route_bonus(corporation, routes)
+          return 0 unless SLC_CORPS.include?(corporation.id)
+          return 0 unless routes.any? { |r| r.visited_stops.any? { |s| s.hex.id == SLC_HEX } }
+
+          soc = company_by_id('SOC')
+          soc && !soc.closed? ? SLC_ROUTE_BONUS_SOC : SLC_ROUTE_BONUS
+        end
+
+        def would_activate?(bonus, routes, home_hex)
+          bonus[:hexes].any? do |hex_id|
+            routes.any? do |route|
+              ids = route.visited_stops.map { |s| s.hex.id }
+              ids.include?(hex_id) && ids.include?(home_hex)
+            end
+          end
+        end
+
+        def bonus_on_route?(bonus, routes)
+          bonus[:hexes].any? do |hex_id|
+            routes.any? { |r| r.visited_stops.any? { |s| s.hex.id == hex_id } }
+          end
+        end
+
+        public
+
+        # ---------------------------------------------------------------------------
+        # GS_TOR is placed on a preprinted gray hex, bypassing normal color progression
+        # and phase gating. Both overrides are needed only for this one special tile.
+        def upgrades_to_correct_color?(from, to, selected_company: nil)
+          return true if to.name == 'GS_TOR'
+
+          super
+        end
+
+        # GS_MTL_GR carries label=M and label=NY; the base engine only checks the last
+        # label on the tile, so we check any label when the tile has more than one.
+        def upgrades_to_correct_label?(from, to)
+          return to.labels.any? { |l| l == from.label } if to.labels.size > 1
+
+          super
+        end
+
+        def tile_valid_for_phase?(tile, hex: nil, phase_color_cache: nil)
+          return true if tile.name == 'GS_TOR'
+
+          super
+        end
+
+        def status_str(corporation)
+          "#{corporation.presidents_percent}% President's Share"
+        end
+
+        # Tile lays
+        # Phase 2:  1 lay or upgrade
+        # Phase 3+: 2 yellow lays OR 1 upgrade  (:not_if_upgraded blocks 2nd lay after upgrade)
+        # ---------------------------------------------------------------------------
+        def tile_lays(entity)
+          return super unless @phase.name.to_i >= 3
+
+          [
+            { lay: true, upgrade: true, cost: 0 },
+            { lay: :not_if_upgraded, upgrade: false, cost: 0 },
+          ]
+        end
+
+        # ---------------------------------------------------------------------------
+        # Group unlock — called after every float event
+        # ---------------------------------------------------------------------------
+        def float_corporation(corporation)
+          super
+          check_group_unlock!(corporation)
+          close_private_on_float!(corporation)
+        end
+
+        def check_group_unlock!(corporation)
+          current_group = corp_group(corporation)
+          return unless current_group
+          return unless CORP_GROUPS[current_group].all? { |sym| corporation_by_id(sym).floated? }
+          return unless CORP_GROUPS[current_group + 1]
+          return if @available_par_groups.include?(current_group + 1)
+
+          @available_par_groups << (current_group + 1)
+          @log << "-- All Group #{current_group} companies floated; "\
+                  "Group #{current_group + 1} is now available --"
+        end
+
+        def corp_group(corporation)
+          CORP_GROUPS.each { |group, syms| return group if syms.include?(corporation.id) }
+          nil
+        end
+
+        # SOC (P7) closes when CPR or UP floats
+        def close_private_on_float!(corporation)
+          return unless %w[CPR UP NYH].include?(corporation.id)
+
+          soc  = company_by_id('SOC')
+          nhsc = company_by_id('NHSC')
+
+          if soc && !soc.closed? && %w[CPR UP].include?(corporation.id)
+            soc.close!
+            @log << "#{soc.name} closes as #{corporation.name} has floated"
+          end
+
+          return if !nhsc || nhsc.closed? || corporation.id != 'NYH'
+
+          nhsc.close!
+          @log << "#{nhsc.name} closes as #{corporation.name} has floated"
+        end
+
+        # ---------------------------------------------------------------------------
+        # Corporation availability — gated by par group
+        # ---------------------------------------------------------------------------
+        def can_par?(corporation, parrer)
+          return false unless @available_par_groups.include?(corp_group(corporation))
+
+          super
+        end
+
+        # ---------------------------------------------------------------------------
+        # Monopoly fee — owning > 60% of a company costs 20% of face value per share
+        # FIXME: implement monopoly fee collection in step/buy_sell_par_shares.rb
+        # ---------------------------------------------------------------------------
+        def monopoly_threshold
+          60
+        end
+
+        def monopoly_fee(share)
+          (share.price * 0.20).to_i
+        end
+
+        # ---------------------------------------------------------------------------
+        # P5/P6 close triggers — called from dividend step when a company first pays
+        # FIXME: hook this into step/dividend.rb
+        # ---------------------------------------------------------------------------
+        def check_private_close_on_dividend!(corporation)
+          psc = company_by_id('PSC')
+          fny = company_by_id('FNY')
+
+          if psc && !psc.closed? && corporation.id == 'WP'
+            psc.close!
+            @log << "#{psc.name} closes as #{corporation.name} has paid its first dividend"
+          end
+
+          return if !fny || fny.closed? || corporation.id != 'NYC'
+
+          fny.close!
+          @log << "#{fny.name} closes as #{corporation.name} has paid its first dividend"
+        end
+
+        # ---------------------------------------------------------------------------
+        # Game end check — stock price > 310 triggers end after current OR set
+        # ---------------------------------------------------------------------------
+        def game_ending_description
+          _, after = game_end_check
+          return unless after
+
+          after == :current_round ? 'Game ends at the end of the current OR set' : super
+        end
+
+        # ---------------------------------------------------------------------------
+        # Round definitions
+        # ---------------------------------------------------------------------------
+        def init_round
+          new_auction_round
+        end
+
+        def stock_round
+          Round::Stock.new(self, [
+            Engine::Step::DiscardTrain,
+            Engine::Step::Exchange,
+            Engine::Step::SpecialTrack,
+            G1862UsaCanada::Step::CompanyPendingPar,
+            G1862UsaCanada::Step::BuySellParShares,
+          ])
+        end
+
+        def operating_round(round_num)
+          Round::Operating.new(self, [
+            Engine::Step::Bankrupt,
+            Engine::Step::Exchange,
+            Engine::Step::SpecialTrack,
+            Engine::Step::BuyCompany,
+            Engine::Step::HomeToken,
+            Engine::Step::Track,
+            G1862UsaCanada::Step::Token,
+            Engine::Step::Route,
+            G1862UsaCanada::Step::Dividend,
+            Engine::Step::DiscardTrain,
+            Engine::Step::BuyTrain,
+            # FIXME: G1862UsaCanada::Step::StockBuyback — share-halving action (phase 3+)
+            G1862UsaCanada::Step::RepayBond,
+            [Engine::Step::BuyCompany, { blocks: true }],
+          ], round_num: round_num)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/map.rb
+++ b/lib/engine/game/g_1862_usa_canada/map.rb
@@ -1,0 +1,358 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      module Map
+        LAYOUT = :pointy
+        AXES = { x: :number, y: :letter }.freeze
+
+        LOCATION_NAMES = {
+          # Pacific Northwest
+          'B2' => 'Vancouver',
+          'C1' => 'Victoria',
+          'C3' => 'Seattle',
+          'C5' => 'Spokane',
+          'D2' => 'Portland',
+          # Western Canada
+          'A7' => 'Calgary',
+          'B10' => 'Regina',
+          'B14' => 'Winnipeg',
+          'B20' => 'Thunder Bay',
+          # Mountain West
+          'E6' => 'Boise',
+          'D10' => 'Billings',
+          'E11' => 'Rapid City',
+          'F8' => 'Ogden',
+          'G9' => 'Salt Lake City/SLC',
+          'G11' => 'Denver',
+          # Pacific Coast
+          'G3' => 'San Francisco/Sacramento',
+          'I5' => 'Los Angeles',
+          'J6' => 'San Diego',
+          # Great Plains
+          'D16' => 'Minneapolis',
+          'D18' => 'Duluth',
+          'G17' => 'Kansas City',
+          'F14' => 'Omaha',
+          'G19' => 'St. Louis',
+          # Midwest / Great Lakes
+          'F20' => 'Chicago',
+          'G23' => 'Columbus',
+          # Canada East
+          'E25' => 'Toronto',
+          'D26' => 'Ottawa',
+          'C29' => 'Quebec',
+          'D28' => 'Montreal',
+          # Northeast
+          'F28' => 'New York',
+          'F30' => 'Boston',
+          # Southwest
+          'I9' => 'Phoenix',
+          'J8' => 'Tucson',
+          'J10' => 'Santa Fe',
+          'H10' => 'Phoenix',
+          # South Central
+          'I15' => 'Oklahoma City',
+          'J16' => 'Dallas',
+          'I17' => 'Little Rock',
+          'K15' => 'Austin',
+          'K17' => 'Houston',
+          # Southeast
+          'J18' => 'Jackson',
+          'I23' => 'Atlanta',
+          'I21' => 'Chattanooga',
+          'H26' => 'Richmond',
+          'K19' => 'New Orleans',
+          'J20' => 'Mobile',
+          # Off-board labels
+          'A29' => 'Labrador',
+          'K9' => 'Mexico',
+          'K11' => 'Mexico',
+          'L24' => 'Florida',
+        }.freeze
+
+        # Tile counts from physical game tile sheet.
+        # Yellow: 80 standard + 5 Sonderteile = 85 total
+        # Green:  42 standard + 9 Sonderteile = 51 total
+        # Brown:  19 standard + 7 Sonderteile = 26 total
+        # Gray:    3 standard + 5 Sonderteile =  8 total
+        TILES = {
+          # Yellow
+          '3' => 4,
+          '4' => 10,
+          '6' => 10,
+          '7' => 4,
+          '8' => 12,
+          '9' => 22,
+          '57' => 10,
+          '58' => 8,
+          # Green
+          '14' => 4,
+          '15' => 4,
+          '16' => 2,
+          '19' => 2,
+          '20' => 2,
+          '23' => 4,
+          '24' => 4,
+          '25' => 2,
+          '26' => 2,
+          '27' => 2,
+          '28' => 2,
+          '29' => 2,
+          # Brown
+          '39' => 1,
+          '40' => 1,
+          '41' => 1,
+          '42' => 1,
+          '43' => 1,
+          '44' => 1,
+          '45' => 1,
+          '46' => 1,
+          '47' => 1,
+          '70' => 1,
+          '611' => 7,
+          # Gray (city upgrade tiles)
+          '895' => 3,
+          '899' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:80,slots:3;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=NO',
+          },
+          # Special brown 5 edges only 10 revenue
+          'GS_204_B' => {
+            'count' => 2,
+            'color' => 'brown',
+            'code' => 'town=revenue:10;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;',
+          },
+          # Special gray — Toronto (placed by TOR private)
+          'GS_TOR' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:30;path=a:1,b:_0;path=a:3,b:_0;path=a:5,b:_0;label=T',
+          },
+          # Montreal upgrades (label=M; preprint is stored as white internally, exits to edge 2 only)
+          'GS_MTL_Y' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'city=revenue:20;path=a:1,b:_0;path=a:2,b:_0;label=M',
+          },
+          'GS_MTL_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=M',
+          },
+          'GS_MTL_B' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:3;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=M',
+          },
+          # New York upgrades (label=NY; preprint yellow has 2 cities, exits 0/4 and 1/3)
+          'GS_NY_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40;city=revenue:40;' \
+                      'path=a:0,b:_0;path=a:4,b:_0;path=a:1,b:_1;path=a:3,b:_1;label=NY',
+          },
+          'GS_NY_B' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:3;' \
+                      'path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=NY',
+          },
+          # Shared gray tile — only one exists; goes to Montreal (M) OR New York (NY), not both
+          'GS_MTL_GR' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:80,slots:3;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;' \
+                      'path=a:4,b:_0;path=a:5,b:_0;label=M;label=NY',
+          },
+          # Salt Lake City upgrade yellow
+          'GS_SLC_Y' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'city=revenue:20;path=a:1,b:_0;path=a:3,b:_0;label=SLC',
+          },
+          'GS_SLC_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=SLC',
+          },
+          'GS_SLC_B' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;' \
+                      'path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=SLC',
+          },
+          'GS_V_Y' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'city=revenue:20;path=a:5,b:_0;path=a:3,b:_0;label=V',
+          },
+          'GS_P_Y' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'city=revenue:20;path=a:0,b:_0;path=a:3,b:_0;label=P',
+          },
+          'GS_L_Y' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'city=revenue:20;path=a:5,b:_0;path=a:2,b:_0;label=L',
+          },
+          'GS_P_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=P',
+          },
+          'GS_V_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=V',
+          },
+          'GS_L_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:5,b:_0;path=a:2,b:_0;path=a:4,b:_0;label=L',
+          },
+          'GS_S_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40;city=revenue:40;path=a:5,b:_0;path=a:2,b:_1;path=a:4,b:_1;label=S',
+          },
+          'GS_VSPL_B' => {
+            'count' => 2,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:3;path=a:2,b:_0;path=a:3,b:_0;' \
+                      'path=a:4,b:_0;path=a:5,b:_0;label=V;label=S;label=P;label=L',
+          },
+          'GS_VSPL_G' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:80,slots:3;path=a:2,b:_0;path=a:3,b:_0;' \
+                      'path=a:4,b:_0;path=a:5,b:_0;label=V;label=S;label=P;label=L',
+          },
+          'GS_C_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=C',
+          },
+          'GS_C_B' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:3;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=C',
+          },
+          'GS_NO_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=NO',
+          },
+          'GS_NO_B' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:3;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=NO',
+          },
+          'GS_C_GR' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:80,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=C',
+          },
+
+        }.freeze
+
+        MAP_HOMECITY_HEXES = %w[
+          C3 B14 D28 D16 F14 F20 F28 G3 J16 J20 K19
+        ].freeze
+
+        HEXES = {
+          white: {
+            # ── Blank upgradeable hexes ──────────────────────────────────────
+            %w[
+              A11 A13 A17 A19 A21 A23 A25 A27 B12 B14 B16 B18
+              B20 B22 B24 B26 C13 C15 C17 C19 C21 C23 C25 C27
+              C29 D4 D14 D16 D18 D20 D24 D26 E19 E27 F22
+              F24 G15 G21 H14 H16 H18 H22 I25 J14 J22 K13 K23
+            ] => '',
+
+            # ── Mountain terrain ($80) ───────────────────────────────────────
+            %w[
+              A3 A5 B4 B6 B8 C7 C9 D6 D8 E3 E7 E9 F4 F6 F10
+              G5 G7 H8 I7
+            ] => 'upgrade=cost:80,terrain:mountain',
+
+            # ── Hill terrain ($40) ───────────────────────────────────────────
+            %w[
+              A9 C11 D12 F12 F26 G13 G25 H12 H24 I11 I13 J12
+            ] => 'upgrade=cost:40,terrain:mountain',
+
+            # ── River terrain ($40) ──────────────────────────────────────────
+            %w[A15 B28 D30 E1 E13 E15 E17 F2 F16 H4 H20 I19 J24 K21] => 'upgrade=cost:40,terrain:river',
+
+            # ── City with River ($40) ────────────────────────────────────────
+            %w[F18 G17] => 'city=revenue:0;upgrade=cost:40,terrain:river',
+
+            # ── Town with river ($40) ────────────────────────────────────────
+            %w[G19 J18] => 'town=revenue:0;upgrade=cost:40,terrain:river',
+
+            # ── Plain cities ─────────────────────────────────────────────────
+            %w[A7 B10 B14 C29 D16 D26 E11 G11 G23 G27 H10 I15 I23 J6 J10 J16 J20 K15] => 'city=revenue:0',
+
+            # ── Towns ────────────────────────────────────────────────────────
+            %w[C5 B20 D10 D18 E5 E29 F8 H6 H26 I9 I17 I21 J8 K17] => 'town=revenue:0',
+
+            # ── Single-slot labeled cities ───────────────────────────────────
+            ['B2'] => 'city=revenue:0;label=V', # Vancouver
+            ['C3'] => 'city=revenue:0', # Seattle (ORN home)
+            ['D2'] => 'city=revenue:0;label=P', # Portland
+            ['D28'] => 'city=revenue:10;path=a:2,b:_0;label=M', # Montreal (CP home)
+            ['F14'] => 'city=revenue:10;path=a:1,b:_0', # Omaha (UP home)
+            ['I5'] => 'city=revenue:0;label=L', # Los Angeles
+            # SLC pre-printed white tile — transcontinental junction
+            ['G9'] => 'city=revenue:0;label=SLC',
+
+          },
+
+          gray: {
+            # Victoria — pre-printed grey town
+            ['C1'] => 'town=revenue:20;path=a:3,b:_0',
+            # Great Lakes / border — grey blank
+            %w[D22 E21] => '',
+            # E23 — grey through-path (Toronto → F22 area), rotated 180° per map
+            ['E23'] => 'path=a:4,b:0',
+            # Toronto — grey city; track exits east into E23
+            ['E25'] => 'city=revenue:20;path=a:1,b:_0',
+            # Boston — grey city; track exits west toward New York (F28)
+            ['F30'] => 'city=revenue:20;path=a:1,b:_0',
+            # Unnamed grey town near Mexico border
+            ['K7'] => 'town=revenue:20;path=a:2,b:_0',
+          },
+
+          yellow: {
+
+            # Chicago: single city, exits W (→F18) and SW (→G19)
+            ['F20'] => 'city=revenue:20;path=a:1,b:_0;path=a:0,b:_0;label=C',
+            # New Orleans: 120° CW from original (edges 5→1, 0→2)
+            ['K19'] => 'city=revenue:20;path=a:1,b:_0;path=a:2,b:_0;label=NO',
+            # Sacramento: city 0=WP (→edge 5), city 1=CPR (→edge 0); 120° CCW from photo
+            ['G3'] => 'city=revenue:0;city=revenue:0;path=a:4,b:_0;path=a:5,b:_1;label=S',
+            # New York: city 0=NYC (NE→E29, W→F26), city 1=NYH (E→F30, SW→G27)
+            ['F28'] => 'city=revenue:20;city=revenue:20;path=a:0,b:_0;path=a:4,b:_0;path=a:1,b:_1;path=a:3,b:_1;label=NY',
+          },
+
+          red: {
+            # Labrador — far northeast off-board (20/40 by phase)
+            ['A29'] =>
+              'offboard=revenue:yellow_20|brown_40;path=a:0,b:_0;path=a:1,b:_0',
+            # Mexico — two hexes south of map (0 yellow, 80 brown)
+            ['K9'] =>
+              'offboard=revenue:yellow_40|brown_80;path=a:2,b:_0;path=a:3,b:_0',
+            ['K11'] =>
+              'offboard=revenue:yellow_40|brown_80;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
+            # Florida — southeast off-board (30/60 by phase)
+            ['L24'] =>
+              'offboard=revenue:yellow_30|brown_60;path=a:2,b:_0',
+          },
+        }.freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/meta.rb
+++ b/lib/engine/game/g_1862_usa_canada/meta.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../meta'
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      module Meta
+        include Game::Meta
+
+        DEV_STAGE = :prealpha
+
+        GAME_TITLE = '1862 USA Canada'
+        GAME_SUBTITLE = 'The First Transcontinental Railroad'
+        GAME_DESIGNER = 'Helmut Ohley'
+        GAME_LOCATION = 'North America'
+        GAME_PUBLISHER = nil
+        GAME_RULES_URL = nil
+        GAME_INFO_URL = nil
+
+        PLAYER_RANGE = [3, 7].freeze
+        OPTIONAL_RULES = [].freeze
+
+        # fs_name must match the actual directory so asset bundling resolves correctly
+        def self.fs_name
+          'g_1862_usa_canada'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
PR 3 — game.rb
Title: [1862] add game.rb — core game logic
Base: neutronc:1862_gs_pr2


N/A — new game implementation

## Before clicking "Create"
- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
Core game logic implementing the following mechanics:

**Corporation unlock groups** — `CORP_GROUPS` + `available_par_groups`
gating. Group 2 unlocks when all of Group 1 have floated; Group 3 when
all of Group 2 have floated.

**Bonds (Schuldschein)** — each corporation may issue one bond for cash;
repayment is optional each OR. The director may not sell shares while a
bond is outstanding. Outstanding bonds at game end are a personal
director liability.

**Monopoly fee** — holding >60% of a corporation costs 20% of the share
face value per 10% share above the threshold, paid to the bank on purchase.

**E-trains** — each base train (2–7) has an express variant as a
`variants:` entry sharing the same pool. E-trains pay for N stops but
may visit an unlimited number of cities/offboards.

**SLC transcontinental bonus** — CPR and UP each earn a per-OR route
bonus when passing through Salt Lake City (G9). The bonus is $30
normally, reduced to $15 while SOC (P7) is open.

**Golden Spike event** — fires the first time either CPR or UP collects
the SLC bonus. Pays a one-time shareholder bonus from the bank and
advances both stock prices one step.

**Bonus markers (Bonusplättchen)** — 8 corporations have pre-assigned
bonus hexes. When a route passes through both the home hex and the bonus
hex, the director chooses to take an immediate cash payout (marker
removed) or retain it as a permanent per-OR route bonus.

**Private close triggers** — SOC/NHSC close on float events; PSC/FNY
close on first dividend payment by their linked corporation.

**Tile overrides** — `upgrades_to_correct_label?` extended to handle
multi-label tiles (GS_MTL_GR carries both label=M and label=NY).
`upgrades_to_correct_color?` and `tile_valid_for_phase?` allow GS_TOR
to be placed on a preprinted gray hex.

**Operating round** — step order: Track → Token (with GHU discount) →
Route → RepayBond → Dividend → BuyTrain.

### Screenshots
N/A

### Any Assumptions / Hacks
- `StockBuyback` step (share halving / 50% buyback, phase 3+) is marked
  FIXME — the step file does not exist yet.
- 3/3E and 6/6E rust triggers are unconfirmed against the rulebook.
- Operating rounds per phase are unverified.
- Golden Spike shareholder bonus amount is marked FIXME pending rulebook
  confirmation.

This is part 3 of 9.