### PR TITLE
[18ESP] Reduce excessive graph computations - prework

### DIFF
--- a/lib/engine/game/g_18_esp/step/check_destination_connection.rb
+++ b/lib/engine/game/g_18_esp/step/check_destination_connection.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G18ESP
+      module Step
+        class CheckDestinationConnection < Engine::Step::Base
+          ACTIONS = %w[destination_connection].freeze
+
+          def actions(_entity)
+            ACTIONS
+          end
+
+          def auto_actions(entity)
+            return [] unless entity&.corporation?
+
+            connected = @game.check_for_destination_connection(entity) ? [entity] : []
+            [Engine::Action::DestinationConnection.new(entity, corporations: connected)]
+          end
+
+          def description
+            'Check destination connection'
+          end
+
+          # Overridden to be a no-op: prevents force_next_entity! from skipping
+          # this step before it has had a chance to fire its auto_action.
+          def pass!; end
+
+          def process_destination_connection(action)
+            action.corporations.each { |c| c.goal_reached!(:destination) }
+            @passed = true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_18_esp/step/check_destination_connection.rb
+++ b/lib/engine/game/g_18_esp/step/check_destination_connection.rb
@@ -24,8 +24,11 @@ module Engine
             'Check destination connection'
           end
 
-          # Old fixtures have no destination_connection sub-action stored; the
-          # direct calls in tracker/home_token still handle loading correctly.
+          # During loading, auto_actions returns [] (performance win) — without this
+          # guard the round would hang because no destination_connection action is
+          # emitted at runtime. New saves carry the action in the log and run through
+          # process_destination_connection; pre-PR-2 saves are state-corrected by
+          # Game#backfill_destination_connections! after replay finishes.
           def blocking?
             return false if @game.loading
 

--- a/lib/engine/game/g_18_esp/step/check_destination_connection.rb
+++ b/lib/engine/game/g_18_esp/step/check_destination_connection.rb
@@ -24,6 +24,14 @@ module Engine
             'Check destination connection'
           end
 
+          # Old fixtures have no destination_connection sub-action stored; the
+          # direct calls in tracker/home_token still handle loading correctly.
+          def blocking?
+            return false if @game.loading
+
+            super
+          end
+
           # Overridden to be a no-op: prevents force_next_entity! from skipping
           # this step before it has had a chance to fire its auto_action.
           def pass!; end

--- a/lib/engine/game/g_18_esp/step/check_destination_connection.rb
+++ b/lib/engine/game/g_18_esp/step/check_destination_connection.rb
@@ -9,39 +9,38 @@ module Engine
         class CheckDestinationConnection < Engine::Step::Base
           ACTIONS = %w[destination_connection].freeze
 
-          def actions(_entity)
+          def actions(entity)
+            return [] if @game.loading
+            return [] unless new_destination_connection?(entity)
+
             ACTIONS
           end
 
           def auto_actions(entity)
-            return [] unless entity&.corporation?
+            return [] if @game.loading
+            return [] unless new_destination_connection?(entity)
 
-            connected = @game.check_for_destination_connection(entity) ? [entity] : []
-            [Engine::Action::DestinationConnection.new(entity, corporations: connected)]
+            [Engine::Action::DestinationConnection.new(entity, corporations: [entity])]
           end
 
           def description
             'Check destination connection'
           end
 
-          # During loading, auto_actions returns [] (performance win) — without this
-          # guard the round would hang because no destination_connection action is
-          # emitted at runtime. New saves carry the action in the log and run through
-          # process_destination_connection; pre-PR-2 saves are state-corrected by
-          # Game#backfill_destination_connections! after replay finishes.
-          def blocking?
-            return false if @game.loading
-
-            super
-          end
-
-          # Overridden to be a no-op: prevents force_next_entity! from skipping
-          # this step before it has had a chance to fire its auto_action.
+          # Step is not player-passable; @passed is set in process_destination_connection
           def pass!; end
 
           def process_destination_connection(action)
-            action.corporations.each { |c| c.goal_reached!(:destination) }
+            action.corporations.first.goal_reached!(:destination)
             @passed = true
+          end
+
+          private
+
+          def new_destination_connection?(entity)
+            entity&.corporation? &&
+              !entity.destination_connected? &&
+              @game.check_for_destination_connection(entity)
           end
         end
       end

--- a/spec/lib/engine/game/g_18_esp/corporation_spec.rb
+++ b/spec/lib/engine/game/g_18_esp/corporation_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Engine::Game::G18ESP::Corporation do
+  # SFVA at action 106: goals_reached_counter=0, destination_connected=false,
+  # par_price=90, cash=350, three blocked tokens (used=true, no hex),
+  # destination icon still present on hex C1.
+  # Action 107 is the first action that causes SFVA to reach its destination,
+  # so 106 is the last moment before any destination goal has been processed.
+  let(:fixture_data) { JSON.parse(File.read("#{FIXTURES_DIR}/18ESP/18ESP_game_end_second_eight.json")) }
+  let(:game) { Engine::Game.load(fixture_data, at_action: 106, strict: false) }
+  let(:corp) { game.corporation_by_id('SFVA') }
+
+  describe '#goal_reached!(:destination)' do
+    context 'when destination is not yet connected' do
+      it 'pays the bonus exactly once no matter how many times it is called' do
+        pre_cash    = corp.cash # 350
+        pre_goals   = corp.goals_reached_counter # 0
+        pre_log     = game.log.to_a.size
+        pre_bank    = game.bank.cash
+        pre_blocked = corp.tokens.count { |t| t.used && !t.hex } # 3
+        expected_bonus = corp.par_price.price * (pre_goals + 1) # 90
+
+        expect(corp.destination_connected?).to be_falsy
+        expect(game.hex_by_id(corp.destination).tile.icons.map(&:name)).to include(corp.name)
+
+        corp.goal_reached!(:destination)
+
+        snap_cash    = corp.cash
+        snap_goals   = corp.goals_reached_counter
+        snap_log     = game.log.to_a.size
+        snap_bank    = game.bank.cash
+        snap_blocked = corp.tokens.count { |t| t.used && !t.hex }
+
+        expect(corp.destination_connected?).to be true
+        expect(snap_goals).to eq(pre_goals + 1)
+        expect(snap_cash).to eq(pre_cash + expected_bonus)
+        expect(snap_bank).to eq(pre_bank - expected_bonus)
+        expect(snap_log).to eq(pre_log + 1)
+        expect(snap_blocked).to eq(pre_blocked - 1)
+        expect(game.hex_by_id(corp.destination).tile.icons.map(&:name)).not_to include(corp.name)
+
+        # second call must change nothing
+        corp.goal_reached!(:destination)
+
+        expect(corp.destination_connected?).to be true
+        expect(corp.goals_reached_counter).to eq(snap_goals)
+        expect(corp.cash).to eq(snap_cash)
+        expect(game.bank.cash).to eq(snap_bank)
+        expect(game.log.to_a.size).to eq(snap_log)
+        expect(corp.tokens.count { |t| t.used && !t.hex }).to eq(snap_blocked)
+      end
+
+      it 'three calls produce the same result as one call' do
+        corp.goal_reached!(:destination)
+        after_one = {
+          goals: corp.goals_reached_counter,
+          cash: corp.cash,
+          blocked: corp.tokens.count { |t| t.used && !t.hex },
+          log: game.log.to_a.size,
+        }
+
+        2.times { corp.goal_reached!(:destination) }
+
+        expect(corp.goals_reached_counter).to eq(after_one[:goals])
+        expect(corp.cash).to eq(after_one[:cash])
+        expect(corp.tokens.count { |t| t.used && !t.hex }).to eq(after_one[:blocked])
+        expect(game.log.to_a.size).to eq(after_one[:log])
+      end
+    end
+
+    context 'when destination is already connected' do
+      before { corp.goal_reached!(:destination) }
+
+      it 'is a no-op' do
+        pre_cash  = corp.cash
+        pre_goals = corp.goals_reached_counter
+        pre_log   = game.log.to_a.size
+        pre_bank  = game.bank.cash
+
+        corp.goal_reached!(:destination)
+
+        expect(corp.cash).to eq(pre_cash)
+        expect(corp.goals_reached_counter).to eq(pre_goals)
+        expect(game.log.to_a.size).to eq(pre_log)
+        expect(game.bank.cash).to eq(pre_bank)
+      end
+    end
+
+    it 'does not affect offboard or harbor goal flags' do
+      expect(corp.ran_offboard).to be_falsy
+      expect(corp.ran_harbor).to be_falsy
+
+      3.times { corp.goal_reached!(:destination) }
+
+      expect(corp.ran_offboard).to be_falsy
+      expect(corp.ran_harbor).to be_falsy
+    end
+  end
+end

--- a/spec/lib/engine/game/g_18_esp/game_spec.rb
+++ b/spec/lib/engine/game/g_18_esp/game_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Frozen snapshot of the destination goal mechanism after a full fixture replay.
+# Any deviation signals that a refactor step (Issue #12579) changed the behaviour,
+# intentionally or not.
+#
+# Values captured with Engine::Game.load(data, strict: false) at commit bc6657312.
+# AVT and TBF reach their destination not via goal_reached!(:destination) but through
+# the full-cap mechanism (game.rb ~line 589), hence goals=0.
+
+describe Engine::Game::G18ESP::Game do
+  describe '18ESP_game_end_second_eight' do
+    subject(:game) do
+      data = JSON.parse(File.read("#{FIXTURES_DIR}/18ESP/18ESP_game_end_second_eight.json"))
+      Engine::Game.load(data, strict: false).tap(&:maybe_raise!)
+    end
+
+    it 'replays without exceptions' do
+      expect(game.exception).to be_nil
+    end
+
+    it 'logs the destination goal exactly 8 times' do
+      count = game.log.to_a.count { |e| e.message.include?('reached destination goal') }
+      expect(count).to eq(8)
+    end
+
+    it 'removes all destination icons by game end' do
+      game.corporations.select(&:destination).each do |corp|
+        icons = game.hex_by_id(corp.destination).tile.icons.map(&:name)
+        expect(icons).not_to include(corp.name),
+                             "#{corp.name}: destination icon still present on #{corp.destination}"
+      end
+    end
+
+    # Frozen expected state per corporation at game end.
+    # goals     = goals_reached_counter
+    # connected = destination_connected?
+    {
+      'CRB' => { goals: 3, connected: true },
+      'MCP' => { goals: 3, connected: true },
+      'ZPB' => { goals: 3, connected: true },
+      'FdSB' => { goals: 3, connected: true },
+      'FdLR' => { goals: 2, connected: true },
+      'SFVA' => { goals: 3, connected: true },
+      'FdC' => { goals: 3, connected: true },
+      'GSSR' => { goals: 3, connected: true },
+      'AVT' => { goals: 0, connected: true },
+      'TBF' => { goals: 0, connected: true },
+    }.each do |sym, expected|
+      it "#{sym} ends with goals_reached_counter=#{expected[:goals]} and destination_connected=#{expected[:connected]}" do
+        corp = game.corporation_by_id(sym)
+        expect(corp.goals_reached_counter).to eq(expected[:goals])
+        expect(corp.destination_connected?).to eq(expected[:connected])
+      end
+    end
+  end
+end

--- a/spec/lib/engine/game/g_18_esp/game_spec.rb
+++ b/spec/lib/engine/game/g_18_esp/game_spec.rb
@@ -6,16 +6,14 @@ require 'spec_helper'
 # Any deviation signals that a refactor step (Issue #12579) changed the behaviour,
 # intentionally or not.
 #
-# Values captured with Engine::Game.load(data, strict: false) at commit bc6657312.
-# AVT and TBF reach their destination not via goal_reached!(:destination) but through
-# the full-cap mechanism (game.rb ~line 589), hence goals=0.
+# Values captured at commit bc6657312. AVT and TBF reach their destination not via
+# goal_reached!(:destination) but through the full-cap mechanism (game.rb ~line 589),
+# hence goals=0.
 
 describe Engine::Game::G18ESP::Game do
   describe '18ESP_game_end_second_eight' do
-    subject(:game) do
-      data = JSON.parse(File.read("#{FIXTURES_DIR}/18ESP/18ESP_game_end_second_eight.json"))
-      Engine::Game.load(data, strict: false).tap(&:maybe_raise!)
-    end
+    # 1334 = total action count for this fixture; loads the complete game.
+    let(:game) { fixture_at_action(1334) }
 
     it 'replays without exceptions' do
       expect(game.exception).to be_nil

--- a/spec/lib/engine/game/g_18_esp/step/check_destination_connection_spec.rb
+++ b/spec/lib/engine/game/g_18_esp/step/check_destination_connection_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Engine::Game::G18ESP::Step::CheckDestinationConnection do
+  # Game loaded at action 106: SFVA not yet destination-connected (first
+  # destination goal is logged at action 107). FdSB also not yet connected.
+  let(:fixture_data) { JSON.parse(File.read("#{FIXTURES_DIR}/18ESP/18ESP_game_end_second_eight.json")) }
+  let(:game)   { Engine::Game.load(fixture_data, at_action: 106, strict: false) }
+  let(:step)   { described_class.new(game, game.round) }
+  let(:corp)   { game.corporation_by_id('SFVA') }
+  let(:player) { game.players.first }
+
+  describe '#actions' do
+    it 'returns destination_connection for any entity' do
+      expect(step.actions(nil)).to eq(%w[destination_connection])
+      expect(step.actions(corp)).to eq(%w[destination_connection])
+      expect(step.actions(player)).to eq(%w[destination_connection])
+    end
+  end
+
+  describe '#auto_actions' do
+    context 'with a non-corporation entity' do
+      it 'returns [] for nil' do
+        expect(step.auto_actions(nil)).to eq([])
+      end
+
+      it 'returns [] for a player' do
+        expect(step.auto_actions(player)).to eq([])
+      end
+    end
+
+    context 'when the corporation has no destination connection' do
+      # SFVA.destination_connected is false at action 106 and graph confirms
+      # it is not yet reachable, so check_for_destination_connection returns false.
+      it 'emits one DestinationConnection action with an empty corporations list' do
+        result = step.auto_actions(corp)
+
+        expect(result.size).to eq(1)
+        expect(result.first).to be_a(Engine::Action::DestinationConnection)
+        expect(result.first.corporations).to eq([])
+      end
+    end
+
+    context 'when the corporation already has a destination connection' do
+      # Setting destination_connected=true short-circuits check_for_destination_connection
+      # without needing graph computation.
+      before { corp.destination_connected = true }
+
+      it 'emits one DestinationConnection action with the corporation' do
+        result = step.auto_actions(corp)
+
+        expect(result.size).to eq(1)
+        expect(result.first).to be_a(Engine::Action::DestinationConnection)
+        expect(result.first.corporations).to eq([corp])
+      end
+    end
+  end
+
+  describe '#process_destination_connection' do
+    let(:corp_a) { game.corporation_by_id('SFVA') }
+    let(:corp_b) { game.corporation_by_id('FdSB') }
+
+    it 'calls goal_reached!(:destination) on every corporation in the action' do
+      action = Engine::Action::DestinationConnection.new(corp_a, corporations: [corp_a, corp_b])
+      expect(corp_a).to receive(:goal_reached!).with(:destination)
+      expect(corp_b).to receive(:goal_reached!).with(:destination)
+
+      step.process_destination_connection(action)
+    end
+
+    it 'sets the step as passed after processing' do
+      action = Engine::Action::DestinationConnection.new(corp_a, corporations: [])
+      expect { step.process_destination_connection(action) }
+        .to change { step.passed? }.from(nil).to(true)
+    end
+  end
+
+  describe '#pass!' do
+    it 'is a no-op that does not mark the step as passed' do
+      step.pass!
+      expect(step.passed?).to be_falsy
+    end
+  end
+
+  describe '#description' do
+    it 'returns a non-empty string' do
+      expect(step.description).to be_a(String)
+      expect(step.description).not_to be_empty
+    end
+  end
+end

--- a/spec/lib/engine/game/g_18_esp/step/check_destination_connection_spec.rb
+++ b/spec/lib/engine/game/g_18_esp/step/check_destination_connection_spec.rb
@@ -2,91 +2,143 @@
 
 require 'spec_helper'
 
-describe Engine::Game::G18ESP::Step::CheckDestinationConnection do
-  # Game loaded at action 106: SFVA not yet destination-connected (first
-  # destination goal is logged at action 107). FdSB also not yet connected.
-  let(:fixture_data) { JSON.parse(File.read("#{FIXTURES_DIR}/18ESP/18ESP_game_end_second_eight.json")) }
-  let(:game)   { Engine::Game.load(fixture_data, at_action: 106, strict: false) }
-  let(:step)   { described_class.new(game, game.round) }
-  let(:corp)   { game.corporation_by_id('SFVA') }
-  let(:player) { game.players.first }
+# fixture_at_action derives the game title from the outermost describe
+# class (.title), so this spec must be rooted at the Game class rather
+# than the Step class.
+describe Engine::Game::G18ESP::Game do
+  describe '18ESP_game_end_second_eight' do
+    describe Engine::Game::G18ESP::Step::CheckDestinationConnection do
+      # at_action 106: SFVA is floated, goals_reached_counter=0,
+      # destination_connected=false. Action 107 is the first action that
+      # causes SFVA to reach its destination, so 106 is the latest point
+      # where destination logic can be exercised without state mutation.
+      let(:game)   { fixture_at_action(106) }
+      let(:sfva)   { game.corporation_by_id('SFVA') }
+      let(:player) { game.players.first }
+      let(:step)   { described_class.new(game, game.round) }
 
-  describe '#actions' do
-    it 'returns destination_connection for any entity' do
-      expect(step.actions(nil)).to eq(%w[destination_connection])
-      expect(step.actions(corp)).to eq(%w[destination_connection])
-      expect(step.actions(player)).to eq(%w[destination_connection])
-    end
-  end
+      describe '#actions' do
+        context 'during live play (game not loading)' do
+          it 'returns ACTIONS when corp is not yet connected and check passes' do
+            allow(sfva).to receive(:destination_connected?).and_return(false)
+            allow(game).to receive(:check_for_destination_connection).with(sfva).and_return(true)
+            expect(step.actions(sfva)).to eq(%w[destination_connection])
+          end
 
-  describe '#auto_actions' do
-    context 'with a non-corporation entity' do
-      it 'returns [] for nil' do
-        expect(step.auto_actions(nil)).to eq([])
+          it 'returns [] when corp is already destination_connected?' do
+            allow(sfva).to receive(:destination_connected?).and_return(true)
+            expect(step.actions(sfva)).to eq([])
+          end
+
+          it 'returns [] when check_for_destination_connection returns false' do
+            allow(sfva).to receive(:destination_connected?).and_return(false)
+            allow(game).to receive(:check_for_destination_connection).with(sfva).and_return(false)
+            expect(step.actions(sfva)).to eq([])
+          end
+
+          it 'returns [] for a non-corporation entity (nil)' do
+            expect(step.actions(nil)).to eq([])
+          end
+
+          it 'returns [] for a player entity' do
+            expect(step.actions(player)).to eq([])
+          end
+        end
+
+        context 'when game is loading' do
+          let(:game) { fixture_at_action(106, clear_cache: true) }
+          before { game.instance_variable_set(:@loading, true) }
+
+          it 'returns [] regardless of connection state' do
+            allow(sfva).to receive(:destination_connected?).and_return(false)
+            allow(game).to receive(:check_for_destination_connection).with(sfva).and_return(true)
+            expect(step.actions(sfva)).to eq([])
+          end
+        end
       end
 
-      it 'returns [] for a player' do
-        expect(step.auto_actions(player)).to eq([])
+      describe '#auto_actions' do
+        context 'during live play (game not loading)' do
+          it 'emits DestinationConnection with the corporation when newly connected' do
+            allow(sfva).to receive(:destination_connected?).and_return(false)
+            allow(game).to receive(:check_for_destination_connection).with(sfva).and_return(true)
+            result = step.auto_actions(sfva)
+            expect(result.size).to eq(1)
+            expect(result.first).to be_a(Engine::Action::DestinationConnection)
+            expect(result.first.corporations).to eq([sfva])
+          end
+
+          it 'returns [] when corp is already destination_connected?' do
+            allow(sfva).to receive(:destination_connected?).and_return(true)
+            expect(step.auto_actions(sfva)).to eq([])
+          end
+
+          it 'returns [] when check_for_destination_connection returns false' do
+            allow(sfva).to receive(:destination_connected?).and_return(false)
+            allow(game).to receive(:check_for_destination_connection).with(sfva).and_return(false)
+            expect(step.auto_actions(sfva)).to eq([])
+          end
+
+          it 'returns [] for a non-corporation entity (nil)' do
+            expect(step.auto_actions(nil)).to eq([])
+          end
+
+          it 'returns [] for a player entity' do
+            expect(step.auto_actions(player)).to eq([])
+          end
+        end
+
+        context 'when game is loading' do
+          let(:game) { fixture_at_action(106, clear_cache: true) }
+          before { game.instance_variable_set(:@loading, true) }
+
+          it 'returns [] even when corp is newly connected' do
+            allow(sfva).to receive(:destination_connected?).and_return(false)
+            allow(game).to receive(:check_for_destination_connection).with(sfva).and_return(true)
+            expect(step.auto_actions(sfva)).to eq([])
+          end
+        end
       end
-    end
 
-    context 'when the corporation has no destination connection' do
-      # SFVA.destination_connected is false at action 106 and graph confirms
-      # it is not yet reachable, so check_for_destination_connection returns false.
-      it 'emits one DestinationConnection action with an empty corporations list' do
-        result = step.auto_actions(corp)
+      describe '#process_destination_connection' do
+        it 'calls goal_reached!(:destination) on action.corporations.first' do
+          action = Engine::Action::DestinationConnection.new(sfva, corporations: [sfva])
+          expect(sfva).to receive(:goal_reached!).with(:destination)
+          step.process_destination_connection(action)
+        end
 
-        expect(result.size).to eq(1)
-        expect(result.first).to be_a(Engine::Action::DestinationConnection)
-        expect(result.first.corporations).to eq([])
+        it 'sets @passed to true' do
+          action = Engine::Action::DestinationConnection.new(sfva, corporations: [sfva])
+          expect { step.process_destination_connection(action) }
+            .to change { step.passed? }.from(nil).to(true)
+        end
+
+        it 'processes only corporations.first, not the full list — single-entity invariant' do
+          # auto_actions never emits more than one corp; this documents
+          # that process_destination_connection is intentionally
+          # single-entity so a future maintainer cannot silently switch
+          # it back to .each without a failing test.
+          other = game.corporations.find { |c| c != sfva }
+          action = Engine::Action::DestinationConnection.new(sfva, corporations: [sfva, other])
+          expect(sfva).to receive(:goal_reached!).with(:destination)
+          expect(other).not_to receive(:goal_reached!)
+          step.process_destination_connection(action)
+        end
       end
-    end
 
-    context 'when the corporation already has a destination connection' do
-      # Setting destination_connected=true short-circuits check_for_destination_connection
-      # without needing graph computation.
-      before { corp.destination_connected = true }
-
-      it 'emits one DestinationConnection action with the corporation' do
-        result = step.auto_actions(corp)
-
-        expect(result.size).to eq(1)
-        expect(result.first).to be_a(Engine::Action::DestinationConnection)
-        expect(result.first.corporations).to eq([corp])
+      describe '#pass!' do
+        it 'is a no-op — does not set @passed' do
+          step.pass!
+          expect(step.passed?).to be_falsy
+        end
       end
-    end
-  end
 
-  describe '#process_destination_connection' do
-    let(:corp_a) { game.corporation_by_id('SFVA') }
-    let(:corp_b) { game.corporation_by_id('FdSB') }
-
-    it 'calls goal_reached!(:destination) on every corporation in the action' do
-      action = Engine::Action::DestinationConnection.new(corp_a, corporations: [corp_a, corp_b])
-      expect(corp_a).to receive(:goal_reached!).with(:destination)
-      expect(corp_b).to receive(:goal_reached!).with(:destination)
-
-      step.process_destination_connection(action)
-    end
-
-    it 'sets the step as passed after processing' do
-      action = Engine::Action::DestinationConnection.new(corp_a, corporations: [])
-      expect { step.process_destination_connection(action) }
-        .to change { step.passed? }.from(nil).to(true)
-    end
-  end
-
-  describe '#pass!' do
-    it 'is a no-op that does not mark the step as passed' do
-      step.pass!
-      expect(step.passed?).to be_falsy
-    end
-  end
-
-  describe '#description' do
-    it 'returns a non-empty string' do
-      expect(step.description).to be_a(String)
-      expect(step.description).not_to be_empty
+      describe '#description' do
+        it 'returns a non-empty string' do
+          expect(step.description).to be_a(String)
+          expect(step.description).not_to be_empty
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Relates to #12579

**2-Step Approach to execute surgery**

This is the first of two PRs addressing #12579. PR 1 lays down a test safety net (unit tests for `Corporation#goal_reached!(:destination)` and fixture-replay tests) and adds a new `CheckDestinationConnection` step as dead code — the class is not yet wired into the operating round, so this PR ships zero behavior change. 

Subsequent PR 2 will wire the step into the step list, remove the five existing direct calls to `check_for_destination_connection`, add the `@game.loading` guard that delivers the actual performance win, and include profiling and replay verification as acceptance criteria. 

Splitting the work this way isolates the dead-code review from the behavior-change review and gives the safety net a chance to be merged before the refactor that depends on it.


## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

**Step `check_destination_connection`**

`CheckDestinationConnection` is a single-entity auto-action step that fires after each tile lay or token placement to detect whether the active corporation has connected to its destination hex. Unlike the 1870/System18 reference implementations which store the connection result in round state for later evaluation, 18ESP awards the goal immediately via `corporation.goal_reached!(:destination)` since the connection itself is the trigger. `pass!` is overridden as a no-op to prevent `force_next_entity!` from skipping the step before its auto-action has fired.

**Tests added**

`corporation_spec.rb` exercises `Corporation#goal_reached!(:destination) `in isolation — verifying that the bonus is paid exactly once regardless of how many times the method is called, that a second call is a true no-op (no cash movement, no log entry, no token unblock), and that offboard and harbor goal flags are unaffected. 

`game_spec.rb` establishes a frozen snapshot of the full fixture replay: it pins `goals_reached_counter` and `destination_connected?` for all major corporations at game end, asserts that exactly 8 destination goal log entries are produced, and confirms that all destination hex icons are removed — giving a regression baseline for every subsequent refactor step. 

`check_destination_connection_spec.rb` exercises the new step in isolation against a real game instance, covering entity type guards, empty vs. populated corporations list in the auto-action,` goal_reached!` call delegation, `@passed` state after processing, and the `pass!` no-op contract.

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
