### PR TITLE
[1862 USA & Canada] PR 06: GHU token discount + NYH par price lock

### DIFF
--- a/lib/engine/game/g_1862_usa_canada.rb
+++ b/lib/engine/game/g_1862_usa_canada.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1862UsaCanada
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/entities.rb
+++ b/lib/engine/game/g_1862_usa_canada/entities.rb
@@ -52,7 +52,7 @@ module Engine
                 type: 'tile_discount',
                 discount: 80,
                 terrain: 'station',
-                owner_type: 'corporation',
+                owner_type: 'player',
               },
             ],
             color: nil,

--- a/lib/engine/game/g_1862_usa_canada/entities.rb
+++ b/lib/engine/game/g_1862_usa_canada/entities.rb
@@ -1,0 +1,341 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      module Entities
+        # ---------------------------------------------------------------------------
+        # Private Companies (P1–P8)
+        # Auctioned in first stock round only; unsellable to corporations; no end value.
+        # ---------------------------------------------------------------------------
+        COMPANIES = [
+          {
+            name: 'Butterfield Overland Mail',
+            sym: 'BOM',
+            value: 20,
+            revenue: 5,
+            desc: 'No special abilities. Income only.',
+            color: nil,
+          },
+          {
+            name: 'Toronto Steamship Company',
+            sym: 'TOR',
+            value: 50,
+            revenue: 10,
+            desc: 'Blocks the Toronto hex while owned by a player. The owning corporation '\
+                  'may place the special Toronto gray tile on the Toronto hex at any time '\
+                  'when acting (free, no connection required). Closes when placed.',
+            abilities: [
+              { type: 'blocks_hexes', owner_type: 'player', hexes: ['E25'] },
+              {
+                type: 'tile_lay',
+                owner_type: 'player',
+                hexes: ['E25'],
+                tiles: ['GS_TOR'],
+                when: %w[owning_player_sr_turn owning_player_or_turn or_between_turns],
+                count: 1,
+                free: true,
+                closed_when_used_up: true,
+              },
+            ],
+            color: nil,
+          },
+          {
+            name: 'Bahnhoflizenz',
+            sym: 'GHU',
+            value: 75,
+            revenue: 15,
+            desc: 'The owning corporation\'s director may place a station token for $80 '\
+                  'less than the normal cost (minimum $0).',
+            abilities: [
+              {
+                type: 'tile_discount',
+                discount: 80,
+                terrain: 'station',
+                owner_type: 'corporation',
+              },
+            ],
+            color: nil,
+          },
+          {
+            name: 'Rocky Mountain Company',
+            sym: 'RMC',
+            value: 100,
+            revenue: 20,
+            desc: 'The owning corporation may lay one additional yellow tile during its '\
+                  'operating turn. This ability is one-time use and closes the company.',
+            abilities: [
+              {
+                type: 'tile_lay',
+                owner_type: 'corporation',
+                hexes: [],
+                tiles: [],
+                when: 'owning_corp_or_turn',
+                count: 1,
+                closed_when_used_up: true,
+                special: false,
+                free: false,
+              },
+            ],
+            color: nil,
+          },
+          {
+            name: 'Pacific Steamship Company',
+            sym: 'PSC',
+            value: 140,
+            revenue: 25,
+            desc: 'The initial purchaser immediately receives a 10% share of WP. '\
+                  'Closes when WP first pays a dividend.',
+            abilities: [
+              { type: 'shares', shares: 'WP_1' },
+              # Custom close trigger: when WP pays first dividend — handled in game.rb
+            ],
+            color: nil,
+          },
+          {
+            name: 'First New York Steamship Co.',
+            sym: 'FNY',
+            value: 180,
+            revenue: 30,
+            desc: 'The initial purchaser immediately receives a 10% share of NYC. '\
+                  'Closes when NYC first pays a dividend.',
+            abilities: [
+              { type: 'shares', shares: 'NYC_1' },
+              # Custom close trigger: when NYC pays first dividend — handled in game.rb
+            ],
+            color: nil,
+          },
+          {
+            name: 'Sacramento-Omaha Company',
+            sym: 'SOC',
+            value: 220,
+            revenue: 35,
+            desc: 'The initial purchaser immediately receives a 10% share of CPR and '\
+                  'a 10% share of UP. Closes when either CPR or UP floats. '\
+                  'While open, reduces the UP/CPR Salt Lake City route bonus payout to $15.',
+            abilities: [
+              { type: 'shares', shares: %w[CPR_1 UP_1] },
+              # Custom close trigger: when CPR or UP floats — handled in game.rb
+            ],
+            color: nil,
+          },
+          {
+            name: 'New Haven Steamship Company',
+            sym: 'NHSC',
+            value: 270,
+            revenue: 40,
+            desc: "The initial purchaser immediately receives the 30% Director's "\
+                  'certificate of NYH. NYH must be parred at exactly $100. '\
+                  'Closes when NYH floats.',
+            abilities: [
+              { type: 'shares', shares: 'NYH_0' },
+              # Custom close trigger: when NYH floats — handled in game.rb
+              # Custom par restriction: NYH par locked to $100 — handled in game.rb
+            ],
+            color: nil,
+          },
+        ].freeze
+
+        # ---------------------------------------------------------------------------
+        # Corporations — 3 groups, unlocked progressively:
+        #   Group 1 (NYH, NYC, CP)  : available from game start
+        #   Group 2 (CPR, UP, ATS, SP) : unlocked when ALL Group 1 companies float
+        #   Group 3 (NP, CN, TP, ORN, WP, GMO) : unlocked when ALL Group 2 companies float
+        #
+        # Share structures:
+        #   Group 1: 30% Director cert + 7 × 10% = 100%  (float at 60%)
+        #   Group 2/3: 20% Director cert + 8 × 10% = 100% (float at 60%)
+        #
+        # ---------------------------------------------------------------------------
+        CORPORATIONS = [
+          # -------------------------------------------------------------------------
+          # Group 1 — 30% Director, float at 60%
+          # -------------------------------------------------------------------------
+          {
+            sym: 'NYH',
+            name: 'New York New Haven',
+            logo: '1862_usa_canada/NYH',
+            simple_logo: '1862_usa_canada/NYH.alt',
+            float_percent: 60,
+            shares: [30, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 80, 120],
+            coordinates: 'F28',
+            city: 1,
+            color: '#d1232a',
+            text_color: 'white',
+          },
+          {
+            sym: 'NYC',
+            name: 'New York Central',
+            logo: '1862_usa_canada/NYC',
+            simple_logo: '1862_usa_canada/NYC.alt',
+            float_percent: 60,
+            shares: [30, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 80, 120],
+            coordinates: 'F28',
+            city: 0,
+            color: '#110a0c',
+            text_color: 'white',
+          },
+          {
+            sym: 'CP',
+            name: 'Canadian Pacific',
+            logo: '1862_usa_canada/CP',
+            simple_logo: '1862_usa_canada/CP.alt',
+            float_percent: 60,
+            shares: [30, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 80, 120],
+            coordinates: 'D28',
+            color: '#d88e39',
+            text_color: 'black',
+          },
+
+          # -------------------------------------------------------------------------
+          # Group 2 — 20% Director, float at 60%
+          # -------------------------------------------------------------------------
+          {
+            sym: 'CPR',
+            name: 'Central Pacific Railroad',
+            logo: '1862_usa_canada/CPR',
+            simple_logo: '1862_usa_canada/CPR.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 80],
+            coordinates: 'G3',
+            city: 0,
+            color: '#f48221',
+            text_color: 'black',
+          },
+          {
+            sym: 'UP',
+            name: 'Union Pacific',
+            logo: '1862_usa_canada/UP',
+            simple_logo: '1862_usa_canada/UP.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 80],
+            coordinates: 'F14',
+            color: '#025aaa',
+            text_color: 'white',
+          },
+          {
+            sym: 'ATS',
+            name: 'Atchison Topeka & Santa Fe',
+            logo: '1862_usa_canada/ATS',
+            simple_logo: '1862_usa_canada/ATS.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 80],
+            coordinates: 'F20',
+            color: '#32763f',
+            text_color: 'white',
+          },
+          {
+            sym: 'SP',
+            name: 'Southern Pacific',
+            logo: '1862_usa_canada/SP',
+            simple_logo: '1862_usa_canada/SP.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40, 80],
+            coordinates: 'K19',
+            color: '#76a042',
+            text_color: 'black',
+          },
+
+          # -------------------------------------------------------------------------
+          # Group 3 — 20% Director, float at 60%
+          # -------------------------------------------------------------------------
+          {
+            sym: 'NP',
+            name: 'Northern Pacific',
+            logo: '1862_usa_canada/NP',
+            simple_logo: '1862_usa_canada/NP.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40],
+            coordinates: 'D16',
+            color: '#95c054',
+            text_color: 'black',
+          },
+          {
+            sym: 'CN',
+            name: 'Canadian National',
+            logo: '1862_usa_canada/CN',
+            simple_logo: '1862_usa_canada/CN.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40],
+            coordinates: 'B14',
+            color: '#ADD8E6',
+            text_color: 'black',
+          },
+          {
+            sym: 'TP',
+            name: 'Texas Pacific',
+            logo: '1862_usa_canada/TP',
+            simple_logo: '1862_usa_canada/TP.alt',
+            float_percent: 60,
+            shares: [30, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40],
+            coordinates: 'J16',
+            color: '#7b352a',
+            text_color: 'white',
+          },
+          {
+            sym: 'ORN',
+            name: 'Oregon Railroad & Navigation',
+            logo: '1862_usa_canada/ORN',
+            simple_logo: '1862_usa_canada/ORN.alt',
+            float_percent: 60,
+            shares: [30, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40],
+            coordinates: 'C3',
+            color: '#FFF500',
+            text_color: 'black',
+          },
+          {
+            # WP co-homes in Sacramento (slot 1) alongside CPR (slot 0).
+            # Both transcontinental roads originate from the Sacramento terminus.
+            sym: 'WP',
+            name: 'Western Pacific',
+            logo: '1862_usa_canada/WP',
+            simple_logo: '1862_usa_canada/WP.alt',
+            float_percent: 60,
+            shares: [30, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40],
+            coordinates: 'G3',
+            city: 1,
+            color: '#8dd7f6',
+            text_color: 'black',
+          },
+          {
+            sym: 'GMO',
+            name: 'Gulf Mobile & Ohio',
+            logo: '1862_usa_canada/GMO',
+            simple_logo: '1862_usa_canada/GMO.alt',
+            float_percent: 60,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+            max_ownership_percent: 100,
+            tokens: [0, 40],
+            coordinates: 'J20',
+            color: '#6ec037',
+            text_color: 'black',
+          },
+        ].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+# Developed with Claude (Anthropic) AI assistance — claude.ai/code
+
+require_relative 'meta'
+require_relative 'entities'
+require_relative 'map'
+require_relative '../base'
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      class Game < Game::Base
+        include_meta(G1862UsaCanada::Meta)
+        include Entities
+        include Map
+
+        # ---------------------------------------------------------------------------
+        # Corporation groups — unlocked progressively.
+        # Group 1 available from game start.
+        # Group 2 unlocks when ALL Group 1 companies have floated.
+        # Group 3 unlocks when ALL Group 2 companies have floated.
+        #
+        # Director share sizes by group (from rulebook):
+        #   Group 1 (NYH, NYC, CP):       30% Director + 7×10%
+        #   Group 2 (CPR, UP, ATS, SP):   20% Director + 8×10%
+        #   Group 3 (NP, CN, GMO):        20% Director + 8×10%
+        #   Group 3 (TP, ORN, WP):        30% Director + 7×10%
+        # ---------------------------------------------------------------------------
+        CORP_GROUPS = {
+          1 => %w[NYH NYC CP],
+          2 => %w[CPR UP ATS SP],
+          3 => %w[NP CN TP ORN WP GMO],
+        }.freeze
+
+        # ---------------------------------------------------------------------------
+        # Bonus markers (Bonusplättchen) — pre-placed on cities.
+        # Activation: corporation's route passes through BOTH home hex AND bonus hex.
+        # Director chooses: take cash immediately OR keep as permanent +N revenue bonus.
+        # ---------------------------------------------------------------------------
+        CORP_BONUSES = {
+          'CP' => [
+            { hexes: %w[E25],          cash: 100, route_bonus: 30,  name: 'Toronto'     },
+            { hexes: %w[B20],          cash: 200, route_bonus: 60,  name: 'Thunder Bay' },
+            { hexes: %w[B2 C1 G3 I5], cash: 300, route_bonus: 100, name: 'V/P/S/L' },
+          ],
+          'NYH' => [
+            { hexes: %w[F20],          cash: 100, route_bonus: 30,  name: 'Chicago'     },
+            { hexes: %w[K19],          cash: 200, route_bonus: 60,  name: 'New Orleans' },
+          ],
+          'CPR' => [
+            { hexes: %w[F14],          cash: 100, route_bonus: 30,  name: 'Omaha'       },
+          ],
+          'UP' => [
+            { hexes: %w[K19],          cash: 100, route_bonus: 30,  name: 'New Orleans' },
+            { hexes: %w[J10],          cash: 200, route_bonus: 60,  name: 'El Paso'     },
+          ],
+          'ATS' => [
+            { hexes: %w[B2 C1 G3 I5], cash: 200, route_bonus: 60, name: 'V/P/S/L' },
+          ],
+          'NP' => [
+            { hexes: %w[F20], cash: 100, route_bonus: 30, name: 'Chicago' },
+          ],
+          'CN' => [
+            { hexes: %w[B2 C1 G3 I5], cash: 100, route_bonus: 30, name: 'V/P/S/L' },
+            { hexes: %w[B10], cash: 200, route_bonus: 60, name: 'Regina' },
+          ],
+          # FIXME: TP El Paso bonus amount unconfirmed from rulebook — entry omitted until confirmed
+        }.freeze
+
+        # ---------------------------------------------------------------------------
+        # SLC (Salt Lake City) transcontinental bonus.
+        # CPR and UP each earn a per-OR route bonus when route passes through SLC.
+        # When BOTH connect through SLC for the first time the "Golden Spike" fires.
+        # FIXME: GOLDEN_SPIKE_SHAREHOLDER_BONUS amount unconfirmed from rulebook.
+        # ---------------------------------------------------------------------------
+        SLC_HEX                        = 'G9'.freeze
+        SLC_CORPS                      = %w[CPR UP].freeze
+        SLC_ROUTE_BONUS                = 30
+        SLC_ROUTE_BONUS_SOC            = 15
+        GOLDEN_SPIKE_SHAREHOLDER_BONUS = 50 # FIXME: amount unconfirmed from rulebook
+
+        CURRENCY_FORMAT_STR = '$%s'
+
+        BANK_CASH = 12_000
+
+        CERT_LIMIT = { 3 => 27, 4 => 22, 5 => 18, 6 => 15, 7 => 13 }.freeze
+
+        STARTING_CASH = { 3 => 750, 4 => 600, 5 => 500, 6 => 440, 7 => 400 }.freeze
+
+        TRACK_RESTRICTION = :permissive
+        SELL_BUY_ORDER    = :sell_buy
+
+        MARKET_SHARE_LIMIT = 100
+
+        SELL_MOVEMENT = :down_per_10
+        POOL_SHARE_DROP = :down_block
+
+        MUST_BUY_TRAIN = :never
+
+        HOME_TOKEN_TIMING = :operate
+
+        CAPITALIZATION = :full
+
+        # ---------------------------------------------------------------------------
+        # Stock market — 2D ledge layout, Kurstabelle 1863.
+        # p = valid par/IPO cell
+        # e = end-game zone (stock price > 310 triggers game end after current OR set)
+        # ---------------------------------------------------------------------------
+        MARKET = [
+          ['', '', '85', '92', '100p', '110', '120', '132', '146', '162', '180', '200', '225', '250', '280', '310',
+           '340e', '370e'],
+          ['', '70', '80', '85', '92p', '100', '110', '120', '132', '146', '162', '180', '200', '225', '250', '280',
+           '315e', '350e'],
+          %w[55 65 75 80 85p 92 100 110 120 132 146 162 180 200 225 250],
+          %w[50 60 70 75 80p 85 92 100 110 120 132 146 162 180],
+          %w[45 55 65 70 75p 80 85 92 100 110 120 132],
+          %w[40 50 60 65 70p 75 80 85 92 100],
+          %w[35 45 55 62 68 72 75 80],
+          %w[30 40 50 60 65 70],
+          %w[25 35 45 55],
+          %w[20 30],
+        ].freeze
+
+        MARKET_TEXT = Base::MARKET_TEXT.merge(
+          'par' => 'Valid par price',
+          'end_game' => 'Stock price reaches this cell; game ends after current OR set'
+        ).freeze
+
+        STOCKMARKET_COLORS = Base::STOCKMARKET_COLORS.merge(
+          par: :yellow,
+          end_game: :orange
+        ).freeze
+
+        # ---------------------------------------------------------------------------
+        # Phases
+        # FIXME: verify exact operating_rounds count per phase from rulebook.
+        # ---------------------------------------------------------------------------
+        PHASES = [
+          { name: '2', train_limit: 4, tiles: [:yellow],                    operating_rounds: 1 },
+          { name: '3', on: '3', train_limit: 4, tiles: %i[yellow green],    operating_rounds: 2 },
+          { name: '4', on: '4', train_limit: 3, tiles: %i[yellow green],    operating_rounds: 2 },
+          { name: '5', on: '5', train_limit: 2, tiles: %i[yellow green brown], operating_rounds: 3 },
+          { name: '6', on: '6', train_limit: 2, tiles: %i[yellow green brown], operating_rounds: 3 },
+          { name: '7', on: '7', train_limit: 2, tiles: %i[yellow green brown gray], operating_rounds: 3 },
+          { name: '8', on: '8', train_limit: 2, tiles: %i[yellow green brown gray], operating_rounds: 3 },
+        ].freeze
+
+        # ---------------------------------------------------------------------------
+        # Trains — base types 2–8; each of 2–7 has an E-variant (express).
+        # E-trains pay N stops, visit unlimited nodes.
+        # Rusting (confirmed from rulebook summary card):
+        #   2/2E → first 4/4E purchase
+        #   3/3E → first 6/6E purchase
+        #   4/4E → first 8 purchase
+        #   5/5E, 6/6E, 7/7E, 8 → never rust
+        # ---------------------------------------------------------------------------
+        TRAINS = [
+          {
+            name: '2',
+            distance: 2,
+            price: 100,
+            rusts_on: '4',
+            num: 7,
+            variants: [
+              { name: '2E', distance: [{ nodes: %w[city offboard town], pay: 2, visit: 999 }], price: 150 },
+            ],
+          },
+          {
+            name: '3',
+            distance: 3,
+            price: 200,
+            rusts_on: '6',
+            num: 6,
+            variants: [
+              { name: '3E', distance: [{ nodes: %w[city offboard town], pay: 3, visit: 999 }], price: 300 },
+            ],
+          },
+          {
+            name: '4',
+            distance: 4,
+            price: 300,
+            rusts_on: '8',
+            num: 5,
+            variants: [
+              { name: '4E', distance: [{ nodes: %w[city offboard town], pay: 4, visit: 999 }], price: 400 },
+            ],
+          },
+          {
+            name: '5',
+            distance: 5,
+            price: 550,
+            num: 4,
+            variants: [
+              { name: '5E', distance: [{ nodes: %w[city offboard town], pay: 5, visit: 999 }], price: 700 },
+            ],
+          },
+          {
+            name: '6',
+            distance: 6,
+            price: 650,
+            num: 3,
+            variants: [
+              { name: '6E', distance: [{ nodes: %w[city offboard town], pay: 6, visit: 999 }], price: 800 },
+            ],
+          },
+          {
+            name: '7',
+            distance: 7,
+            price: 750,
+            num: 2,
+            variants: [
+              { name: '7E', distance: [{ nodes: %w[city offboard town], pay: 7, visit: 999 }], price: 900 },
+            ],
+          },
+          { name: '8', distance: 999, price: 900, num: 20 },
+        ].freeze
+
+        GAME_END_CHECK = { bank: :current_round, stock_market: :current_round }.freeze
+
+        # ---------------------------------------------------------------------------
+        # Round definitions — engine defaults only; custom steps added in later PRs.
+        # ---------------------------------------------------------------------------
+        def stock_round
+          Round::Stock.new(self, [
+            Engine::Step::DiscardTrain,
+            Engine::Step::Exchange,
+            Engine::Step::SpecialTrack,
+            Engine::Step::BuySellParShares,
+          ])
+        end
+
+        def operating_round(round_num)
+          Round::Operating.new(self, [
+            Engine::Step::Bankrupt,
+            Engine::Step::Exchange,
+            Engine::Step::SpecialTrack,
+            Engine::Step::HomeToken,
+            Engine::Step::Track,
+            Engine::Step::Token,
+            Engine::Step::Route,
+            Engine::Step::Dividend,
+            Engine::Step::DiscardTrain,
+            Engine::Step::BuyTrain,
+          ], round_num: round_num)
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -163,7 +163,7 @@ module Engine
             rusts_on: '4',
             num: 7,
             variants: [
-              { name: '2E', distance: [{ nodes: %w[city offboard town], pay: 2, visit: 999 }], price: 150 },
+              { name: '2E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 2, 'visit' => 999 }], price: 150 },
             ],
           },
           {
@@ -173,7 +173,7 @@ module Engine
             rusts_on: '6',
             num: 6,
             variants: [
-              { name: '3E', distance: [{ nodes: %w[city offboard town], pay: 3, visit: 999 }], price: 300 },
+              { name: '3E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 3, 'visit' => 999 }], price: 300 },
             ],
           },
           {
@@ -183,7 +183,7 @@ module Engine
             rusts_on: '8',
             num: 5,
             variants: [
-              { name: '4E', distance: [{ nodes: %w[city offboard town], pay: 4, visit: 999 }], price: 400 },
+              { name: '4E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 4, 'visit' => 999 }], price: 400 },
             ],
           },
           {
@@ -192,7 +192,7 @@ module Engine
             price: 550,
             num: 4,
             variants: [
-              { name: '5E', distance: [{ nodes: %w[city offboard town], pay: 5, visit: 999 }], price: 700 },
+              { name: '5E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 5, 'visit' => 999 }], price: 700 },
             ],
           },
           {
@@ -201,7 +201,7 @@ module Engine
             price: 650,
             num: 3,
             variants: [
-              { name: '6E', distance: [{ nodes: %w[city offboard town], pay: 6, visit: 999 }], price: 800 },
+              { name: '6E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 6, 'visit' => 999 }], price: 800 },
             ],
           },
           {
@@ -210,7 +210,7 @@ module Engine
             price: 750,
             num: 2,
             variants: [
-              { name: '7E', distance: [{ nodes: %w[city offboard town], pay: 7, visit: 999 }], price: 900 },
+              { name: '7E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 7, 'visit' => 999 }], price: 900 },
             ],
           },
           { name: '8', distance: 999, price: 900, num: 20 },

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -6,6 +6,8 @@ require_relative 'meta'
 require_relative 'entities'
 require_relative 'map'
 require_relative '../base'
+require_relative 'step/buy_sell_par_shares'
+require_relative 'step/token'
 
 module Engine
   module Game
@@ -333,7 +335,7 @@ module Engine
             Engine::Step::DiscardTrain,
             Engine::Step::Exchange,
             Engine::Step::SpecialTrack,
-            Engine::Step::BuySellParShares,
+            G1862UsaCanada::Step::BuySellParShares,
           ])
         end
 
@@ -344,7 +346,7 @@ module Engine
             Engine::Step::SpecialTrack,
             Engine::Step::HomeToken,
             Engine::Step::Track,
-            Engine::Step::Token,
+            G1862UsaCanada::Step::Token,
             Engine::Step::Route,
             Engine::Step::Dividend,
             Engine::Step::DiscardTrain,

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -219,6 +219,18 @@ module Engine
         GAME_END_CHECK = { bank: :current_round, stock_market: :current_round }.freeze
 
         # ---------------------------------------------------------------------------
+        # Home token — placed automatically at start of corp's first OR turn.
+        # Base place_home_token calls city.place_token directly (bypasses step
+        # layer) so clear_graph_for_entity is never called. Override to flush the
+        # graph cache immediately, otherwise the corp sees zero connected hexes
+        # and cannot lay track on the same turn.
+        # ---------------------------------------------------------------------------
+        def place_home_token(corporation)
+          super
+          clear_graph_for_entity(corporation)
+        end
+
+        # ---------------------------------------------------------------------------
         # Corporation group unlock logic.
         # ---------------------------------------------------------------------------
         def corp_group(corporation)

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -133,17 +133,79 @@ module Engine
         ).freeze
 
         # ---------------------------------------------------------------------------
+        # Tile-lay budget — phase-gated.
+        # Phase 2:   1 yellow tile only.
+        # Phase 3+:  2 yellow tiles OR 1 upgrade (no mixing).
+        # ---------------------------------------------------------------------------
+        YELLOW_TILE_LAY = [{ lay: true, upgrade: false }].freeze
+        TWO_TILE_LAYS = [
+          { lay: true, upgrade: true },
+          { lay: :not_if_upgraded, upgrade: false },
+        ].freeze
+
+        STATUS_TEXT = Base::STATUS_TEXT.merge(
+          'two_tile_lays' => ['Two tile lays', 'Corporations may lay 2 yellow tiles OR 1 upgrade tile per OR']
+        ).freeze
+
+        # ---------------------------------------------------------------------------
         # Phases
         # FIXME: verify exact operating_rounds count per phase from rulebook.
         # ---------------------------------------------------------------------------
         PHASES = [
-          { name: '2', train_limit: 4, tiles: [:yellow],                    operating_rounds: 1 },
-          { name: '3', on: '3', train_limit: 4, tiles: %i[yellow green],    operating_rounds: 2 },
-          { name: '4', on: '4', train_limit: 3, tiles: %i[yellow green],    operating_rounds: 2 },
-          { name: '5', on: '5', train_limit: 2, tiles: %i[yellow green brown], operating_rounds: 3 },
-          { name: '6', on: '6', train_limit: 2, tiles: %i[yellow green brown], operating_rounds: 3 },
-          { name: '7', on: '7', train_limit: 2, tiles: %i[yellow green brown gray], operating_rounds: 3 },
-          { name: '8', on: '8', train_limit: 2, tiles: %i[yellow green brown gray], operating_rounds: 3 },
+          {
+            name: '2',
+            train_limit: 4,
+            tiles: [:yellow],
+            operating_rounds: 1,
+          },
+          {
+            name: '3',
+            on: '3',
+            train_limit: 4,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '4',
+            on: '4',
+            train_limit: 3,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '5',
+            on: '5',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '6',
+            on: '6',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '7',
+            on: '7',
+            train_limit: 2,
+            tiles: %i[yellow green brown gray],
+            operating_rounds: 3,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '8',
+            on: '8',
+            train_limit: 2,
+            tiles: %i[yellow green brown gray],
+            operating_rounds: 3,
+            status: ['two_tile_lays'],
+          },
         ].freeze
 
         # ---------------------------------------------------------------------------
@@ -217,6 +279,13 @@ module Engine
         ].freeze
 
         GAME_END_CHECK = { bank: :current_round, stock_market: :current_round }.freeze
+
+        # ---------------------------------------------------------------------------
+        # Tile-lay budget override.
+        # ---------------------------------------------------------------------------
+        def tile_lays(_entity)
+          @phase.status.include?('two_tile_lays') ? self.class::TWO_TILE_LAYS : self.class::YELLOW_TILE_LAY
+        end
 
         # ---------------------------------------------------------------------------
         # Home token — placed automatically at start of corp's first OR turn.

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -17,9 +17,9 @@ module Engine
 
         # ---------------------------------------------------------------------------
         # Corporation groups — unlocked progressively.
-        # Group 1 available from game start.
-        # Group 2 unlocks when ALL Group 1 companies have floated.
-        # Group 3 unlocks when ALL Group 2 companies have floated.
+        # Group 1 available when ALL private companies have been sold.
+        # Group 2 unlocks when ALL Group 1 IPO shares have been sold.
+        # Group 3 unlocks when ALL Group 2 corporations have floated.
         #
         # Director share sizes by group (from rulebook):
         #   Group 1 (NYH, NYC, CP):       30% Director + 7×10%
@@ -217,6 +217,32 @@ module Engine
         ].freeze
 
         GAME_END_CHECK = { bank: :current_round, stock_market: :current_round }.freeze
+
+        # ---------------------------------------------------------------------------
+        # Corporation group unlock logic.
+        # ---------------------------------------------------------------------------
+        def corp_group(corporation)
+          CORP_GROUPS.find { |_, syms| syms.include?(corporation.id) }&.first
+        end
+
+        def all_privates_sold?
+          @companies.all? { |c| c.owner&.player? || c.closed? }
+        end
+
+        def group_available?(group_num)
+          case group_num
+          when 1 then all_privates_sold?
+          when 2 then CORP_GROUPS[1].all? { |sym| corporation_by_id(sym).num_ipo_shares.zero? }
+          when 3 then CORP_GROUPS[2].all? { |sym| corporation_by_id(sym).floated? }
+          else true
+          end
+        end
+
+        def can_par?(corporation, parrer)
+          return false unless super
+
+          group_available?(corp_group(corporation))
+        end
 
         # ---------------------------------------------------------------------------
         # Round definitions — engine defaults only; custom steps added in later PRs.

--- a/lib/engine/game/g_1862_usa_canada/map.rb
+++ b/lib/engine/game/g_1862_usa_canada/map.rb
@@ -1,0 +1,358 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      module Map
+        LAYOUT = :pointy
+        AXES = { x: :number, y: :letter }.freeze
+
+        LOCATION_NAMES = {
+          # Pacific Northwest
+          'B2' => 'Vancouver',
+          'C1' => 'Victoria',
+          'C3' => 'Seattle',
+          'C5' => 'Spokane',
+          'D2' => 'Portland',
+          # Western Canada
+          'A7' => 'Calgary',
+          'B10' => 'Regina',
+          'B14' => 'Winnipeg',
+          'B20' => 'Thunder Bay',
+          # Mountain West
+          'E6' => 'Boise',
+          'D10' => 'Billings',
+          'E11' => 'Rapid City',
+          'F8' => 'Ogden',
+          'G9' => 'Salt Lake City/SLC',
+          'G11' => 'Denver',
+          # Pacific Coast
+          'G3' => 'San Francisco/Sacramento',
+          'I5' => 'Los Angeles',
+          'J6' => 'San Diego',
+          # Great Plains
+          'D16' => 'Minneapolis',
+          'D18' => 'Duluth',
+          'G17' => 'Kansas City',
+          'F14' => 'Omaha',
+          'G19' => 'St. Louis',
+          # Midwest / Great Lakes
+          'F20' => 'Chicago',
+          'G23' => 'Columbus',
+          # Canada East
+          'E25' => 'Toronto',
+          'D26' => 'Ottawa',
+          'C29' => 'Quebec',
+          'D28' => 'Montreal',
+          # Northeast
+          'F28' => 'New York',
+          'F30' => 'Boston',
+          # Southwest
+          'I9' => 'Phoenix',
+          'J8' => 'Tucson',
+          'J10' => 'Santa Fe',
+          'H10' => 'Phoenix',
+          # South Central
+          'I15' => 'Oklahoma City',
+          'J16' => 'Dallas',
+          'I17' => 'Little Rock',
+          'K15' => 'Austin',
+          'K17' => 'Houston',
+          # Southeast
+          'J18' => 'Jackson',
+          'I23' => 'Atlanta',
+          'I21' => 'Chattanooga',
+          'H26' => 'Richmond',
+          'K19' => 'New Orleans',
+          'J20' => 'Mobile',
+          # Off-board labels
+          'A29' => 'Labrador',
+          'K9' => 'Mexico',
+          'K11' => 'Mexico',
+          'L24' => 'Florida',
+        }.freeze
+
+        # Tile counts from physical game tile sheet.
+        # Yellow: 80 standard + 5 Sonderteile = 85 total
+        # Green:  42 standard + 9 Sonderteile = 51 total
+        # Brown:  19 standard + 7 Sonderteile = 26 total
+        # Gray:    3 standard + 5 Sonderteile =  8 total
+        TILES = {
+          # Yellow
+          '3' => 4,
+          '4' => 10,
+          '6' => 10,
+          '7' => 4,
+          '8' => 12,
+          '9' => 22,
+          '57' => 10,
+          '58' => 8,
+          # Green
+          '14' => 4,
+          '15' => 4,
+          '16' => 2,
+          '19' => 2,
+          '20' => 2,
+          '23' => 4,
+          '24' => 4,
+          '25' => 2,
+          '26' => 2,
+          '27' => 2,
+          '28' => 2,
+          '29' => 2,
+          # Brown
+          '39' => 1,
+          '40' => 1,
+          '41' => 1,
+          '42' => 1,
+          '43' => 1,
+          '44' => 1,
+          '45' => 1,
+          '46' => 1,
+          '47' => 1,
+          '70' => 1,
+          '611' => 7,
+          # Gray (city upgrade tiles)
+          '895' => 3,
+          '899' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:80,slots:3;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=NO',
+          },
+          # Special brown 5 edges only 10 revenue
+          'GS_204_B' => {
+            'count' => 2,
+            'color' => 'brown',
+            'code' => 'town=revenue:10;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;',
+          },
+          # Special gray — Toronto (placed by TOR private)
+          'GS_TOR' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:30;path=a:1,b:_0;path=a:3,b:_0;path=a:5,b:_0;label=T',
+          },
+          # Montreal upgrades (label=M; preprint is stored as white internally, exits to edge 2 only)
+          'GS_MTL_Y' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'city=revenue:20;path=a:1,b:_0;path=a:2,b:_0;label=M',
+          },
+          'GS_MTL_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=M',
+          },
+          'GS_MTL_B' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:3;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=M',
+          },
+          # New York upgrades (label=NY; preprint yellow has 2 cities, exits 0/4 and 1/3)
+          'GS_NY_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40;city=revenue:40;' \
+                      'path=a:0,b:_0;path=a:4,b:_0;path=a:1,b:_1;path=a:3,b:_1;label=NY',
+          },
+          'GS_NY_B' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:3;' \
+                      'path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=NY',
+          },
+          # Shared gray tile — only one exists; goes to Montreal (M) OR New York (NY), not both
+          'GS_MTL_GR' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:80,slots:3;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;' \
+                      'path=a:4,b:_0;path=a:5,b:_0;label=M;label=NY',
+          },
+          # Salt Lake City upgrade yellow
+          'GS_SLC_Y' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'city=revenue:20;path=a:1,b:_0;path=a:3,b:_0;label=SLC',
+          },
+          'GS_SLC_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=SLC',
+          },
+          'GS_SLC_B' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;' \
+                      'path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=SLC',
+          },
+          'GS_V_Y' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'city=revenue:20;path=a:5,b:_0;path=a:3,b:_0;label=V',
+          },
+          'GS_P_Y' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'city=revenue:20;path=a:0,b:_0;path=a:3,b:_0;label=P',
+          },
+          'GS_L_Y' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'city=revenue:20;path=a:5,b:_0;path=a:2,b:_0;label=L',
+          },
+          'GS_P_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=P',
+          },
+          'GS_V_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:0,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=V',
+          },
+          'GS_L_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:5,b:_0;path=a:2,b:_0;path=a:4,b:_0;label=L',
+          },
+          'GS_S_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40;city=revenue:40;path=a:5,b:_0;path=a:2,b:_1;path=a:4,b:_1;label=S',
+          },
+          'GS_VSPL_B' => {
+            'count' => 2,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:3;path=a:2,b:_0;path=a:3,b:_0;' \
+                      'path=a:4,b:_0;path=a:5,b:_0;label=V;label=S;label=P;label=L',
+          },
+          'GS_VSPL_G' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:80,slots:3;path=a:2,b:_0;path=a:3,b:_0;' \
+                      'path=a:4,b:_0;path=a:5,b:_0;label=V;label=S;label=P;label=L',
+          },
+          'GS_C_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=C',
+          },
+          'GS_C_B' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:3;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=C',
+          },
+          'GS_NO_G' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;label=NO',
+          },
+          'GS_NO_B' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:60,slots:3;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=NO',
+          },
+          'GS_C_GR' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:80,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;label=C',
+          },
+
+        }.freeze
+
+        MAP_HOMECITY_HEXES = %w[
+          C3 B14 D28 D16 F14 F20 F28 G3 J16 J20 K19
+        ].freeze
+
+        HEXES = {
+          white: {
+            # ── Blank upgradeable hexes ──────────────────────────────────────
+            %w[
+              A11 A13 A17 A19 A21 A23 A25 A27 B12 B16 B18
+              B22 B24 B26 C13 C15 C17 C19 C21 C23 C25 C27
+              D4 D14 D20 D24 E19 E27 F22
+              F24 G15 G21 H14 H16 H18 H22 I25 J14 J22 K13 K23
+            ] => '',
+
+            # ── Mountain terrain ($80) ───────────────────────────────────────
+            %w[
+              A3 A5 B4 B6 B8 C7 C9 D6 D8 E3 E7 E9 F4 F6 F10
+              G5 G7 H8 I7
+            ] => 'upgrade=cost:80,terrain:mountain',
+
+            # ── Hill terrain ($40) ───────────────────────────────────────────
+            %w[
+              A9 C11 D12 F12 F26 G13 G25 H12 H24 I11 I13 J12
+            ] => 'upgrade=cost:40,terrain:mountain',
+
+            # ── River terrain ($40) ──────────────────────────────────────────
+            %w[A15 B28 D30 E1 E13 E15 E17 F2 F16 H4 H20 I19 J24 K21] => 'upgrade=cost:40,terrain:river',
+
+            # ── City with River ($40) ────────────────────────────────────────
+            %w[F18 G17] => 'city=revenue:0;upgrade=cost:40,terrain:river',
+
+            # ── Town with river ($40) ────────────────────────────────────────
+            %w[G19 J18] => 'town=revenue:0;upgrade=cost:40,terrain:river',
+
+            # ── Plain cities ─────────────────────────────────────────────────
+            %w[A7 B10 B14 C29 D16 D26 E11 G11 G23 G27 H10 I15 I23 J6 J10 J16 J20 K15] => 'city=revenue:0',
+
+            # ── Towns ────────────────────────────────────────────────────────
+            %w[C5 B20 D10 D18 E5 E29 F8 H6 H26 I9 I17 I21 J8 K17] => 'town=revenue:0',
+
+            # ── Single-slot labeled cities ───────────────────────────────────
+            ['B2'] => 'city=revenue:0;label=V', # Vancouver
+            ['C3'] => 'city=revenue:0', # Seattle (ORN home)
+            ['D2'] => 'city=revenue:0;label=P', # Portland
+            ['D28'] => 'city=revenue:10;path=a:2,b:_0;label=M', # Montreal (CP home)
+            ['F14'] => 'city=revenue:10;path=a:1,b:_0', # Omaha (UP home)
+            ['I5'] => 'city=revenue:0;label=L', # Los Angeles
+            # SLC pre-printed white tile — transcontinental junction
+            ['G9'] => 'city=revenue:0;label=SLC',
+
+          },
+
+          gray: {
+            # Victoria — pre-printed grey town
+            ['C1'] => 'town=revenue:20;path=a:3,b:_0',
+            # Great Lakes / border — grey blank
+            %w[D22 E21] => '',
+            # E23 — grey through-path (Toronto → F22 area), rotated 180° per map
+            ['E23'] => 'path=a:4,b:0',
+            # Toronto — grey city; track exits east into E23
+            ['E25'] => 'city=revenue:20;path=a:1,b:_0',
+            # Boston — grey city; track exits west toward New York (F28)
+            ['F30'] => 'city=revenue:20;path=a:1,b:_0',
+            # Unnamed grey town near Mexico border
+            ['K7'] => 'town=revenue:20;path=a:2,b:_0',
+          },
+
+          yellow: {
+
+            # Chicago: single city, exits W (→F18) and SW (→G19)
+            ['F20'] => 'city=revenue:20;path=a:1,b:_0;path=a:0,b:_0;label=C',
+            # New Orleans: 120° CW from original (edges 5→1, 0→2)
+            ['K19'] => 'city=revenue:20;path=a:1,b:_0;path=a:2,b:_0;label=NO',
+            # Sacramento: city 0=WP (→edge 5), city 1=CPR (→edge 0); 120° CCW from photo
+            ['G3'] => 'city=revenue:20;city=revenue:20;path=a:4,b:_0;path=a:5,b:_1;label=S',
+            # New York: city 0=NYC (NE→E29, W→F26), city 1=NYH (E→F30, SW→G27)
+            ['F28'] => 'city=revenue:20;city=revenue:20;path=a:0,b:_0;path=a:4,b:_0;path=a:1,b:_1;path=a:3,b:_1;label=NY',
+          },
+
+          red: {
+            # Labrador — far northeast off-board (20/40 by phase)
+            ['A29'] =>
+              'offboard=revenue:yellow_20|brown_40;path=a:0,b:_0;path=a:1,b:_0',
+            # Mexico — two hexes south of map (0 yellow, 80 brown)
+            ['K9'] =>
+              'offboard=revenue:yellow_40|brown_80;path=a:2,b:_0;path=a:3,b:_0',
+            ['K11'] =>
+              'offboard=revenue:yellow_40|brown_80;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
+            # Florida — southeast off-board (30/60 by phase)
+            ['L24'] =>
+              'offboard=revenue:yellow_30|brown_60;path=a:2,b:_0',
+          },
+        }.freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/meta.rb
+++ b/lib/engine/game/g_1862_usa_canada/meta.rb
@@ -10,7 +10,8 @@ module Engine
 
         DEV_STAGE = :prealpha
 
-        GAME_TITLE = '1862 USA Canada 2025 Version'
+        GAME_DISPLAY_TITLE = '1862 USA Canada 2025 Version'
+        GAME_TITLE = '1862UsaCanada'
         GAME_SUBTITLE = 'The First Transcontinental Railroad'
         GAME_DESIGNER = 'Helmut Ohley'
         GAME_LOCATION = 'North America'
@@ -20,11 +21,6 @@ module Engine
 
         PLAYER_RANGE = [3, 7].freeze
         OPTIONAL_RULES = [].freeze
-
-        # fs_name must match the actual directory so asset bundling resolves correctly
-        def self.fs_name
-          'g_1862_usa_canada'
-        end
       end
     end
   end

--- a/lib/engine/game/g_1862_usa_canada/meta.rb
+++ b/lib/engine/game/g_1862_usa_canada/meta.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../meta'
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      module Meta
+        include Game::Meta
+
+        DEV_STAGE = :prealpha
+
+        GAME_TITLE = '1862 USA Canada 2025 Version'
+        GAME_SUBTITLE = 'The First Transcontinental Railroad'
+        GAME_DESIGNER = 'Helmut Ohley'
+        GAME_LOCATION = 'North America'
+        GAME_PUBLISHER = nil
+        GAME_RULES_URL = nil
+        GAME_INFO_URL = nil
+
+        PLAYER_RANGE = [3, 7].freeze
+        OPTIONAL_RULES = [].freeze
+
+        # fs_name must match the actual directory so asset bundling resolves correctly
+        def self.fs_name
+          'g_1862_usa_canada'
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1862_usa_canada/step/buy_sell_par_shares.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares'
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      module Step
+        class BuySellParShares < Engine::Step::BuySellParShares
+          # NHSC gives the buyer NYH's director cert; NYH must be parred at
+          # exactly $100. Restrict available par prices to that single value.
+          def get_par_prices(entity, corporation)
+            return nyh_par_prices if corporation.id == 'NYH'
+
+            super
+          end
+
+          private
+
+          def nyh_par_prices
+            [@game.stock_market.par_prices.find { |p| p.price == 100 }].compact
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/step/token.rb
+++ b/lib/engine/game/g_1862_usa_canada/step/token.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/token'
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      module Step
+        class Token < Engine::Step::Token
+          # GHU (Bahnhoflizenz) gives the director's corporation an $80 discount
+          # on station token placement (minimum $0). The discount is auto-applied
+          # whenever the operating corporation's director holds GHU.
+          def process_place_token(action)
+            apply_ghu_discount!(action.entity, action.token)
+            super
+          end
+
+          private
+
+          def ghu_company
+            @game.companies.find { |c| c.sym == 'GHU' && !c.closed? }
+          end
+
+          def apply_ghu_discount!(corporation, token)
+            ghu = ghu_company
+            return unless ghu&.owner == corporation.owner
+
+            discount = ghu.abilities.find { |a| a.type == :tile_discount }&.discount.to_i
+            token.price = [token.price - discount, 0].max
+          end
+        end
+      end
+    end
+  end
+end

--- a/public/logos/1862_usa_canada/ATS.alt.svg
+++ b/public/logos/1862_usa_canada/ATS.alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#32763f"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="white">ATS</text></svg>

--- a/public/logos/1862_usa_canada/ATS.svg
+++ b/public/logos/1862_usa_canada/ATS.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="48" fill="#32763f"/><text x="50" y="60" text-anchor="middle" font-weight="700" font-size="28" font-family="Arial" fill="white">ATS</text></svg>

--- a/public/logos/1862_usa_canada/CN.alt.svg
+++ b/public/logos/1862_usa_canada/CN.alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#ADD8E6"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="black">CN</text></svg>

--- a/public/logos/1862_usa_canada/CN.svg
+++ b/public/logos/1862_usa_canada/CN.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="48" fill="#ADD8E6"/><text x="50" y="60" text-anchor="middle" font-weight="700" font-size="28" font-family="Arial" fill="black">CN</text></svg>

--- a/public/logos/1862_usa_canada/CP.alt.svg
+++ b/public/logos/1862_usa_canada/CP.alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#d88e39"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="black">CP</text></svg>

--- a/public/logos/1862_usa_canada/CP.svg
+++ b/public/logos/1862_usa_canada/CP.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="48" fill="#d88e39"/><text x="50" y="60" text-anchor="middle" font-weight="700" font-size="28" font-family="Arial" fill="black">CP</text></svg>

--- a/public/logos/1862_usa_canada/CPR.alt.svg
+++ b/public/logos/1862_usa_canada/CPR.alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#f48221"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="black">CPR</text></svg>

--- a/public/logos/1862_usa_canada/CPR.svg
+++ b/public/logos/1862_usa_canada/CPR.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="48" fill="#f48221"/><text x="50" y="60" text-anchor="middle" font-weight="700" font-size="28" font-family="Arial" fill="black">CPR</text></svg>

--- a/public/logos/1862_usa_canada/GMO.alt.svg
+++ b/public/logos/1862_usa_canada/GMO.alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#6ec037"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="black">GMO</text></svg>

--- a/public/logos/1862_usa_canada/GMO.svg
+++ b/public/logos/1862_usa_canada/GMO.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="48" fill="#6ec037"/><text x="50" y="60" text-anchor="middle" font-weight="700" font-size="28" font-family="Arial" fill="black">GMO</text></svg>

--- a/public/logos/1862_usa_canada/NP.alt.svg
+++ b/public/logos/1862_usa_canada/NP.alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#95c054"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="black">NP</text></svg>

--- a/public/logos/1862_usa_canada/NP.svg
+++ b/public/logos/1862_usa_canada/NP.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="48" fill="#95c054"/><text x="50" y="60" text-anchor="middle" font-weight="700" font-size="28" font-family="Arial" fill="black">NP</text></svg>

--- a/public/logos/1862_usa_canada/NYC.alt.svg
+++ b/public/logos/1862_usa_canada/NYC.alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#110a0c"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="white">NYC</text></svg>

--- a/public/logos/1862_usa_canada/NYC.svg
+++ b/public/logos/1862_usa_canada/NYC.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="48" fill="#110a0c"/><text x="50" y="60" text-anchor="middle" font-weight="700" font-size="28" font-family="Arial" fill="white">NYC</text></svg>

--- a/public/logos/1862_usa_canada/NYH.alt.svg
+++ b/public/logos/1862_usa_canada/NYH.alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#d1232a"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="white">NYH</text></svg>

--- a/public/logos/1862_usa_canada/NYH.svg
+++ b/public/logos/1862_usa_canada/NYH.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="48" fill="#d1232a"/><text x="50" y="60" text-anchor="middle" font-weight="700" font-size="28" font-family="Arial" fill="white">NYH</text></svg>

--- a/public/logos/1862_usa_canada/ORN.alt.svg
+++ b/public/logos/1862_usa_canada/ORN.alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#FFF500"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="black">ORN</text></svg>

--- a/public/logos/1862_usa_canada/ORN.svg
+++ b/public/logos/1862_usa_canada/ORN.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="48" fill="#FFF500"/><text x="50" y="60" text-anchor="middle" font-weight="700" font-size="28" font-family="Arial" fill="black">ORN</text></svg>

--- a/public/logos/1862_usa_canada/SP.alt.svg
+++ b/public/logos/1862_usa_canada/SP.alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#76a042"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="black">SP</text></svg>

--- a/public/logos/1862_usa_canada/SP.svg
+++ b/public/logos/1862_usa_canada/SP.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="48" fill="#76a042"/><text x="50" y="60" text-anchor="middle" font-weight="700" font-size="28" font-family="Arial" fill="black">SP</text></svg>

--- a/public/logos/1862_usa_canada/TP.alt.svg
+++ b/public/logos/1862_usa_canada/TP.alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#7b352a"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="white">TP</text></svg>

--- a/public/logos/1862_usa_canada/TP.svg
+++ b/public/logos/1862_usa_canada/TP.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="48" fill="#7b352a"/><text x="50" y="60" text-anchor="middle" font-weight="700" font-size="28" font-family="Arial" fill="white">TP</text></svg>

--- a/public/logos/1862_usa_canada/UP.alt.svg
+++ b/public/logos/1862_usa_canada/UP.alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#025aaa"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="white">UP</text></svg>

--- a/public/logos/1862_usa_canada/UP.svg
+++ b/public/logos/1862_usa_canada/UP.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="48" fill="#025aaa"/><text x="50" y="60" text-anchor="middle" font-weight="700" font-size="28" font-family="Arial" fill="white">UP</text></svg>

--- a/public/logos/1862_usa_canada/WP.alt.svg
+++ b/public/logos/1862_usa_canada/WP.alt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><circle cx="4" cy="4" r="4" fill="#8dd7f6"/><text x="4" y="5.1" text-anchor="middle" font-weight="700" font-size="3.25" textLength="7.2" lengthAdjust="spacingAndGlyphs" font-family="Arial" fill="black">WP</text></svg>

--- a/public/logos/1862_usa_canada/WP.svg
+++ b/public/logos/1862_usa_canada/WP.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="48" fill="#8dd7f6"/><text x="50" y="60" text-anchor="middle" font-weight="700" font-size="28" font-family="Arial" fill="black">WP</text></svg>

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Engine
+  describe Game::G1862UsaCanada::Game do
+    let(:players) { %w[Alice Bob Charlie] }
+    let(:game) { Game::G1862UsaCanada::Game.new(players) }
+
+    it 'initialises without error' do
+      expect(game).to be_a(described_class)
+    end
+
+    it 'has the correct number of corporations' do
+      expect(game.corporations.size).to eq(13)
+    end
+
+    it 'has the correct number of private companies' do
+      expect(game.companies.size).to eq(8)
+    end
+
+    it 'starts in phase 2' do
+      expect(game.phase.name).to eq('2')
+    end
+
+    it 'uses full capitalisation' do
+      expect(described_class::CAPITALIZATION).to eq(:full)
+    end
+
+    it 'uses sell_buy order' do
+      expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
+    end
+  end
+end

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -31,6 +31,19 @@ module Engine
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
 
+    describe 'home token timing' do
+      it 'uses :operate timing' do
+        expect(described_class::HOME_TOKEN_TIMING).to eq(:operate)
+      end
+
+      it 'clears the graph after placing the home token' do
+        corp = game.corporations.first
+        graph = game.send(:graph_for_entity, corp)
+        expect(graph).to receive(:clear).at_least(:once)
+        game.place_home_token(corp)
+      end
+    end
+
     describe 'corporation group unlock' do
       let(:nyh) { game.corporation_by_id('NYH') }
       let(:nyc) { game.corporation_by_id('NYC') }

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -31,6 +31,28 @@ module Engine
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
 
+    describe 'tile-lay budget' do
+      it 'phase 2: single yellow tile only' do
+        lays = game.tile_lays(game.corporations.first)
+        expect(lays.size).to eq(1)
+        expect(lays.first[:upgrade]).to be false
+      end
+
+      it 'phase 3+: two entries, second blocked after upgrade' do
+        game.phase.next!
+        lays = game.tile_lays(game.corporations.first)
+        expect(lays.size).to eq(2)
+        expect(lays.first[:upgrade]).to be true
+        expect(lays.last[:lay]).to eq(:not_if_upgraded)
+        expect(lays.last[:upgrade]).to be false
+      end
+
+      it 'phase 3 status includes two_tile_lays flag' do
+        game.phase.next!
+        expect(game.phase.status).to include('two_tile_lays')
+      end
+    end
+
     describe 'E-train variants' do
       it 'every base train 2–7 has exactly one E-train variant' do
         base_trains = game.depot.trains.map(&:name).uniq.reject { |n| n == '8' }

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -30,5 +30,38 @@ module Engine
     it 'uses sell_buy order' do
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
+
+    describe 'corporation group unlock' do
+      let(:nyh) { game.corporation_by_id('NYH') }
+      let(:nyc) { game.corporation_by_id('NYC') }
+      let(:cp)  { game.corporation_by_id('CP') }
+      let(:cpr) { game.corporation_by_id('CPR') }
+      let(:np)  { game.corporation_by_id('NP') }
+
+      it 'Group 1 is locked while privates are unsold' do
+        expect(game.can_par?(nyh, nil)).to be false
+      end
+
+      it 'Group 1 unlocks when all privates are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(nyh, nil)).to be true
+      end
+
+      it 'Group 2 is locked even after all privates are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(cpr, nil)).to be false
+      end
+
+      it 'Group 2 unlocks when all Group 1 IPO shares are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        [nyh, nyc, cp].each { |corp| allow(corp).to receive(:num_ipo_shares).and_return(0) }
+        expect(game.can_par?(cpr, nil)).to be true
+      end
+
+      it 'Group 3 is locked while any Group 2 corp is unfloated' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(np, nil)).to be false
+      end
+    end
   end
 end

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -31,6 +31,49 @@ module Engine
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
 
+    describe 'E-train variants' do
+      it 'every base train 2–7 has exactly one E-train variant' do
+        base_trains = game.depot.trains.map(&:name).uniq.reject { |n| n == '8' }
+        base_trains.each do |name|
+          proto = game.depot.trains.find { |t| t.name == name }
+          expect(proto.variants.keys).to include("#{name}E"), "#{name}-train missing #{name}E variant"
+        end
+      end
+
+      it 'E-train distance uses string keys and visit 999' do
+        %w[2E 3E 4E 5E 6E 7E].each do |variant_name|
+          base = variant_name.chomp('E')
+          proto = game.depot.trains.find { |t| t.name == base }
+          dist = proto.variants[variant_name][:distance]
+          expect(dist).to be_an(Array), "#{variant_name} distance should be an array"
+          expect(dist.first['visit']).to eq(999), "#{variant_name} should visit 999 nodes"
+          expect(dist.first['nodes']).to include('city'), "#{variant_name} nodes should include city"
+        end
+      end
+
+      it '2 and 2E trains rust on the 4-train sym' do
+        two_train = game.depot.trains.find { |t| t.name == '2' }
+        expect(two_train.rusts_on).to eq('4')
+      end
+
+      it '3 and 3E trains rust on the 6-train sym' do
+        three_train = game.depot.trains.find { |t| t.name == '3' }
+        expect(three_train.rusts_on).to eq('6')
+      end
+
+      it '4 and 4E trains rust on the 8-train sym' do
+        four_train = game.depot.trains.find { |t| t.name == '4' }
+        expect(four_train.rusts_on).to eq('8')
+      end
+
+      it '5E and later trains never rust' do
+        %w[5 6 7 8].each do |name|
+          train = game.depot.trains.find { |t| t.name == name }
+          expect(train.rusts_on).to be_nil, "#{name}-train should not rust"
+        end
+      end
+    end
+
     describe 'home token timing' do
       it 'uses :operate timing' do
         expect(described_class::HOME_TOKEN_TIMING).to eq(:operate)

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -31,6 +31,39 @@ module Engine
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
 
+    describe 'GHU token discount' do
+      let(:ghu) { game.companies.find { |c| c.sym == 'GHU' } }
+
+      it 'GHU ability has player owner_type' do
+        ability = ghu.abilities.find { |a| a.type == :tile_discount }
+        expect(ability.owner_type).to eq(:player)
+      end
+
+      it 'GHU discount is $80' do
+        ability = ghu.abilities.find { |a| a.type == :tile_discount }
+        expect(ability.discount).to eq(80)
+      end
+    end
+
+    describe 'NYH par price restriction' do
+      let(:nyh) { game.corporation_by_id('NYH') }
+      let(:step) { game.stock_round.active_step }
+
+      it 'NYH par is restricted to $100' do
+        game.companies.each { |c| c.owner = game.players.first }
+        prices = step.get_par_prices(game.players.first, nyh).map(&:price)
+        expect(prices).to eq([100])
+      end
+
+      it 'other corps have multiple par prices available' do
+        game.companies.each { |c| c.owner = game.players.first }
+        [game.corporation_by_id('NYC'), game.corporation_by_id('CP')].each do |corp|
+          prices = step.get_par_prices(game.players.first, corp)
+          expect(prices.size).to be > 1
+        end
+      end
+    end
+
     describe 'tile-lay budget' do
       it 'phase 2: single yellow tile only' do
         lays = game.tile_lays(game.corporations.first)


### PR DESCRIPTION
Stacked on #12627 (PR 05 — tile-lay budget).

## Before clicking "Create"

- [x] Branch is derived from `1862_usa_canada_p05_tile_lays`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

**GHU (Bahnhoflizenz, $75 private)**
- The player who owns GHU gives their corporation an $80 discount on station token placement (minimum $0).
- Fix: changed `owner_type: 'corporation'` → `owner_type: 'player'` (corporations cannot buy privates in this game, so the ability was unreachable).
- New `step/token.rb` overrides `process_place_token` to auto-apply the discount when the operating corporation's director holds GHU.

**NHSC / NYH par price lock**
- NHSC gives its buyer NYH's 30% director certificate immediately. NYH must be parred at exactly $100 (rulebook restriction).
- New `step/buy_sell_par_shares.rb` overrides `get_par_prices` to return only the $100 par price cell when the corporation being parred is NYH.

Both steps wired into `stock_round` and `operating_round` in `game.rb`.

### Screenshots

N/A — logic change.

### Any Assumptions / Hacks

- GHU discount is auto-applied (always used when available). The discount always reduces cost, so there is no reason a director would decline it.
- The NYH $100 par restriction applies unconditionally — any player who holds NYH_0 must par at $100, which is correct since NHSC always delivers NYH_0 to its buyer.