### PR TITLE
[1880 Romania] fix p3 application

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1742,29 +1742,29 @@ module Engine
 
       def upgrade_cost(tile, hex, entity, spender)
         entity = entity.owner if !entity.corporation? && entity.owner&.corporation?
-        ability = entity.all_abilities.find do |a|
+        abilities = entity.all_abilities.select do |a|
           a.type == :tile_discount &&
             (!a.hexes || a.hexes.include?(hex.name))
         end
 
-        discount = ability&.discounts_tile?(tile) ? ability.discount : 0
-        log_cost_discount(spender, ability, discount)
+        discount = abilities.sum { |a| a.discounts_tile?(tile) ? a.discount : 0 }
+        log_cost_discount(spender, abilities, discount)
 
         tile.upgrades.sum(&:cost) - discount
       end
 
       def tile_cost_with_discount(_tile, hex, entity, spender, cost)
         entity = entity.owner if !entity.corporation? && entity.owner&.corporation?
-        ability = entity.all_abilities.find do |a|
+        abilities = entity.all_abilities.select do |a|
           a.type == :tile_discount &&
             !a.terrain &&
             (!a.hexes || a.hexes.include?(hex.name))
         end
 
-        return cost unless ability
+        return cost if abilities.empty?
 
-        discount = [cost, ability.discount].min
-        log_cost_discount(spender, ability, discount)
+        discount = [cost, abilities.sum(&:discount)].min
+        log_cost_discount(spender, abilities, discount)
 
         cost - discount
       end

--- a/lib/engine/game/g_1880_romania/entities.rb
+++ b/lib/engine/game/g_1880_romania/entities.rb
@@ -39,9 +39,8 @@ module Engine
               discount: 20,
               terrain: 'mountain',
               exact_match: false,
-              owner_type: 'player',
               when: 'owning_player_track',
-              description: 'Discount of L20 for each hex with mountain terrain costs',
+              description: 'L20 discount on mountain terrain costs',
             }],
           },
           {


### PR DESCRIPTION
Fixes #12635

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Ability wasn't triggering. Removing the owner_type ability key from the definition fixes this. 

At that point, I noticed that it still wasn't working for the TR corporation, which has a built-in terrain discount. When I pulled up the base methods for `def upgrade_cost` and `def tile_cost_with_discount`, they only account for a single terrain discount, so I tweaked them to be able to accommodate multiple discounts. 

### Screenshots

Before: 

<img width="495" height="70" alt="image" src="https://github.com/user-attachments/assets/792e862e-122c-42f9-b2bc-2647af402be0" />

After:

<img width="437" height="121" alt="image" src="https://github.com/user-attachments/assets/e9c340be-1959-4c0a-90f4-155352a7da91" />

TR corporation after changes: 

<img width="553" height="84" alt="image" src="https://github.com/user-attachments/assets/dfd00d95-0cfc-4910-bcd9-5970c9f174f7" />



### Any Assumptions / Hacks
