### PR TITLE
[core] compute_stops should sort distance by number of node types rather than hash keys

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1560,7 +1560,7 @@ module Engine
         # Stops use the first available slot, so for each stop in this case
         # we'll try to put it in a town slot if possible and then
         # in a city/town/offboard slot.
-        distance = distance.sort_by { |types, _| types.size }
+        distance = distance.sort_by { |h| h['nodes'].size }
 
         max_num_stops = [distance.sum { |h| h['pay'].to_i }, visits.size].min
 


### PR DESCRIPTION
Fixes #12614 

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

The original code uses Ruby's multi-value block destructuring:

`rubydistance.sort_by { |types, _| types.size }`

This works correctly for arrays of arrays, but for the TRAINS constant, `distance` is an array of hashes. When Ruby destructures a hash into multiple block variables, it assigns the entire hash to types and nil to _, so types.size returns the number of keys in the hash (always 3: nodes, pay, visit) rather than the number of node types, making the sort a no-op.

This isn't a problem if the trains' distance hash is arranged like this: 

```
distance: [{ 'nodes' => ['town'], 'pay' => 4, 'visit' => 4 },
           { 'nodes' => %w[city offboard town], 'pay' => 4, 'visit' => 4 }],
```

but if it's in the reverse order, towns can use up city nodes and the route calculation gets messed up.

The fix is to use: 

`rubydistance.sort_by { |h| h['nodes'].size }`

This sorts by the number of node types in each bucket, so more restrictive buckets (e.g. ['town']) sort before less restrictive ones like `['city', 'offboard', 'town']`. In practice this bug has gone unnoticed because all existing plus-train games define their distance arrays with the town bucket already first. it only becomes visible when a distance array is constructed at runtime with buckets in a different order. 

I encountered the problem because I was adding a hash through a private assignment. Yes, I could have used `distance.unshift` rather than `distance <<`, but this is a more robust solution, I think.

### Screenshots

### Any Assumptions / Hacks
