### PR TITLE
[1880 Romania] blue hexes should count as towns

### DIFF
--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -615,6 +615,12 @@ module Engine
           @minors.select { |m| m.owner == player }
         end
 
+        def stop_type(stop)
+          return 'town' if stop.hex.tile.color == :blue
+
+          super
+        end
+
         def revenue_for(route, stops)
           revenue = super
           revenue -= 10 * (route.all_hexes & ferry_hexes).size unless route.corporation.owner == ferry_company.owner

--- a/lib/engine/game/g_1880/map.rb
+++ b/lib/engine/game/g_1880/map.rb
@@ -234,9 +234,9 @@ module Engine
             ['F12'] => 'offboard=revenue:-10,hide:1;path=a:3,b:1',
             %w[F14 J16] => 'offboard=revenue:-10,hide:1;path=a:2,b:0',
             ['I15'] => 'path=a:2,b:5',
-            ['N16'] => 'town=style:hidden,revenue:yellow_30|green_30|brown_0|gray_0;path=a:0,b:_0,terminal:1;'\
+            ['N16'] => 'offboard=revenue:yellow_30|green_30|brown_0|gray_0;path=a:0,b:_0,terminal:1;'\
                        'path=a:1,b:_0,terminal:1;path=a:2,b:_0,terminal:1',
-            ['Q13'] => 'town=style:hidden,revenue:yellow_20|green_30|brown_40|gray_50;'\
+            ['Q13'] => 'offboard=revenue:yellow_20|green_30|brown_40|gray_50;'\
                        'path=a:2,b:_0,terminal:1;path=a:3,b:_0,terminal:1',
           },
           yellow: {

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -284,12 +284,6 @@ module Engine
           clear_graph if removed
         end
 
-        def stop_type(stop)
-          return 'town' if %w[J26 H26].include?(stop.hex.id)
-
-          super
-        end
-
         def revenue_for(route, stops)
           revenue = super
           revenue += 10 if danube_port_bonus?(route, stops)

--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -284,6 +284,12 @@ module Engine
           clear_graph if removed
         end
 
+        def stop_type(stop)
+          return 'town' if %w[J26 H26].include?(stop.hex.id)
+
+          super
+        end
+
         def revenue_for(route, stops)
           revenue = super
           revenue += 10 if danube_port_bonus?(route, stops)


### PR DESCRIPTION
Fixes #12619

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Blue hexes should count as towns. I took advantage of the `stop_type` method used by 1822CA to return 'town' for these hexes. This was needed specifically for J26, because it's an offboard with a token slot, so I couldn't just call it a hidden town like in 1880' China's code.  

### Screenshots

### Any Assumptions / Hacks
