### PR TITLE
[1862 USA & Canada] PR 02: corporation group unlock

### DIFF
--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -224,9 +224,9 @@ module Engine
         def corp_groups
           @corp_groups ||= CORP_GROUPS.transform_values { |sym| corporation_by_id(sym) }
         end
-        
+
         def corp_group(corporation)
-          corp_groups.find { |_, corps| corps.include?(corporation) }&.first
+          corp_groups.find { |_, corps| corps.include?(corporation) }.first
         end
 
         def all_privates_sold?
@@ -237,7 +237,7 @@ module Engine
           case group_num
           when 1 then all_privates_sold?
           when 2 then corp_groups[1].all? { |corp| corp.num_ipo_shares.zero? }
-          when 3 then corp_groups[2].all? { |corp| corp.floated? }
+          when 3 then corp_groups[2].all?(&:floated?)
           else true
           end
         end

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -221,8 +221,12 @@ module Engine
         # ---------------------------------------------------------------------------
         # Corporation group unlock logic.
         # ---------------------------------------------------------------------------
+        def corp_groups
+          @corp_groups ||= CORP_GROUPS.transform_values { |sym| corporation_by_id(sym) }
+        end
+        
         def corp_group(corporation)
-          CORP_GROUPS.find { |_, syms| syms.include?(corporation.id) }&.first
+          corp_groups.find { |_, corps| corps.include?(corporation) }&.first
         end
 
         def all_privates_sold?
@@ -232,8 +236,8 @@ module Engine
         def group_available?(group_num)
           case group_num
           when 1 then all_privates_sold?
-          when 2 then CORP_GROUPS[1].all? { |sym| corporation_by_id(sym).num_ipo_shares.zero? }
-          when 3 then CORP_GROUPS[2].all? { |sym| corporation_by_id(sym).floated? }
+          when 2 then corp_groups[1].all? { |corp| corp.num_ipo_shares.zero? }
+          when 3 then corp_groups[2].all? { |corp| corp.floated? }
           else true
           end
         end

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -238,7 +238,7 @@ module Engine
           when 1 then all_privates_sold?
           when 2 then corp_groups[1].all? { |corp| corp.num_ipo_shares.zero? }
           when 3 then corp_groups[2].all?(&:floated?)
-          else true
+          else raise GameError, "Unknown corporation group #{group_num}"
           end
         end
 

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -17,9 +17,9 @@ module Engine
 
         # ---------------------------------------------------------------------------
         # Corporation groups — unlocked progressively.
-        # Group 1 available from game start.
-        # Group 2 unlocks when ALL Group 1 companies have floated.
-        # Group 3 unlocks when ALL Group 2 companies have floated.
+        # Group 1 available when ALL private companies have been sold.
+        # Group 2 unlocks when ALL Group 1 IPO shares have been sold.
+        # Group 3 unlocks when ALL Group 2 corporations have floated.
         #
         # Director share sizes by group (from rulebook):
         #   Group 1 (NYH, NYC, CP):       30% Director + 7×10%
@@ -217,6 +217,32 @@ module Engine
         ].freeze
 
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or }.freeze
+
+        # ---------------------------------------------------------------------------
+        # Corporation group unlock logic.
+        # ---------------------------------------------------------------------------
+        def corp_group(corporation)
+          CORP_GROUPS.find { |_, syms| syms.include?(corporation.id) }&.first
+        end
+
+        def all_privates_sold?
+          @companies.all? { |c| c.owner&.player? || c.closed? }
+        end
+
+        def group_available?(group_num)
+          case group_num
+          when 1 then all_privates_sold?
+          when 2 then CORP_GROUPS[1].all? { |sym| corporation_by_id(sym).num_ipo_shares.zero? }
+          when 3 then CORP_GROUPS[2].all? { |sym| corporation_by_id(sym).floated? }
+          else true
+          end
+        end
+
+        def can_par?(corporation, parrer)
+          return false unless super
+
+          group_available?(corp_group(corporation))
+        end
 
         # ---------------------------------------------------------------------------
         # Round definitions — engine defaults only; custom steps added in later PRs.

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -222,7 +222,7 @@ module Engine
         # Corporation group unlock logic.
         # ---------------------------------------------------------------------------
         def corp_groups
-          @corp_groups ||= CORP_GROUPS.transform_values { |sym| corporation_by_id(sym) }
+          @corp_groups ||= CORP_GROUPS.transform_values { |syms| syms.map { |s| corporation_by_id(s) } }
         end
 
         def corp_group(corporation)

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -30,5 +30,38 @@ module Engine
     it 'uses sell_buy order' do
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
+
+    describe 'corporation group unlock' do
+      let(:nyh) { game.corporation_by_id('NYH') }
+      let(:nyc) { game.corporation_by_id('NYC') }
+      let(:cp)  { game.corporation_by_id('CP') }
+      let(:cpr) { game.corporation_by_id('CPR') }
+      let(:np)  { game.corporation_by_id('NP') }
+
+      it 'Group 1 is locked while privates are unsold' do
+        expect(game.can_par?(nyh, nil)).to be false
+      end
+
+      it 'Group 1 unlocks when all privates are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(nyh, nil)).to be true
+      end
+
+      it 'Group 2 is locked even after all privates are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(cpr, nil)).to be false
+      end
+
+      it 'Group 2 unlocks when all Group 1 IPO shares are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        [nyh, nyc, cp].each { |corp| allow(corp).to receive(:num_ipo_shares).and_return(0) }
+        expect(game.can_par?(cpr, nil)).to be true
+      end
+
+      it 'Group 3 is locked while any Group 2 corp is unfloated' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(np, nil)).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
Stacked on #12622 (PR 01 — data skeleton, merged).

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Implements `can_par?` with the three progressive group unlock conditions:

| Group | Corps | Can par when… |
|-------|-------|--------------|
| 1 | NYH, NYC, CP | All 8 private companies have been sold (player-owned or closed) |
| 2 | CPR, UP, ATS, SP | All Group 1 IPO shares are fully sold out (`num_ipo_shares == 0`) |
| 3 | NP, CN, TP, ORN, WP, GMO | All Group 2 corporations have floated |

Adds helpers `corp_group`, `all_privates_sold?`, `group_available?` in `game.rb`.
Spec covers all three lock/unlock gates.

### Screenshots

N/A — logic change, no UI change.

### Any Assumptions / Hacks

"All privates sold" for Groups 1→2 means the IPO pool is empty for every Group 1 corp, not merely that they have floated. A corp floats on a threshold (e.g. 60%) but may still have unsold IPO shares; group unlock waits for the full sellout.