### PR TITLE
[1862 USA & Canada] PR 03: fix graph cache cleared after home token placement

### DIFF
--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -219,6 +219,18 @@ module Engine
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or }.freeze
 
         # ---------------------------------------------------------------------------
+        # Home token — placed automatically at start of corp's first OR turn.
+        # Base place_home_token calls city.place_token directly (bypasses step
+        # layer) so clear_graph_for_entity is never called. Override to flush the
+        # graph cache immediately, otherwise the corp sees zero connected hexes
+        # and cannot lay track on the same turn.
+        # ---------------------------------------------------------------------------
+        def place_home_token(corporation)
+          super
+          clear_graph_for_entity(corporation)
+        end
+
+        # ---------------------------------------------------------------------------
         # Corporation group unlock logic.
         # ---------------------------------------------------------------------------
         def corp_group(corporation)

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -17,9 +17,9 @@ module Engine
 
         # ---------------------------------------------------------------------------
         # Corporation groups — unlocked progressively.
-        # Group 1 available from game start.
-        # Group 2 unlocks when ALL Group 1 companies have floated.
-        # Group 3 unlocks when ALL Group 2 companies have floated.
+        # Group 1 available when ALL private companies have been sold.
+        # Group 2 unlocks when ALL Group 1 IPO shares have been sold.
+        # Group 3 unlocks when ALL Group 2 corporations have floated.
         #
         # Director share sizes by group (from rulebook):
         #   Group 1 (NYH, NYC, CP):       30% Director + 7×10%
@@ -217,6 +217,32 @@ module Engine
         ].freeze
 
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or }.freeze
+
+        # ---------------------------------------------------------------------------
+        # Corporation group unlock logic.
+        # ---------------------------------------------------------------------------
+        def corp_group(corporation)
+          CORP_GROUPS.find { |_, syms| syms.include?(corporation.id) }&.first
+        end
+
+        def all_privates_sold?
+          @companies.all? { |c| c.owner&.player? || c.closed? }
+        end
+
+        def group_available?(group_num)
+          case group_num
+          when 1 then all_privates_sold?
+          when 2 then CORP_GROUPS[1].all? { |sym| corporation_by_id(sym).num_ipo_shares.zero? }
+          when 3 then CORP_GROUPS[2].all? { |sym| corporation_by_id(sym).floated? }
+          else true
+          end
+        end
+
+        def can_par?(corporation, parrer)
+          return false unless super
+
+          group_available?(corp_group(corporation))
+        end
 
         # ---------------------------------------------------------------------------
         # Round definitions — engine defaults only; custom steps added in later PRs.

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -31,6 +31,19 @@ module Engine
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
 
+    describe 'home token timing' do
+      it 'uses :operate timing' do
+        expect(described_class::HOME_TOKEN_TIMING).to eq(:operate)
+      end
+
+      it 'clears the graph after placing the home token' do
+        corp = game.corporations.first
+        graph = game.send(:graph_for_entity, corp)
+        expect(graph).to receive(:clear).at_least(:once)
+        game.place_home_token(corp)
+      end
+    end
+
     describe 'corporation group unlock' do
       let(:nyh) { game.corporation_by_id('NYH') }
       let(:nyc) { game.corporation_by_id('NYC') }

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -30,5 +30,38 @@ module Engine
     it 'uses sell_buy order' do
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
+
+    describe 'corporation group unlock' do
+      let(:nyh) { game.corporation_by_id('NYH') }
+      let(:nyc) { game.corporation_by_id('NYC') }
+      let(:cp)  { game.corporation_by_id('CP') }
+      let(:cpr) { game.corporation_by_id('CPR') }
+      let(:np)  { game.corporation_by_id('NP') }
+
+      it 'Group 1 is locked while privates are unsold' do
+        expect(game.can_par?(nyh, nil)).to be false
+      end
+
+      it 'Group 1 unlocks when all privates are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(nyh, nil)).to be true
+      end
+
+      it 'Group 2 is locked even after all privates are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(cpr, nil)).to be false
+      end
+
+      it 'Group 2 unlocks when all Group 1 IPO shares are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        [nyh, nyc, cp].each { |corp| allow(corp).to receive(:num_ipo_shares).and_return(0) }
+        expect(game.can_par?(cpr, nil)).to be true
+      end
+
+      it 'Group 3 is locked while any Group 2 corp is unfloated' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(np, nil)).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
Stacked on #12643 (PR 02 — corporation group unlock, not yet merged). This PR adds one commit on top; the first commit in the diff belongs to PR 02.

## Before clicking "Create"

- [x] Branch is derived from the latest `master` (rebased; stacked on #12643 for reviewer convenience)
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

With `HOME_TOKEN_TIMING = :operate` the base `place_home_token` places the token directly via `city.place_token`, bypassing the step layer, so `clear_graph_for_entity` is never called. The stale graph cache then shows zero connected hexes, blocking track lays on the corp's first OR turn.

Override `place_home_token` to call `super` then `clear_graph_for_entity` so connectivity is queryable immediately after the token lands.

### Screenshots

N/A — logic fix, no visual change.

### Any Assumptions / Hacks

N/A