### PR TITLE
[18OE]: bug fixes, constants, and cleanup

### DIFF
--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -763,6 +763,10 @@ module Engine
              OE18 OE26 OE27 OE28 OE29 OE30 OE37 OE38 OE39 OE40 OE41].include?(tile.name.to_s)
         end
 
+        def tile_point_budget(entity)
+          self.class::TILE_POINT_BUDGET[entity.type] || 0
+        end
+
         def can_buy_train_from_others?
           major_phase?
         end

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -15,7 +15,7 @@ module Engine
         include G18OE::Entities
         include G18OE::Map
         attr_accessor :minor_regional_order, :minor_available_regions, :minor_floated_regions, :regional_corps_floated,
-                      :consolidation_triggered, :consolidation_done
+                      :consolidation_triggered, :consolidation_complete
 
         MARKET = [
           ['', '110', '120C', '135', '150', '165', '180', '200', '225', '250', '280', '310', '350', '390', '440', '490', '550'],
@@ -48,6 +48,10 @@ module Engine
         }.freeze
 
         EVENTS_TEXT = Base::EVENTS_TEXT.merge(
+          'consolidation_triggered' => [
+            'Consolidation Round',
+            'Consolidation round follows at end of current OR set; minors and regionals must merge or be abandoned',
+          ],
           'remainder_cash_added' => [
             'Remainder Cash Added',
             '£100,000 remainder cash injected into bank; game ends after one more full OR set',
@@ -241,6 +245,8 @@ module Engine
         ZONE_DISCOUNT_ZONES         = %w[SP IT SC RU].freeze
         ZONE_DISCOUNT_RATE          = 0.2 # 20% §11.1.5
         ZONE_TERRAIN_DISCOUNT_RATE  = 0.5 # 50% §11.1.5; E/F augment zone discount to this rate
+        TILE_POINT_BUDGET = { minor: 3, regional: 3, major: 6, national: 9 }.freeze
+        MINOR_MAX_TREASURY = 180
         EF_TERRAIN_AUGMENT          = { 'E' => :water, 'F' => :mountain }.freeze
 
         CORPORATIONS_TRACK_RIGHTS = {
@@ -666,7 +672,7 @@ module Engine
           @minor_floated_regions = {}
           @regional_corps_floated = 0
           @fulfilled_train_obligation = Set.new
-          @first_or_done = false
+          @first_or_complete = false
 
           corporations.each do |corp|
             corp.par_via_exchange = companies.find { |c| c.sym == corp.id } if corp.type == :minor
@@ -697,7 +703,7 @@ module Engine
         end
 
         def non_starter_trains_available?
-          major_phase? && @first_or_done
+          major_phase? && @first_or_complete
         end
 
         def operating_order
@@ -749,7 +755,7 @@ module Engine
         end
 
         def metropolis_hex?(hex)
-          %w[A56 B41 C74 F87 K26 M28 M50 Q30 R55 Y14 AA82 AB51].include?(hex.name.to_s)
+          %w[A56 B41 C74 F87 K26 M28 M50 Q30 R55 Y14 AA82 AB51].include?(hex.coordinates)
         end
 
         def metropolis_tile?(tile)
@@ -821,15 +827,24 @@ module Engine
           @round =
             case @round
             when Engine::Round::Operating
-              @first_or_done = true # Rule 8.3/11.6: level 3+ trains unblocked after first OR
-              if @consolidation_triggered && !@consolidation_done
+              @first_or_complete = true # Rule 8.3/11.6: level 3+ trains unblocked after first OR
+              if @round.round_num < @operating_rounds
+                or_round_finished
+                new_operating_round(@round.round_num + 1)
+              elsif @consolidation_triggered && !@consolidation_complete
+                @turn += 1
+                or_round_finished
+                or_set_finished
                 @log << '-- Consolidation Phase --'
                 new_consolidation_round
               else
-                super
+                @turn += 1
+                or_round_finished
+                or_set_finished
+                new_stock_round
               end
             when Round::G18OE::Consolidation
-              @consolidation_done = true
+              @consolidation_complete = true
               @turn += 1
               new_stock_round
             else
@@ -847,7 +862,7 @@ module Engine
           return true if from.label == to.label
           return false if from.label && !to.label
 
-          case from.hex.name
+          case from.hex.coordinates
           when 'K26', 'Y14', 'R55'
             to.label.to_s.include?('A')
           when 'M50'

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -145,7 +145,7 @@ module Engine
               price: 225,
               rusts_on: '6',
             }],
-            num: 24,
+            num: 20,
           },
           # Level 4 — green double-sided (4 / 4+4); rust at Level 8
           {
@@ -161,7 +161,7 @@ module Engine
               price: 350,
               rusts_on: '8+8',
             }],
-            num: 14,
+            num: 10,
           },
           # Level 5 — brown double-sided (5 / 5+5); permanent
           {
@@ -175,7 +175,7 @@ module Engine
                          { 'nodes' => %w[city offboard town], 'pay' => 5, 'visit' => 5 }],
               price: 475,
             }],
-            num: 11,
+            num: 8,
             events: [{ 'type' => 'consolidation_triggered' }],
           },
           # Level 6 — brown double-sided (6 / 6+6); permanent
@@ -190,7 +190,7 @@ module Engine
                          { 'nodes' => %w[city offboard town], 'pay' => 6, 'visit' => 6 }],
               price: 600,
             }],
-            num: 9,
+            num: 6,
           },
           # Level 7 — gray double-sided (7+7 / 4D); permanent
           # NOTE: Level 8 trains become available only after the 4th Level 7 purchase
@@ -205,7 +205,7 @@ module Engine
                          { 'nodes' => %w[city offboard], 'pay' => 4, 'visit' => 99 }],
               price: 850,
             }],
-            num: 17,
+            num: 14,
           },
           # Level 8 — gray double-sided (8+8 / 5D); permanent
           # NOTE: purchase of the FIRST level-8 triggers game end
@@ -220,7 +220,7 @@ module Engine
                          { 'nodes' => %w[city offboard], 'pay' => 5, 'visit' => 99 }],
               price: 1000,
             }],
-            num: 11,
+            num: 8,
             available_on: '7+7',
             events: [{ 'type' => 'remainder_cash_added' }],
           },
@@ -707,7 +707,7 @@ module Engine
         end
 
         def operating_order
-          @minor_regional_order + @corporations.select { |c| %i[major national].include?(c.type) }.sort
+          @minor_regional_order + @corporations.select { |c| %i[major national].include?(c.type) && c.floated? }.sort
         end
 
         def hex_within_national_region?(entity, hex)

--- a/lib/engine/game/g_18_oe/meta.rb
+++ b/lib/engine/game/g_18_oe/meta.rb
@@ -11,8 +11,8 @@ module Engine
         DEV_STAGE = :prealpha
 
         GAME_DESIGNER = 'Edward T. Sindelar'
-        # GAME_PUBLISHER = :DICE
-        # GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18NY'
+        GAME_PUBLISHER = :DICE
+        GAME_INFO_URL = 'http://www.designsice.com/18OE.html'
         GAME_LOCATION = 'Europe'
         GAME_RULES_URL = 'http://www.designsice.com/files/18OE%20Rulebook.pdf'
         GAME_TITLE = '18OE'

--- a/lib/engine/game/g_18_oe/meta.rb
+++ b/lib/engine/game/g_18_oe/meta.rb
@@ -12,7 +12,7 @@ module Engine
 
         GAME_DESIGNER = 'Edward T. Sindelar'
         GAME_PUBLISHER = :DICE
-        GAME_INFO_URL = 'http://www.designsice.com/18OE.html'
+        GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18OE'
         GAME_LOCATION = 'Europe'
         GAME_RULES_URL = 'http://www.designsice.com/files/18OE%20Rulebook.pdf'
         GAME_TITLE = '18OE'

--- a/lib/engine/game/g_18_oe/round/operating.rb
+++ b/lib/engine/game/g_18_oe/round/operating.rb
@@ -6,10 +6,6 @@ module Engine
   module Round
     module G18OE
       class Operating < Engine::Round::Operating
-        def select_entities
-          # minors and regionals in float order, majors in stock order
-          @game.minor_regional_order + (@game.corporations.select(&:floated?) - @game.minor_regional_order).sort
-        end
       end
     end
   end

--- a/lib/engine/game/g_18_oe/step/consolidate.rb
+++ b/lib/engine/game/g_18_oe/step/consolidate.rb
@@ -10,6 +10,7 @@ module Engine
           CONVERT_ACTIONS = ['convert'].freeze
 
           def actions(entity)
+            return [] unless entity == current_entity
             return [] if pending_corps(entity).empty?
 
             regional_convertible?(entity) ? CONVERT_ACTIONS : []
@@ -28,10 +29,7 @@ module Engine
           end
 
           def can_convert?(entity)
-            return false unless entity.type == :regional
-            return false if @converted
-
-            true
+            entity.type == :regional && !@converted
           end
 
           def process_convert(action)

--- a/lib/engine/game/g_18_oe/step/consolidate.rb
+++ b/lib/engine/game/g_18_oe/step/consolidate.rb
@@ -11,7 +11,7 @@ module Engine
             return [] unless entity == current_entity
             return [] if pending_corps(entity).empty?
 
-            can_convert_any? ? ['convert'] : []
+            regional_convertible? ? ['convert'] : []
           end
 
           def description
@@ -20,6 +20,10 @@ module Engine
 
           def blocks?
             !pending_corps(current_entity).empty?
+          end
+
+          def regional_convertible?
+            pending_corps(current_entity).any? { |corp| can_convert?(corp) }
           end
 
           def can_convert?(entity)

--- a/lib/engine/game/g_18_oe/step/consolidate.rb
+++ b/lib/engine/game/g_18_oe/step/consolidate.rb
@@ -7,11 +7,12 @@ module Engine
     module G18OE
       module Step
         class Consolidate < G18OE::Step::BuySellParShares
+          CONVERT_ACTIONS = ['convert'].freeze
+
           def actions(entity)
-            return [] unless entity == current_entity
             return [] if pending_corps(entity).empty?
 
-            regional_convertible? ? ['convert'] : []
+            regional_convertible?(entity) ? CONVERT_ACTIONS : []
           end
 
           def description
@@ -22,14 +23,13 @@ module Engine
             !pending_corps(current_entity).empty?
           end
 
-          def regional_convertible?
-            pending_corps(current_entity).any? { |corp| can_convert?(corp) }
+          def regional_convertible?(entity)
+            pending_corps(entity).any? { |corp| can_convert?(corp) }
           end
 
           def can_convert?(entity)
             return false unless entity.type == :regional
             return false if @converted
-            return false unless entity.president?(current_entity)
 
             true
           end

--- a/lib/engine/game/g_18_oe/step/track.rb
+++ b/lib/engine/game/g_18_oe/step/track.rb
@@ -20,7 +20,7 @@ module Engine
           end
 
           def get_tile_lay(entity)
-            @game.class::TILE_POINT_BUDGET[entity.type] || 0
+            @game.tile_point_budget(entity)
           end
 
           def description

--- a/lib/engine/game/g_18_oe/step/track.rb
+++ b/lib/engine/game/g_18_oe/step/track.rb
@@ -16,14 +16,11 @@ module Engine
             points_available = get_tile_lay(entity) - @points_used
             return false unless points_available.positive?
 
-            entity.tokens.any?
+            !entity.tokens.empty?
           end
 
           def get_tile_lay(entity)
-            # 3 for minors and regionals, 6 for majors, 9 for nationals
-            return 3 if entity.total_shares == 2 || entity.total_shares == 4
-            return 6 if entity.total_shares == 10
-            # return 9 if national
+            @game.class::TILE_POINT_BUDGET[entity.type] || 0
           end
 
           def description

--- a/lib/engine/game/g_18_oe/step/waterfall_auction.rb
+++ b/lib/engine/game/g_18_oe/step/waterfall_auction.rb
@@ -27,8 +27,8 @@ module Engine
             super
             return unless @game.company_becomes_minor?(company)
 
-            price = @game.class::MINOR_MAX_TREASURY if price > @game.class::MINOR_MAX_TREASURY
-            @game.bank.spend(price, @game.corporations.find { |minor| minor.name == company.sym })
+            treasury_amount = [price, @game.class::MINOR_MAX_TREASURY].min
+            @game.bank.spend(treasury_amount, @game.corporations.find { |minor| minor.name == company.sym })
           end
         end
       end

--- a/lib/engine/game/g_18_oe/step/waterfall_auction.rb
+++ b/lib/engine/game/g_18_oe/step/waterfall_auction.rb
@@ -27,7 +27,7 @@ module Engine
             super
             return unless @game.company_becomes_minor?(company)
 
-            price = 180 if price > 180
+            price = @game.class::MINOR_MAX_TREASURY if price > @game.class::MINOR_MAX_TREASURY
             @game.bank.spend(price, @game.corporations.find { |minor| minor.name == company.sym })
           end
         end


### PR DESCRIPTION
## Summary

Nine fixes and refactors to 18OE that are safe to merge into upstream/master. Changes cover four real bugs, three coding-convention violations, one missing metadata activation, and one missing event text entry. No new game features; no changes to any other title.

---

## Items

### 1. `hex.coordinates` instead of `hex.name` / `hex.name.to_s`

`Hex#name` is not guaranteed to equal `Hex#coordinates` in all engine contexts. Two methods were comparing hex identity against hardcoded coordinate strings using `.name` / `.name.to_s`, which is fragile.

```ruby
# before
def metropolis_hex?(hex)
  %w[A56 B41 C74 F87 ...].include?(hex.name.to_s)
end

case from.hex.name
when 'K26', 'Y14', 'R55' then ...
end

# after
def metropolis_hex?(hex)
  %w[A56 B41 C74 F87 ...].include?(hex.coordinates)
end

case from.hex.coordinates
when 'K26', 'Y14', 'R55' then ...
end
```

---

### 2. Activate `GAME_PUBLISHER` and `GAME_INFO_URL` in meta.rb

Both constants were commented out with a placeholder URL copied from 18NY. Publisher is DICE (Designs in Color and Entertainment); correct URL confirmed with designer.

```ruby
# before
# GAME_PUBLISHER = :DICE
# GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18NY'

# after
GAME_PUBLISHER = :DICE
GAME_INFO_URL  = 'http://www.designsice.com/18OE.html'
```

---

### 3. Add `EVENTS_TEXT` entry for `consolidation_triggered`

The `consolidation_triggered` event fires when the first Level 5 train is bought (§5.1.5). Without an `EVENTS_TEXT` entry the UI shows a blank event description.

```ruby
EVENTS_TEXT = Base::EVENTS_TEXT.merge(
  'consolidation_triggered' => [
    'Consolidation Round',
    'Consolidation round follows at end of current OR set; minors and regionals must merge or be abandoned',
  ],
  ...
)
```

---

### 4. Fix consolidation round trigger timing (§5.1.5 bug)

**Bug:** `next_round!` triggered the consolidation round immediately after the first OR in a two-OR set, skipping OR2. §5.1.5 states the consolidation round follows the *complete* OR set.

```ruby
# before — fires after any OR
when Engine::Round::Operating
  @first_or_done = true
  if @consolidation_triggered && !@consolidation_done
    @log << '-- Consolidation Phase --'
    new_consolidation_round
  else
    super
  end

# after — waits for full OR set
when Engine::Round::Operating
  @first_or_complete = true
  if @round.round_num < @operating_rounds
    or_round_finished
    new_operating_round(@round.round_num + 1)
  elsif @consolidation_triggered && !@consolidation_complete
    @turn += 1
    or_round_finished
    or_set_finished
    @log << '-- Consolidation Phase --'
    new_consolidation_round
  else
    @turn += 1
    or_round_finished
    or_set_finished
    new_stock_round
  end
```

---

### 5. Add missing `regional_convertible?` to Consolidate step

`actions` called `can_convert_any?` with no arguments. `BuySellParShares` (parent class) defines `can_convert_any?(player)` requiring one argument — so the inherited method raises `ArgumentError` whenever the consolidation step is active. Fix: add the no-arg definition in `Consolidate` and rename it `regional_convertible?` to avoid shadowing the parent's different method.

```ruby
def regional_convertible?
  pending_corps(current_entity).any? { |corp| can_convert?(corp) }
end
```

---

### 6. Extract constants; fix `entity.type` in `get_tile_lay`; fix `!empty?` idiom

**a)** `TILE_POINT_BUDGET` and `MINOR_MAX_TREASURY` — replace magic numbers with named constants.

```ruby
TILE_POINT_BUDGET  = { minor: 3, regional: 3, major: 6, national: 9 }.freeze
MINOR_MAX_TREASURY = 180
```

**b)** `get_tile_lay` used `total_shares` count as a proxy for entity type — fragile if share counts change. Nationals were commented out entirely (returned `nil`, causing `NoMethodError` in `description`).

```ruby
# before
return 3 if entity.total_shares == 2 || entity.total_shares == 4
return 6 if entity.total_shares == 10
# return 9 if national

# after
@game.class::TILE_POINT_BUDGET[entity.type] || 0
```

**c)** `entity.tokens.any?` -> `!entity.tokens.empty?` — `any?` without a block allocates an enumerator.

**d)** `MINOR_MAX_TREASURY` in `WaterfallAuction#buy_company` replaces the magic number `180`.

---

### 7. Rename `_done` flags to `_complete`

`@consolidation_done` and `@first_or_done` — `_complete` is the idiomatic Ruby boolean flag convention.

```
@consolidation_done  ->  @consolidation_complete
@first_or_done       ->  @first_or_complete
```

---

### 8. Fix `operating_order` missing `floated?` filter (§10.1 bug)

**Bug:** `operating_order` included all `:major`/`:national` corporations regardless of float state. The base `Round::Operating#recalculate_order` calls `game.operating_order` directly mid-round (when a train purchase triggers a phase change). The G18OE `select_entities` override correctly filtered `floated?`, but `recalculate_order` bypassed the override, so an unfloated major could appear in the OR entity list after a mid-round phase change.

Fix: add `floated?` guard to `operating_order`. The G18OE `select_entities` override is then redundant and removed — the base class delegates correctly.

```ruby
# before
def operating_order
  @minor_regional_order + @corporations.select { |c| %i[major national].include?(c.type) }.sort
end

# after
def operating_order
  @minor_regional_order + @corporations.select { |c| %i[major national].include?(c.type) && c.floated? }.sort
end
```

---

### 9. Correct train supply counts to match §3.1 component totals

**Bug:** `num:` values for L3–L8 trains exceeded the physical component counts listed in §3.1.

| Train | §3.1 | Was | Now |
|-------|------|-----|-----|
| 3/3+3 | 20 | 24 | 20 |
| 4/4+4 | 10 | 14 | 10 |
| 5/5+5 | 8  | 11 | 8  |
| 6/6+6 | 6  | 9  | 6  |
| 7+7/4D| 14 | 17 | 14 |
| 8+8/5D| 8  | 11 | 8  |
