### PR TITLE
[1880 Romania] disable 1880's ferry_hexes

### DIFF
--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -343,6 +343,10 @@ module Engine
           stops.any? { |stop| stop.hex.assigned?(danube_port.id) } && route.corporation.owner == danube_port.owner
         end
 
+        def ferry_hexes
+          []
+        end
+
         # This game's Electroputere S.A. private company's forced train exchange is identical to the forced exchange for the
         # Rocket of China in 1880, so we can reuse that logic here rather than recoding the whole thing.
         def forced_exchange_rocket?


### PR DESCRIPTION
Fixes #12645

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

`revenue_for` calls super, but 1880's `revenue_for` subtracts 10 from routes that include F12 F14 J16, because of Ferry costs.

I defined ferry_hexes as [] for 1880 Romania now, issue resolved. 

### Screenshots

### Any Assumptions / Hacks
