### PR TITLE
[18Uruguay] Change currency marker from $U to $

### DIFF
--- a/lib/engine/game/g_18_uruguay/game.rb
+++ b/lib/engine/game/g_18_uruguay/game.rb
@@ -49,7 +49,7 @@ module Engine
         SELL_BUY_ORDER = :sell_buy
         SELL_AFTER = :p_any_operate
         TILE_RESERVATION_BLOCKS_OTHERS = true
-        CURRENCY_FORMAT_STR = '$U%d'
+        CURRENCY_FORMAT_STR = '$%d'
         HOME_TOKEN_TIMING = :float
 
         MUST_BUY_TRAIN = :always


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Uruguay usually just uses the dollar sign. The $U or U$ distinction is only used in financial papers to distinguish from USD, which isn't a concern here. 

The rulebook uses $, the physical components all use $, and $ is much cleaner to read than $U

### Screenshots

### Any Assumptions / Hacks
