### PR TITLE
[core] support unlimited bank

### DIFF
--- a/assets/app/view/game/bank.rb
+++ b/assets/app/view/game/bank.rb
@@ -31,12 +31,10 @@ module View
 
         trs = []
         interest_change = (@game.interest_change if @game.respond_to?(:interest_change))
-        if @game.game_end_check_values.include?(:bank)
-          trs << h(:tr, [
-            h(:td, 'Cash'),
-            h('td.right', @game.format_currency(@game.bank_cash)),
-          ])
-        end
+        trs << h(:tr, [
+          h(:td, 'Cash'),
+          h('td.right', @game.unlimited_bank? ? '∞' : @game.format_currency(@game.bank_cash)),
+        ])
         if (rate = @game.interest_rate)
           trs << h(:tr, [
             h(:td, 'Interest per Loan'),

--- a/assets/app/view/game/bank.rb
+++ b/assets/app/view/game/bank.rb
@@ -33,7 +33,7 @@ module View
         interest_change = (@game.interest_change if @game.respond_to?(:interest_change))
         trs << h(:tr, [
           h(:td, 'Cash'),
-          h('td.right', @game.unlimited_bank? ? '∞' : @game.format_currency(@game.bank_cash)),
+          h('td.right', @game.unlimited_bank? ? 'Unlimited' : @game.format_currency(@game.bank_cash)),
         ])
         if (rate = @game.interest_rate)
           trs << h(:tr, [

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2550,7 +2550,7 @@ module Engine
       end
 
       def init_bank_kwargs
-        { check: !unlimited_bank? && game_end_check_values.include?(:bank) }
+        { check: game_end_check_values.include?(:bank) }
       end
 
       def unlimited_bank?

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -2543,12 +2543,18 @@ module Engine
       end
 
       def bank_starting_cash
+        return 0 if unlimited_bank?
+
         cash = self.class::BANK_CASH
         cash.is_a?(Hash) ? cash[players.size] : cash
       end
 
       def init_bank_kwargs
-        { check: game_end_check_values.include?(:bank) }
+        { check: !unlimited_bank? && game_end_check_values.include?(:bank) }
+      end
+
+      def unlimited_bank?
+        self.class::BANK_CASH == :unlimited
       end
 
       def spenders

--- a/lib/engine/game/g_1817/game.rb
+++ b/lib/engine/game/g_1817/game.rb
@@ -17,7 +17,7 @@ module Engine
 
         CURRENCY_FORMAT_STR = '$%s'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = { 3 => 21, 4 => 16, 5 => 13, 6 => 11, 7 => 9, 8 => 8, 9 => 7, 10 => 6, 11 => 6, 12 => 5 }.freeze
 

--- a/lib/engine/game/g_1817_de/game.rb
+++ b/lib/engine/game/g_1817_de/game.rb
@@ -15,7 +15,7 @@ module Engine
 
         CURRENCY_FORMAT_STR = '%s ℳ'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = { 2 => 21, 3 => 16, 4 => 13, 5 => 11, 6 => 9 }.freeze
 

--- a/lib/engine/game/g_1817_na/game.rb
+++ b/lib/engine/game/g_1817_na/game.rb
@@ -15,7 +15,7 @@ module Engine
 
         CURRENCY_FORMAT_STR = '$%s'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = { 2 => 21, 3 => 16, 4 => 13, 5 => 11, 6 => 9 }.freeze
 

--- a/lib/engine/game/g_1817_wo/game.rb
+++ b/lib/engine/game/g_1817_wo/game.rb
@@ -18,7 +18,7 @@ module Engine
 
         CURRENCY_FORMAT_STR = '$%s'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = { 2 => 16, 3 => 13, 4 => 11, 5 => 9 }.freeze
 

--- a/lib/engine/game/g_1822_africa/game.rb
+++ b/lib/engine/game/g_1822_africa/game.rb
@@ -41,7 +41,7 @@ module Engine
 
         CURRENCY_FORMAT_STR = 'A%s'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         MARKET = [
           %w[40 50p 60xp 70xp 80xp 95m 115 140 170 205 250 300 350e 400e],

--- a/lib/engine/game/g_1828/game.rb
+++ b/lib/engine/game/g_1828/game.rb
@@ -20,7 +20,7 @@ module Engine
 
         CURRENCY_FORMAT_STR = '$%s'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = { 3 => 99, 4 => 99, 5 => 99 }.freeze
 

--- a/lib/engine/game/g_1840/game.rb
+++ b/lib/engine/game/g_1840/game.rb
@@ -19,7 +19,7 @@ module Engine
         SELL_BUY_ORDER = :sell_buy
         CURRENCY_FORMAT_STR = '%s'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = { 2 => 18, 3 => 16, 4 => 14, 5 => 13, 6 => 12 }.freeze
 

--- a/lib/engine/game/g_1866/game.rb
+++ b/lib/engine/game/g_1866/game.rb
@@ -36,7 +36,7 @@ module Engine
 
         BANKRUPTCY_ALLOWED = false
         CURRENCY_FORMAT_STR = '£%s'
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CAPITALIZATION = :incremental
 

--- a/lib/engine/game/g_1868_wy/game.rb
+++ b/lib/engine/game/g_1868_wy/game.rb
@@ -61,7 +61,7 @@ module Engine
                     :busters
 
         # overrides
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
         STARTING_CASH = { 2 => 1100, 3 => 734, 4 => 550, 5 => 440 }.freeze
         CERT_LIMIT = { 2 => 30, 3 => 20, 4 => 15, 5 => 12 }.freeze
         CAPITALIZATION = :incremental

--- a/lib/engine/game/g_1871/game.rb
+++ b/lib/engine/game/g_1871/game.rb
@@ -37,7 +37,7 @@ module Engine
 
         # Standard config
         ALLOW_TRAIN_BUY_FROM_OTHER_PLAYERS = true
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
         CAPITALIZATION = :full
         CERT_LIMIT = { 3 => 20, 4 => 16 }.freeze
         CURRENCY_FORMAT_STR = '$%s'

--- a/lib/engine/game/g_1873/game.rb
+++ b/lib/engine/game/g_1873/game.rb
@@ -25,7 +25,7 @@ module Engine
         attr_accessor :premium, :premium_order, :premium_winner, :reimbursed_hexes
 
         CURRENCY_FORMAT_STR = '%s ℳ'
-        BANK_CASH = 100_000
+        BANK_CASH = :unlimited
         CERT_LIMIT = {
           2 => 999,
           3 => 999,

--- a/lib/engine/game/g_1877/game.rb
+++ b/lib/engine/game/g_1877/game.rb
@@ -16,7 +16,7 @@ module Engine
 
         CURRENCY_FORMAT_STR = 'Bs.%s'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = { 2 => 21, 3 => 16, 4 => 13, 5 => 11, 6 => 9, 7 => 9 }.freeze
 

--- a/lib/engine/game/g_1877_stockholm_tramways/game.rb
+++ b/lib/engine/game/g_1877_stockholm_tramways/game.rb
@@ -26,7 +26,7 @@ module Engine
 
         CURRENCY_FORMAT_STR = '%skr'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = {
           3 => 16,

--- a/lib/engine/game/g_1880/game.rb
+++ b/lib/engine/game/g_1880/game.rb
@@ -42,7 +42,7 @@ module Engine
         EBUY_CAN_TAKE_PLAYER_LOAN = true
         MARKET_SHARE_LIMIT = 80 # percent
 
-        BANK_CASH = 37_860
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = { 3 => 20, 4 => 16, 5 => 14, 6 => 12, 7 => 11 }.freeze
 

--- a/lib/engine/game/g_1894/game.rb
+++ b/lib/engine/game/g_1894/game.rb
@@ -17,7 +17,7 @@ module Engine
 
         CURRENCY_FORMAT_STR = '%s F'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = { 3 => 18, 4 => 14 }.freeze
 

--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -17,7 +17,7 @@ module Engine
 
         CURRENCY_FORMAT_STR = '%s K'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = { 2 => 14, 3 => 14, 4 => 12, 5 => 10, 6 => 9 }.freeze
 

--- a/lib/engine/game/g_18_esp/game.rb
+++ b/lib/engine/game/g_18_esp/game.rb
@@ -23,7 +23,7 @@ module Engine
 
         CURRENCY_FORMAT_STR = '₧%d'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         IMPASSABLE_HEX_COLORS = %i[gray red blue orange].freeze
 

--- a/lib/engine/game/g_18_fr/game.rb
+++ b/lib/engine/game/g_18_fr/game.rb
@@ -18,7 +18,7 @@ module Engine
 
         CURRENCY_FORMAT_STR = '%s F'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = { 3 => 16, 4 => 12, 5 => 10, 6 => 8 }.freeze
 

--- a/lib/engine/game/g_18_gb/game.rb
+++ b/lib/engine/game/g_18_gb/game.rb
@@ -37,7 +37,7 @@ module Engine
 
         BANKRUPTCY_ALLOWED = false
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CURRENCY_FORMAT_STR = '£%s'
 

--- a/lib/engine/game/g_18_mag/game.rb
+++ b/lib/engine/game/g_18_mag/game.rb
@@ -15,7 +15,7 @@ module Engine
         attr_reader :tile_groups, :unused_tiles, :sik, :skev, :ldsteg, :mavag, :raba, :snw, :gc, :ciwl, :terrain_tokens
 
         CURRENCY_FORMAT_STR = '%s Ft'
-        BANK_CASH = 100_000
+        BANK_CASH = :unlimited
         CERT_LIMIT = {
           2 => 10,
           3 => 18,

--- a/lib/engine/game/g_18_norway/game.rb
+++ b/lib/engine/game/g_18_norway/game.rb
@@ -39,7 +39,7 @@ module Engine
 
         BANKRUPTCY_ENDS_GAME_AFTER = :one
 
-        BANK_CASH = 999_000
+        BANK_CASH = :unlimited
 
         CLOSED_CORP_RESERVATIONS_REMOVED = false
 

--- a/lib/engine/game/g_18_royal_gorge/game.rb
+++ b/lib/engine/game/g_18_royal_gorge/game.rb
@@ -21,7 +21,7 @@ module Engine
                     :treaty_of_boston, :hanging_bridge_lease_payment_due, :sf_debt
 
         CURRENCY_FORMAT_STR = '$%s'
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
         CERT_LIMIT = { 2 => 20, 3 => 14, 4 => 10 }.freeze
         STARTING_CASH = { 2 => 800, 3 => 550, 4 => 400 }.freeze
 

--- a/lib/engine/game/g_18_usa/game.rb
+++ b/lib/engine/game/g_18_usa/game.rb
@@ -21,7 +21,7 @@ module Engine
 
         CURRENCY_FORMAT_STR = '$%s'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = { 2 => 32, 3 => 21, 4 => 16, 5 => 16, 6 => 13, 7 => 11 }.freeze
 

--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -11,7 +11,7 @@ module Engine
       class Game < Game::Base
         CURRENCY_FORMAT_STR = '%s$N'
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = {
           2 => { '5' => 10, '7' => 12 },

--- a/lib/engine/game/g_22_mars/game.rb
+++ b/lib/engine/game/g_22_mars/game.rb
@@ -17,7 +17,7 @@ module Engine
 
         BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
         CURRENCY_FORMAT_STR = '%sc'
 
         STARTING_CASH = { 2 => 450, 3 => 300, 4 => 225, 5 => 180 }.freeze

--- a/lib/engine/game/g_steam_over_holland/game.rb
+++ b/lib/engine/game/g_steam_over_holland/game.rb
@@ -23,7 +23,7 @@ module Engine
         MUST_EMERGENCY_ISSUE_BEFORE_EBUY = true
         BANKRUPTCY_ALLOWED = false
 
-        BANK_CASH = 99_999
+        BANK_CASH = :unlimited
 
         CERT_LIMIT = { 2 => 18, 3 => 16, 4 => 14, 5 => 12 }.freeze
 


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

In the same way #1846 added support unlimited tiles and #12236 added support for unlimited trains, this will add support for games with an unlimited bank. 

In the change, I set the `bank_starting_cash` to zero if the bank is unlimited. Initially I set it to `return Float::INFINITY if unlimited_bank?`, but the problem there is that the  'all expected cash is accounted for' check in the fixtures_spec.rb file fails because it can't compare the starting and ending bank values. 

I decided to always display the bank in The Bank section Market and Spreadsheet tabs, since I've definitely spent a minute hunting for the bank info in games when I forgot it was unlimited. With this change, any game with an unlimited bank will simply show Cash: ∞ in that field rather than rendering the actual amount. 

If this is approved, I can add a commit with changes to all the relevant games before we merge it in. I already checked rake on that as well, and it passed. 

### Screenshots

Example on the Market page: 

<img width="373" height="302" alt="image" src="https://github.com/user-attachments/assets/39ffacb8-2cab-4dbc-8974-46812d83744b" />

Spreadsheet page: 

<img width="454" height="261" alt="image" src="https://github.com/user-attachments/assets/6b338528-7c0c-47e8-a380-6121c165da59" />

Even in a game like 1817, it just adds one line: 

<img width="411" height="519" alt="image" src="https://github.com/user-attachments/assets/bd691cb8-2a7c-455b-b443-15239a0011f9" />


### Any Assumptions / Hacks
