### PR TITLE
[18CZ] fix timeline display for last set

### DIFF
--- a/lib/engine/game/g_18_cz/game.rb
+++ b/lib/engine/game/g_18_cz/game.rb
@@ -318,7 +318,14 @@ module Engine
           ]
           @timeline.append("Game ends after OR #{OR_SETS.size}.#{OR_SETS.last}")
           @timeline.append("Current value of each private company is #{COMPANY_VALUES[[0, @or - 1].max]}")
-          @timeline.append("Next set of Operating Rounds will have #{OR_SETS[@turn - 1]} ORs")
+          next_ors = case @round
+                     when Engine::Round::Stock
+                       OR_SETS[@turn - 1]
+                     when Engine::Round::Operating
+                       OR_SETS[@turn]
+                     end
+          @timeline.append("Next set of Operating Rounds will have #{next_ors} OR#{'s' if next_ors > 1}") if next_ors
+          @timeline
         end
 
         def able_to_operate?(entity, _train, name)


### PR DESCRIPTION
Fixes #9828

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Corrects calculation for the Timeline to show the correct number of ORs in the next set. Also sets OR to singular when there is only one, and removes that entry entirely in the final set. 

### Screenshots

### Any Assumptions / Hacks
