### PR TITLE
[Core] - Add :invisible track type to path traversal and renderer, for use by 2038.

### DIFF
--- a/assets/app/view/game/part/track.rb
+++ b/assets/app/view/game/part/track.rb
@@ -40,6 +40,11 @@ module View
             width: 6,
             dash: '9 3',
           },
+          invisible: {
+            color: 'none',
+            width: 0,
+            dash: '0',
+          },
         }.freeze
 
         # width here is added to track width
@@ -87,6 +92,9 @@ module View
           },
           dual: {
             width: 8,
+          },
+          invisible: {
+            width: 0,
           },
         }.freeze
 

--- a/lib/engine/part/path.rb
+++ b/lib/engine/part/path.rb
@@ -10,7 +10,7 @@ module Engine
       attr_accessor :ignore_gauge_walk, :ignore_gauge_compare
 
       LANES = [[1, 0].freeze, [1, 0].freeze].freeze
-      MATCHES_BROAD = %i[broad dual].freeze
+      MATCHES_BROAD = %i[broad dual invisible].freeze
       MATCHES_NARROW = %i[narrow dual].freeze
       LANE_INDEX = 1
       LANE_WIDTH = 0
@@ -89,6 +89,8 @@ module Engine
           MATCHES_NARROW.include?(other_track)
         when :dual
           dual_ok || other_track == :dual
+        when :invisible
+          true
         end
       end
 


### PR DESCRIPTION
Adds a new :invisible track type that can be traversed by all train types when building routes. Invisible paths allow hex-to-hex movement without visible track on the map, needed for spaceship-based games where routes are not constrained to laid track.

- Add :invisible to MATCHES_BROAD so broad-gauge trains enter invisible paths
- Add when :invisible case to tracks_match? returning true (connects to all types)
- Add :invisible entry to TRACK and MULTI_PATH in the renderer so that TRACK[:invisible] returns a valid hash (color: none, width: 0) instead of nil, preventing a crash when invisible paths are present on a tile


