### PR TITLE
[core] Move zoom controls above map to prevent obscuring map content

### DIFF
--- a/assets/app/view/game/map.rb
+++ b/assets/app/view/game/map.rb
@@ -82,7 +82,7 @@ module View
         end
         @hexes.compact!
 
-        children = [render_map, h(MapZoom, map_zoom: map_zoom)]
+        children = [render_map]
 
         if current_entity && @tile_selector
           left = (@tile_selector.x + map_x) * @scale
@@ -150,7 +150,7 @@ module View
           },
         }
 
-        map_elements = [h(:div, props, children), h(MapControls)]
+        map_elements = [h(MapZoom, map_zoom: map_zoom), h(:div, props, children), h(MapControls)]
         map_elements << h(MapLegend, game: @game) if @game.show_map_legend? && !@game.show_map_legend_on_left?
 
         h(:div, { style: { marginBottom: '1rem' } }, map_elements)

--- a/assets/app/view/game/map_zoom.rb
+++ b/assets/app/view/game/map_zoom.rb
@@ -24,7 +24,7 @@ module View
             display: 'inline-block',
             padding: '0 2px 2px 0',
             borderRadius: '5px',
-            marginBottom: '2px',
+            marginTop: '8px',
           },
         }
 

--- a/assets/app/view/game/map_zoom.rb
+++ b/assets/app/view/game/map_zoom.rb
@@ -21,11 +21,10 @@ module View
         props = {
           style: {
             background: color_for(:bg),
-            position: 'absolute',
-            left: '0',
-            top: '0',
+            display: 'inline-block',
             padding: '0 2px 2px 0',
             borderRadius: '5px',
+            marginBottom: '2px',
           },
         }
 


### PR DESCRIPTION
Fixes #12653

The zoom control (−, 0, +) was rendered with position: absolute; left: 0; top: 0 inside the scrollable map container, causing it to sit directly on top of the upper-left corner of the map. This obscured the first axis labels (column 1, 2) and any map hexes drawn near the upper-left corner.

This PR lifts the zoom widget out of the scrollable map container and renders it in a thin strip just above the map, flush left. The visual location is nearly identical — still top-left of the map area — but the buttons no longer overlap any map content.

Changes:

assets/app/view/game/map.rb: render MapZoom above the scrollable map div rather than inside it
assets/app/view/game/map_zoom.rb: replace position: absolute with display: inline-block and a 2px bottom margin

<img width="443" height="453" alt="image" src="https://github.com/user-attachments/assets/cebea94f-3df8-4352-9d83-849f8feb2dd6" />


