### PR TITLE
fix(view): guard nil train owner in buy_trains view

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -191,7 +191,7 @@ module View
         @depot = @game.depot
 
         available = @step.buyable_trains(@corporation).group_by(&:owner)
-        depot_trains = available.delete(@depot) || []
+        depot_trains = (available.delete(@depot) || []) + (available.delete(nil) || [])
         other_corp_trains = available.sort_by { |c, _| corp_owner(c) == corp_owner(@corporation) ? 0 : 1 }
         children = []
 
@@ -581,6 +581,7 @@ module View
       end
 
       def corp_owner(corp)
+        return nil unless corp
         @step.respond_to?(:corp_owner) ? @step.corp_owner(corp) : corp.owner
       end
 


### PR DESCRIPTION
## Summary

`BuyTrains#render` groups available trains by owner with `group_by(&:owner)`. If a step's `buyable_trains` returns any train with `owner == nil`, the resulting hash has a `nil` key. After `available.delete(@depot)` the nil key survives, and the `sort_by` call reaches `corp_owner(nil)` → `nil.owner` → crash.

Two guards added:

- **`available.delete(nil)`** — routes nil-owner trains into `depot_trains` rather than `other_corp_trains`. Semantically correct: trains with no corporate owner are bank/depot items, not trains belonging to another corporation.
- **`corp_owner` nil guard** — `return nil unless corp` as defensive fallback for any remaining path.

## Why this is needed for 18OE

18OE introduces National Railroads with option to claim already-rusted trains from the depot for free (§1.3 of the 18OE rules). Those rusted trains have `owner == nil` — set by the standard `base.rb` rust event. The 18OE `BuyTrain` step exposes them via a `buyable_trains` override:

```ruby
# g_18_oe/step/buy_train.rb
def buyable_trains(entity)
  return unclaimed_rusted_trains if entity.type == :national
  super
end

def unclaimed_rusted_trains
  @game.depot.trains.select { |t| t.rusted && t.owner.nil? }
end
```

Without this fix, loading any 18OE game where a national has reached its operating turn crashes the buy-trains view with `undefined method 'owner' for nil`.

## Why other games are not affected

The standard `Depot#other_trains` already excludes nil-owner trains at the source:

```ruby
# lib/engine/depot.rb
all_others = @trains.reject do |train|
  !train.buyable(...) || [corporation, self, nil].include?(train.owner)
end
```

Every game that calls `super` in `buyable_trains` is safe. The only games that set `train.owner = nil` outside the rust event are **G1840** and **G18CZ**, but both first call `remove_train(train)` which removes the train from the available pool entirely — nil-owner trains there are unreachable via `buyable_trains`.

18OE is the only game that deliberately surfaces nil-owner trains through `buyable_trains`. The fix is nonetheless general and correct: a nil owner is not a corporation, so the train belongs in the depot section of the UI, not the per-corporation section.

