### PR TITLE
[Core] Fall-back handling of excessive discounts

### DIFF
--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1748,9 +1748,11 @@ module Engine
         end
 
         discount = abilities.sum { |a| a.discounts_tile?(tile) ? a.discount : 0 }
+        sum_cost = tile.upgrades.sum(&:cost)
+        discount = [sum_cost, discount].min # In case discount exceeds total cost
         log_cost_discount(spender, abilities, discount)
 
-        tile.upgrades.sum(&:cost) - discount
+        sum_cost - discount
       end
 
       def tile_cost_with_discount(_tile, hex, entity, spender, cost)

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -240,6 +240,11 @@ module Engine
       end
 
       def pay_tile_cost!(entity_or_entities, tile, rotation, hex, spender, cost, _extra_cost)
+        if cost.negative?
+          cost = 0
+          @log << "Discounts exceed cost for tile lay, so cost reduced to zero for #{spender.name}."
+        end
+
         # entity_or_entities is an array when combining private company abilities
         entities = Array(entity_or_entities)
         entity, *_combo_entities = entities

--- a/lib/engine/step/tracker.rb
+++ b/lib/engine/step/tracker.rb
@@ -240,11 +240,6 @@ module Engine
       end
 
       def pay_tile_cost!(entity_or_entities, tile, rotation, hex, spender, cost, _extra_cost)
-        if cost.negative?
-          cost = 0
-          @log << "Discounts exceed cost for tile lay, so cost reduced to zero for #{spender.name}."
-        end
-
         # entity_or_entities is an array when combining private company abilities
         entities = Array(entity_or_entities)
         entity, *_combo_entities = entities


### PR DESCRIPTION
During development of an 1880 Romania variant I encountered a case where a log appeared with negative payment.
This turned out to be a case where discounts exceeded cost.

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

This should not break any game, but in case it does I believe games are broken. So pin or archive if any games do appear broken due to this bug fix.

## Implementation Notes

I chose to make the change in the pay method. Possibly one could have checked the callers but this catches any faulty cost.

### Explanation of Change

Negative costs should not exists. They should be a bonus if they are, and also should not be logged as negative pay.

### Screenshots

In the hot seat game I was trying the TR corporation laid two yellow tiles.
First on a hex with 40 terrain (mountain), and then on a hex with 10 terrain (hill).
TR do have 10 + 20 discount for mountain terrain.

Here is the log before the fix:

<img width="512" height="129" alt="image" src="https://github.com/user-attachments/assets/4bd221bd-43fd-40e5-92d8-7e89b9813732" />

As can be seen discount is 30. When cost is 40 TR get to pay 10. But when cost is 10 TR
pays -20, in other words receives 20 money.

And here is the same log after the fix ((image below is after update after review comment)):

<img width="507" height="99" alt="image" src="https://github.com/user-attachments/assets/6d292662-3234-455e-9710-f7c907dcc43e" />

Discount is automatically adjusted to avoid negative costs.

### Any Assumptions / Hacks

Assumption is that no game uses negative cost to receive money. It looks strange in the log so that should have been reported.