### PR TITLE
[core] - Autobid engine updates

### DIFF
--- a/assets/app/view/game/auto.rb
+++ b/assets/app/view/game/auto.rb
@@ -24,8 +24,11 @@ module View
         children = [
           h(:h2, 'What are Auto Actions?'),
           h(:p, "You can pre-program share purchases and passes during #{@game.stock_round_name}s."),
-          *(@game.available_programmed_actions.include?(Engine::Action::ProgramAuctionBid) ?
-            [h(:p, 'You can pre-program bids during auctions.')] : []),
+          *(if @game.available_programmed_actions.include?(Engine::Action::ProgramAuctionBid)
+              [h(:p, 'You can pre-program bids during auctions.')]
+            else
+              []
+            end),
           h(:p, 'Deactivates when players take actions that may affect you (e.g. shares are sold).'),
           h('p.bold', 'Your Auto Actions are not secret from other players.'),
           h(:p, render_wiki),

--- a/assets/app/view/game/auto.rb
+++ b/assets/app/view/game/auto.rb
@@ -24,6 +24,8 @@ module View
         children = [
           h(:h2, 'What are Auto Actions?'),
           h(:p, "You can pre-program share purchases and passes during #{@game.stock_round_name}s."),
+          *(@game.available_programmed_actions.include?(Engine::Action::ProgramAuctionBid) ?
+            [h(:p, 'You can pre-program bids during auctions.')] : []),
           h(:p, 'Deactivates when players take actions that may affect you (e.g. shares are sold).'),
           h('p.bold', 'Your Auto Actions are not secret from other players.'),
           h(:p, render_wiki),

--- a/assets/app/view/game/auto_action/auction_bid.rb
+++ b/assets/app/view/game/auto_action/auction_bid.rb
@@ -6,16 +6,19 @@ module View
   module Game
     module AutoAction
       class AuctionBid < Base
-        needs :bid_target, store: true, default: nil
-
         def name
           "Auto bid in Auction Round#{' (Enabled)' if @settings}"
         end
 
         def description
-          'Automatically bid, buy or pass in the auction round. '\
-            'Bids increase by the minimum increment. '\
-            'Buys only when the current price matches your specified price.'
+          if step.programmable_buy_price?
+            'Automatically bid, buy or pass in the auction round. '\
+              'Bids increase by the minimum increment. '\
+              'Buys only when the current price matches your specified price.'
+          else
+            'Automatically bid or pass in the auction round. '\
+              'Bids increase by the minimum increment.'
+          end
         end
 
         def render
@@ -23,13 +26,18 @@ module View
 
           form = {}
 
-          children = [h(:h3, name), h(:p, description), h(:div, [render_entity_selector(form)])]
+          children = [h(:h3, name), h(:p, description)]
+
+          unless selected
+            children << h('p.italic', 'No entity currently up for auction.')
+            return children
+          end
 
           children << h(Corporation, corporation: selected) if selected&.corporation? || selected&.minor?
           children << h(Company, company: selected) if selected&.company?
 
           children << h(:div, [render_enable_maximum_bid(form), render_maximum_bid(form)])
-          children << h(:div, [render_enable_buy_price(form), render_buy_price(form)])
+          children << h(:div, [render_enable_buy_price(form), render_buy_price(form)]) if step.programmable_buy_price?
           children << h(:div, [render_auto_pass(form)])
 
           subchildren = [render_button(@settings ? 'Update' : 'Enable') { enable(form) }]
@@ -37,20 +45,6 @@ module View
           children << h(:div, subchildren)
 
           children
-        end
-
-        def render_entity_selector(form)
-          bid_target_change = lambda do
-            target = Native(form[:bid_target]).elm&.value
-            bid_target = @game.corporation_by_id(target) || @game.company_by_id(target) || @game.minor_by_id(target)
-            store(:bid_target, bid_target)
-          end
-
-          render_input('Bid Target',
-                       id: 'bid_target',
-                       el: 'select',
-                       on: { input: bid_target_change },
-                       children: values, inputs: form)
         end
 
         def render_enable_maximum_bid(form)
@@ -77,7 +71,8 @@ module View
                          value: value,
                          step: step.min_increment,
                          min: step.min_bid(selected),
-                       })
+                       }.compact,
+                       input_style: { width: '4.25rem' })
         end
 
         def render_enable_buy_price(form)
@@ -112,38 +107,30 @@ module View
 
         def render_auto_pass(form)
           checked = selected == @settings&.bid_target ? !!@settings&.auto_pass_after : false
+          label = step.programmable_buy_price? ? 'Pass after max bid reached / buy price impossible' \
+                                               : 'Pass after max bid reached'
 
-          render_checkbox('Pass after max bid reached / buy price impossible  ',
-                          'auto_pass_after',
-                          form,
-                          checked)
+          render_checkbox(label, 'auto_pass_after', form, checked)
         end
 
         def enable(form)
           @settings = params(form)
 
-          bid_target = @game.corporation_by_id(@settings['bid_target']) ||
-                        @game.company_by_id(@settings['bid_target']) ||
-                        @game.minor_by_id(@settings['bid_target'])
-
-          checked = @settings['enable_buy_price'] || @settings['enable_maximum_bid'] || @settings['auto_pass_after']
+          checked = (step.programmable_buy_price? && @settings['enable_buy_price']) ||
+                    @settings['enable_maximum_bid'] || @settings['auto_pass_after']
           return unless checked
 
           process_action(
             Engine::Action::ProgramAuctionBid.new(
               @sender,
-              bid_target: bid_target,
+              bid_target: selected,
               enable_maximum_bid: @settings['enable_maximum_bid'],
-              maximum_bid: @settings['maximum_bid'],
+              maximum_bid: @settings['maximum_bid'] || 0,
               enable_buy_price: @settings['enable_buy_price'],
-              buy_price: @settings['buy_price'],
+              buy_price: @settings['buy_price'] || 0,
               auto_pass_after: @settings['auto_pass_after'],
             )
           )
-        end
-
-        def available_targets
-          step.available
         end
 
         def step
@@ -151,15 +138,7 @@ module View
         end
 
         def selected
-          @bid_target || @settings&.bid_target || available_targets.first
-        end
-
-        def values
-          available_targets.map do |entity|
-            attrs = { value: entity.id }
-            attrs[:selected] = true if selected == entity
-            h(:option, { attrs: attrs }, entity.name)
-          end
+          step.auctioning || @settings&.bid_target
         end
       end
     end

--- a/assets/app/view/game/auto_action/auction_bid.rb
+++ b/assets/app/view/game/auto_action/auction_bid.rb
@@ -33,6 +33,11 @@ module View
             return children
           end
 
+          if step.respond_to?(:auction_participant?) && !step.auction_participant?(@sender)
+            children << h('p.italic', 'You do not have a bid in this auction.')
+            return children
+          end
+
           children << h(Corporation, corporation: selected) if selected&.corporation? || selected&.minor?
           children << h(Company, company: selected) if selected&.company?
 
@@ -107,8 +112,11 @@ module View
 
         def render_auto_pass(form)
           checked = selected == @settings&.bid_target ? !!@settings&.auto_pass_after : false
-          label = step.programmable_buy_price? ? 'Pass after max bid reached / buy price impossible' \
-                                               : 'Pass after max bid reached'
+          label = if step.programmable_buy_price?
+                    'Pass after max bid reached / buy price impossible'
+                  else
+                    'Pass after max bid reached'
+                  end
 
           render_checkbox(label, 'auto_pass_after', form, checked)
         end

--- a/lib/engine/game/g_18_eu/step/modified_dutch_auction.rb
+++ b/lib/engine/game/g_18_eu/step/modified_dutch_auction.rb
@@ -142,6 +142,10 @@ module Engine
             @current_reduction.positive?
           end
 
+          def programmable_buy_price?
+            true
+          end
+
           def may_choose?(_entity)
             !@auctioning
           end

--- a/lib/engine/round/base.rb
+++ b/lib/engine/round/base.rb
@@ -174,7 +174,8 @@ module Engine
       end
 
       def auto_actions
-        active_step(current_entity)&.auto_actions(current_entity)
+        step = active_step
+        step&.auto_actions(step.current_entity)
       end
 
       def finished?

--- a/lib/engine/step/programmer_auction_bid.rb
+++ b/lib/engine/step/programmer_auction_bid.rb
@@ -89,6 +89,10 @@ module Engine
       def auto_bid_on_empty?(_entity, program)
         program.enable_buy_price
       end
+
+      def programmable_buy_price?
+        true
+      end
     end
   end
 end

--- a/lib/engine/step/programmer_auction_bid.rb
+++ b/lib/engine/step/programmer_auction_bid.rb
@@ -91,7 +91,7 @@ module Engine
       end
 
       def programmable_buy_price?
-        true
+        false
       end
     end
   end

--- a/lib/engine/step/selection_auction.rb
+++ b/lib/engine/step/selection_auction.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative 'base'
+require_relative 'programmer_auction_bid'
 
 module Engine
   module Step
     class SelectionAuction < Base
       include Engine::Step::PassableAuction
+      include Engine::Step::ProgrammerAuctionBid
       ACTIONS = %w[bid pass].freeze
 
       attr_reader :companies
@@ -119,6 +121,14 @@ module Engine
 
       def max_bid(player, _company)
         player.cash
+      end
+
+      def auto_requires_auctioning?(_entity, program)
+        @auctioning && program.bid_target != @auctioning
+      end
+
+      def programmable_buy_price?
+        false
       end
 
       protected

--- a/lib/engine/step/waterfall_auction.rb
+++ b/lib/engine/step/waterfall_auction.rb
@@ -91,6 +91,10 @@ module Engine
         company && company == @companies.first
       end
 
+      def programmable_buy_price?
+        false
+      end
+
       def committed_cash(player, _show_hidden = false)
         bids_for_player(player).sum(&:price)
       end

--- a/lib/engine/step/waterfall_auction.rb
+++ b/lib/engine/step/waterfall_auction.rb
@@ -91,8 +91,10 @@ module Engine
         company && company == @companies.first
       end
 
-      def programmable_buy_price?
-        false
+      def auction_participant?(player)
+        return true unless auctioning
+
+        current_bid_amount(player, auctioning).positive?
       end
 
       def committed_cash(player, _show_hidden = false)


### PR DESCRIPTION
Partially addresses #12403

## Summary

The engine already had a complete autobid mechanism for auction rounds (`ProgrammerAuctionBid`, `Action::ProgramAuctionBid`, `AuctionBid` view) — 18EU was the only game using it, via its `ModifiedDutchAuction` step. This PR extends that mechanism to `Engine::Step::SelectionAuction` so all games that use it inherit auto-bid support with no per-game code required.

- **`Engine::Step::SelectionAuction`** — add `require` + `include ProgrammerAuctionBid`, plus `auto_requires_auctioning?` (deactivates the program when a different company comes up) and `programmable_buy_price? false` (no dutch buy-price for selection auctions)
- **`ProgrammerAuctionBid`** — add `programmable_buy_price?` defaulting to `false`; only dutch-auction steps opt in with `true`
- **`G18EU::Step::ModifiedDutchAuction`** — add `programmable_buy_price? true` to opt in, since 18EU's price-drop mechanic is the only case where a buy price is meaningful
- **`Engine::Step::WaterfallAuction`** — add `auction_participant?(player)` returning false when an auction is active and the player has no existing bid; prevents the autobid panel from showing to ineligible players
- **`Engine::Round::Base#auto_actions`** — fix to call `step.current_entity` instead of `round.current_entity` so auto-bid chains correctly in passable auctions where `@active_bidders` rotates independently of `@entity_index`
- **`AuctionBid` view** — rewrite to use `step.auctioning` as the bid target (removes the dropdown); show contextual messages when no entity is up for auction or the player is not a participant; conditionally show buy price controls and adjust label text based on `programmable_buy_price?`
- **`Auto` view** — add a note that auction auto-actions are available when in an auction round

## Tested

| Game | Result |
|------|--------|
| 18EU | Max bid, buy price, auto-pass, and dutch price drop all verified. Regression check passed. |
| 18MT | Max bid and auto-pass verified. Buy price controls correctly hidden. Non-participating players correctly excluded from waterfall auction panel. |

## Notes

Per-game PRs to follow for games using a custom `SelectionAuction` subclass (~10 lines each). Games using `Engine::Step::SelectionAuction` directly only need `available_programmed_actions` wired up. Known waterfall auction display issues (panel appearing between auctions) are deferred to a follow-up PR.

Presently, only 18EU and for some reason 18MT had the hooks to use autobid.  18EU actually implemented it, 18MT did not but it was wired to do so once we updated the engine.  

Assuming this update is approved, I can start rolling this feature out to other games that would benefit from it.  I propose to start with games where users select assets to be auctioned (e.g. 1817, 18USA) and then move to games like 1861/67 and 1880 that run auctions in a set order, then move to the waterfall auctions.  This feature doesn't make much sense to implement in games that don't use immediate auctions (e.g. 1822, 1846, 18VA). 

## Test plan

- [x ] Start an 18EU game and verify max bid, buy price, and auto-pass all function correctly
- [x ] Start an 18MT game and verify: buy price controls are absent, only bidders see the panel during a waterfall auction, max bid and auto-pass function correctly
- [ x] Verify the Auto tab description updates appropriately for auction vs. non-auction games

🤖 Generated with [Claude Code](https://claude.com/claude-code)
