### PR TITLE
[18OE] - Centered Double Towns - Layout and Routing

### DIFF
--- a/TILES.md
+++ b/TILES.md
@@ -135,6 +135,10 @@ Towns, cities, and offboards have a few "sub parts" in common:
     - `dot` - default when 0 or 3+ paths connect to the town
     - `hidden` - don't show at all, useful for special offboards that count as
       towns instead of cities; construct with a hidden town and `terminal` paths
+- **size** - integer (default: `1`) - number of scoring slots in the town.
+  `size:2` renders as an oval containing two dots and counts as two stops when
+  computing route revenue, allowing trains to score the town once or twice
+  depending on the train's remaining pay slots. Used by 18OE double-town tiles.
 
 #### Lanes
 

--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -153,16 +153,7 @@ module View
             raise NotImplementedError, "Unsupported town size: #{@town.size}"
           end
 
-          unless @town.solo?
-            if @town.size > 1
-              [-TWO_DOT_OFFSET, TWO_DOT_OFFSET].each do |dx|
-                children << h(HitBox, click: -> { touch_node(@town) },
-                               transform: "#{translate} translate(#{dx} 0)", r: 18)
-              end
-            else
-              children << h(HitBox, click: -> { touch_node(@town) }, transform: translate)
-            end
-          end
+          children << h(HitBox, click: -> { touch_node(@town) }, transform: translate) unless @town.solo?
           h(:g, { key: "#{@town.id}-d" }, children)
         end
 

--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -20,6 +20,7 @@ module View
         REVENUE_DISPLACEMENT = 42
         REVENUE_EDGE_DISPLACEMENT = 25
         REVENUE_ANGLE = -60
+        DOUBLE_DOT_OFFSET = 12
 
         REVENUE_REGIONS = {
           flat: [9, 16],
@@ -109,25 +110,68 @@ module View
 
         def render_part
           radius = 10 * (0.8 + (@width.to_i / 40))
-
-          dot_attrs = {
-            transform: translate.to_s,
-            r: radius,
-            fill: (@town.halt? ? 'gray' : @color),
-            stroke: (@town.halt? ? @color : 'white'),
-            'stroke-width': 4,
-          }
+          fill = @town.halt? ? 'gray' : @color
+          stroke = @town.halt? ? @color : 'white'
 
           children = []
 
-          children << h(:circle, attrs: dot_attrs)
-          children << render_boom if @town.boom
-
-          if @show_revenue && (rendered = render_revenue)
-            children << rendered
+          if @town.size > 1
+            children << h(:ellipse, attrs: {
+                            transform: translate.to_s,
+                            rx: DOUBLE_DOT_OFFSET + radius + 4,
+                            ry: radius + 3,
+                            fill: 'white',
+                            stroke: @color,
+                            'stroke-width': 2,
+                          })
+            [-DOUBLE_DOT_OFFSET, DOUBLE_DOT_OFFSET].each do |dx|
+              children << h(:circle, attrs: {
+                              transform: "#{translate} translate(#{dx} 0)",
+                              r: radius,
+                              fill: fill,
+                              stroke: stroke,
+                              'stroke-width': 4,
+                            })
+            end
+            children.concat(render_revenue_double) if @show_revenue
+          else
+            children << h(:circle, attrs: {
+                            transform: translate.to_s,
+                            r: radius,
+                            fill: fill,
+                            stroke: stroke,
+                            'stroke-width': 4,
+                          })
+            children << render_boom if @town.boom
+            if @show_revenue && (rendered = render_revenue)
+              children << rendered
+            end
           end
+
           children << h(HitBox, click: -> { touch_node(@town) }, transform: translate) unless @town.solo?
           h(:g, { key: "#{@town.id}-d" }, children)
+        end
+
+        def render_revenue_double
+          revenues = @town.uniq_revenues
+          return [] if revenues.size > 1
+
+          revenue = revenues.first
+          return [] if revenue.zero?
+
+          x = render_location[:x]
+          y = render_location[:y]
+
+          increment_weight_for_regions(REVENUE_REGIONS[layout])
+
+          [-REVENUE_DISPLACEMENT, REVENUE_DISPLACEMENT].map.with_index do |dx, i|
+            h(:g, {
+                key: "#{@town.id}-r#{i}",
+                attrs: { transform: "translate(#{(x + dx).round(2)} #{y.round(2)})" },
+              }, [
+              h(Part::SingleRevenue, revenue: revenue, transform: rotation_for_layout),
+            ])
+          end
         end
 
         def render_boom(transform: nil)

--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -153,7 +153,16 @@ module View
             raise NotImplementedError, "Unsupported town size: #{@town.size}"
           end
 
-          children << h(HitBox, click: -> { touch_node(@town) }, transform: translate) unless @town.solo?
+          unless @town.solo?
+            if @town.size > 1
+              [-TWO_DOT_OFFSET, TWO_DOT_OFFSET].each do |dx|
+                children << h(HitBox, click: -> { touch_node(@town) },
+                               transform: "#{translate} translate(#{dx} 0)", r: 18)
+              end
+            else
+              children << h(HitBox, click: -> { touch_node(@town) }, transform: translate)
+            end
+          end
           h(:g, { key: "#{@town.id}-d" }, children)
         end
 

--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -116,45 +116,56 @@ module View
           children = []
 
           case @town.size
-          when 2
-            children << h(:ellipse, attrs: {
-                            transform: translate.to_s,
-                            rx: TWO_DOT_OFFSET + radius + 4,
-                            ry: radius + 3,
-                            fill: 'white',
-                            stroke: @color,
-                            'stroke-width': 2,
-                          })
-            [-TWO_DOT_OFFSET, TWO_DOT_OFFSET].each do |dx|
-              children << h(:circle, attrs: {
-                              transform: "#{translate} translate(#{dx} 0)",
-                              r: radius,
-                              fill: fill,
-                              stroke: stroke,
-                              'stroke-width': 4,
-                            })
-            end
-            if @show_revenue && !(rendered = render_revenue_size2).empty?
-              children.concat(rendered)
-            end
-          when 1
-            children << h(:circle, attrs: {
-                            transform: translate.to_s,
-                            r: radius,
-                            fill: fill,
-                            stroke: stroke,
-                            'stroke-width': 4,
-                          })
-            children << render_boom if @town.boom
-            if @show_revenue && (rendered = render_revenue)
-              children << rendered
-            end
-          else
-            raise NotImplementedError, "Unsupported town size: #{@town.size}"
+          when 2 then children.concat(render_double_town(radius, fill, stroke))
+          when 1 then children.concat(render_single_town(radius, fill, stroke))
+          else raise NotImplementedError, "Unsupported town size: #{@town.size}"
           end
 
           children << h(HitBox, click: -> { touch_node(@town) }, transform: translate) unless @town.solo?
           h(:g, { key: "#{@town.id}-d" }, children)
+        end
+
+        def render_double_town(radius, fill, stroke)
+          result = []
+          result << h(:ellipse, attrs: {
+                        transform: translate.to_s,
+                        rx: TWO_DOT_OFFSET + radius + 4,
+                        ry: radius + 3,
+                        fill: 'white',
+                        stroke: @color,
+                        'stroke-width': 2,
+                      })
+          [-TWO_DOT_OFFSET, TWO_DOT_OFFSET].each do |dx|
+            result << h(:circle, attrs: {
+                          transform: "#{translate} translate(#{dx} 0)",
+                          r: radius,
+                          fill: fill,
+                          stroke: stroke,
+                          'stroke-width': 4,
+                        })
+          end
+          if @show_revenue
+            rev = render_revenue_size2
+            result.concat(rev) unless rev.empty?
+          end
+          result
+        end
+
+        def render_single_town(radius, fill, stroke)
+          result = []
+          result << h(:circle, attrs: {
+                        transform: translate.to_s,
+                        r: radius,
+                        fill: fill,
+                        stroke: stroke,
+                        'stroke-width': 4,
+                      })
+          result << render_boom if @town.boom
+          if @show_revenue
+            rev = render_revenue
+            result << rev if rev
+          end
+          result
         end
 
         def render_revenue_size2

--- a/assets/app/view/game/part/town_dot.rb
+++ b/assets/app/view/game/part/town_dot.rb
@@ -20,7 +20,7 @@ module View
         REVENUE_DISPLACEMENT = 42
         REVENUE_EDGE_DISPLACEMENT = 25
         REVENUE_ANGLE = -60
-        DOUBLE_DOT_OFFSET = 12
+        TWO_DOT_OFFSET = 12
 
         REVENUE_REGIONS = {
           flat: [9, 16],
@@ -115,16 +115,17 @@ module View
 
           children = []
 
-          if @town.size > 1
+          case @town.size
+          when 2
             children << h(:ellipse, attrs: {
                             transform: translate.to_s,
-                            rx: DOUBLE_DOT_OFFSET + radius + 4,
+                            rx: TWO_DOT_OFFSET + radius + 4,
                             ry: radius + 3,
                             fill: 'white',
                             stroke: @color,
                             'stroke-width': 2,
                           })
-            [-DOUBLE_DOT_OFFSET, DOUBLE_DOT_OFFSET].each do |dx|
+            [-TWO_DOT_OFFSET, TWO_DOT_OFFSET].each do |dx|
               children << h(:circle, attrs: {
                               transform: "#{translate} translate(#{dx} 0)",
                               r: radius,
@@ -133,8 +134,10 @@ module View
                               'stroke-width': 4,
                             })
             end
-            children.concat(render_revenue_double) if @show_revenue
-          else
+            if @show_revenue && !(rendered = render_revenue_size2).empty?
+              children.concat(rendered)
+            end
+          when 1
             children << h(:circle, attrs: {
                             transform: translate.to_s,
                             r: radius,
@@ -146,13 +149,15 @@ module View
             if @show_revenue && (rendered = render_revenue)
               children << rendered
             end
+          else
+            raise NotImplementedError, "Unsupported town size: #{@town.size}"
           end
 
           children << h(HitBox, click: -> { touch_node(@town) }, transform: translate) unless @town.solo?
           h(:g, { key: "#{@town.id}-d" }, children)
         end
 
-        def render_revenue_double
+        def render_revenue_size2
           revenues = @town.uniq_revenues
           return [] if revenues.size > 1
 

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -1604,6 +1604,7 @@ module Engine
 
       def visited_stops(route)
         route.connection_data.flat_map { |c| [c[:left], c[:right]] }.uniq.compact
+             .flat_map { |s| s.respond_to?(:sub_stops) ? s.sub_stops : [s] }
       end
 
       def revenue_stops(route)

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -561,7 +561,7 @@ module Engine
             {
               'count' => 3,
               'color' => 'brown',
-              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:5,b:_0',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0',
             },
           'OE21' =>
             {

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -931,6 +931,14 @@ module Engine
           super
         end
 
+        def upgrades_to_correct_city_town?(from, to)
+          from_double = from.towns.any? { |t| t.size > 1 }
+          to_double   = to.towns.any? { |t| t.size > 1 }
+          return false if from_double != to_double
+
+          super
+        end
+
         def company_becomes_minor?(company)
           corp = @corporations.find { |c| c.name == company.sym }
           return false unless corp

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -388,15 +388,26 @@ module Engine
         MAX_FLOATED_REGIONALS = 18
         CONVERSION_NEW_SHARES = 6
 
-        # still need green+ OE specific track tiles
+        METROPOLIS_UPGRADE_CHAINS = {
+          'K26' => %w[OE4 OE12 OE26 OE37].freeze, # Birmingham
+          'M28' => %w[OE6 OE15 OE28 OE40].freeze, # London
+          'Q30' => %w[OE4 OE17 OE30 OE37].freeze, # Paris
+          'Y14' => %w[OE4 OE12 OE26 OE37].freeze, # Madrid
+          'M50' => %w[OE4 OE13 OE27 OE38].freeze, # Berlin
+          'R55' => %w[OE4 OE12 OE26 OE37].freeze, # Wien
+          'AB51' => %w[OE7 OE16 OE29 OE41].freeze, # Napoli
+          'AA82' => %w[OE5 OE14 OE26 OE39].freeze, # Constantinople
+          'C74' => %w[OE8 OE18 OE26 OE37].freeze, # Sankt-Peterburg
+        }.freeze
+
         TILES = {
           '3' => 14,
           '4' => 25,
-          '5' => 25,
-          '6' => 15,
+          '5' => 15,
+          '6' => 25,
           '7' => 14,
-          '8' => 99,
-          '9' => 99,
+          '8' => 88,
+          '9' => 90,
           '12' => 10,
           '13' => 8,
           '57' => 19,
@@ -471,12 +482,27 @@ module Engine
               'color' => 'yellow',
               'code' => 'city=revenue:30;city=revenue:30;path=a:0,b:_0;path=a:5,b:_1;label=S',
             },
-          # 'OE9' => 3, green, double town
-          # 'OE10' => 3, green, double town
-          # 'OE11' => 3, green, double town
-          'OE12' =>
+          'OE9' =>
             {
               'count' => 3,
+              'color' => 'green',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
+            },
+          'OE10' =>
+            {
+              'count' => 3,
+              'color' => 'green',
+              'code' => 'town=revenue:10,size:2;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
+            },
+          'OE11' =>
+            {
+              'count' => 3,
+              'color' => 'green',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
+            },
+          'OE12' =>
+            {
+              'count' => 1,
               'color' => 'green',
               'code' => 'city=revenue:50;city=revenue:50;city=revenue:50;path=a:0,b:_0;path=a:_0,b:3;'\
                         'path=a:2,b:_1;path=a:_1,b:5;path=a:4,b:_2;path=a:_2,b:1;label=A',
@@ -519,9 +545,25 @@ module Engine
               'color' => 'green',
               'code' => 'city=revenue:50;city=revenue:50,slots:2;path=a:0,b:_0;path=a:_0,b:2;path=a:5,b:_1;path=a:_1,b:3;label=S',
             },
-          # 'OE20' => 3, brown, two towns
-          # 'OE21' => 2, brown, two towns
-          # 'OE22' => 6, brown, two towns
+          'OE20' =>
+            {
+              'count' => 3,
+              'color' => 'brown',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:5,b:_0',
+            },
+          'OE21' =>
+            {
+              'count' => 2,
+              'color' => 'brown',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
+            },
+          'OE22' =>
+            {
+              'count' => 6,
+              'color' => 'brown',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;' \
+                        'path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
+            },
           'OE23' =>
             {
               'count' => 12,
@@ -542,7 +584,7 @@ module Engine
             },
           'OE26' =>
             {
-              'count' => 5,
+              'count' => 1,
               'color' => 'brown',
               'code' => 'city=revenue:80,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;'\
                         'path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=ACS',
@@ -612,7 +654,7 @@ module Engine
             },
           'OE37' =>
             {
-              'count' => 5,
+              'count' => 3,
               'color' => 'gray',
               'code' => 'city=revenue:100,slots:3;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;'\
                         'path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;label=APS',
@@ -799,6 +841,10 @@ module Engine
           cost
         end
 
+        def revenue_stops(route)
+          super.flat_map { |stop| stop.town? && stop.size > 1 ? Array.new(stop.size, stop) : [stop] }
+        end
+
         def level8_train_available?
           return false if phase.name.to_i < 7
           return true if phase.name.to_i == 8
@@ -863,23 +909,10 @@ module Engine
         end
 
         def upgrades_to_correct_label?(from, to)
-          return true if from.label == to.label
-          return false if from.label && !to.label
+          chain = self.class::METROPOLIS_UPGRADE_CHAINS[from.hex&.coordinates]
+          return (chain[chain.index(from.name) + 1] == to.name) if chain&.include?(from.name)
 
-          case from.hex.coordinates
-          when 'K26', 'Y14', 'R55'
-            to.label.to_s.include?('A')
-          when 'M50'
-            to.label.to_s.include?('B')
-          when 'AA82'
-            to.label.to_s.include?('C')
-          when 'AB51'
-            to.label.to_s.include?('N')
-          when 'Q30'
-            to.label.to_s.include?('P')
-          when 'C74'
-            to.label.to_s.include?('S')
-          end
+          super
         end
 
         def company_becomes_minor?(company)

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -853,6 +853,10 @@ module Engine
           cost
         end
 
+        def visited_stops(route)
+          super.flat_map { |stop| stop.town? && stop.size > 1 ? Array.new(stop.size, stop) : [stop] }
+        end
+
         def revenue_stops(route)
           super.flat_map { |stop| stop.town? && stop.size > 1 ? Array.new(stop.size, stop) : [stop] }
         end

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -504,7 +504,7 @@ module Engine
             {
               'count' => 3,
               'color' => 'green',
-              'code' => 'town=revenue:10,size:2;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:5,b:_0',
             },
           'OE11' =>
             {
@@ -561,7 +561,7 @@ module Engine
             {
               'count' => 3,
               'color' => 'brown',
-              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:5,b:_0',
             },
           'OE21' =>
             {

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -853,14 +853,6 @@ module Engine
           cost
         end
 
-        def visited_stops(route)
-          super.flat_map { |stop| stop.town? && stop.size > 1 ? Array.new(stop.size, stop) : [stop] }
-        end
-
-        def revenue_stops(route)
-          super.flat_map { |stop| stop.town? && stop.size > 1 ? Array.new(stop.size, stop) : [stop] }
-        end
-
         def level8_train_available?
           return false if phase.name.to_i < 7
           return true if phase.name.to_i == 8

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -922,7 +922,7 @@ module Engine
 
         def upgrades_to_correct_label?(from, to)
           chain = self.class::METROPOLIS_UPGRADE_CHAINS[from.hex&.coordinates]
-          return (chain[chain.index(from.name) + 1] == to.name) if chain&.include?(from.name)
+          return (chain[chain.find_index(from.name) + 1] == to.name) if chain&.include?(from.name)
 
           super
         end

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -450,19 +450,19 @@ module Engine
             {
               'count' => 4,
               'color' => 'yellow',
-              'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0;path=a:3,b:_0;path=a:_0,b:_1;path=a:0,b:_1;path=a:3,b:_1',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:3,b:_0',
             },
           'OE2' =>
             {
               'count' => 6,
               'color' => 'yellow',
-              'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0;path=a:2,b:_0;path=a:_0,b:_1;path=a:0,b:_1;path=a:2,b:_1',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:2,b:_0',
             },
           'OE3' =>
             {
               'count' => 2,
               'color' => 'yellow',
-              'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0;path=a:1,b:_0;path=a:_0,b:_1;path=a:0,b:_1;path=a:1,b:_1',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0',
             },
           'OE4' =>
             {
@@ -498,25 +498,19 @@ module Engine
             {
               'count' => 3,
               'color' => 'green',
-              'code' => 'town=revenue:10;town=revenue:10;' \
-                        'path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0;path=a:_0,b:_1;' \
-                        'path=a:0,b:_1;path=a:2,b:_1;path=a:3,b:_1;path=a:5,b:_1',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
             },
           'OE10' =>
             {
               'count' => 3,
               'color' => 'green',
-              'code' => 'town=revenue:10;town=revenue:10;' \
-                        'path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0;path=a:_0,b:_1;' \
-                        'path=a:1,b:_1;path=a:2,b:_1;path=a:3,b:_1;path=a:5,b:_1',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:5,b:_0',
             },
           'OE11' =>
             {
               'count' => 3,
               'color' => 'green',
-              'code' => 'town=revenue:10;town=revenue:10;' \
-                        'path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:_0,b:_1;' \
-                        'path=a:0,b:_1;path=a:2,b:_1;path=a:3,b:_1;path=a:4,b:_1',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
             },
           'OE12' =>
             {
@@ -567,25 +561,20 @@ module Engine
             {
               'count' => 3,
               'color' => 'brown',
-              'code' => 'town=revenue:10;town=revenue:10;' \
-                        'path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:_0,b:_1;' \
-                        'path=a:0,b:_1;path=a:1,b:_1;path=a:2,b:_1;path=a:4,b:_1;path=a:5,b:_1',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:5,b:_0',
             },
           'OE21' =>
             {
               'count' => 2,
               'color' => 'brown',
-              'code' => 'town=revenue:10;town=revenue:10;' \
-                        'path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0;path=a:_0,b:_1;' \
-                        'path=a:0,b:_1;path=a:1,b:_1;path=a:2,b:_1;path=a:3,b:_1;path=a:5,b:_1',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
             },
           'OE22' =>
             {
               'count' => 6,
               'color' => 'brown',
-              'code' => 'town=revenue:10;town=revenue:10;' \
-                        'path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:_0,b:_1;' \
-                        'path=a:0,b:_1;path=a:1,b:_1;path=a:2,b:_1;path=a:3,b:_1;path=a:4,b:_1;path=a:5,b:_1',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;' \
+                        'path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
             },
           'OE23' =>
             {
@@ -864,36 +853,8 @@ module Engine
           cost
         end
 
-        def check_overlap(routes)
-          tracks = {}
-
-          check = lambda do |key|
-            raise GameError, "Route cannot reuse track on #{key[0].id}" if tracks[key]
-
-            tracks[key] = true
-          end
-
-          routes.each do |route|
-            route.paths.each do |path|
-              a = path.a
-              b = path.b
-
-              check.call([path.hex, a.num, path.lanes[0][1]]) if a.edge?
-              check.call([path.hex, b.num, path.lanes[1][1]]) if b.edge?
-
-              if b.edge? && a.town? && (nedge = a.tile.preferred_city_town_edges[a]) && nedge != b.num
-                check.call([path.hex, a, path.lanes[0][1]])
-              end
-              if a.edge? && b.town? && (nedge = b.tile.preferred_city_town_edges[b]) && nedge != a.num
-                check.call([path.hex, b, path.lanes[1][1]])
-              end
-
-              # §11.3.8: multiple trains independently score all towns at double-town junction tiles
-              next if path.nodes.size > 1 && path.nodes.all?(&:town?)
-
-              check.call([path.hex, path]) if path.nodes.size > 1
-            end
-          end
+        def revenue_stops(route)
+          super.flat_map { |stop| stop.town? && stop.size > 1 ? Array.new(stop.size, stop) : [stop] }
         end
 
         def level8_train_available?

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -450,19 +450,19 @@ module Engine
             {
               'count' => 4,
               'color' => 'yellow',
-              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:3,b:_0',
+              'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0;path=a:3,b:_0;path=a:_0,b:_1;path=a:0,b:_1;path=a:3,b:_1',
             },
           'OE2' =>
             {
               'count' => 6,
               'color' => 'yellow',
-              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:2,b:_0',
+              'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0;path=a:2,b:_0;path=a:_0,b:_1;path=a:0,b:_1;path=a:2,b:_1',
             },
           'OE3' =>
             {
               'count' => 2,
               'color' => 'yellow',
-              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0',
+              'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0;path=a:1,b:_0;path=a:_0,b:_1;path=a:0,b:_1;path=a:1,b:_1',
             },
           'OE4' =>
             {
@@ -498,19 +498,25 @@ module Engine
             {
               'count' => 3,
               'color' => 'green',
-              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
+              'code' => 'town=revenue:10;town=revenue:10;' \
+                        'path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0;path=a:_0,b:_1;' \
+                        'path=a:0,b:_1;path=a:2,b:_1;path=a:3,b:_1;path=a:5,b:_1',
             },
           'OE10' =>
             {
               'count' => 3,
               'color' => 'green',
-              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:5,b:_0',
+              'code' => 'town=revenue:10;town=revenue:10;' \
+                        'path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0;path=a:_0,b:_1;' \
+                        'path=a:1,b:_1;path=a:2,b:_1;path=a:3,b:_1;path=a:5,b:_1',
             },
           'OE11' =>
             {
               'count' => 3,
               'color' => 'green',
-              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0',
+              'code' => 'town=revenue:10;town=revenue:10;' \
+                        'path=a:0,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:_0,b:_1;' \
+                        'path=a:0,b:_1;path=a:2,b:_1;path=a:3,b:_1;path=a:4,b:_1',
             },
           'OE12' =>
             {
@@ -561,20 +567,25 @@ module Engine
             {
               'count' => 3,
               'color' => 'brown',
-              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:5,b:_0',
+              'code' => 'town=revenue:10;town=revenue:10;' \
+                        'path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:_0,b:_1;' \
+                        'path=a:0,b:_1;path=a:1,b:_1;path=a:2,b:_1;path=a:4,b:_1;path=a:5,b:_1',
             },
           'OE21' =>
             {
               'count' => 2,
               'color' => 'brown',
-              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
+              'code' => 'town=revenue:10;town=revenue:10;' \
+                        'path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0;path=a:_0,b:_1;' \
+                        'path=a:0,b:_1;path=a:1,b:_1;path=a:2,b:_1;path=a:3,b:_1;path=a:5,b:_1',
             },
           'OE22' =>
             {
               'count' => 6,
               'color' => 'brown',
-              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;' \
-                        'path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
+              'code' => 'town=revenue:10;town=revenue:10;' \
+                        'path=a:0,b:_0;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0;path=a:_0,b:_1;' \
+                        'path=a:0,b:_1;path=a:1,b:_1;path=a:2,b:_1;path=a:3,b:_1;path=a:4,b:_1;path=a:5,b:_1',
             },
           'OE23' =>
             {
@@ -853,8 +864,36 @@ module Engine
           cost
         end
 
-        def revenue_stops(route)
-          super.flat_map { |stop| stop.town? && stop.size > 1 ? Array.new(stop.size, stop) : [stop] }
+        def check_overlap(routes)
+          tracks = {}
+
+          check = lambda do |key|
+            raise GameError, "Route cannot reuse track on #{key[0].id}" if tracks[key]
+
+            tracks[key] = true
+          end
+
+          routes.each do |route|
+            route.paths.each do |path|
+              a = path.a
+              b = path.b
+
+              check.call([path.hex, a.num, path.lanes[0][1]]) if a.edge?
+              check.call([path.hex, b.num, path.lanes[1][1]]) if b.edge?
+
+              if b.edge? && a.town? && (nedge = a.tile.preferred_city_town_edges[a]) && nedge != b.num
+                check.call([path.hex, a, path.lanes[0][1]])
+              end
+              if a.edge? && b.town? && (nedge = b.tile.preferred_city_town_edges[b]) && nedge != a.num
+                check.call([path.hex, b, path.lanes[1][1]])
+              end
+
+              # §11.3.8: multiple trains independently score all towns at double-town junction tiles
+              next if path.nodes.size > 1 && path.nodes.all?(&:town?)
+
+              check.call([path.hex, path]) if path.nodes.size > 1
+            end
+          end
         end
 
         def level8_train_available?

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -401,8 +401,16 @@ module Engine
         }.freeze
 
         TILES = {
-          '3' => 14,
-          '4' => 25,
+          '3' => {
+            'count' => 14,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10,style:dot,loc:center;path=a:0,b:_0;path=a:_0,b:1',
+          },
+          '4' => {
+            'count' => 25,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10,style:dot,loc:center;path=a:0,b:_0;path=a:_0,b:3',
+          },
           '5' => 15,
           '6' => 25,
           '7' => 14,
@@ -411,7 +419,11 @@ module Engine
           '12' => 10,
           '13' => 8,
           '57' => 19,
-          '58' => 25,
+          '58' => {
+            'count' => 25,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10,style:dot,loc:center;path=a:0,b:_0;path=a:_0,b:2',
+          },
           '80' => 5,
           '81' => 5,
           '82' => 20,

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -926,7 +926,7 @@ module Engine
 
         def upgrades_to_correct_label?(from, to)
           chain = self.class::METROPOLIS_UPGRADE_CHAINS[from.hex&.coordinates]
-          return (chain[chain.find_index(from.name) + 1] == to.name) if chain&.include?(from.name)
+          return (chain[chain.index(from.name) + 1] == to.name) if chain&.include?(from.name)
 
           super
         end

--- a/lib/engine/game/g_18_oe/game.rb
+++ b/lib/engine/game/g_18_oe/game.rb
@@ -438,19 +438,19 @@ module Engine
             {
               'count' => 4,
               'color' => 'yellow',
-              'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0;path=a:_0,b:_1;path=a:_1,b:3',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:3,b:_0',
             },
           'OE2' =>
             {
               'count' => 6,
               'color' => 'yellow',
-              'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0;path=a:_0,b:_1;path=a:_1,b:2',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:2,b:_0',
             },
           'OE3' =>
             {
               'count' => 2,
               'color' => 'yellow',
-              'code' => 'town=revenue:10;town=revenue:10;path=a:0,b:_0;path=a:_0,b:_1;path=a:_1,b:1',
+              'code' => 'town=revenue:10,size:2;path=a:0,b:_0;path=a:1,b:_0',
             },
           'OE4' =>
             {

--- a/lib/engine/game/g_18_oe/map.rb
+++ b/lib/engine/game/g_18_oe/map.rb
@@ -527,9 +527,9 @@ module Engine
             # Double towns
             %w[J29 M26 W32
                N41 Q46 U64 W46 AF53
-               J77 P77] => 'town=revenue:0;town=revenue:0',
-            %w[AC6 C58 U6] => 'town=revenue:0;town=revenue:0;icon=image:port,sticky:1',
-            ['T37'] => 'town=revenue:0;town=revenue:0;upgrade=cost:45,terrain:hill;' \
+               J77 P77] => 'town=revenue:0,size:2',
+            %w[AC6 C58 U6] => 'town=revenue:0,size:2;icon=image:port,sticky:1',
+            ['T37'] => 'town=revenue:0,size:2;upgrade=cost:45,terrain:hill;' \
                        'partition=a:3,b:0,type:province,length:0.5;partition=a:5,b:2,type:province,length:0.5',
             # Cities — no label, no terrain
             %w[
@@ -585,7 +585,7 @@ module Engine
             ['D81'] => 'town=revenue:0;upgrade=cost:30,terrain:water',
             ['I52'] => 'city=revenue:0;upgrade=cost:45,terrain:river',
             ['J63'] => 'city=revenue:0;label=Y;upgrade=cost:30,terrain:water;icon=image:port,sticky:1',
-            ['L39'] => 'town=revenue:0;town=revenue:0;upgrade=cost:30,terrain:water',
+            ['L39'] => 'town=revenue:0,size:2;upgrade=cost:30,terrain:water',
             ['M36'] => 'city=revenue:0;upgrade=cost:30,terrain:water;border=edge:0,type:province',
             ['M38'] => 'town=revenue:0;upgrade=cost:30,terrain:water',
             ['M72'] => 'town=revenue:0;upgrade=cost:30,terrain:water',

--- a/lib/engine/game/g_18_oe/map.rb
+++ b/lib/engine/game/g_18_oe/map.rb
@@ -527,9 +527,9 @@ module Engine
             # Double towns
             %w[J29 M26 W32
                N41 Q46 U64 W46 AF53
-               J77 P77] => 'town=revenue:0,size:2',
-            %w[AC6 C58 U6] => 'town=revenue:0,size:2;icon=image:port,sticky:1',
-            ['T37'] => 'town=revenue:0,size:2;upgrade=cost:45,terrain:hill;' \
+               J77 P77] => 'town=revenue:0;town=revenue:0',
+            %w[AC6 C58 U6] => 'town=revenue:0;town=revenue:0;icon=image:port,sticky:1',
+            ['T37'] => 'town=revenue:0;town=revenue:0;upgrade=cost:45,terrain:hill;' \
                        'partition=a:3,b:0,type:province,length:0.5;partition=a:5,b:2,type:province,length:0.5',
             # Cities — no label, no terrain
             %w[
@@ -585,7 +585,7 @@ module Engine
             ['D81'] => 'town=revenue:0;upgrade=cost:30,terrain:water',
             ['I52'] => 'city=revenue:0;upgrade=cost:45,terrain:river',
             ['J63'] => 'city=revenue:0;label=Y;upgrade=cost:30,terrain:water;icon=image:port,sticky:1',
-            ['L39'] => 'town=revenue:0,size:2;upgrade=cost:30,terrain:water',
+            ['L39'] => 'town=revenue:0;town=revenue:0;upgrade=cost:30,terrain:water',
             ['M36'] => 'city=revenue:0;upgrade=cost:30,terrain:water;border=edge:0,type:province',
             ['M38'] => 'town=revenue:0;upgrade=cost:30,terrain:water',
             ['M72'] => 'town=revenue:0;upgrade=cost:30,terrain:water',

--- a/lib/engine/game/g_18_oe/meta.rb
+++ b/lib/engine/game/g_18_oe/meta.rb
@@ -11,7 +11,7 @@ module Engine
         DEV_STAGE = :prealpha
 
         GAME_DESIGNER = 'Edward T. Sindelar'
-        GAME_PUBLISHER = :DICE
+        GAME_PUBLISHER = :self_published
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18OE'
         GAME_LOCATION = 'Europe'
         GAME_RULES_URL = 'http://www.designsice.com/files/18OE%20Rulebook.pdf'

--- a/lib/engine/game/g_18_oe/meta.rb
+++ b/lib/engine/game/g_18_oe/meta.rb
@@ -11,7 +11,7 @@ module Engine
         DEV_STAGE = :prealpha
 
         GAME_DESIGNER = 'Edward T. Sindelar'
-        GAME_PUBLISHER = :self_published
+        GAME_PUBLISHER = :dice
         GAME_INFO_URL = 'https://github.com/tobymao/18xx/wiki/18OE'
         GAME_LOCATION = 'Europe'
         GAME_RULES_URL = 'http://www.designsice.com/files/18OE%20Rulebook.pdf'

--- a/lib/engine/part/double_town.rb
+++ b/lib/engine/part/double_town.rb
@@ -79,11 +79,11 @@ module Engine
           end
         end
 
-        if converging_path
-          visited.delete(self)
-          visited.delete(@town_a)
-          visited.delete(@town_b)
-        end
+        return unless converging_path
+
+        visited.delete(self)
+        visited.delete(@town_a)
+        visited.delete(@town_b)
       end
     end
   end

--- a/lib/engine/part/double_town.rb
+++ b/lib/engine/part/double_town.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative 'town'
+
+module Engine
+  module Part
+    class DoubleTown < Town
+      attr_reader :sub_stops
+
+      def initialize(revenue, **opts)
+        super
+        @size = 2
+        @town_a = Town.new(revenue, **opts)
+        @town_b = Town.new(revenue, **opts)
+        @sub_stops = [@town_a, @town_b].freeze
+      end
+
+      def size
+        2
+      end
+
+      def walk(
+        visited: {},
+        corporation: nil,
+        visited_paths: {},
+        skip_paths: nil,
+        counter: Hash.new(0),
+        skip_track: nil,
+        converging_path: true,
+        walk_calls: Hash.new(0),
+        backtracking: false,
+        &block
+      )
+        walk_calls[:all] += 1
+
+        return if visited[self]
+
+        walk_calls[:not_skipped] += 1
+
+        visited[self] = true
+        visited[@town_a] = true
+        visited[@town_b] = true
+
+        paths.each do |node_path|
+          next if node_path.track == skip_track
+          next if node_path.ignore?
+
+          node_path.walk(
+            visited: visited_paths,
+            skip_paths: skip_paths,
+            skip_track: skip_track,
+            counter: counter,
+            converging: converging_path,
+            walk_calls: walk_calls,
+            backtracking: backtracking,
+          ) do |path, vp, ct, converging|
+            ret = yield path, vp, visited
+            next if ret == :abort
+            next if path.terminal?
+
+            path.nodes.each do |next_node|
+              next if next_node == self
+              next if corporation && next_node.blocks?(corporation)
+
+              next_node.walk(
+                visited: visited,
+                counter: ct,
+                corporation: corporation,
+                visited_paths: vp,
+                skip_track: skip_track,
+                skip_paths: skip_paths,
+                converging_path: converging_path || converging,
+                walk_calls: walk_calls,
+                backtracking: backtracking,
+                &block
+              )
+            end
+          end
+        end
+
+        visited.delete(self) if converging_path
+      end
+    end
+  end
+end

--- a/lib/engine/part/double_town.rb
+++ b/lib/engine/part/double_town.rb
@@ -9,9 +9,10 @@ module Engine
 
       def initialize(revenue, **opts)
         super
+        # Town#rect? reads @size directly; must be 2 so rect? returns false
         @size = 2
-        @town_a = Town.new(revenue, **opts)
-        @town_b = Town.new(revenue, **opts)
+        @town_a = Town.new(revenue, **opts.merge(size: nil))
+        @town_b = Town.new(revenue, **opts.merge(size: nil))
         @sub_stops = [@town_a, @town_b].freeze
       end
 
@@ -78,7 +79,11 @@ module Engine
           end
         end
 
-        visited.delete(self) if converging_path
+        if converging_path
+          visited.delete(self)
+          visited.delete(@town_a)
+          visited.delete(@town_b)
+        end
       end
     end
   end

--- a/lib/engine/part/town.rb
+++ b/lib/engine/part/town.rb
@@ -33,8 +33,6 @@ module Engine
       # in the center or it is in the center and has less than two exits and
       # less than three paths
       def rect?
-        return false if @size > 1
-
         @style ? (@style == :rect) : (!paths.empty? && paths.size < 3)
       end
 

--- a/lib/engine/part/town.rb
+++ b/lib/engine/part/town.rb
@@ -33,6 +33,8 @@ module Engine
       # in the center or it is in the center and has less than two exits and
       # less than three paths
       def rect?
+        return false if @size > 1
+
         @style ? (@style == :rect) : (!paths.empty? && paths.size < 3)
       end
 

--- a/lib/engine/part/town.rb
+++ b/lib/engine/part/town.rb
@@ -6,7 +6,7 @@ module Engine
   module Part
     class Town < RevenueCenter
       attr_accessor :style
-      attr_reader :to_city, :boom
+      attr_reader :to_city, :boom, :size
 
       def initialize(revenue, **opts)
         super
@@ -14,6 +14,7 @@ module Engine
         @to_city = opts[:to_city]
         @boom = opts[:boom]
         @style = opts[:style]&.to_sym
+        @size = opts[:size]&.to_i || 1
       end
 
       def <=(other)

--- a/lib/engine/publisher.rb
+++ b/lib/engine/publisher.rb
@@ -12,6 +12,11 @@ module Engine
         url: 'https://boardgamegeek.com/boardgamepublisher/4192/deep-thought-games-llc',
         hidden: true,
       },
+      dice: {
+        name: 'Designs in Computer Entertainment',
+        url: 'http://designsice.com',
+        hidden: true,
+      },
       gmt_games: {
         name: 'GMT Games',
         url: 'https://www.gmtgames.com/',

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -467,7 +467,7 @@ module Engine
       # if a tile has no cities and exactly one town that doesn't have two exits, place in center
       # size>1 towns (double towns) always center regardless of exit count
       if @cities.empty? && @towns.one? &&
-          (@towns[0].exits.size != 2 || @towns[0].size > 1) &&
+          @towns[0].exits.size != 2 &&
           !compute_loc(@towns.first.loc)
         ct_edges[@towns.first] = nil
         return ct_edges

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -137,17 +137,18 @@ module Engine
         cache << pass
         pass
       when 'town'
-        town = Part::Town.new(params['revenue'],
-                              groups: params['groups'],
-                              hide: params['hide'],
-                              visit_cost: params['visit_cost'],
-                              route: params['route'],
-                              format: params['format'],
-                              loc: params['loc'],
-                              boom: params['boom'],
-                              style: params['style'],
-                              size: params['size'],
-                              to_city: params['to_city'])
+        klass = params['size'].to_i > 1 ? Part::DoubleTown : Part::Town
+        town = klass.new(params['revenue'],
+                         groups: params['groups'],
+                         hide: params['hide'],
+                         visit_cost: params['visit_cost'],
+                         route: params['route'],
+                         format: params['format'],
+                         loc: params['loc'],
+                         boom: params['boom'],
+                         style: params['style'],
+                         size: params['size'],
+                         to_city: params['to_city'])
         cache << town
         town
       when 'halt'

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -146,6 +146,7 @@ module Engine
                               loc: params['loc'],
                               boom: params['boom'],
                               style: params['style'],
+                              size: params['size'],
                               to_city: params['to_city'])
         cache << town
         town

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -467,7 +467,7 @@ module Engine
       # if a tile has no cities and exactly one town that doesn't have two exits, place in center
       # size>1 towns (double towns) always center regardless of exit count
       if @cities.empty? && @towns.one? &&
-          @towns[0].exits.size != 2 &&
+          (@towns[0].exits.size != 2 || @towns[0].size > 1) &&
           !compute_loc(@towns.first.loc)
         ct_edges[@towns.first] = nil
         return ct_edges

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -465,7 +465,10 @@ module Engine
         return ct_edges
       end
       # if a tile has no cities and exactly one town that doesn't have two exits, place in center
-      if @cities.empty? && @towns.one? && (@towns[0].exits.size != 2) && !compute_loc(@towns.first.loc)
+      # size>1 towns (double towns) always center regardless of exit count
+      if @cities.empty? && @towns.one? &&
+          (@towns[0].exits.size != 2 || @towns[0].size > 1) &&
+          !compute_loc(@towns.first.loc)
         ct_edges[@towns.first] = nil
         return ct_edges
       end

--- a/public/fixtures/18OE/18OE_double_town_test.json
+++ b/public/fixtures/18OE/18OE_double_town_test.json
@@ -1,0 +1,2236 @@
+{
+  "status": "active",
+  "id": "hs_dt_test_001",
+  "players": [
+    {
+      "name": "Diana"
+    },
+    {
+      "name": "Eve"
+    },
+    {
+      "name": "Frank"
+    }
+  ],
+  "title": "18OE",
+  "description": "DoubleTown test \u2014 LNWR at J27, J29=OE10 yellow double-town, 2+2 train. Run route J27\u2192J29 to verify \u00a320 revenue.",
+  "mode": "hotseat",
+  "user": {
+    "id": 0,
+    "name": "You"
+  },
+  "created_at": "2026-06-04",
+  "loaded": false,
+  "settings": {},
+  "actions": [
+    {
+      "type": "bid",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 1,
+      "created_at": 1780228508,
+      "company": "RSC",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 2,
+      "created_at": 1780228508,
+      "company": "PeC",
+      "price": 20
+    },
+    {
+      "type": "bid",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 3,
+      "created_at": 1780228508,
+      "company": "WS",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 4,
+      "created_at": 1780228508,
+      "company": "BBBT",
+      "price": 40
+    },
+    {
+      "type": "bid",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 5,
+      "created_at": 1780228508,
+      "company": "SHTC",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 6,
+      "created_at": 1780228508,
+      "company": "CCTC",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 7,
+      "created_at": 1780228508,
+      "company": "WCF",
+      "price": 60
+    },
+    {
+      "type": "bid",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 8,
+      "created_at": 1780228508,
+      "company": "HMLC",
+      "price": 80
+    },
+    {
+      "type": "bid",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 9,
+      "created_at": 1780228508,
+      "company": "BBE",
+      "price": 100
+    },
+    {
+      "type": "bid",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 10,
+      "created_at": 1780228508,
+      "company": "SML",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 11,
+      "created_at": 1780228508,
+      "company": "C",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 12,
+      "created_at": 1780228508,
+      "company": "H",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 13,
+      "created_at": 1780228508,
+      "company": "K",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 14,
+      "created_at": 1780228508,
+      "company": "M",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 15,
+      "created_at": 1780228508,
+      "company": "A",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 16,
+      "created_at": 1780228508,
+      "company": "B",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 17,
+      "created_at": 1780228508,
+      "company": "D",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 18,
+      "created_at": 1780228508,
+      "company": "E",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 19,
+      "created_at": 1780228508,
+      "company": "F",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 20,
+      "created_at": 1780228508,
+      "company": "G",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 21,
+      "created_at": 1780228508,
+      "company": "J",
+      "price": 120
+    },
+    {
+      "type": "bid",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 22,
+      "created_at": 1780228508,
+      "company": "L",
+      "price": 120
+    },
+    {
+      "type": "par",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 23,
+      "created_at": 1780228508,
+      "corporation": "D",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "place_token",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 24,
+      "created_at": 1780228508,
+      "city": "A64-0-0"
+    },
+    {
+      "type": "par",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 25,
+      "created_at": 1780228508,
+      "corporation": "E",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "place_token",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 26,
+      "created_at": 1780228508,
+      "city": "A64-0-0"
+    },
+    {
+      "type": "choose",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 27,
+      "created_at": 1780228508,
+      "choice": "bbbt_D"
+    },
+    {
+      "type": "par",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 28,
+      "created_at": 1780228508,
+      "corporation": "F",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "place_token",
+      "entity": "F",
+      "entity_type": "corporation",
+      "id": 29,
+      "created_at": 1780228508,
+      "city": "Z1-0-0"
+    },
+    {
+      "type": "par",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 30,
+      "created_at": 1780228508,
+      "corporation": "M",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "place_token",
+      "entity": "M",
+      "entity_type": "corporation",
+      "id": 31,
+      "created_at": 1780228508,
+      "city": "J25-0-0"
+    },
+    {
+      "type": "par",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 32,
+      "created_at": 1780228508,
+      "corporation": "J",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "place_token",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 33,
+      "created_at": 1780228508,
+      "city": "L37-0-0"
+    },
+    {
+      "type": "par",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 34,
+      "created_at": 1780228508,
+      "corporation": "B",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "place_token",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 35,
+      "created_at": 1780228508,
+      "city": "V39-0-0"
+    },
+    {
+      "type": "par",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 36,
+      "created_at": 1780228508,
+      "corporation": "G",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "place_token",
+      "entity": "G",
+      "entity_type": "corporation",
+      "id": 37,
+      "created_at": 1780228508,
+      "city": "N31-0-0"
+    },
+    {
+      "type": "par",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 38,
+      "created_at": 1780228508,
+      "corporation": "A",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "place_token",
+      "entity": "A",
+      "entity_type": "corporation",
+      "id": 39,
+      "created_at": 1780228508,
+      "city": "X33-0-0"
+    },
+    {
+      "type": "par",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 40,
+      "created_at": 1780228508,
+      "corporation": "K",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "place_token",
+      "entity": "K",
+      "entity_type": "corporation",
+      "id": 41,
+      "created_at": 1780228508,
+      "city": "C48-0-0"
+    },
+    {
+      "type": "par",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 42,
+      "created_at": 1780228508,
+      "corporation": "C",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "place_token",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 43,
+      "created_at": 1780228508,
+      "city": "X13-9-0"
+    },
+    {
+      "type": "par",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 44,
+      "created_at": 1780228508,
+      "corporation": "H",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "place_token",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 45,
+      "created_at": 1780228508,
+      "city": "T53-18-0"
+    },
+    {
+      "type": "par",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 46,
+      "created_at": 1780228508,
+      "corporation": "L",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "place_token",
+      "entity": "L",
+      "entity_type": "corporation",
+      "id": 47,
+      "created_at": 1780228509,
+      "city": "P53-0-0"
+    },
+    {
+      "type": "par",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 48,
+      "created_at": 1780228509,
+      "corporation": "CHN",
+      "share_price": "60,6,0"
+    },
+    {
+      "type": "par",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 49,
+      "created_at": 1780228509,
+      "corporation": "GSWR",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "par",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 50,
+      "created_at": 1780228509,
+      "corporation": "MIDI",
+      "share_price": "60,6,0"
+    },
+    {
+      "type": "par",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 51,
+      "created_at": 1780228509,
+      "corporation": "RCP",
+      "share_price": "60,6,0"
+    },
+    {
+      "type": "par",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 52,
+      "created_at": 1780228509,
+      "corporation": "SFAI",
+      "share_price": "60,6,0"
+    },
+    {
+      "type": "par",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 53,
+      "created_at": 1780228509,
+      "corporation": "MKV",
+      "share_price": "60,6,0"
+    },
+    {
+      "type": "par",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 54,
+      "created_at": 1780228509,
+      "corporation": "GWR",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "par",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 55,
+      "created_at": 1780228509,
+      "corporation": "MSP",
+      "share_price": "60,6,0"
+    },
+    {
+      "type": "par",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 56,
+      "created_at": 1780228509,
+      "corporation": "KSS",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "par",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 57,
+      "created_at": 1780228509,
+      "corporation": "LRZD",
+      "share_price": "60,6,0"
+    },
+    {
+      "type": "par",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 58,
+      "created_at": 1780228509,
+      "corporation": "WW",
+      "share_price": "60,6,0"
+    },
+    {
+      "type": "par",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 59,
+      "created_at": 1780228509,
+      "corporation": "LNWR",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "par",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 60,
+      "created_at": 1780228509,
+      "corporation": "KBS",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "par",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 61,
+      "created_at": 1780228509,
+      "corporation": "MZA",
+      "share_price": "60,6,0"
+    },
+    {
+      "type": "par",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 62,
+      "created_at": 1780228509,
+      "corporation": "OU",
+      "share_price": "60,6,0"
+    },
+    {
+      "type": "par",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 63,
+      "created_at": 1780228509,
+      "corporation": "SB",
+      "share_price": "60,6,0"
+    },
+    {
+      "type": "par",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 64,
+      "created_at": 1780228509,
+      "corporation": "MAV",
+      "share_price": "60,6,0"
+    },
+    {
+      "type": "par",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 65,
+      "created_at": 1780228509,
+      "corporation": "BHB",
+      "share_price": "70,4,0"
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 66,
+      "created_at": 1780228509,
+      "shares": [
+        "KBS_1"
+      ],
+      "percent": 25
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 67,
+      "created_at": 1780228509,
+      "shares": [
+        "SFAI_1"
+      ],
+      "percent": 25
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 68,
+      "created_at": 1780228509,
+      "shares": [
+        "BHB_1"
+      ],
+      "percent": 25
+    },
+    {
+      "type": "convert",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 69,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 70,
+      "created_at": 1780228509,
+      "shares": [
+        "GWR_1"
+      ],
+      "percent": 25
+    },
+    {
+      "type": "pass",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 71,
+      "created_at": 1780228509
+    },
+    {
+      "type": "pass",
+      "entity": "Eve",
+      "entity_type": "player",
+      "id": 72,
+      "created_at": 1780228509
+    },
+    {
+      "type": "convert",
+      "entity": "GSWR",
+      "entity_type": "corporation",
+      "id": 73,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 74,
+      "created_at": 1780228509,
+      "shares": [
+        "GSWR_1"
+      ],
+      "percent": 25
+    },
+    {
+      "type": "pass",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 75,
+      "created_at": 1780228509
+    },
+    {
+      "type": "pass",
+      "entity": "Frank",
+      "entity_type": "player",
+      "id": 76,
+      "created_at": 1780228509
+    },
+    {
+      "type": "convert",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 77,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_shares",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 78,
+      "created_at": 1780228509,
+      "shares": [
+        "LNWR_1"
+      ],
+      "percent": 25
+    },
+    {
+      "type": "pass",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 79,
+      "created_at": 1780228509
+    },
+    {
+      "type": "pass",
+      "entity": "Diana",
+      "entity_type": "player",
+      "id": 80,
+      "created_at": 1780228509
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 81,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 82,
+      "created_at": 1780228509,
+      "hex": "X13",
+      "tile": "5-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 83,
+      "created_at": 1780228509,
+      "hex": "Y12",
+      "tile": "7-0",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 84,
+      "created_at": 1780228509,
+      "hex": "X11",
+      "tile": "3-0",
+      "rotation": 3
+    },
+    {
+      "type": "buy_train",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 85,
+      "created_at": 1780228509,
+      "train": "2+2-0",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 86,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 87,
+      "created_at": 1780228509,
+      "hex": "A66",
+      "tile": "7-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 88,
+      "created_at": 1780228509,
+      "hex": "B65",
+      "tile": "7-2",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 89,
+      "created_at": 1780228509,
+      "hex": "B67",
+      "tile": "5-1",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 90,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 91,
+      "created_at": 1780228509,
+      "train": "2+2-1",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "D",
+      "entity_type": "corporation",
+      "id": 92,
+      "created_at": 1780228509
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 93,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 94,
+      "created_at": 1780228509,
+      "hex": "B63",
+      "tile": "7-3",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 95,
+      "created_at": 1780228509,
+      "hex": "C66",
+      "tile": "7-4",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 96,
+      "created_at": 1780228509
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 97,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 98,
+      "created_at": 1780228509,
+      "train": "2+2-2",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "E",
+      "entity_type": "corporation",
+      "id": 99,
+      "created_at": 1780228509
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 100,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "F",
+      "entity_type": "corporation",
+      "id": 101,
+      "created_at": 1780228509,
+      "hex": "Z3",
+      "tile": "3-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "F",
+      "entity_type": "corporation",
+      "id": 102,
+      "created_at": 1780228509,
+      "hex": "AA2",
+      "tile": "7-5",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "F",
+      "entity_type": "corporation",
+      "id": 103,
+      "created_at": 1780228509,
+      "hex": "Y2",
+      "tile": "7-6",
+      "rotation": 5
+    },
+    {
+      "type": "buy_train",
+      "entity": "F",
+      "entity_type": "corporation",
+      "id": 104,
+      "created_at": 1780228509,
+      "train": "2+2-3",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "F",
+      "entity_type": "corporation",
+      "id": 105,
+      "created_at": 1780228509
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 106,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "M",
+      "entity_type": "corporation",
+      "id": 107,
+      "created_at": 1780228509,
+      "hex": "I20",
+      "tile": "5-2",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "M",
+      "entity_type": "corporation",
+      "id": 108,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "M",
+      "entity_type": "corporation",
+      "id": 109,
+      "created_at": 1780228509,
+      "train": "2+2-4",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 110,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 111,
+      "created_at": 1780228509,
+      "hex": "M38",
+      "tile": "3-2",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 112,
+      "created_at": 1780228509,
+      "hex": "M36",
+      "tile": "5-3",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 113,
+      "created_at": 1780228509
+    },
+    {
+      "type": "pass",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 114,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "J",
+      "entity_type": "corporation",
+      "id": 115,
+      "created_at": 1780228509,
+      "train": "2+2-5",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 116,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 117,
+      "created_at": 1780228509,
+      "hex": "V39",
+      "tile": "5-4",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 118,
+      "created_at": 1780228509,
+      "hex": "V37",
+      "tile": "7-7",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 119,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "B",
+      "entity_type": "corporation",
+      "id": 120,
+      "created_at": 1780228509,
+      "train": "2+2-6",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 121,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "G",
+      "entity_type": "corporation",
+      "id": 122,
+      "created_at": 1780228509,
+      "hex": "N31",
+      "tile": "201-0",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "G",
+      "entity_type": "corporation",
+      "id": 123,
+      "created_at": 1780228509,
+      "hex": "O30",
+      "tile": "7-8",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "G",
+      "entity_type": "corporation",
+      "id": 124,
+      "created_at": 1780228509,
+      "hex": "O32",
+      "tile": "7-9",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "G",
+      "entity_type": "corporation",
+      "id": 125,
+      "created_at": 1780228509,
+      "hex": "P31",
+      "tile": "7-10",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "G",
+      "entity_type": "corporation",
+      "id": 126,
+      "created_at": 1780228509
+    },
+    {
+      "type": "pass",
+      "entity": "G",
+      "entity_type": "corporation",
+      "id": 127,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "G",
+      "entity_type": "corporation",
+      "id": 128,
+      "created_at": 1780228509,
+      "train": "2+2-7",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 129,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "pass",
+      "entity": "A",
+      "entity_type": "corporation",
+      "id": 130,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "A",
+      "entity_type": "corporation",
+      "id": 131,
+      "created_at": 1780228509,
+      "train": "2+2-8",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 132,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "K",
+      "entity_type": "corporation",
+      "id": 133,
+      "created_at": 1780228509,
+      "hex": "C48",
+      "tile": "5-5",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "K",
+      "entity_type": "corporation",
+      "id": 134,
+      "created_at": 1780228509,
+      "hex": "C46",
+      "tile": "7-11",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "K",
+      "entity_type": "corporation",
+      "id": 135,
+      "created_at": 1780228509,
+      "hex": "B47",
+      "tile": "7-12",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "K",
+      "entity_type": "corporation",
+      "id": 136,
+      "created_at": 1780228509,
+      "train": "2+2-9",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "K",
+      "entity_type": "corporation",
+      "id": 137,
+      "created_at": 1780228509
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 138,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 139,
+      "created_at": 1780228509,
+      "hex": "T53",
+      "tile": "5-6",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 140,
+      "created_at": 1780228509,
+      "hex": "U52",
+      "tile": "3-3",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 141,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "H",
+      "entity_type": "corporation",
+      "id": 142,
+      "created_at": 1780228509,
+      "train": "2+2-10",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 143,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L",
+      "entity_type": "corporation",
+      "id": 144,
+      "created_at": 1780228509,
+      "hex": "P53",
+      "tile": "201-1",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L",
+      "entity_type": "corporation",
+      "id": 145,
+      "created_at": 1780228509,
+      "hex": "Q52",
+      "tile": "3-4",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "L",
+      "entity_type": "corporation",
+      "id": 146,
+      "created_at": 1780228509,
+      "hex": "P51",
+      "tile": "7-13",
+      "rotation": 3
+    },
+    {
+      "type": "buy_train",
+      "entity": "L",
+      "entity_type": "corporation",
+      "id": 147,
+      "created_at": 1780228509,
+      "train": "2+2-11",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 148,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CHN",
+      "entity_type": "corporation",
+      "id": 149,
+      "created_at": 1780228509,
+      "hex": "Z27",
+      "tile": "201-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CHN",
+      "entity_type": "corporation",
+      "id": 150,
+      "created_at": 1780228509,
+      "hex": "Z25",
+      "tile": "3-5",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "CHN",
+      "entity_type": "corporation",
+      "id": 151,
+      "created_at": 1780228509,
+      "hex": "Y26",
+      "tile": "8-0",
+      "rotation": 0
+    },
+    {
+      "type": "buy_train",
+      "entity": "CHN",
+      "entity_type": "corporation",
+      "id": 152,
+      "created_at": 1780228509,
+      "train": "2+2-12",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "CHN",
+      "entity_type": "corporation",
+      "id": 153,
+      "created_at": 1780228509
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 154,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MIDI",
+      "entity_type": "corporation",
+      "id": 155,
+      "created_at": 1780228509,
+      "hex": "U24",
+      "tile": "5-7",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MIDI",
+      "entity_type": "corporation",
+      "id": 156,
+      "created_at": 1780228509,
+      "hex": "U22",
+      "tile": "8-1",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MIDI",
+      "entity_type": "corporation",
+      "id": 157,
+      "created_at": 1780228509,
+      "hex": "V21",
+      "tile": "3-6",
+      "rotation": 3
+    },
+    {
+      "type": "buy_train",
+      "entity": "MIDI",
+      "entity_type": "corporation",
+      "id": 158,
+      "created_at": 1780228509,
+      "train": "2+2-13",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 159,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RCP",
+      "entity_type": "corporation",
+      "id": 160,
+      "created_at": 1780228509,
+      "hex": "AA4",
+      "tile": "3-7",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "RCP",
+      "entity_type": "corporation",
+      "id": 161,
+      "created_at": 1780228509,
+      "hex": "AB3",
+      "tile": "3-8",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "RCP",
+      "entity_type": "corporation",
+      "id": 162,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "RCP",
+      "entity_type": "corporation",
+      "id": 163,
+      "created_at": 1780228509,
+      "train": "2+2-14",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "RCP",
+      "entity_type": "corporation",
+      "id": 164,
+      "created_at": 1780228509
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 165,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SFAI",
+      "entity_type": "corporation",
+      "id": 166,
+      "created_at": 1780228509,
+      "hex": "V41",
+      "tile": "201-3",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "SFAI",
+      "entity_type": "corporation",
+      "id": 167,
+      "created_at": 1780228509,
+      "hex": "W40",
+      "tile": "5-8",
+      "rotation": 2
+    },
+    {
+      "type": "pass",
+      "entity": "SFAI",
+      "entity_type": "corporation",
+      "id": 168,
+      "created_at": 1780228509
+    },
+    {
+      "type": "pass",
+      "entity": "SFAI",
+      "entity_type": "corporation",
+      "id": 169,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "SFAI",
+      "entity_type": "corporation",
+      "id": 170,
+      "created_at": 1780228509,
+      "train": "2+2-15",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "SFAI",
+      "entity_type": "corporation",
+      "id": 171,
+      "created_at": 1780228509
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 172,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MKV",
+      "entity_type": "corporation",
+      "id": 173,
+      "created_at": 1780228509,
+      "hex": "O80",
+      "tile": "201-4",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MKV",
+      "entity_type": "corporation",
+      "id": 174,
+      "created_at": 1780228509,
+      "hex": "O78",
+      "tile": "8-2",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MKV",
+      "entity_type": "corporation",
+      "id": 175,
+      "created_at": 1780228509,
+      "hex": "N77",
+      "tile": "8-3",
+      "rotation": 3
+    },
+    {
+      "type": "buy_train",
+      "entity": "MKV",
+      "entity_type": "corporation",
+      "id": 176,
+      "created_at": 1780228509,
+      "train": "2+2-16",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 177,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSP",
+      "entity_type": "corporation",
+      "id": 178,
+      "created_at": 1780228509,
+      "hex": "C74",
+      "tile": "OE8-0",
+      "rotation": 0
+    },
+    {
+      "type": "place_token",
+      "entity": "MSP",
+      "entity_type": "corporation",
+      "id": 179,
+      "created_at": 1780228509,
+      "city": "OE8-0-0"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MSP",
+      "entity_type": "corporation",
+      "id": 180,
+      "created_at": 1780228509,
+      "hex": "D73",
+      "tile": "8-4",
+      "rotation": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "MSP",
+      "entity_type": "corporation",
+      "id": 181,
+      "created_at": 1780228509,
+      "train": "2+2-17",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 182,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KSS",
+      "entity_type": "corporation",
+      "id": 183,
+      "created_at": 1780228509,
+      "hex": "N49",
+      "tile": "5-9",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KSS",
+      "entity_type": "corporation",
+      "id": 184,
+      "created_at": 1780228509,
+      "hex": "N47",
+      "tile": "8-5",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KSS",
+      "entity_type": "corporation",
+      "id": 185,
+      "created_at": 1780228509,
+      "hex": "M46",
+      "tile": "8-6",
+      "rotation": 3
+    },
+    {
+      "type": "buy_train",
+      "entity": "KSS",
+      "entity_type": "corporation",
+      "id": 186,
+      "created_at": 1780228509,
+      "train": "2+2-18",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 187,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LRZD",
+      "entity_type": "corporation",
+      "id": 188,
+      "created_at": 1780228509,
+      "hex": "J73",
+      "tile": "5-10",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LRZD",
+      "entity_type": "corporation",
+      "id": 189,
+      "created_at": 1780228509,
+      "hex": "K72",
+      "tile": "8-7",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LRZD",
+      "entity_type": "corporation",
+      "id": 190,
+      "created_at": 1780228509,
+      "hex": "J71",
+      "tile": "8-8",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "LRZD",
+      "entity_type": "corporation",
+      "id": 191,
+      "created_at": 1780228509,
+      "train": "2+2-19",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 192,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WW",
+      "entity_type": "corporation",
+      "id": 193,
+      "created_at": 1780228509,
+      "hex": "M62",
+      "tile": "201-5",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WW",
+      "entity_type": "corporation",
+      "id": 194,
+      "created_at": 1780228509,
+      "hex": "N61",
+      "tile": "8-9",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "WW",
+      "entity_type": "corporation",
+      "id": 195,
+      "created_at": 1780228509,
+      "hex": "M60",
+      "tile": "8-10",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "WW",
+      "entity_type": "corporation",
+      "id": 196,
+      "created_at": 1780228509,
+      "train": "2+2-20",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "WW",
+      "entity_type": "corporation",
+      "id": 197,
+      "created_at": 1780228509
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 198,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KBS",
+      "entity_type": "corporation",
+      "id": 199,
+      "created_at": 1780228509,
+      "hex": "R47",
+      "tile": "201-6",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KBS",
+      "entity_type": "corporation",
+      "id": 200,
+      "created_at": 1780228509,
+      "hex": "S46",
+      "tile": "3-9",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "KBS",
+      "entity_type": "corporation",
+      "id": 201,
+      "created_at": 1780228509,
+      "hex": "R45",
+      "tile": "8-11",
+      "rotation": 2
+    },
+    {
+      "type": "buy_train",
+      "entity": "KBS",
+      "entity_type": "corporation",
+      "id": 202,
+      "created_at": 1780228509,
+      "train": "2+2-21",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "KBS",
+      "entity_type": "corporation",
+      "id": 203,
+      "created_at": 1780228509
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 204,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MZA",
+      "entity_type": "corporation",
+      "id": 205,
+      "created_at": 1780228509,
+      "hex": "AD17",
+      "tile": "5-11",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MZA",
+      "entity_type": "corporation",
+      "id": 206,
+      "created_at": 1780228509,
+      "hex": "AD15",
+      "tile": "3-10",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MZA",
+      "entity_type": "corporation",
+      "id": 207,
+      "created_at": 1780228509,
+      "hex": "AC16",
+      "tile": "5-12",
+      "rotation": 0
+    },
+    {
+      "type": "pass",
+      "entity": "MZA",
+      "entity_type": "corporation",
+      "id": 208,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "MZA",
+      "entity_type": "corporation",
+      "id": 209,
+      "created_at": 1780228509,
+      "train": "2+2-22",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "MZA",
+      "entity_type": "corporation",
+      "id": 210,
+      "created_at": 1780228509
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 211,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "OU",
+      "entity_type": "corporation",
+      "id": 212,
+      "created_at": 1780228509,
+      "hex": "Q26",
+      "tile": "5-13",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "OU",
+      "entity_type": "corporation",
+      "id": 213,
+      "created_at": 1780228509,
+      "hex": "Q24",
+      "tile": "8-12",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "OU",
+      "entity_type": "corporation",
+      "id": 214,
+      "created_at": 1780228509,
+      "hex": "P23",
+      "tile": "8-13",
+      "rotation": 3
+    },
+    {
+      "type": "buy_train",
+      "entity": "OU",
+      "entity_type": "corporation",
+      "id": 215,
+      "created_at": 1780228509,
+      "train": "2+2-23",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 216,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "pass",
+      "entity": "SB",
+      "entity_type": "corporation",
+      "id": 217,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "SB",
+      "entity_type": "corporation",
+      "id": 218,
+      "created_at": 1780228509,
+      "train": "2+2-24",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 219,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MAV",
+      "entity_type": "corporation",
+      "id": 220,
+      "created_at": 1780228509,
+      "hex": "S60",
+      "tile": "201-7",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MAV",
+      "entity_type": "corporation",
+      "id": 221,
+      "created_at": 1780228509,
+      "hex": "S58",
+      "tile": "8-14",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "MAV",
+      "entity_type": "corporation",
+      "id": 222,
+      "created_at": 1780228509,
+      "hex": "R57",
+      "tile": "8-15",
+      "rotation": 3
+    },
+    {
+      "type": "buy_train",
+      "entity": "MAV",
+      "entity_type": "corporation",
+      "id": 223,
+      "created_at": 1780228509,
+      "train": "2+2-25",
+      "price": 100
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 224,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BHB",
+      "entity_type": "corporation",
+      "id": 225,
+      "created_at": 1780228509,
+      "hex": "K46",
+      "tile": "201-8",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BHB",
+      "entity_type": "corporation",
+      "id": 226,
+      "created_at": 1780228509,
+      "hex": "K44",
+      "tile": "8-16",
+      "rotation": 4
+    },
+    {
+      "type": "lay_tile",
+      "entity": "BHB",
+      "entity_type": "corporation",
+      "id": 227,
+      "created_at": 1780228509,
+      "hex": "L45",
+      "tile": "8-17",
+      "rotation": 1
+    },
+    {
+      "type": "buy_train",
+      "entity": "BHB",
+      "entity_type": "corporation",
+      "id": 228,
+      "created_at": 1780228509,
+      "train": "2+2-26",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "BHB",
+      "entity_type": "corporation",
+      "id": 229,
+      "created_at": 1780228509
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 230,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 231,
+      "created_at": 1780228509,
+      "hex": "L25",
+      "tile": "5-14",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 232,
+      "created_at": 1780228509,
+      "hex": "L23",
+      "tile": "3-11",
+      "rotation": 3
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 233,
+      "created_at": 1780228509,
+      "hex": "K24",
+      "tile": "8-18",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 234,
+      "created_at": 1780228509,
+      "hex": "M24",
+      "tile": "8-19",
+      "rotation": 1
+    },
+    {
+      "type": "lay_tile",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 235,
+      "created_at": 1780228509,
+      "hex": "J23",
+      "tile": "3-12",
+      "rotation": 4
+    },
+    {
+      "type": "pass",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 236,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 237,
+      "created_at": 1780228509,
+      "train": "2+2-27",
+      "price": 100
+    },
+    {
+      "type": "sell_shares",
+      "entity": "GWR",
+      "entity_type": "corporation",
+      "id": 238,
+      "created_at": 1780228509,
+      "shares": [
+        "GWR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 239,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 240,
+      "created_at": 1780228509,
+      "hex": "J29",
+      "tile": "OE10-2",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 241,
+      "created_at": 1780228509,
+      "hex": "K30",
+      "tile": "8-20",
+      "rotation": 0
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 242,
+      "created_at": 1780228509,
+      "hex": "L29",
+      "tile": "3-13",
+      "rotation": 2
+    },
+    {
+      "type": "lay_tile",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 243,
+      "created_at": 1780228509,
+      "hex": "K28",
+      "tile": "8-21",
+      "rotation": 3
+    },
+    {
+      "type": "pass",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 244,
+      "created_at": 1780228509
+    },
+    {
+      "type": "buy_train",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 245,
+      "created_at": 1780228509,
+      "train": "2+2-28",
+      "price": 100
+    },
+    {
+      "type": "pass",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 246,
+      "created_at": 1780228509
+    },
+    {
+      "type": "sell_shares",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 247,
+      "created_at": 1780228509,
+      "shares": [
+        "LNWR_2"
+      ],
+      "percent": 10
+    },
+    {
+      "type": "choose",
+      "entity": "C",
+      "entity_type": "corporation",
+      "id": 248,
+      "created_at": 1780228509,
+      "choice": "first"
+    },
+    {
+      "type": "pass",
+      "entity": "LNWR",
+      "entity_type": "corporation",
+      "id": 249,
+      "created_at": 1780228509
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements double-town tiles for 18OE and the engine infrastructure to support them.

 Original Tile: 
<img width="246" height="213" alt="OE11" src="https://github.com/user-attachments/assets/ab91c504-d704-4eab-a40b-927f85dad7a5" />

18xx tile:
<img width="288" height="143" alt="grafik" src="https://github.com/user-attachments/assets/10e622ee-14e4-4c40-88a0-df5c412baad6" />


### Engine changes (backward-compatible, all games)

- **`lib/engine/part/town.rb`** — adds `size:` DSL parameter (`@size`, `attr_reader`). Defaults to `1`; no behavioural change for existing tiles.
- **`lib/engine/tile.rb`** — passes `size: params['size']` to `Town.new`. No effect on any tile that doesn't declare `size:`.
- **`assets/app/view/game/part/town_dot.rb`** — when `town.size == 2`, renders two side-by-side dots inside a white oval instead of a single dot. Revenue labels rendered symmetrically left/right. Values other than `1` or `2` raise `NotImplementedError`. All existing single-dot rendering unchanged.

> **Design credit:** Oliver Burnett-Hall suggested extending `Part::Town` with a `size:` parameter and the `town=revenue:10,size:2;path=…` DSL form. Additional routing logic clarified in community discussion with Marek, TheCat, Anthony White, and Sebastian Schmitz.

### 18OE tile definitions

Six double-town tiles added, all using `size:2` center town:

| Tile | Color | Count | Exits |
|------|-------|-------|-------|
| OE9  | green | 3 | 0, 2, 3, 5 |
| OE10 | green | 3 | 1, 2, 3, 5 |
| OE11 | green | 3 | 0, 2, 3, 4 |
| OE20 | brown | 3 | 0, 1, 2, 5 |
| OE21 | brown | 2 | 0, 1, 2, 3, 5 |
| OE22 | brown | 6 | 0, 1, 2, 3, 4, 5 |

### 18OE routing logic

- **`game.rb` — `revenue_stops` override:** expands a `size == 2` town into two entries before `compute_stops` runs. This allows the engine to score 0, 1, or 2 town revenues from a double town based on the train's remaining town-pay capacity — no changes to `compute_stops` or `revenue_for` required.
- `visited_stops` is intentionally **not** overridden: that layer feeds `check_distance!` and the min-stop guard, so expanding there would cause a size-2 town to count as 2 distance units and break express train routes passing through one.
- Express and D-trains (`pay: 0` for towns in distance definition) are unaffected — neither expanded entry can fill a pay slot, so both are ignored automatically.
- Partial scoring (1 of 2) works naturally: if a train has 1 town slot remaining, `compute_stops` picks one of the two expanded entries.

### Compatibility

`size:` on a `town=` DSL part is unused in all existing games. The only existing `size:` usage in tile strings is on `upgrade=` parts (e.g. `g_1868_wy`) which is parsed separately and unaffected.