### PR TITLE
[1824] Set base 1824 as beta

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -18,6 +18,8 @@ module View
       message = <<~MESSAGE
         <p><a href="https://github.com/tobymao/18xx/wiki/1880-Romania">1880 Romania</a> is now in alpha.</p>
 
+        <p><a href="https://github.com/tobymao/18xx/wiki/1824">1824</a> is now in beta.</p>
+
         <p>Report bugs and make feature requests <a href='https://github.com/tobymao/18xx/issues'>on GitHub</a>.</p>
       MESSAGE
 

--- a/lib/engine/game/g_1824/meta.rb
+++ b/lib/engine/game/g_1824/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :alpha
+        DEV_STAGE = :beta
         DEPENDS_ON = '1837'
 
         GAME_SUBTITLE = 'Austrian-Hungarian Railway'.freeze


### PR DESCRIPTION
Make 1824 base game Beta.

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

No functional changes, so no pins or archive needed.

## Implementation Notes

N/A

### Explanation of Change

Base 1824 feels stable, so it is time to move it to Beta.

1824 Cisleithania is still in alpha, as I think there is one more thing needed (which is about selling to stock market) for 2 player game.

### Screenshots

<img width="478" height="182" alt="image" src="https://github.com/user-attachments/assets/e6782447-dedc-4890-99b7-298f8283486a" />

### Any Assumptions / Hacks

N/A