### PR TITLE
[1880 Romania] P2 fix and events text for borders

### DIFF
--- a/lib/engine/game/g_1880_romania/game.rb
+++ b/lib/engine/game/g_1880_romania/game.rb
@@ -155,7 +155,9 @@ module Engine
                   { name: '2R', distance: 2, price: 250, num: 10, available_on: 'C2' }].freeze
 
         EVENTS_TEXT = G1880::Game::EVENTS_TEXT.merge(
-          'signal_end_game' => ['Signal End Game', 'Game ends 3 ORs after purchase/export of last 6E train']
+          'signal_end_game' => ['Signal End Game', 'Game ends 3 ORs after purchase/export of last 6E train'],
+          'open_borders' => ['Open Borders', 'Borders are opened, owner of P2 Consorţiu still receives payment for crossings'],
+          'remove_borders' => ['Remove Borders', 'Borders are removed entirely'],
         ).freeze
 
         GAME_END_REASONS_TEXT = {

--- a/lib/engine/game/g_1880_romania/step/tracker.rb
+++ b/lib/engine/game/g_1880_romania/step/tracker.rb
@@ -21,31 +21,22 @@ module Engine
         end
 
         def hex_neighbors(entity, hex)
-          connected_edges = super
+          connected_edges = Array(super)
           return connected_edges unless can_ignore_borders?(entity)
 
-          connected = @game.graph_for_entity(entity).connected_hexes(entity)
+          hex.tile.borders.each do |border|
+            next unless border.type == :impassable
 
-          borders = hex.tile.borders.select { |b| b.type == :impassable }
-
-          extra_edges = borders.filter_map do |border|
-            edge = border.edge
-            border = hex.tile.borders.find { |b| b.edge == edge && b.type == :impassable }
-            next unless border
-
-            neighbor = hex.all_neighbors[edge]
+            neighbor = hex.all_neighbors[border.edge]
             next unless neighbor
 
-            # The neighbor must already be connected AND must have track pointing back at us
-            inv_edge = Engine::Hex.invert(edge)
-            next unless connected[neighbor]&.include?(inv_edge)
+            inv_edge = Engine::Hex.invert(border.edge)
+            next if neighbor.paths[inv_edge].empty?
 
-            edge
+            connected_edges |= [border.edge]
           end
 
-          return connected_edges if extra_edges.empty?
-
-          Array(connected_edges) | extra_edges
+          connected_edges
         end
 
         def hex_neighbor_exists?(entity, hex, edge)

--- a/lib/engine/game/g_1880_romania/step/tracker.rb
+++ b/lib/engine/game/g_1880_romania/step/tracker.rb
@@ -21,12 +21,15 @@ module Engine
         end
 
         def hex_neighbors(entity, hex)
-          result = super
-          return result unless can_ignore_borders?(entity)
+          connected_edges = super
+          return connected_edges unless can_ignore_borders?(entity)
 
           connected = @game.graph_for_entity(entity).connected_hexes(entity)
 
-          extra_edges = (0..5).filter_map do |edge|
+          borders = hex.tile.borders.select { |b| b.type == :impassable }
+
+          extra_edges = borders.filter_map do |border|
+            edge = border.edge
             border = hex.tile.borders.find { |b| b.edge == edge && b.type == :impassable }
             next unless border
 
@@ -40,16 +43,17 @@ module Engine
             edge
           end
 
-          return result if extra_edges.empty?
+          return connected_edges if extra_edges.empty?
 
-          (Array(result) + extra_edges).uniq
+          Array(connected_edges) | extra_edges
         end
 
         def hex_neighbor_exists?(entity, hex, edge)
           return super unless can_ignore_borders?(entity)
 
-          border = hex.tile.borders.find { |b| b.edge == edge && b.type == :impassable }
-          border ? hex.all_neighbors[edge] : super
+          return super if hex.tile.borders.none? { |b| b.edge == edge && b.type == :impassable }
+
+          hex.all_neighbors[edge]
         end
       end
     end

--- a/lib/engine/game/g_1880_romania/step/tracker.rb
+++ b/lib/engine/game/g_1880_romania/step/tracker.rb
@@ -20,8 +20,36 @@ module Engine
           entity.owner == @game.consortiu&.owner
         end
 
+        def hex_neighbors(entity, hex)
+          result = super
+          return result unless can_ignore_borders?(entity)
+
+          connected = @game.graph_for_entity(entity).connected_hexes(entity)
+
+          extra_edges = (0..5).filter_map do |edge|
+            border = hex.tile.borders.find { |b| b.edge == edge && b.type == :impassable }
+            next unless border
+
+            neighbor = hex.all_neighbors[edge]
+            next unless neighbor
+
+            # The neighbor must already be connected AND must have track pointing back at us
+            inv_edge = Engine::Hex.invert(edge)
+            next unless connected[neighbor]&.include?(inv_edge)
+
+            edge
+          end
+
+          return result if extra_edges.empty?
+
+          (Array(result) + extra_edges).uniq
+        end
+
         def hex_neighbor_exists?(entity, hex, edge)
-          can_ignore_borders?(entity) ? hex.all_neighbors[edge] : super
+          return super unless can_ignore_borders?(entity)
+
+          border = hex.tile.borders.find { |b| b.edge == edge && b.type == :impassable }
+          border ? hex.all_neighbors[edge] : super
         end
       end
     end


### PR DESCRIPTION
Fixes #12573 
Fixes #12658
Fixes #12597

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

P2 wasn't allowing laying track across orange border. Fixed that.

Also added EVENTS_TEXT entries for the `open_borders` and `remove_borders` events

### Screenshots

before: 
<img width="321" height="222" alt="image" src="https://github.com/user-attachments/assets/96796c09-9504-4805-bad3-d009b365b00c" />


after:

<img width="440" height="371" alt="image" src="https://github.com/user-attachments/assets/2473f6d7-1884-4588-aaa9-5e3b3d13ed09" />

<img width="453" height="327" alt="image" src="https://github.com/user-attachments/assets/dcc29f49-b449-4a53-aabe-656093292e4f" />


### Any Assumptions / Hacks
