### PR TITLE
[18MO] Fixes half-price token with teleport token ability

### DIFF
--- a/lib/engine/game/g_18_mo/step/special_token.rb
+++ b/lib/engine/game/g_18_mo/step/special_token.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../../step/special_token'
+
 module Engine
   module Game
     module G18MO

--- a/lib/engine/game/g_18_mo/step/special_token.rb
+++ b/lib/engine/game/g_18_mo/step/special_token.rb
@@ -32,8 +32,12 @@ module Engine
           def available_hex(entity, hex)
             ability = ability(entity)
             return unless ability
-            return @game.token_graph_for_entity(entity.owner).reachable_hexes(entity.owner)[hex] if
-              ability.type == :token && ability.hexes.empty?
+
+            if ability.type == :token && ability.hexes.empty?
+              return true if entity.owner.all_abilities.any? { |a| a.type == :token && a.hexes.include?(hex.id) }
+
+              return @game.token_graph_for_entity(entity.owner).reachable_hexes(entity.owner)[hex]
+            end
 
             super
           end
@@ -42,7 +46,7 @@ module Engine
             return super unless entity&.company?
 
             @game.abilities(entity, :token) do |ability, _|
-              next if ability.owner_type == 'corporation'
+              next if ability.owner_type == 'corporation' && !ability.discount
 
               return ability
             end

--- a/lib/engine/game/g_18_mo/step/special_token.rb
+++ b/lib/engine/game/g_18_mo/step/special_token.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative '../../../step/special_token'
-
 module Engine
   module Game
     module G18MO
@@ -27,6 +26,31 @@ module Engine
 
             teleport_complete if @round.teleported
             @game.remove_teleport_destination(entity, action.city)
+          end
+
+          def available_hex(entity, hex)
+            ability = ability(entity)
+            return unless ability
+            return @game.token_graph_for_entity(entity.owner).reachable_hexes(entity.owner)[hex] if
+              ability.type == :token && ability.hexes.empty?
+
+            super
+          end
+
+          def ability(entity)
+            return super unless entity&.company?
+
+            @game.abilities(entity, :token) do |ability, _|
+              next if ability.owner_type == 'corporation'
+
+              return ability
+            end
+
+            @game.abilities(entity, :teleport) do |ability, _|
+              return ability if ability.used?
+            end
+
+            nil
           end
         end
       end

--- a/lib/engine/game/g_18_mo/step/track_and_token.rb
+++ b/lib/engine/game/g_18_mo/step/track_and_token.rb
@@ -1,15 +1,53 @@
 # frozen_string_literal: true
 
 require_relative '../../g_1846/step/track_and_token'
-
 module Engine
   module Game
     module G18MO
       module Step
         class TrackAndToken < G1846::Step::TrackAndToken
+          def actions(entity)
+            return super unless hptok_company?(entity)
+            return [] if entity.owner != current_entity || !can_place_token?(current_entity)
+
+            ['place_token']
+          end
+
           def process_place_token(action)
+            if hptok_company?(action.entity)
+              hptok_ability = action.entity.all_abilities.find { |a| a.type == :token && a.owner_type == 'corporation' }
+              token = action.token
+              hex = action.city.hex
+              corp_ability = current_entity.all_abilities.find { |a| a.type == :token && a.hexes.include?(hex.id) }
+              base_price = if corp_ability && @game.token_graph_for_entity(current_entity).reachable_hexes(current_entity)[hex]
+                             corp_ability.price(token)
+                           elsif corp_ability&.teleport_price
+                             corp_ability.teleport_price
+                           else
+                             token.price
+                           end
+              token.price = (base_price * hptok_ability.discount).to_i
+              @hptok_price_set = true
+              place_token(current_entity, action.city, token)
+              @hptok_price_set = false
+              action.entity.remove_ability(hptok_ability)
+              pass! unless can_lay_tile?(current_entity)
+            else
+              super
+            end
+            @game.remove_teleport_destination(current_entity, action.city)
+          end
+
+          def available_hex(entity, hex)
+            return tokener_available_hex(current_entity, hex) if hptok_company?(entity)
+
             super
-            @game.remove_teleport_destination(action.entity, action.city)
+          end
+
+          def adjust_token_price_ability!(entity, token, hex, city, special_ability: nil)
+            return [token, nil] if @hptok_price_set
+
+            super
           end
 
           def tokener_available_hex(entity, hex)
@@ -17,6 +55,12 @@ module Engine
               return true if ability.type == :token && ability.hexes.include?(hex.id)
             end
             super
+          end
+
+          private
+
+          def hptok_company?(entity)
+            entity == @game.company_by_id('HPTOK')
           end
         end
       end

--- a/lib/engine/game/g_18_mo/step/track_and_token.rb
+++ b/lib/engine/game/g_18_mo/step/track_and_token.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../g_1846/step/track_and_token'
+
 module Engine
   module Game
     module G18MO

--- a/lib/engine/game/g_18_mo/step/track_and_token.rb
+++ b/lib/engine/game/g_18_mo/step/track_and_token.rb
@@ -7,36 +7,10 @@ module Engine
     module G18MO
       module Step
         class TrackAndToken < G1846::Step::TrackAndToken
-          def actions(entity)
-            return super unless hptok_company?(entity)
-            return [] if entity.owner != current_entity || !can_place_token?(current_entity)
-
-            ['place_token']
-          end
-
           def process_place_token(action)
-            if hptok_company?(action.entity)
-              hptok_ability = action.entity.all_abilities.find { |a| a.type == :token && a.owner_type == 'corporation' }
-              token = action.token
-              hex = action.city.hex
-              corp_ability = current_entity.all_abilities.find { |a| a.type == :token && a.hexes.include?(hex.id) }
-              base_price = if corp_ability && @game.token_graph_for_entity(current_entity).reachable_hexes(current_entity)[hex]
-                             corp_ability.price(token)
-                           elsif corp_ability&.teleport_price
-                             corp_ability.teleport_price
-                           else
-                             token.price
-                           end
-              token.price = (base_price * hptok_ability.discount).to_i
-              @hptok_price_set = true
-              place_token(current_entity, action.city, token)
-              @hptok_price_set = false
-              action.entity.remove_ability(hptok_ability)
-              pass! unless can_lay_tile?(current_entity)
-            else
-              super
-            end
-            @game.remove_teleport_destination(current_entity, action.city)
+            super
+
+            @game.remove_teleport_destination(action.entity, action.city)
           end
 
           def available_hex(entity, hex)

--- a/lib/engine/step/tokener.rb
+++ b/lib/engine/step/tokener.rb
@@ -68,7 +68,7 @@ module Engine
         tokener = entity.name
         if ability
           tokener += " (#{ability.owner.sym})" if ability.owner != entity
-          entity.remove_ability(ability)
+          entity.remove_ability(ability) unless ability == special_ability
         end
 
         raise GameError, 'Token is already used' if token.used
@@ -126,11 +126,16 @@ module Engine
           return [token, special_ability]
         end
 
-        # TODO: special_ability token here
+        ability_found = false
+
         @game.abilities(entity, :token) do |ability, _|
+          discount = ability.discount
           next if ability.special_only && ability != special_ability
+          next if !discount.nil? && discount.positive? && discount < 1 && ability.hexes.empty? && ability != special_ability
           next if ability.hexes.any? && !ability.hexes.include?(hex.id)
           next if ability.city && ability.city != city.index
+
+          ability_found = true
 
           if ability.neutral
             neutral_corp = Corporation.new(
@@ -146,11 +151,29 @@ module Engine
           end
 
           token.price = ability.teleport_price if ability.teleport_price
-          token.price = ability.price(token) if @game.token_graph_for_entity(entity).reachable_hexes(entity)[hex]
+          token.price = ability.price(token).to_i if @game.token_graph_for_entity(entity).reachable_hexes(entity)[hex]
+
+          return [token, special_ability] if apply_token_discount!(token, special_ability, ability)
+
           return [token, ability]
         end
 
+        return [token, special_ability] if !ability_found && apply_token_discount!(token, special_ability, nil)
+
         [token, nil]
+      end
+
+      def apply_token_discount!(token, special_ability, ability)
+        if special_ability&.discount.is_a?(Float) &&
+          special_ability.discount < 1 &&
+          special_ability.hexes.empty? &&
+          special_ability != ability
+          token.price = (token.price * special_ability.discount).to_i
+          special_ability.use!
+          return true
+        end
+
+        false
       end
 
       def check_connected(entity, city, hex)


### PR DESCRIPTION
Fixes #7490

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Half price Token private wasn't working to discount the teleport tokens that different corporations have. 

This adds in a check for the half price token private in the process_place_token step, and inserts needed code in there to allow both abilities to work together. 

### Screenshots

### Any Assumptions / Hacks
