### PR TITLE
[1862 USA & Canada] PR 05: phase-gated tile-lay budget

### DIFF
--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -224,9 +224,9 @@ module Engine
         def corp_groups
           @corp_groups ||= CORP_GROUPS.transform_values { |sym| corporation_by_id(sym) }
         end
-        
+
         def corp_group(corporation)
-          corp_groups.find { |_, corps| corps.include?(corporation) }&.first
+          corp_groups.find { |_, corps| corps.include?(corporation) }.first
         end
 
         def all_privates_sold?
@@ -237,7 +237,7 @@ module Engine
           case group_num
           when 1 then all_privates_sold?
           when 2 then corp_groups[1].all? { |corp| corp.num_ipo_shares.zero? }
-          when 3 then corp_groups[2].all? { |corp| corp.floated? }
+          when 3 then corp_groups[2].all?(&:floated?)
           else true
           end
         end

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -221,8 +221,12 @@ module Engine
         # ---------------------------------------------------------------------------
         # Corporation group unlock logic.
         # ---------------------------------------------------------------------------
+        def corp_groups
+          @corp_groups ||= CORP_GROUPS.transform_values { |sym| corporation_by_id(sym) }
+        end
+        
         def corp_group(corporation)
-          CORP_GROUPS.find { |_, syms| syms.include?(corporation.id) }&.first
+          corp_groups.find { |_, corps| corps.include?(corporation) }&.first
         end
 
         def all_privates_sold?
@@ -232,8 +236,8 @@ module Engine
         def group_available?(group_num)
           case group_num
           when 1 then all_privates_sold?
-          when 2 then CORP_GROUPS[1].all? { |sym| corporation_by_id(sym).num_ipo_shares.zero? }
-          when 3 then CORP_GROUPS[2].all? { |sym| corporation_by_id(sym).floated? }
+          when 2 then corp_groups[1].all? { |corp| corp.num_ipo_shares.zero? }
+          when 3 then corp_groups[2].all? { |corp| corp.floated? }
           else true
           end
         end

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -219,6 +219,18 @@ module Engine
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or }.freeze
 
         # ---------------------------------------------------------------------------
+        # Home token — placed automatically at start of corp's first OR turn.
+        # Base place_home_token calls city.place_token directly (bypasses step
+        # layer) so clear_graph_for_entity is never called. Override to flush the
+        # graph cache immediately, otherwise the corp sees zero connected hexes
+        # and cannot lay track on the same turn.
+        # ---------------------------------------------------------------------------
+        def place_home_token(corporation)
+          super
+          clear_graph_for_entity(corporation)
+        end
+
+        # ---------------------------------------------------------------------------
         # Corporation group unlock logic.
         # ---------------------------------------------------------------------------
         def corp_groups

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -17,9 +17,9 @@ module Engine
 
         # ---------------------------------------------------------------------------
         # Corporation groups — unlocked progressively.
-        # Group 1 available from game start.
-        # Group 2 unlocks when ALL Group 1 companies have floated.
-        # Group 3 unlocks when ALL Group 2 companies have floated.
+        # Group 1 available when ALL private companies have been sold.
+        # Group 2 unlocks when ALL Group 1 IPO shares have been sold.
+        # Group 3 unlocks when ALL Group 2 corporations have floated.
         #
         # Director share sizes by group (from rulebook):
         #   Group 1 (NYH, NYC, CP):       30% Director + 7×10%
@@ -217,6 +217,32 @@ module Engine
         ].freeze
 
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or }.freeze
+
+        # ---------------------------------------------------------------------------
+        # Corporation group unlock logic.
+        # ---------------------------------------------------------------------------
+        def corp_group(corporation)
+          CORP_GROUPS.find { |_, syms| syms.include?(corporation.id) }&.first
+        end
+
+        def all_privates_sold?
+          @companies.all? { |c| c.owner&.player? || c.closed? }
+        end
+
+        def group_available?(group_num)
+          case group_num
+          when 1 then all_privates_sold?
+          when 2 then CORP_GROUPS[1].all? { |sym| corporation_by_id(sym).num_ipo_shares.zero? }
+          when 3 then CORP_GROUPS[2].all? { |sym| corporation_by_id(sym).floated? }
+          else true
+          end
+        end
+
+        def can_par?(corporation, parrer)
+          return false unless super
+
+          group_available?(corp_group(corporation))
+        end
 
         # ---------------------------------------------------------------------------
         # Round definitions — engine defaults only; custom steps added in later PRs.

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -163,7 +163,7 @@ module Engine
             rusts_on: '4',
             num: 7,
             variants: [
-              { name: '2E', distance: [{ nodes: %w[city offboard town], pay: 2, visit: 999 }], price: 150 },
+              { name: '2E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 2, 'visit' => 999 }], price: 150 },
             ],
           },
           {
@@ -173,7 +173,7 @@ module Engine
             rusts_on: '6',
             num: 6,
             variants: [
-              { name: '3E', distance: [{ nodes: %w[city offboard town], pay: 3, visit: 999 }], price: 300 },
+              { name: '3E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 3, 'visit' => 999 }], price: 300 },
             ],
           },
           {
@@ -183,7 +183,7 @@ module Engine
             rusts_on: '8',
             num: 5,
             variants: [
-              { name: '4E', distance: [{ nodes: %w[city offboard town], pay: 4, visit: 999 }], price: 400 },
+              { name: '4E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 4, 'visit' => 999 }], price: 400 },
             ],
           },
           {
@@ -192,7 +192,7 @@ module Engine
             price: 550,
             num: 4,
             variants: [
-              { name: '5E', distance: [{ nodes: %w[city offboard town], pay: 5, visit: 999 }], price: 700 },
+              { name: '5E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 5, 'visit' => 999 }], price: 700 },
             ],
           },
           {
@@ -201,7 +201,7 @@ module Engine
             price: 650,
             num: 3,
             variants: [
-              { name: '6E', distance: [{ nodes: %w[city offboard town], pay: 6, visit: 999 }], price: 800 },
+              { name: '6E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 6, 'visit' => 999 }], price: 800 },
             ],
           },
           {
@@ -210,7 +210,7 @@ module Engine
             price: 750,
             num: 2,
             variants: [
-              { name: '7E', distance: [{ nodes: %w[city offboard town], pay: 7, visit: 999 }], price: 900 },
+              { name: '7E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 7, 'visit' => 999 }], price: 900 },
             ],
           },
           { name: '8', distance: 999, price: 900, num: 'unlimited' },

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -133,17 +133,79 @@ module Engine
         ).freeze
 
         # ---------------------------------------------------------------------------
+        # Tile-lay budget — phase-gated.
+        # Phase 2:   1 yellow tile only.
+        # Phase 3+:  2 yellow tiles OR 1 upgrade (no mixing).
+        # ---------------------------------------------------------------------------
+        YELLOW_TILE_LAY = [{ lay: true, upgrade: false }].freeze
+        TWO_TILE_LAYS = [
+          { lay: true, upgrade: true },
+          { lay: :not_if_upgraded, upgrade: false },
+        ].freeze
+
+        STATUS_TEXT = Base::STATUS_TEXT.merge(
+          'two_tile_lays' => ['Two tile lays', 'Corporations may lay 2 yellow tiles OR 1 upgrade tile per OR']
+        ).freeze
+
+        # ---------------------------------------------------------------------------
         # Phases
         # FIXME: verify exact operating_rounds count per phase from rulebook.
         # ---------------------------------------------------------------------------
         PHASES = [
-          { name: '2',          train_limit: 4, tiles: [:yellow],           operating_rounds: 1 },
-          { name: '3', on: '3', train_limit: 4, tiles: %i[yellow green],    operating_rounds: 2 },
-          { name: '4', on: '4', train_limit: 3, tiles: %i[yellow green],    operating_rounds: 2 },
-          { name: '5', on: '5', train_limit: 2, tiles: %i[yellow green brown], operating_rounds: 3 },
-          { name: '6', on: '6', train_limit: 2, tiles: %i[yellow green brown], operating_rounds: 3 },
-          { name: '7', on: '7', train_limit: 2, tiles: %i[yellow green brown gray], operating_rounds: 3 },
-          { name: '8', on: '8', train_limit: 2, tiles: %i[yellow green brown gray], operating_rounds: 3 },
+          {
+            name: '2',
+            train_limit: 4,
+            tiles: [:yellow],
+            operating_rounds: 1,
+          },
+          {
+            name: '3',
+            on: '3',
+            train_limit: 4,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '4',
+            on: '4',
+            train_limit: 3,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '5',
+            on: '5',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '6',
+            on: '6',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '7',
+            on: '7',
+            train_limit: 2,
+            tiles: %i[yellow green brown gray],
+            operating_rounds: 3,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '8',
+            on: '8',
+            train_limit: 2,
+            tiles: %i[yellow green brown gray],
+            operating_rounds: 3,
+            status: ['two_tile_lays'],
+          },
         ].freeze
 
         # ---------------------------------------------------------------------------
@@ -217,6 +279,13 @@ module Engine
         ].freeze
 
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or }.freeze
+
+        # ---------------------------------------------------------------------------
+        # Tile-lay budget override.
+        # ---------------------------------------------------------------------------
+        def tile_lays(_entity)
+          @phase.status.include?('two_tile_lays') ? self.class::TWO_TILE_LAYS : self.class::YELLOW_TILE_LAY
+        end
 
         # ---------------------------------------------------------------------------
         # Home token — placed automatically at start of corp's first OR turn.

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -222,7 +222,7 @@ module Engine
         # Corporation group unlock logic.
         # ---------------------------------------------------------------------------
         def corp_groups
-          @corp_groups ||= CORP_GROUPS.transform_values { |sym| corporation_by_id(sym) }
+          @corp_groups ||= CORP_GROUPS.transform_values { |syms| syms.map { |s| corporation_by_id(s) } }
         end
 
         def corp_group(corporation)

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -31,6 +31,19 @@ module Engine
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
 
+    describe 'home token timing' do
+      it 'uses :operate timing' do
+        expect(described_class::HOME_TOKEN_TIMING).to eq(:operate)
+      end
+
+      it 'clears the graph after placing the home token' do
+        corp = game.corporations.first
+        graph = game.send(:graph_for_entity, corp)
+        expect(graph).to receive(:clear).at_least(:once)
+        game.place_home_token(corp)
+      end
+    end
+
     describe 'corporation group unlock' do
       let(:nyh) { game.corporation_by_id('NYH') }
       let(:nyc) { game.corporation_by_id('NYC') }

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -31,6 +31,28 @@ module Engine
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
 
+    describe 'tile-lay budget' do
+      it 'phase 2: single yellow tile only' do
+        lays = game.tile_lays(game.corporations.first)
+        expect(lays.size).to eq(1)
+        expect(lays.first[:upgrade]).to be false
+      end
+
+      it 'phase 3+: two entries, second blocked after upgrade' do
+        game.phase.next!
+        lays = game.tile_lays(game.corporations.first)
+        expect(lays.size).to eq(2)
+        expect(lays.first[:upgrade]).to be true
+        expect(lays.last[:lay]).to eq(:not_if_upgraded)
+        expect(lays.last[:upgrade]).to be false
+      end
+
+      it 'phase 3 status includes two_tile_lays flag' do
+        game.phase.next!
+        expect(game.phase.status).to include('two_tile_lays')
+      end
+    end
+
     describe 'E-train variants' do
       it 'every base train 2–7 has exactly one E-train variant' do
         base_trains = game.depot.trains.map(&:name).uniq.reject { |n| n == '8' }

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -30,5 +30,38 @@ module Engine
     it 'uses sell_buy order' do
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
+
+    describe 'corporation group unlock' do
+      let(:nyh) { game.corporation_by_id('NYH') }
+      let(:nyc) { game.corporation_by_id('NYC') }
+      let(:cp)  { game.corporation_by_id('CP') }
+      let(:cpr) { game.corporation_by_id('CPR') }
+      let(:np)  { game.corporation_by_id('NP') }
+
+      it 'Group 1 is locked while privates are unsold' do
+        expect(game.can_par?(nyh, nil)).to be false
+      end
+
+      it 'Group 1 unlocks when all privates are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(nyh, nil)).to be true
+      end
+
+      it 'Group 2 is locked even after all privates are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(cpr, nil)).to be false
+      end
+
+      it 'Group 2 unlocks when all Group 1 IPO shares are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        [nyh, nyc, cp].each { |corp| allow(corp).to receive(:num_ipo_shares).and_return(0) }
+        expect(game.can_par?(cpr, nil)).to be true
+      end
+
+      it 'Group 3 is locked while any Group 2 corp is unfloated' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(np, nil)).to be false
+      end
+    end
   end
 end

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -31,6 +31,49 @@ module Engine
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
 
+    describe 'E-train variants' do
+      it 'every base train 2–7 has exactly one E-train variant' do
+        base_trains = game.depot.trains.map(&:name).uniq.reject { |n| n == '8' }
+        base_trains.each do |name|
+          proto = game.depot.trains.find { |t| t.name == name }
+          expect(proto.variants.keys).to include("#{name}E"), "#{name}-train missing #{name}E variant"
+        end
+      end
+
+      it 'E-train distance uses string keys and visit 999' do
+        %w[2E 3E 4E 5E 6E 7E].each do |variant_name|
+          base = variant_name.chomp('E')
+          proto = game.depot.trains.find { |t| t.name == base }
+          dist = proto.variants[variant_name][:distance]
+          expect(dist).to be_an(Array), "#{variant_name} distance should be an array"
+          expect(dist.first['visit']).to eq(999), "#{variant_name} should visit 999 nodes"
+          expect(dist.first['nodes']).to include('city'), "#{variant_name} nodes should include city"
+        end
+      end
+
+      it '2 and 2E trains rust on the 4-train sym' do
+        two_train = game.depot.trains.find { |t| t.name == '2' }
+        expect(two_train.rusts_on).to eq('4')
+      end
+
+      it '3 and 3E trains rust on the 6-train sym' do
+        three_train = game.depot.trains.find { |t| t.name == '3' }
+        expect(three_train.rusts_on).to eq('6')
+      end
+
+      it '4 and 4E trains rust on the 8-train sym' do
+        four_train = game.depot.trains.find { |t| t.name == '4' }
+        expect(four_train.rusts_on).to eq('8')
+      end
+
+      it '5E and later trains never rust' do
+        %w[5 6 7 8].each do |name|
+          train = game.depot.trains.find { |t| t.name == name }
+          expect(train.rusts_on).to be_nil, "#{name}-train should not rust"
+        end
+      end
+    end
+
     describe 'home token timing' do
       it 'uses :operate timing' do
         expect(described_class::HOME_TOKEN_TIMING).to eq(:operate)


### PR DESCRIPTION
Stacked on #12674 (PR 04 — E-train fix).

## Before clicking "Create"

- [x] Branch is derived from `1862_usa_canada_p04_etrains`
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Implements the phase-gated tile-lay budget:

| Phase | Trigger | Tile lays allowed |
|-------|---------|------------------|
| 2 | game start | 1 yellow tile only |
| 3–8 | first 3/3E purchase | 2 yellow tiles **OR** 1 upgrade (no mixing) |

"No mixing" means: if the first tile laid is an upgrade, the second slot is blocked (`:not_if_upgraded`). A yellow + upgrade combination is not permitted.

Implementation:
- `YELLOW_TILE_LAY` / `TWO_TILE_LAYS` constants define the two budgets
- `status: ['two_tile_lays']` added to phases 3–8 in `PHASES`
- `tile_lays` override keys on `@phase.status`
- `STATUS_TEXT` entry added so the phase legend in the UI shows the rule

### Screenshots

N/A.

### Any Assumptions / Hacks

None. Pattern is directly analogous to 18FR, corrected to use `lay: :not_if_upgraded` (not `lay: true`) on the second slot so yellow+upgrade mixing is blocked.