### PR TITLE
[assets] improves tile render with icons

### DIFF
--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -82,6 +82,7 @@ module View
         large, normal = @tile.icons.partition(&:large)
         render_tile_parts_by_loc(Part::Icons, parts: normal).each { |i| children << i }
         children << render_tile_part(Part::Cities, show_revenue: !render_revenue) unless @tile.cities.empty?
+
         children << render_tile_part(Part::Towns, routes: @routes, show_revenue: !render_revenue) unless @tile.towns.empty?
 
         borders = render_tile_part(Part::Borders) if @tile.borders.any?(&:type)

--- a/assets/app/view/game/tile.rb
+++ b/assets/app/view/game/tile.rb
@@ -79,8 +79,9 @@ module View
         if !@tile.paths.empty? || !@tile.stubs.empty? || !@tile.future_paths.empty?
           children << render_tile_part(Part::Track, routes: @routes)
         end
+        large, normal = @tile.icons.partition(&:large)
+        render_tile_parts_by_loc(Part::Icons, parts: normal).each { |i| children << i }
         children << render_tile_part(Part::Cities, show_revenue: !render_revenue) unless @tile.cities.empty?
-
         children << render_tile_part(Part::Towns, routes: @routes, show_revenue: !render_revenue) unless @tile.towns.empty?
 
         borders = render_tile_part(Part::Borders) if @tile.borders.any?(&:type)
@@ -105,8 +106,6 @@ module View
           children << render_tile_part(Part::Reservation, reservation: r) if @game.render_hex_reservation?(r)
         end
 
-        large, normal = @tile.icons.partition(&:large)
-        render_tile_parts_by_loc(Part::Icons, parts: normal).each { |i| children << i }
         children << render_tile_part(Part::LargeIcons) unless large.empty?
         children << render_tile_part(Part::FutureLabel) if @tile.future_label
 


### PR DESCRIPTION
Fixes #5167

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Currently, icons are rendered (and claim their regions in @region_use) after cities, so when a city renders its inline revenue circle it doesn't know the icon is coming and can pick the same spot. Moving icon rendering before cities means the icon claims its region first, and the city's revenue circle then picks a different spot that doesn't overlap.

The change is simply moving these two lines earlier in the render method, before Part::Cities is rendered:

```
large, normal = @tile.icons.partition(&:large)
render_tile_parts_by_loc(Part::Icons, parts: normal).each { |i| children << i }
```

### Screenshots

Before: 

<img width="133" height="114" alt="image" src="https://github.com/user-attachments/assets/6f5edfe4-b4e3-4338-b70c-593886ff5bd4" />


after:

<img width="360" height="321" alt="image" src="https://github.com/user-attachments/assets/b28edfb3-4475-47f5-a3c2-0bf2b4f67538" />


### Any Assumptions / Hacks
