### PR TITLE
[1871] fixes EMR for Union Bank

### DIFF
--- a/lib/engine/game/g_1871/game.rb
+++ b/lib/engine/game/g_1871/game.rb
@@ -498,14 +498,30 @@ module Engine
         end
 
         def can_go_bankrupt?(player, corporation)
-          return false if player == @union_bank
+          # Normalize: player might be @union_bank itself or the human who owns it
+          acting = player == @union_bank ? company_by_id('UB').owner : player
+          ub_owner = company_by_id('UB')&.owner
 
-          if corporation.owner == @union_bank && company_by_id('UB').owner == player
-            total_emr_buying_power(player, corporation) +
-              total_emr_buying_power(@union_bank, corporation) < @depot.min_depot_price
+          if acting == ub_owner
+            player_power = liquidity(acting, emergency: true)
+            ub_power = liquidity(@union_bank, emergency: true)
+            corp_power = corporation.cash + emergency_issuable_cash(corporation)
+            player_power + ub_power + corp_power < @depot.min_depot_price
           else
             super
           end
+        end
+
+        def total_emr_buying_power(player, corporation)
+          # When UB is the acting entity, combine UB + owner liquidity
+          if player == @union_bank
+            ub_owner = company_by_id('UB')&.owner
+            owner_power = ub_owner ? liquidity(ub_owner, emergency: true) : 0
+            ub_power = liquidity(@union_bank, emergency: true)
+            corp_power = corporation ? corporation.cash + emergency_issuable_cash(corporation) : 0
+            return owner_power + ub_power + corp_power
+          end
+          super
         end
 
         def purchasable_companies(entity = nil)

--- a/lib/engine/game/g_1871/game.rb
+++ b/lib/engine/game/g_1871/game.rb
@@ -497,25 +497,27 @@ module Engine
           super
         end
 
-        def can_go_bankrupt?(player, corporation)
-          # Normalize: player might be @union_bank itself or the human who owns it
-          acting = player == @union_bank ? company_by_id('UB').owner : player
-          ub_owner = company_by_id('UB')&.owner
+        def ub_owner
+          company_by_id('UB')&.owner
+        end
 
-          if acting == ub_owner
-            player_power = liquidity(acting, emergency: true)
-            ub_power = liquidity(@union_bank, emergency: true)
-            corp_power = corporation.cash + emergency_issuable_cash(corporation)
-            player_power + ub_power + corp_power < @depot.min_depot_price
-          else
-            super
-          end
+        def acting_as_union_bank?(player)
+          player == @union_bank || player == ub_owner
+        end
+
+        def can_go_bankrupt?(player, corporation)
+          return super unless acting_as_union_bank?(player)
+
+          acting = player == @union_bank ? ub_owner : player
+          player_power = liquidity(acting, emergency: true)
+          ub_power = liquidity(@union_bank, emergency: true)
+          corp_power = corporation.cash + emergency_issuable_cash(corporation)
+          player_power + ub_power + corp_power < @depot.min_depot_price
         end
 
         def total_emr_buying_power(player, corporation)
           # When UB is the acting entity, combine UB + owner liquidity
           if player == @union_bank
-            ub_owner = company_by_id('UB')&.owner
             owner_power = ub_owner ? liquidity(ub_owner, emergency: true) : 0
             ub_power = liquidity(@union_bank, emergency: true)
             corp_power = corporation ? corporation.cash + emergency_issuable_cash(corporation) : 0

--- a/lib/engine/step/train.rb
+++ b/lib/engine/step/train.rb
@@ -86,8 +86,8 @@ module Engine
           if borrow_from && player.cash < remaining
             current_cash = player.cash
             extra_needed = remaining - current_cash
-            player.spend(current_cash, entity)
-            @log << "#{player.name} contributes #{@game.format_currency(current_cash)}"
+            player.spend(current_cash, entity) if current_cash.positive?
+            @log << "#{player.name} contributes #{@game.format_currency(current_cash)}" if current_cash.positive?
             borrow_from.spend(extra_needed, entity)
             @log << "#{borrow_from.name} contributes #{@game.format_currency(extra_needed)}"
           else


### PR DESCRIPTION
Fixes #8831
Fixes #11197

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Reworked the `can_go_bankrupt?` method so that it also checks the UB owner, and added a custom `total_emr_buying_power` method to factor in the UB owner's liquidity. 

As I'm continuing testing, I've discovered an issue if UB has $0. Will continue troubleshooting this and add a commit once i've corrected that. 

This PR could require pins for any games where the UB president couldn't afford a train, but those games would have been stuck anyway, so it's likely not an issue. 

EDIT: 

I added a change to Engine/Step/Train.rb It adds a  `if current_cash.positive?` gate onto two of the lines in the borrow_from section. 

The base code assumes that when borrow_from is set, the player always has some cash to contribute first. But that assumption breaks when:

- The player entity is the Union Bank with $0 (all shares sold, all cash exhausted)
- Any other game where a president legitimately reaches $0 before the train buy completes

In both cases, spend(0) and logging "X contributes $0" are meaningless operations that crash or pollute the log. The guards simply skip them when there's nothing to contribute, letting borrow_from.spend(extra_needed, entity) handle the full remaining amount cleanly. The end result, that the corporation gets the cash it needs, is identical.

### Screenshots

### Any Assumptions / Hacks
