### PR TITLE
[1871] UB can borrow from owner to par corp

### DIFF
--- a/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
+++ b/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
@@ -27,13 +27,6 @@ module Engine
             @round.bank_bought = true if action.purchase_for == @game.union_bank
           end
 
-          def can_buy_for(entity)
-            return [] unless entity == @game.company_by_id('UB').owner
-            return [] if @round.bank_bought
-
-            [@game.union_bank]
-          end
-
           # This makes sure we don't auto pass if the player is allowed to
           # exchange a share
           def can_exchange_any?(entity)
@@ -145,7 +138,8 @@ module Engine
           def get_par_prices_with_help(entity, _corp, extra_cash: 0)
             available_cash = entity.cash + extra_cash
 
-            available_cash += @game.union_bank.cash if entity == @game.company_by_id('UB')&.owner && !@round.bank_bought
+            # UB can borrow from its owner to par corporations (Fixes #10461)
+            available_cash += @game.union_bank.cash if union_bank_owner_can_help?(entity)
 
             @game
               .stock_market
@@ -202,11 +196,7 @@ module Engine
               next true if can_buy?(entity, bundle)
 
               # Check if entity can par with UB as the purchase target
-              if entity == @game.company_by_id('UB')&.owner && !@round.bank_bought
-                can_buy?(@game.union_bank, bundle)
-              else
-                false
-              end
+              can_buy?(@game.union_bank, bundle) if union_bank_owner_can_help?(entity)
             end
           end
 
@@ -214,6 +204,10 @@ module Engine
           def activate_program_buy_shares(entity, program)
             program.from_market = true
             super
+          end
+
+          def union_bank_owner_can_help?(entity)
+            entity == @game.company_by_id('UB')&.owner && !@round.bank_bought
           end
         end
       end

--- a/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
+++ b/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
@@ -143,10 +143,14 @@ module Engine
           end
 
           def get_par_prices_with_help(entity, _corp, extra_cash: 0)
+            available_cash = entity.cash + extra_cash
+
+            available_cash += @game.union_bank.cash if entity == @game.company_by_id('UB')&.owner && !@round.bank_bought
+
             @game
               .stock_market
               .par_prices
-              .select { |p| p.price * 2 <= entity.cash + extra_cash }
+              .select { |p| p.price * 2 <= available_cash }
           end
 
           # On Prince Edward Island we par from the market
@@ -189,7 +193,20 @@ module Engine
           # Ditto
           def can_ipo_any?(entity)
             !bought? && @game.corporations.any? do |c|
-              @game.can_par?(c, entity) && can_buy?(entity, @game.share_by_id("#{c.name}_0")&.to_bundle)
+              next false unless @game.can_par?(c, entity)
+
+              bundle = @game.share_by_id("#{c.name}_0")&.to_bundle
+              next false unless bundle
+
+              # Check if entity can par directly
+              next true if can_buy?(entity, bundle)
+
+              # Check if entity can par with UB as the purchase target
+              if entity == @game.company_by_id('UB')&.owner && !@round.bank_bought
+                can_buy?(@game.union_bank, bundle)
+              else
+                false
+              end
             end
           end
 


### PR DESCRIPTION
Fixes #10461

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

A long-standing bug meant that the UB couldn't par a corp unless it had enough money to buy the president's cert outright. It should be able to borrow money from its owner for this, just like any other share buy it does. 

### Screenshots

### Any Assumptions / Hacks
