### PR TITLE
[1871] Allow UB to split corps

### DIFF
--- a/lib/engine/game/g_1871/game.rb
+++ b/lib/engine/game/g_1871/game.rb
@@ -580,16 +580,20 @@ module Engine
 
         # Allow a company to split, if the owner has >= 40 percent, at least two
         # tokens out and there is a tranch available
-        def can_split?(corporation, spliter)
+        def can_split?(corporation, splitter)
           return false unless tranch_available?
           return false if corporation.name == 'PEIR'
           return false unless corporation.ipoed
 
+          # Resolve the effective splitter — if the UB is president, its owner acts on its behalf
+          effective_splitter = splitter
+          effective_splitter = union_bank if splitter == company_by_id('UB')&.owner && union_bank == corporation.owner
+
           # Have to own the company in question
-          return false unless corporation.owner == spliter
+          return false unless corporation.owner == effective_splitter
 
           # Have to own at least 40 percent
-          return false unless spliter.percent_of(corporation) >= 40
+          return false unless effective_splitter.percent_of(corporation) >= 40
 
           # Have to have two tokens of this corporation out on the map
           corporation.placed_tokens.size >= 2

--- a/lib/engine/game/g_1871/round/stock.rb
+++ b/lib/engine/game/g_1871/round/stock.rb
@@ -43,7 +43,10 @@ module Engine
           end
 
           def split_active_entities
-            [@split_corporation&.owner].compact
+            owner = @split_corporation&.owner
+            # If the UB is president, its owner (the player) is the active entity
+            owner = @game.company_by_id('UB').owner if owner == @game.union_bank
+            [owner].compact
           end
 
           def split_choice_entity

--- a/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
+++ b/lib/engine/game/g_1871/step/buy_sell_par_split_shares.rb
@@ -182,7 +182,9 @@ module Engine
           # Check if we are allowed to split any of the current corporations
           def can_split_any?(entity)
             !bought? && @game.corporations.any? do |c|
-              @game.can_split?(c, entity)
+              @game.can_split?(c, entity) ||
+                (entity == @game.company_by_id('UB')&.owner &&
+                @game.can_split?(c, @game.union_bank))
             end
           end
 


### PR DESCRIPTION
Fixes #9944

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

- `can_split?` was checking `corporation.owner == splitter`, which would never match a player when the UB is president. Fixed to resolve an effective_splitter: if the splitter is the UB's owner and the UB is the corporation's president, treat the UB as the effective splitter for ownership and percent checks.
- `can_split_any?` was only checking if the player directly satisfied `can_split?`. Fixed to also check if the UB satisfies `can_split?` when the entity is the UB's owner.
- `split_active_entities` was returning [@split_corporation.owner], which would be the UB (a corporation) rather than a player, so no one would get the choice prompt. Fixed to resolve the UB's owner as the active entity when the UB is the corporation's president.

- minor: corrected typo in method (splitter, not spliter)

### Screenshots

<img width="335" height="423" alt="image" src="https://github.com/user-attachments/assets/7b03a52d-98c1-4973-8c05-cb41d73e7763" />


### Any Assumptions / Hacks
