### PR TITLE
[Front Page] Adds "Hide Full Games" checkbox to New Games section

### DIFF
--- a/assets/app/view/game_row.rb
+++ b/assets/app/view/game_row.rb
@@ -9,6 +9,7 @@ module View
     include GameManager
 
     needs :header
+    needs :header_extra, default: nil
     needs :game_row_games
     needs :user
     needs :type
@@ -27,6 +28,7 @@ module View
 
     def render_header(header)
       children = [h(:h2, header)]
+      children << @header_extra if @header_extra
       p = url_search_params[@type].to_i
       @offset = @type == :hotseat ? (p * @limit) : 0
       if p.positive?

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -17,9 +17,12 @@ module View
 
     needs :user
     needs :refreshing, default: nil, store: true
+    needs :hide_full_games, default: false, store: true
 
     def render
-      your_games, other_games = @games.partition { |game| user_in_game?(@user, game) || user_owns_game?(@user, game) }
+      your_games, other_games = @games.partition do |game|
+        user_in_game?(@user, game) || user_owns_game?(@user, game)
+      end
 
       children = [
         h(Welcome),
@@ -45,9 +48,32 @@ module View
         .map { |k| Lib::Storage[k] }
         .sort_by { |gd| [-(gd[:updated_at] || now), gd[:id]] }
 
+      new_games = grouped['new']&.sort_by { |g| -g['created_at'] }
+      new_games = new_games&.reject { |g| full_game?(g) } if @hide_full_games
+
       render_row(children, 'Your Games', your_games, :personal) if @user
       render_row(children, 'Hotseat Games', hotseat, :hotseat) if hotseat.any?
-      render_row(children, 'New Games', grouped['new']&.sort_by { |g| -g['created_at'] }, :new) if @user
+      hide_full_checkbox = h('label', { style: { marginLeft: '1rem' } }, [
+        h('input', {
+            attrs: { type: 'checkbox', id: 'hide_full_games_checkbox' },
+            hook: {
+              insert: ->(_vnode) { `document.getElementById('hide_full_games_checkbox').checked = #{@hide_full_games}` },
+              update: lambda { |_old_vnode, _vnode|
+                        `document.getElementById('hide_full_games_checkbox').checked = #{@hide_full_games}`
+                      },
+            },
+            on: { change: ->(e) { store(:hide_full_games, e.JS[:target].JS[:checked]) } },
+          }),
+        ' Hide Full Games',
+      ])
+
+      if @user
+        if new_games&.any?
+          render_row(children, 'New Games', new_games, :new, header_extra: hide_full_checkbox)
+        else
+          children << h('div', [h(:h2, 'New Games'), hide_full_checkbox])
+        end
+      end
       render_row(children, 'Active Games', grouped['active']&.sort_by { |g| -g['updated_at'] }, :active)
       render_row(children, 'Finished Games', grouped['finished']&.sort_by { |g| -g['finished_at'] }, :finished)
       render_filter_row(children)
@@ -88,7 +114,7 @@ module View
       store(:refreshing, timeout, skip: true)
     end
 
-    def render_row(children, header, games, type)
+    def render_row(children, header, games, type, header_extra: nil)
       return unless games&.any?
 
       children << h(
@@ -97,7 +123,12 @@ module View
         game_row_games: games,
         type: type,
         user: @user,
+        header_extra: header_extra,
       )
+    end
+
+    def full_game?(game)
+      game['players'].size >= game['max_players']
     end
 
     def render_filter_row(children)

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -20,9 +20,7 @@ module View
     needs :hide_full_games, default: false, store: true
 
     def render
-      your_games, other_games = @games.partition do |game|
-        user_in_game?(@user, game) || user_owns_game?(@user, game)
-      end
+      your_games, other_games = @games.partition { |game| user_in_game?(@user, game) || user_owns_game?(@user, game) }
 
       children = [
         h(Welcome),


### PR DESCRIPTION
Fixes #8658

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

This adds a checkbox to the New Games section of the front page, allowing users to hide full new games that haven't started yet. It doesn't affect the display of active, hotseat, or finished games in any way. 

### Explanation of Change

### Screenshots

Unchecked:
<img width="677" height="406" alt="image" src="https://github.com/user-attachments/assets/65447cf9-c06a-426e-af13-084596471f05" />

Checked:
<img width="692" height="392" alt="image" src="https://github.com/user-attachments/assets/afa48a4d-2b5a-4584-a41f-4fb8867056ae" />

### Any Assumptions / Hacks
