### PR TITLE
Improves log message when buy_trains is skipped due to space

### DIFF
--- a/lib/engine/step/buy_train.rb
+++ b/lib/engine/step/buy_train.rb
@@ -73,6 +73,12 @@ module Engine
         pass! if !can_buy_train?(action.entity) && pass_if_cannot_buy_train?(action.entity)
       end
 
+      def log_skip(entity)
+        return super if @game.num_corp_trains(entity) < @game.train_limit(entity)
+
+        @log << "#{entity.name} automatically skips #{description.downcase} because it has no room for more trains"
+      end
+
       def swap_sell(_player, _corporation, _bundle, _pool_share); end
     end
   end


### PR DESCRIPTION
Fixes #8808

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

This started as an enhancement for 1880, but I realized it was useful for all games.

First, I'll mention that the initial report was wrong. The site doesn't skip the buy trains step if you can't afford a train from the depot (this may have been a behaviour before, it is not now). However, it does skip the step if you're at the train limit.

Right now, when a corp skips the buy_train step due to being train-locked, the log simply says "{corp} skips buy trains" with no explanation as to why. That can be confusing. This PR modifies the `log_skip` message to "#{entity.name} automatically skips #{description.downcase} because it has no room for more trains" if the corp is at its train limit. 

This has no impact on games where you can discard or upgrade trains, since they won't trigger the log_skip message in that situation.

### Screenshots

<img width="615" height="98" alt="image" src="https://github.com/user-attachments/assets/f06efa05-eaec-45ef-8a16-c8913829873a" />


### Any Assumptions / Hacks
