### PR TITLE
[1828] allow choice of odd share in merger even when only holding president's cert

### DIFF
--- a/lib/engine/game/g_1828/step/merger.rb
+++ b/lib/engine/game/g_1828/step/merger.rb
@@ -321,11 +321,13 @@ module Engine
             total_shares = entity.num_shares_of(@merger) + entity.num_shares_of(@target)
             return unless total_shares.odd?
 
-            merger_share = entity.shares_of(@merger).reject(&:president).first
-            target_share = entity.shares_of(@target).reject(&:president).first
+            merger_share = entity.shares_of(@merger).reject(&:president).first || entity.shares_of(@merger).find(&:president)
+            target_share = entity.shares_of(@target).reject(&:president).first || entity.shares_of(@target).find(&:president)
 
             if @player_selection
-              @odd_share = @player_selection.include?(@merger.name) ? merger_share : target_share
+              chosen_corp = @player_selection.include?(@merger.name) ? @merger : @target
+              chosen_share = entity.shares_of(chosen_corp).reject(&:president).first
+              @odd_share = chosen_share || (chosen_corp == @merger ? target_share : merger_share)
               @player_selection = nil
             elsif entity.player? && merger_share && target_share
               choices = merging_corporations.map do |c|


### PR DESCRIPTION
Fixes #8160 

<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

When a player holds only a president's certificate of one of the merging corporations, they weren't being offered a choice of which share to keep as their odd share.

The original code fetched candidate odd shares using .reject(&:president), meaning a president's cert was invisible to the logic. If a player held only a president's cert of one corp and a regular share of the other, one of the two variables would be nil, and the elsif condition merger_share && target_share would fail, silently skipping the choice prompt and falling through to the else branch.

I changed the share fetching lines to fall back to the president's cert if no regular share exists:

```
merger_share = entity.shares_of(@merger).reject(&:president).first || entity.shares_of(@merger).find(&:president)
target_share = entity.shares_of(@target).reject(&:president).first || entity.shares_of(@target).find(&:president)
```

This means the choice is now correctly offered to the player even when one of their holdings is solely a president's cert.
Second fix: When the player's selection is resolved, if they chose the corp where their only holding is a president's cert, that cert counts as 2 shares and can't be the odd share. So the selection is redirected to the other corp's share instead:

```
if @player_selection
  chosen_corp = @player_selection.include?(@merger.name) ? @merger : @target
  chosen_share = entity.shares_of(chosen_corp).reject(&:president).first
  @odd_share = chosen_share || (chosen_corp == @merger ? target_share : merger_share)
  @player_selection = nil
```

If the player picked a corp where they only have a president's cert (chosen_share is nil), the odd share falls back to the other corp's share, correctly treating the cert as 2 shares that will form a pair in the exchange.

### Screenshots

### Any Assumptions / Hacks
