### PR TITLE
Send notification when minimum player count is reached

### DIFF
--- a/routes/game.rb
+++ b/routes/game.rb
@@ -25,6 +25,14 @@ class Api
             halt(400, 'Cannot join game because it is full') if users.size >= game.max_players
             halt(400, 'Cannot join because game has started') unless game.status == 'new'
 
+            if users.size == game.min_players - 1
+              # Generate a message to the game owner
+              type = 'Minimum player count reached'
+              user_ids = [game.user_id]
+              force = true
+              publish_turn(user_ids, game, r.base_url, type, force)
+            end
+
             if users.size == game.max_players - 1
               # Generate a message to the game owner
               type = 'Game Full'

--- a/routes/game.rb
+++ b/routes/game.rb
@@ -25,17 +25,15 @@ class Api
             halt(400, 'Cannot join game because it is full') if users.size >= game.max_players
             halt(400, 'Cannot join because game has started') unless game.status == 'new'
 
-            if users.size == game.min_players - 1
-              # Generate a message to the game owner
-              type = 'Minimum player count reached'
-              user_ids = [game.user_id]
-              force = true
-              publish_turn(user_ids, game, r.base_url, type, force)
-            end
-
             if users.size == game.max_players - 1
               # Generate a message to the game owner
               type = 'Game Full'
+              user_ids = [game.user_id]
+              force = true
+              publish_turn(user_ids, game, r.base_url, type, force)
+            elsif users.size == game.min_players - 1
+              # Generate a message to the game owner
+              type = 'Minimum player count reached'
               user_ids = [game.user_id]
               force = true
               publish_turn(user_ids, game, r.base_url, type, force)


### PR DESCRIPTION
Fixes #12445

<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Much like my PR that added a notification when your game is full (#11627), this one adds a notification when the set minimum player count has been reached. 

I realized that not everyone is necessarily waiting for the game to fill up before starting. Knowing that the minimum threshold has been reached has its usefulness as well.

### Screenshots

### Any Assumptions / Hacks
