### PR TITLE
[1850] Western Land Grant should allow Mesabi Token buy

### DIFF
--- a/lib/engine/game/g_1850/step/special_track.rb
+++ b/lib/engine/game/g_1850/step/special_track.rb
@@ -29,14 +29,6 @@ module Engine
             ability.use!
           end
 
-          def process_choose(action)
-            return unless action.choice == 'Buy Mesabi Token'
-
-            ability = abilities(@game.wlg_company)
-            track_step.buy_mesabi_token(@game.wlg_company.owner)
-            ability.use!
-          end
-
           def can_use_special_track?(entity)
             @round.steps.find { |step| step.is_a?(Track) }.acted || entity == @game.river_company
           end

--- a/lib/engine/game/g_1850/step/special_track.rb
+++ b/lib/engine/game/g_1850/step/special_track.rb
@@ -10,7 +10,31 @@ module Engine
           def actions(entity)
             return [] unless can_use_special_track?(entity)
 
-            super
+            acts = super
+            acts += ['choose_ability'] if can_buy_mesabi_token_with_wlg?(entity)
+            acts
+          end
+
+          def choices_ability(entity)
+            return [] unless can_buy_mesabi_token_with_wlg?(entity)
+
+            [['Buy Mesabi Token', 'Buy Mesabi Token']]
+          end
+
+          def process_choose_ability(action)
+            return unless action.choice == 'Buy Mesabi Token'
+
+            ability = @game.abilities(@game.wlg_company, :tile_lay, time: 'track')
+            track_step.buy_mesabi_token(@game.wlg_company.owner)
+            ability.use!
+          end
+
+          def process_choose(action)
+            return unless action.choice == 'Buy Mesabi Token'
+
+            ability = abilities(@game.wlg_company)
+            track_step.buy_mesabi_token(@game.wlg_company.owner)
+            ability.use!
           end
 
           def can_use_special_track?(entity)
@@ -25,6 +49,24 @@ module Engine
 
           def fix_ability_only_western(ability)
             ability.hexes = @game.class::WEST_RIVER_HEXES
+          end
+
+          private
+
+          def can_buy_mesabi_token_with_wlg?(entity)
+            corp = if entity == @game.wlg_company
+                     entity.owner
+                   elsif entity.corporation?
+                     entity
+                   end
+            return false unless corp&.corporation?
+            return false unless corp.companies.include?(@game.wlg_company)
+
+            track_step.can_buy_mesabi_token_without_lay?(corp)
+          end
+
+          def track_step
+            @round.steps.find { |step| step.is_a?(Track) }
           end
         end
       end

--- a/lib/engine/game/g_1850/step/track.rb
+++ b/lib/engine/game/g_1850/step/track.rb
@@ -80,13 +80,16 @@ module Engine
           end
 
           def can_buy_mesabi_token?(entity)
+            can_buy_mesabi_token_without_lay?(entity) && get_tile_lay(entity)
+          end
+
+          def can_buy_mesabi_token_without_lay?(entity)
             entity.corporation? &&
-            !entity.mesabi_token &&
-            @game.mesabi_company_sold_or_closed &&
-            @game.mesabi_token_counter.positive? &&
-            entity.cash >= 80 &&
-            hex_neighbors(entity, @game.mesabi_hex) &&
-            get_tile_lay(entity)
+              !entity.mesabi_token &&
+              @game.mesabi_company_sold_or_closed &&
+              @game.mesabi_token_counter.positive? &&
+              entity.cash >= 80 &&
+              hex_neighbors(entity, @game.mesabi_hex)
           end
         end
       end


### PR DESCRIPTION
Fixes #10401 

<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Players who are connected to the Mesabi hex should be able to use an additional tile lay granted by the Western Land Grant to purchase a Mesabi Token (confirmed by the designer here: https://groups.io/g/18xx/message/51396)

### Screenshots

<img width="959" height="749" alt="image" src="https://github.com/user-attachments/assets/526ff6c5-28cf-4410-b242-3c0818180d60" />

### Any Assumptions / Hacks
