### PR TITLE
[21Moon] Improve UN Contract description

### DIFF
--- a/lib/engine/game/g_21_moon/entities.rb
+++ b/lib/engine/game/g_21_moon/entities.rb
@@ -29,9 +29,9 @@ module Engine
             revenue: 5,
             min_price: 1,
             max_price: 45,
-            desc: 'When this private is bought by a company, the president of the company may choose to add or remove '\
-                  'a 2/3/4/5/6 train to/from the depot. If a train is added, it must be of the '\
-                  'current phase or later. This will close the company. Can be sold to a corporation for ₡1-₡45.',
+            desc: 'When this private is bought by a corporation, the president of that corporation may choose to add or remove '\
+                  'a 2/3/4/5/6 train to/from the depot. The train must be of the current phase or later. '\
+                  'The UN Contract closes upon being bought by a corporation. Can be sold to a corporation for ₡1-₡45.',
             abilities: [],
             color: nil,
           },
@@ -43,8 +43,8 @@ module Engine
             min_price: 1,
             max_price: 60,
             desc: 'The corporation owning the SBC can build and upgrade road tiles crossing the rift. '\
-                  'The owning company receives a bonus of 60 credits after the connection across the rift is '\
-                  'made and the SBC will close. Can be sold to a corporation for ₡1-₡60.',
+                  'The owning corporation receives a bonus of 60 credits after the connection across the rift is '\
+                  'made, at which time the SBC will close. Can be sold to a corporation for ₡1-₡60.',
             abilities: [],
             color: nil,
           },


### PR DESCRIPTION
Fixes #10739

<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Clarified the description of the UN Contract to make it clear that it closes upon purchase by a Corporation. 

Also, the various privates used company and corporation interchangeably when talking about corporations. I standardized it to corporation for all cases. 

### Screenshots

### Any Assumptions / Hacks
