### PR TITLE
Truncate long game descriptions, and hide full games, on front page

### DIFF
--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -21,7 +21,9 @@ module View
     needs :confirm_delete, store: true, default: false
     needs :confirm_kick, store: true, default: nil
     needs :flash_opts, default: {}, store: true
+    needs :expanded_descriptions, store: true, default: {}
 
+    DESCRIPTION_TRUNCATE_LENGTH = 120
     BUTTON_STYLE = {
       margin: '0',
       padding: '0.2rem 0',
@@ -245,7 +247,27 @@ module View
         children << h(:div, [h(:i, ['Auto Routing', auto_route_whats_this])]) if @gdata.dig('settings', 'auto_routing')
         children << h(:div, [h(:i, ['Engine V2', engine_v2_whats_this])]) if @gdata.dig('settings', 'use_engine_v2')
       end
-      children << h(:div, [h(:strong, 'Description: '), @gdata['description']]) unless @gdata['description'].empty?
+      unless @gdata['description'].empty?
+        desc = @gdata['description']
+        if desc.length > DESCRIPTION_TRUNCATE_LENGTH
+          expanded = @expanded_descriptions[@gdata['id']]
+          toggle = lambda do
+            store(:expanded_descriptions, @expanded_descriptions.merge(@gdata['id'] => !expanded), skip: false)
+          end
+          toggle_props = {
+            style: { marginLeft: '0.4rem', fontSize: '0.85em', cursor: 'pointer', textDecoration: 'underline' },
+            on: { click: toggle },
+          }
+          displayed = expanded ? desc : "#{desc[0...DESCRIPTION_TRUNCATE_LENGTH]}…"
+          children << h(:div, [
+            h(:strong, 'Description: '),
+            displayed,
+            h(:span, toggle_props, expanded ? 'Show less' : 'Show more'),
+          ])
+        else
+          children << h(:div, [h(:strong, 'Description: '), desc])
+        end
+      end
 
       optional = render_optional_rules
       children << optional if optional

--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -249,24 +249,10 @@ module View
       end
       unless @gdata['description'].empty?
         desc = @gdata['description']
-        if desc.length > DESCRIPTION_TRUNCATE_LENGTH
-          expanded = @expanded_descriptions[@gdata['id']]
-          toggle = lambda do
-            store(:expanded_descriptions, @expanded_descriptions.merge(@gdata['id'] => !expanded), skip: false)
-          end
-          toggle_props = {
-            style: { marginLeft: '0.4rem', fontSize: '0.85em', cursor: 'pointer', textDecoration: 'underline' },
-            on: { click: toggle },
-          }
-          displayed = expanded ? desc : "#{desc[0...DESCRIPTION_TRUNCATE_LENGTH]}…"
-          children << h(:div, [
-            h(:strong, 'Description: '),
-            displayed,
-            h(:span, toggle_props, expanded ? 'Show less' : 'Show more'),
-          ])
-        else
-          children << h(:div, [h(:strong, 'Description: '), desc])
-        end
+        url_search_params = Lib::Params::URLSearchParams.new
+        truncate = !url_search_params.unsupported && url_search_params['truncate_desc'] == 'true'
+        displayed = truncate && desc.length > DESCRIPTION_TRUNCATE_LENGTH ? "#{desc[0...DESCRIPTION_TRUNCATE_LENGTH]}…" : desc
+        children << h(:div, [h(:strong, 'Description: '), displayed])
       end
 
       optional = render_optional_rules

--- a/assets/app/view/game_row_filters.rb
+++ b/assets/app/view/game_row_filters.rb
@@ -114,6 +114,24 @@ module View
           }, label)
       end
 
+      hide_full_active = url_search_params['hide_full'] == 'true'
+      on_hide_full_click = lambda do
+        url_search_params['hide_full'] = hide_full_active ? '' : 'true'
+        update_filters(url_search_params.to_query_string)
+      end
+      buttons << h(:button, {
+                     attrs: { title: 'Hides new games that are already at their maximum player count' },
+                     style: {
+                       padding: '4px 12px',
+                       cursor: 'pointer',
+                       background: hide_full_active ? '#4a4a4a' : '#ddd',
+                       color: hide_full_active ? '#fff' : '#333',
+                       border: '1px solid #888',
+                       fontWeight: hide_full_active ? 'bold' : 'normal',
+                     },
+                     on: { click: on_hide_full_click },
+                   }, 'Hide Full')
+
       truncate_active = url_search_params['truncate_desc'] == 'true'
       on_truncate_click = lambda do
         url_search_params['truncate_desc'] = truncate_active ? '' : 'true'

--- a/assets/app/view/game_row_filters.rb
+++ b/assets/app/view/game_row_filters.rb
@@ -114,6 +114,24 @@ module View
           }, label)
       end
 
+      truncate_active = url_search_params['truncate_desc'] == 'true'
+      on_truncate_click = lambda do
+        url_search_params['truncate_desc'] = truncate_active ? '' : 'true'
+        update_filters(url_search_params.to_query_string)
+      end
+      buttons << h(:button, {
+                     attrs: { title: 'Truncates all game descriptions to 120 characters' },
+                     style: {
+                       padding: '4px 12px',
+                       cursor: 'pointer',
+                       background: truncate_active ? '#4a4a4a' : '#ddd',
+                       color: truncate_active ? '#fff' : '#333',
+                       border: '1px solid #888',
+                       fontWeight: truncate_active ? 'bold' : 'normal',
+                     },
+                     on: { click: on_truncate_click },
+                   }, 'Short Desc.')
+
       h(:div, { style: { display: 'flex', margin: '6px 0' } }, buttons)
     end
 

--- a/assets/app/view/home.rb
+++ b/assets/app/view/home.rb
@@ -5,6 +5,7 @@
 require 'game_manager'
 require 'lib/settings'
 require 'lib/storage'
+require 'lib/params'
 require 'view/chat'
 require 'view/game_row'
 require 'view/game_row_filters'
@@ -45,9 +46,15 @@ module View
         .map { |k| Lib::Storage[k] }
         .sort_by { |gd| [-(gd[:updated_at] || now), gd[:id]] }
 
+      url_search_params = Lib::Params::URLSearchParams.new
+      new_games = grouped['new']&.sort_by { |g| -g['created_at'] }
+      if !url_search_params.unsupported && url_search_params['hide_full'] == 'true'
+        new_games = new_games&.reject { |g| g['players'].size >= g['max_players'] }
+      end
+
       render_row(children, 'Your Games', your_games, :personal) if @user
       render_row(children, 'Hotseat Games', hotseat, :hotseat) if hotseat.any?
-      render_row(children, 'New Games', grouped['new']&.sort_by { |g| -g['created_at'] }, :new) if @user
+      render_row(children, 'New Games', new_games, :new) if @user
       render_row(children, 'Active Games', grouped['active']&.sort_by { |g| -g['updated_at'] }, :active)
       render_row(children, 'Finished Games', grouped['finished']&.sort_by { |g| -g['finished_at'] }, :finished)
       render_filter_row(children)


### PR DESCRIPTION
Fixes #10006
Fixes #8658

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Truncates long game descriptions on the front page, with a 'Show more' text to expand the description upon request.

### Screenshots

Before: 
<img width="1470" height="946" alt="image" src="https://github.com/user-attachments/assets/807a87bb-be7d-46b3-b78d-17b85b46b41a" />

After: 
<img width="1463" height="349" alt="image" src="https://github.com/user-attachments/assets/cd07931c-2742-4aae-83c9-8d65bac5b81c" />


### Any Assumptions / Hacks
