### PR TITLE
[18 India] Fix GIPR bond conversion: manager and float

### DIFF
--- a/lib/engine/game/g_18_india/corporation.rb
+++ b/lib/engine/game/g_18_india/corporation.rb
@@ -116,6 +116,13 @@ module Engine
         def mangaged_company?
           presidents_share.percent.zero?
         end
+
+        def percent_to_float
+          return 0 if floated?
+
+          non_ipo_pct = share_holders.sum { |holder, pct| holder == ipo_owner ? 0 : pct }
+          [@float_percent - non_ipo_pct, 0].max
+        end
       end
     end
   end

--- a/lib/engine/game/g_18_india/game.rb
+++ b/lib/engine/game/g_18_india/game.rb
@@ -783,14 +783,33 @@ module Engine
           gipr.share_holders[entity] += new_gipr_share.percent
           entity.spend(railroad_bond_convert_cost, @bank) if railroad_bond_convert_cost.positive? # Pay conversion cost
           @bank.spend(bond.value, gipr) # Bank pays GIPR $100
-          @log << "#{entity.name} converts a Railrod Bond to a GIPR Share for #{format_currency(railroad_bond_convert_cost)}"
+          @log << "#{entity.name} converts a Railroad Bond to a GIPR Share for #{format_currency(railroad_bond_convert_cost)}"
           @log << "The Bank pays GIPR #{format_currency(bond.value)}"
-          # Check if if there is new Manager for GIPR
-          check_manager_change(entity, gipr) if entity.player?
+          return unless entity.player?
+
+          if gipr.owner.nil?
+            gipr.make_manager(entity)
+          else
+            check_manager_change(entity, gipr)
+          end
+        end
+
+        # Bond shares bypass the IPO, so the standard floated? check (which tracks IPO owner holdings)
+        # never fires for bond-only conversions. Check share_holders directly instead.
+        def check_gipr_float
+          return if gipr.floated?
+          return unless gipr.floatable
+
+          non_ipo_pct = gipr.share_holders.sum { |holder, pct| holder == gipr.ipo_owner ? 0 : pct }
+          return unless non_ipo_pct >= gipr.float_percent
+
+          gipr.floated = true
+          float_corporation(gipr)
         end
 
         def check_manager_change(entity, corporation)
-          return unless entity.percent_of(corporation) > gipr.owner.percent_of(corporation)
+          return unless corporation.owner
+          return unless entity.percent_of(corporation) > corporation.owner.percent_of(corporation)
 
           @share_pool.change_president(corporation.presidents_share, corporation.owner, entity)
           corporation.owner = entity

--- a/lib/engine/game/g_18_india/step/sell_once_then_buy_certs.rb
+++ b/lib/engine/game/g_18_india/step/sell_once_then_buy_certs.rb
@@ -134,8 +134,10 @@ module Engine
           def process_choose(action)
             entity = action.entity
             bond = first_bond(entity)
+            already_floated = @game.gipr.floated?
             @game.convert_bond_to_gipr(entity, bond)
-
+            @game.check_gipr_float
+            maybe_place_home_token(@game.gipr) if !already_floated && @game.gipr.floated?
             track_action(action, bond)
           end
 


### PR DESCRIPTION
Fixes #11289, #11242

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Bond shares in GIPR are created outside the normal IPO system, which caused two bugs when players converted Railroad Bonds.

**#11289 - Crash on bond conversion if nobody was GIPR manager yet (undefined method 'percent_of' for nil):**
convert_bond_to_gipr called check_manager_change, which accessed gipr.owner.percent_of(...). If no normal GIPR share had been purchased yet, gipr.owner is nil and the game crashes. Fixed by calling make_manager on the converting player when GIPR has no manager yet, mirroring what normal share purchases already do.

**#11242 - GIPR doesn't float when exchanging bonds:**
Bond shares bypass the IPO, so @ipo_owner.percent_of(self) never decreases from bond conversions and the standard floated? check never fires. Fixed with a new check_gipr_float method in game.rb that sums share_holders directly - capturing both normal IPO sales and bond conversions - and explicitly sets floated and calls float_corporation when the 30% threshold is reached. The percent_to_float display on the charter was also incorrect for the same reason; fixed with an override in Corporation using the same share_holders approach.

Home token placement after a bond-triggered float is handled in process_choose in the step, following the same pattern as normal share purchases.

### Screenshots

### Any Assumptions / Hacks