### PR TITLE
[1862 USA & Canada] PR 08: revenue mechanics — bonus markers + SLC transcontinental

### DIFF
--- a/lib/engine/game/g_1862_usa_canada/entities.rb
+++ b/lib/engine/game/g_1862_usa_canada/entities.rb
@@ -52,7 +52,7 @@ module Engine
                 type: 'token',
                 hexes: [],
                 discount: 80,
-                owner_type: 'corporation',
+                owner_type: 'player',
               },
             ],
             color: nil,

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -224,9 +224,9 @@ module Engine
         def corp_groups
           @corp_groups ||= CORP_GROUPS.transform_values { |sym| corporation_by_id(sym) }
         end
-        
+
         def corp_group(corporation)
-          corp_groups.find { |_, corps| corps.include?(corporation) }&.first
+          corp_groups.find { |_, corps| corps.include?(corporation) }.first
         end
 
         def all_privates_sold?
@@ -237,7 +237,7 @@ module Engine
           case group_num
           when 1 then all_privates_sold?
           when 2 then corp_groups[1].all? { |corp| corp.num_ipo_shares.zero? }
-          when 3 then corp_groups[2].all? { |corp| corp.floated? }
+          when 3 then corp_groups[2].all?(&:floated?)
           else true
           end
         end

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -221,8 +221,12 @@ module Engine
         # ---------------------------------------------------------------------------
         # Corporation group unlock logic.
         # ---------------------------------------------------------------------------
+        def corp_groups
+          @corp_groups ||= CORP_GROUPS.transform_values { |sym| corporation_by_id(sym) }
+        end
+        
         def corp_group(corporation)
-          CORP_GROUPS.find { |_, syms| syms.include?(corporation.id) }&.first
+          corp_groups.find { |_, corps| corps.include?(corporation) }&.first
         end
 
         def all_privates_sold?
@@ -232,8 +236,8 @@ module Engine
         def group_available?(group_num)
           case group_num
           when 1 then all_privates_sold?
-          when 2 then CORP_GROUPS[1].all? { |sym| corporation_by_id(sym).num_ipo_shares.zero? }
-          when 3 then CORP_GROUPS[2].all? { |sym| corporation_by_id(sym).floated? }
+          when 2 then corp_groups[1].all? { |corp| corp.num_ipo_shares.zero? }
+          when 3 then corp_groups[2].all? { |corp| corp.floated? }
           else true
           end
         end

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -296,6 +296,8 @@ module Engine
           CORP_BONUSES.each do |sym, bonuses|
             bonuses.each_index { |i| @bonus_state[[sym, i]] = :unactivated }
           end
+          @slc_connected = {}
+          @slc_bonus_paid = false
         end
 
         # ---------------------------------------------------------------------------
@@ -341,7 +343,30 @@ module Engine
           return super if routes.empty?
 
           corp = routes.first.train.owner
-          super + corp_bonus_revenue(corp, routes)
+          super + corp_bonus_revenue(corp, routes) + slc_route_bonus(corp, routes)
+        end
+
+        # ---------------------------------------------------------------------------
+        # SLC transcontinental bonus + Golden Spike event.
+        # CPR and UP each earn a per-OR bonus whenever their route passes through SLC.
+        # The first time both corps have connected through SLC the Golden Spike fires:
+        # a one-time shareholder bonus is paid from the bank and both stocks advance.
+        # ---------------------------------------------------------------------------
+
+        # Called from Step::Dividend before super each time a corporation runs routes.
+        def check_golden_spike!(corporation, routes)
+          return unless SLC_CORPS.include?(corporation.id)
+          return if @slc_connected[corporation.id]
+          return unless routes.any? { |r| r.visited_stops.any? { |s| s.hex.id == SLC_HEX } }
+
+          @slc_connected[corporation.id] = true
+          @log << "#{corporation.name} reaches Salt Lake City — transcontinental route active"
+
+          return unless SLC_CORPS.all? { |sym| @slc_connected[sym] }
+          return if @slc_bonus_paid
+
+          @slc_bonus_paid = true
+          golden_spike_event!
         end
 
         # ---------------------------------------------------------------------------
@@ -460,6 +485,34 @@ module Engine
         end
 
         private
+
+        def slc_route_bonus(corporation, routes)
+          return 0 unless SLC_CORPS.include?(corporation.id)
+          return 0 unless routes.any? { |r| r.visited_stops.any? { |s| s.hex.id == SLC_HEX } }
+
+          soc = company_by_id('SOC')
+          soc && !soc.closed? ? SLC_ROUTE_BONUS_SOC : SLC_ROUTE_BONUS
+        end
+
+        def golden_spike_event!
+          @log << '-- GOLDEN SPIKE! Transcontinental railroad complete --'
+          SLC_CORPS.each do |sym|
+            corp = corporation_by_id(sym)
+            next unless corp&.floated?
+
+            corp.share_holders.each do |entity, percent|
+              next unless entity.player?
+
+              bonus = (percent / 10) * GOLDEN_SPIKE_SHAREHOLDER_BONUS
+              @bank.spend(bonus, entity)
+              @log << "#{entity.name} receives #{format_currency(bonus)} Golden Spike bonus " \
+                      "(#{percent}% #{corp.name})"
+            end
+
+            @stock_market.move_up(corp)
+            @log << "#{corp.name} stock advances to #{format_currency(corp.share_price.price)}"
+          end
+        end
 
         def would_activate?(bonus, routes, home)
           bonus[:hexes].any? do |hex_id|

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -219,6 +219,18 @@ module Engine
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or }.freeze
 
         # ---------------------------------------------------------------------------
+        # Home token — placed automatically at start of corp's first OR turn.
+        # Base place_home_token calls city.place_token directly (bypasses step
+        # layer) so clear_graph_for_entity is never called. Override to flush the
+        # graph cache immediately, otherwise the corp sees zero connected hexes
+        # and cannot lay track on the same turn.
+        # ---------------------------------------------------------------------------
+        def place_home_token(corporation)
+          super
+          clear_graph_for_entity(corporation)
+        end
+
+        # ---------------------------------------------------------------------------
         # Corporation group unlock logic.
         # ---------------------------------------------------------------------------
         def corp_groups

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -284,6 +284,67 @@ module Engine
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or }.freeze
 
         # ---------------------------------------------------------------------------
+        # Bonus state initialisation.
+        # @bonus_state: { [corp_sym, bonus_index] => :unactivated | :permanent | :cash }
+        # :unactivated — bonus not yet earned.
+        # :permanent   — director chose to keep as recurring per-OR revenue.
+        # :cash        — director chose the one-time cash payout (not yet implemented;
+        #                auto-selects :permanent for now — FIXME).
+        # ---------------------------------------------------------------------------
+        def setup
+          @bonus_state = {}
+          CORP_BONUSES.each do |sym, bonuses|
+            bonuses.each_index { |i| @bonus_state[[sym, i]] = :unactivated }
+          end
+        end
+
+        # ---------------------------------------------------------------------------
+        # Bonus markers (Bonusplättchen) — revenue and activation.
+        # A bonus activates when a corp's route passes through BOTH its home hex AND
+        # the bonus target hex in the same OR turn.
+        # ---------------------------------------------------------------------------
+
+        # Pure calculation — called by routes_revenue and during route display.
+        def corp_bonus_revenue(corporation, routes)
+          return 0 unless (bonuses = CORP_BONUSES[corporation.id])
+
+          home = corporation.coordinates
+          bonuses.each_with_index.sum do |bonus, i|
+            case @bonus_state[[corporation.id, i]]
+            when :unactivated
+              would_activate?(bonus, routes, home) ? bonus[:route_bonus] : 0
+            when :permanent
+              bonus_on_route?(bonus, routes) ? bonus[:route_bonus] : 0
+            else
+              0
+            end
+          end
+        end
+
+        # Called from Step::Dividend before super — commits any newly earned bonuses.
+        # FIXME: should offer cash-vs-permanent choice; auto-selects :permanent for now.
+        def activate_new_bonuses!(corporation, routes)
+          return unless (bonuses = CORP_BONUSES[corporation.id])
+
+          home = corporation.coordinates
+          bonuses.each_with_index do |bonus, i|
+            next unless @bonus_state[[corporation.id, i]] == :unactivated
+            next unless would_activate?(bonus, routes, home)
+
+            @bonus_state[[corporation.id, i]] = :permanent
+            @log << "#{corporation.name} activates #{bonus[:name]} connection bonus " \
+                    "(permanent +#{format_currency(bonus[:route_bonus])} per OR)"
+          end
+        end
+
+        def routes_revenue(routes)
+          return super if routes.empty?
+
+          corp = routes.first.train.owner
+          super + corp_bonus_revenue(corp, routes)
+        end
+
+        # ---------------------------------------------------------------------------
         # Private company close triggers.
         # SOC closes when CPR or UP floats.
         # NHSC closes when NYH floats.
@@ -396,6 +457,23 @@ module Engine
             Engine::Step::DiscardTrain,
             Engine::Step::BuyTrain,
           ], round_num: round_num)
+        end
+
+        private
+
+        def would_activate?(bonus, routes, home)
+          bonus[:hexes].any? do |hex_id|
+            routes.any? do |route|
+              ids = route.visited_stops.map { |s| s.hex.id }
+              ids.include?(hex_id) && ids.include?(home)
+            end
+          end
+        end
+
+        def bonus_on_route?(bonus, routes)
+          bonus[:hexes].any? do |hex_id|
+            routes.any? { |r| r.visited_stops.any? { |s| s.hex.id == hex_id } }
+          end
         end
       end
     end

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -7,6 +7,7 @@ require_relative 'entities'
 require_relative 'map'
 require_relative '../base'
 require_relative 'step/buy_sell_par_shares'
+require_relative 'step/dividend'
 require_relative 'step/token'
 
 module Engine
@@ -283,6 +284,45 @@ module Engine
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or }.freeze
 
         # ---------------------------------------------------------------------------
+        # Private company close triggers.
+        # SOC closes when CPR or UP floats.
+        # NHSC closes when NYH floats.
+        # PSC closes when WP pays its first dividend (via on_first_payout!).
+        # FNY closes when NYC pays its first dividend (via on_first_payout!).
+        # TOR closes automatically via closed_when_used_up on its tile_lay ability.
+        # ---------------------------------------------------------------------------
+        def float_corporation(corporation)
+          super
+          on_corporation_floated!(corporation)
+        end
+
+        def on_corporation_floated!(corporation)
+          case corporation.id
+          when 'CPR', 'UP'
+            close_private_if_open!('SOC', "#{corporation.name} floats")
+          when 'NYH'
+            close_private_if_open!('NHSC', "#{corporation.name} floats")
+          end
+        end
+
+        def on_first_payout!(corporation)
+          case corporation.id
+          when 'WP'
+            close_private_if_open!('PSC', "#{corporation.name} pays first dividend")
+          when 'NYC'
+            close_private_if_open!('FNY', "#{corporation.name} pays first dividend")
+          end
+        end
+
+        def close_private_if_open!(sym, reason)
+          company = companies.find { |c| c.sym == sym && !c.closed? }
+          return unless company
+
+          company.close!
+          @log << "#{company.name} closes (#{reason})"
+        end
+
+        # ---------------------------------------------------------------------------
         # Tile-lay budget override.
         # ---------------------------------------------------------------------------
         def tile_lays(_entity)
@@ -352,7 +392,7 @@ module Engine
             Engine::Step::Track,
             G1862UsaCanada::Step::Token,
             Engine::Step::Route,
-            Engine::Step::Dividend,
+            G1862UsaCanada::Step::Dividend,
             Engine::Step::DiscardTrain,
             Engine::Step::BuyTrain,
           ], round_num: round_num)

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -17,9 +17,9 @@ module Engine
 
         # ---------------------------------------------------------------------------
         # Corporation groups — unlocked progressively.
-        # Group 1 available from game start.
-        # Group 2 unlocks when ALL Group 1 companies have floated.
-        # Group 3 unlocks when ALL Group 2 companies have floated.
+        # Group 1 available when ALL private companies have been sold.
+        # Group 2 unlocks when ALL Group 1 IPO shares have been sold.
+        # Group 3 unlocks when ALL Group 2 corporations have floated.
         #
         # Director share sizes by group (from rulebook):
         #   Group 1 (NYH, NYC, CP):       30% Director + 7×10%
@@ -217,6 +217,32 @@ module Engine
         ].freeze
 
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or }.freeze
+
+        # ---------------------------------------------------------------------------
+        # Corporation group unlock logic.
+        # ---------------------------------------------------------------------------
+        def corp_group(corporation)
+          CORP_GROUPS.find { |_, syms| syms.include?(corporation.id) }&.first
+        end
+
+        def all_privates_sold?
+          @companies.all? { |c| c.owner&.player? || c.closed? }
+        end
+
+        def group_available?(group_num)
+          case group_num
+          when 1 then all_privates_sold?
+          when 2 then CORP_GROUPS[1].all? { |sym| corporation_by_id(sym).num_ipo_shares.zero? }
+          when 3 then CORP_GROUPS[2].all? { |sym| corporation_by_id(sym).floated? }
+          else true
+          end
+        end
+
+        def can_par?(corporation, parrer)
+          return false unless super
+
+          group_available?(corp_group(corporation))
+        end
 
         # ---------------------------------------------------------------------------
         # Round definitions — engine defaults only; custom steps added in later PRs.

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -163,7 +163,7 @@ module Engine
             rusts_on: '4',
             num: 7,
             variants: [
-              { name: '2E', distance: [{ nodes: %w[city offboard town], pay: 2, visit: 999 }], price: 150 },
+              { name: '2E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 2, 'visit' => 999 }], price: 150 },
             ],
           },
           {
@@ -173,7 +173,7 @@ module Engine
             rusts_on: '6',
             num: 6,
             variants: [
-              { name: '3E', distance: [{ nodes: %w[city offboard town], pay: 3, visit: 999 }], price: 300 },
+              { name: '3E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 3, 'visit' => 999 }], price: 300 },
             ],
           },
           {
@@ -183,7 +183,7 @@ module Engine
             rusts_on: '8',
             num: 5,
             variants: [
-              { name: '4E', distance: [{ nodes: %w[city offboard town], pay: 4, visit: 999 }], price: 400 },
+              { name: '4E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 4, 'visit' => 999 }], price: 400 },
             ],
           },
           {
@@ -192,7 +192,7 @@ module Engine
             price: 550,
             num: 4,
             variants: [
-              { name: '5E', distance: [{ nodes: %w[city offboard town], pay: 5, visit: 999 }], price: 700 },
+              { name: '5E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 5, 'visit' => 999 }], price: 700 },
             ],
           },
           {
@@ -201,7 +201,7 @@ module Engine
             price: 650,
             num: 3,
             variants: [
-              { name: '6E', distance: [{ nodes: %w[city offboard town], pay: 6, visit: 999 }], price: 800 },
+              { name: '6E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 6, 'visit' => 999 }], price: 800 },
             ],
           },
           {
@@ -210,7 +210,7 @@ module Engine
             price: 750,
             num: 2,
             variants: [
-              { name: '7E', distance: [{ nodes: %w[city offboard town], pay: 7, visit: 999 }], price: 900 },
+              { name: '7E', distance: [{ 'nodes' => %w[city offboard town], 'pay' => 7, 'visit' => 999 }], price: 900 },
             ],
           },
           { name: '8', distance: 999, price: 900, num: 'unlimited' },

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -133,17 +133,79 @@ module Engine
         ).freeze
 
         # ---------------------------------------------------------------------------
+        # Tile-lay budget — phase-gated.
+        # Phase 2:   1 yellow tile only.
+        # Phase 3+:  2 yellow tiles OR 1 upgrade (no mixing).
+        # ---------------------------------------------------------------------------
+        YELLOW_TILE_LAY = [{ lay: true, upgrade: false }].freeze
+        TWO_TILE_LAYS = [
+          { lay: true, upgrade: true },
+          { lay: :not_if_upgraded, upgrade: false },
+        ].freeze
+
+        STATUS_TEXT = Base::STATUS_TEXT.merge(
+          'two_tile_lays' => ['Two tile lays', 'Corporations may lay 2 yellow tiles OR 1 upgrade tile per OR']
+        ).freeze
+
+        # ---------------------------------------------------------------------------
         # Phases
         # FIXME: verify exact operating_rounds count per phase from rulebook.
         # ---------------------------------------------------------------------------
         PHASES = [
-          { name: '2',          train_limit: 4, tiles: [:yellow],           operating_rounds: 1 },
-          { name: '3', on: '3', train_limit: 4, tiles: %i[yellow green],    operating_rounds: 2 },
-          { name: '4', on: '4', train_limit: 3, tiles: %i[yellow green],    operating_rounds: 2 },
-          { name: '5', on: '5', train_limit: 2, tiles: %i[yellow green brown], operating_rounds: 3 },
-          { name: '6', on: '6', train_limit: 2, tiles: %i[yellow green brown], operating_rounds: 3 },
-          { name: '7', on: '7', train_limit: 2, tiles: %i[yellow green brown gray], operating_rounds: 3 },
-          { name: '8', on: '8', train_limit: 2, tiles: %i[yellow green brown gray], operating_rounds: 3 },
+          {
+            name: '2',
+            train_limit: 4,
+            tiles: [:yellow],
+            operating_rounds: 1,
+          },
+          {
+            name: '3',
+            on: '3',
+            train_limit: 4,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '4',
+            on: '4',
+            train_limit: 3,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '5',
+            on: '5',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '6',
+            on: '6',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 3,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '7',
+            on: '7',
+            train_limit: 2,
+            tiles: %i[yellow green brown gray],
+            operating_rounds: 3,
+            status: ['two_tile_lays'],
+          },
+          {
+            name: '8',
+            on: '8',
+            train_limit: 2,
+            tiles: %i[yellow green brown gray],
+            operating_rounds: 3,
+            status: ['two_tile_lays'],
+          },
         ].freeze
 
         # ---------------------------------------------------------------------------
@@ -217,6 +279,13 @@ module Engine
         ].freeze
 
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or }.freeze
+
+        # ---------------------------------------------------------------------------
+        # Tile-lay budget override.
+        # ---------------------------------------------------------------------------
+        def tile_lays(_entity)
+          @phase.status.include?('two_tile_lays') ? self.class::TWO_TILE_LAYS : self.class::YELLOW_TILE_LAY
+        end
 
         # ---------------------------------------------------------------------------
         # Home token — placed automatically at start of corp's first OR turn.

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -45,7 +45,7 @@ module Engine
           'CP' => [
             { hexes: %w[E25],          cash: 100, route_bonus: 30,  name: 'Toronto'     },
             { hexes: %w[B20],          cash: 200, route_bonus: 60,  name: 'Thunder Bay' },
-            { hexes: %w[B2 C1 G3 I5], cash: 300, route_bonus: 100, name: 'V/P/S/L' },
+            { hexes: %w[B2 D2 G3 I5], cash: 300, route_bonus: 100, name: 'V/P/S/L' },
           ],
           'NYH' => [
             { hexes: %w[F20],          cash: 100, route_bonus: 30,  name: 'Chicago'     },
@@ -59,13 +59,13 @@ module Engine
             { hexes: %w[J10],          cash: 200, route_bonus: 60,  name: 'El Paso'     },
           ],
           'ATS' => [
-            { hexes: %w[B2 C1 G3 I5], cash: 200, route_bonus: 60, name: 'V/P/S/L' },
+            { hexes: %w[B2 D2 G3 I5], cash: 200, route_bonus: 60, name: 'V/P/S/L' },
           ],
           'NP' => [
             { hexes: %w[F20], cash: 100, route_bonus: 30, name: 'Chicago' },
           ],
           'CN' => [
-            { hexes: %w[B2 C1 G3 I5], cash: 100, route_bonus: 30, name: 'V/P/S/L' },
+            { hexes: %w[B2 D2 G3 I5], cash: 100, route_bonus: 30, name: 'V/P/S/L' },
             { hexes: %w[B10], cash: 200, route_bonus: 60, name: 'Regina' },
           ],
           # FIXME: TP El Paso bonus amount unconfirmed from rulebook — entry omitted until confirmed

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -6,6 +6,8 @@ require_relative 'meta'
 require_relative 'entities'
 require_relative 'map'
 require_relative '../base'
+require_relative 'step/buy_sell_par_shares'
+require_relative 'step/token'
 
 module Engine
   module Game
@@ -337,7 +339,7 @@ module Engine
             Engine::Step::DiscardTrain,
             Engine::Step::Exchange,
             Engine::Step::SpecialTrack,
-            Engine::Step::BuySellParShares,
+            G1862UsaCanada::Step::BuySellParShares,
           ])
         end
 
@@ -348,7 +350,7 @@ module Engine
             Engine::Step::SpecialTrack,
             Engine::Step::HomeToken,
             Engine::Step::Track,
-            Engine::Step::Token,
+            G1862UsaCanada::Step::Token,
             Engine::Step::Route,
             Engine::Step::Dividend,
             Engine::Step::DiscardTrain,

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -222,7 +222,7 @@ module Engine
         # Corporation group unlock logic.
         # ---------------------------------------------------------------------------
         def corp_groups
-          @corp_groups ||= CORP_GROUPS.transform_values { |sym| corporation_by_id(sym) }
+          @corp_groups ||= CORP_GROUPS.transform_values { |syms| syms.map { |s| corporation_by_id(s) } }
         end
 
         def corp_group(corporation)

--- a/lib/engine/game/g_1862_usa_canada/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1862_usa_canada/step/buy_sell_par_shares.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_sell_par_shares'
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      module Step
+        class BuySellParShares < Engine::Step::BuySellParShares
+          # NHSC gives the buyer NYH's director cert; NYH must be parred at
+          # exactly $100. Restrict available par prices to that single value.
+          def get_par_prices(entity, corporation)
+            return nyh_par_prices if corporation.id == 'NYH'
+
+            super
+          end
+
+          private
+
+          def nyh_par_prices
+            [@game.stock_market.par_prices.find { |p| p.price == 100 }].compact
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/step/dividend.rb
+++ b/lib/engine/game/g_1862_usa_canada/step/dividend.rb
@@ -11,6 +11,7 @@ module Engine
             entity = action.entity
             first_time = entity.operating_history.none? { |_, info| info.dividend.kind.to_sym == :payout }
             @game.activate_new_bonuses!(entity, routes)
+            @game.check_golden_spike!(entity, routes)
             super
             @game.on_first_payout!(entity) if first_time && action.kind.to_sym == :payout
           end

--- a/lib/engine/game/g_1862_usa_canada/step/dividend.rb
+++ b/lib/engine/game/g_1862_usa_canada/step/dividend.rb
@@ -10,6 +10,7 @@ module Engine
           def process_dividend(action)
             entity = action.entity
             first_time = entity.operating_history.none? { |_, info| info.dividend.kind.to_sym == :payout }
+            @game.activate_new_bonuses!(entity, routes)
             super
             @game.on_first_payout!(entity) if first_time && action.kind.to_sym == :payout
           end

--- a/lib/engine/game/g_1862_usa_canada/step/dividend.rb
+++ b/lib/engine/game/g_1862_usa_canada/step/dividend.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/dividend'
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      module Step
+        class Dividend < Engine::Step::Dividend
+          def process_dividend(action)
+            entity = action.entity
+            first_time = entity.operating_history.none? { |_, info| info.dividend.kind.to_sym == :payout }
+            super
+            @game.on_first_payout!(entity) if first_time && action.kind.to_sym == :payout
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1862_usa_canada/step/token.rb
+++ b/lib/engine/game/g_1862_usa_canada/step/token.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/token'
+
+module Engine
+  module Game
+    module G1862UsaCanada
+      module Step
+        class Token < Engine::Step::Token
+          # GHU (Bahnhoflizenz) gives the director's corporation an $80 discount
+          # on station token placement (minimum $0). The discount is auto-applied
+          # whenever the operating corporation's director holds GHU.
+          def process_place_token(action)
+            apply_ghu_discount!(action.entity, action.token)
+            super
+          end
+
+          private
+
+          def ghu_company
+            @game.companies.find { |c| c.sym == 'GHU' && !c.closed? }
+          end
+
+          def apply_ghu_discount!(corporation, token)
+            ghu = ghu_company
+            return unless ghu&.owner == corporation.owner
+
+            discount = ghu.abilities.find { |a| a.type == :token }&.discount.to_i
+            token.price = [token.price - discount, 0].max
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -31,6 +31,19 @@ module Engine
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
 
+    describe 'home token timing' do
+      it 'uses :operate timing' do
+        expect(described_class::HOME_TOKEN_TIMING).to eq(:operate)
+      end
+
+      it 'clears the graph after placing the home token' do
+        corp = game.corporations.first
+        graph = game.send(:graph_for_entity, corp)
+        expect(graph).to receive(:clear).at_least(:once)
+        game.place_home_token(corp)
+      end
+    end
+
     describe 'corporation group unlock' do
       let(:nyh) { game.corporation_by_id('NYH') }
       let(:nyc) { game.corporation_by_id('NYC') }

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -31,6 +31,28 @@ module Engine
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
 
+    describe 'tile-lay budget' do
+      it 'phase 2: single yellow tile only' do
+        lays = game.tile_lays(game.corporations.first)
+        expect(lays.size).to eq(1)
+        expect(lays.first[:upgrade]).to be false
+      end
+
+      it 'phase 3+: two entries, second blocked after upgrade' do
+        game.phase.next!
+        lays = game.tile_lays(game.corporations.first)
+        expect(lays.size).to eq(2)
+        expect(lays.first[:upgrade]).to be true
+        expect(lays.last[:lay]).to eq(:not_if_upgraded)
+        expect(lays.last[:upgrade]).to be false
+      end
+
+      it 'phase 3 status includes two_tile_lays flag' do
+        game.phase.next!
+        expect(game.phase.status).to include('two_tile_lays')
+      end
+    end
+
     describe 'E-train variants' do
       it 'every base train 2–7 has exactly one E-train variant' do
         base_trains = game.depot.trains.map(&:name).uniq.reject { |n| n == '8' }

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -31,6 +31,53 @@ module Engine
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
 
+    describe 'private close triggers' do
+      let(:soc)  { game.companies.find { |c| c.sym == 'SOC' } }
+      let(:nhsc) { game.companies.find { |c| c.sym == 'NHSC' } }
+      let(:psc)  { game.companies.find { |c| c.sym == 'PSC' } }
+      let(:fny)  { game.companies.find { |c| c.sym == 'FNY' } }
+      let(:cpr)  { game.corporation_by_id('CPR') }
+      let(:up)   { game.corporation_by_id('UP') }
+      let(:nyh)  { game.corporation_by_id('NYH') }
+      let(:wp)   { game.corporation_by_id('WP') }
+      let(:nyc)  { game.corporation_by_id('NYC') }
+
+      it 'SOC closes when CPR floats' do
+        game.on_corporation_floated!(cpr)
+        expect(soc.closed?).to be true
+      end
+
+      it 'SOC closes when UP floats' do
+        game.on_corporation_floated!(up)
+        expect(soc.closed?).to be true
+      end
+
+      it 'NHSC closes when NYH floats' do
+        game.on_corporation_floated!(nyh)
+        expect(nhsc.closed?).to be true
+      end
+
+      it 'SOC does not close when NYH floats' do
+        game.on_corporation_floated!(nyh)
+        expect(soc.closed?).to be false
+      end
+
+      it 'PSC closes on first WP payout' do
+        game.on_first_payout!(wp)
+        expect(psc.closed?).to be true
+      end
+
+      it 'FNY closes on first NYC payout' do
+        game.on_first_payout!(nyc)
+        expect(fny.closed?).to be true
+      end
+
+      it 'FNY does not close when WP pays first dividend' do
+        game.on_first_payout!(wp)
+        expect(fny.closed?).to be false
+      end
+    end
+
     describe 'GHU token discount' do
       let(:ghu) { game.companies.find { |c| c.sym == 'GHU' } }
 

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -30,5 +30,38 @@ module Engine
     it 'uses sell_buy order' do
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
+
+    describe 'corporation group unlock' do
+      let(:nyh) { game.corporation_by_id('NYH') }
+      let(:nyc) { game.corporation_by_id('NYC') }
+      let(:cp)  { game.corporation_by_id('CP') }
+      let(:cpr) { game.corporation_by_id('CPR') }
+      let(:np)  { game.corporation_by_id('NP') }
+
+      it 'Group 1 is locked while privates are unsold' do
+        expect(game.can_par?(nyh, nil)).to be false
+      end
+
+      it 'Group 1 unlocks when all privates are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(nyh, nil)).to be true
+      end
+
+      it 'Group 2 is locked even after all privates are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(cpr, nil)).to be false
+      end
+
+      it 'Group 2 unlocks when all Group 1 IPO shares are sold' do
+        game.companies.each { |c| c.owner = game.players.first }
+        [nyh, nyc, cp].each { |corp| allow(corp).to receive(:num_ipo_shares).and_return(0) }
+        expect(game.can_par?(cpr, nil)).to be true
+      end
+
+      it 'Group 3 is locked while any Group 2 corp is unfloated' do
+        game.companies.each { |c| c.owner = game.players.first }
+        expect(game.can_par?(np, nil)).to be false
+      end
+    end
   end
 end

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -176,14 +176,14 @@ module Engine
       end
     end
 
+    def stub_route(*hex_ids)
+      stops = hex_ids.map { |id| double('Stop', hex: double('Hex', id: id)) }
+      double('Route', visited_stops: stops)
+    end
+
     describe 'bonus markers' do
       let(:cp)  { game.corporation_by_id('CP') }
       let(:nyc) { game.corporation_by_id('NYC') }
-
-      def stub_route(*hex_ids)
-        stops = hex_ids.map { |id| double('Stop', hex: double('Hex', id: id)) }
-        double('Route', visited_stops: stops)
-      end
 
       it 'initialises all bonus states to :unactivated' do
         described_class::CORP_BONUSES.each do |sym, bonuses|
@@ -229,6 +229,77 @@ module Engine
         game.activate_new_bonuses!(cp, [route])
         game.activate_new_bonuses!(cp, [route])
         expect(game.instance_variable_get(:@bonus_state)[['CP', 0]]).to eq(:permanent)
+      end
+    end
+
+    describe 'SLC transcontinental bonus + Golden Spike' do
+      let(:cpr) { game.corporation_by_id('CPR') }
+      let(:up)  { game.corporation_by_id('UP') }
+      let(:nyc) { game.corporation_by_id('NYC') }
+      let(:slc_hex) { described_class::SLC_HEX }
+      let(:soc) { game.companies.find { |c| c.sym == 'SOC' } }
+
+      it 'initialises @slc_connected as empty hash' do
+        expect(game.instance_variable_get(:@slc_connected)).to eq({})
+      end
+
+      it 'initialises @slc_bonus_paid as false' do
+        expect(game.instance_variable_get(:@slc_bonus_paid)).to be false
+      end
+
+      it 'SLC bonus is 0 for non-SLC corp' do
+        route = stub_route(slc_hex)
+        expect(game.send(:slc_route_bonus, nyc, [route])).to eq(0)
+      end
+
+      it 'SLC bonus is 0 when route does not visit SLC hex' do
+        route = stub_route('F14', 'K19')
+        expect(game.send(:slc_route_bonus, cpr, [route])).to eq(0)
+      end
+
+      it 'SLC bonus is 15 while SOC is open' do
+        route = stub_route(slc_hex)
+        expect(game.send(:slc_route_bonus, cpr, [route])).to eq(15)
+      end
+
+      it 'SLC bonus is 30 after SOC closes' do
+        soc.close!
+        route = stub_route(slc_hex)
+        expect(game.send(:slc_route_bonus, cpr, [route])).to eq(30)
+      end
+
+      it 'SLC bonus applies to UP as well' do
+        soc.close!
+        route = stub_route(slc_hex)
+        expect(game.send(:slc_route_bonus, up, [route])).to eq(30)
+      end
+
+      it 'check_golden_spike! marks CPR as connected' do
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        expect(game.instance_variable_get(:@slc_connected)['CPR']).to be true
+      end
+
+      it 'Golden Spike does not fire when only CPR connects' do
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        expect(game.instance_variable_get(:@slc_bonus_paid)).to be false
+      end
+
+      it 'Golden Spike fires when both CPR and UP connect' do
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        game.check_golden_spike!(up, [stub_route(slc_hex)])
+        expect(game.instance_variable_get(:@slc_bonus_paid)).to be true
+      end
+
+      it 'check_golden_spike! is idempotent for already-connected corp' do
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        log_size = game.log.size
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        expect(game.log.size).to eq(log_size)
+      end
+
+      it 'non-SLC corp does not mark connection' do
+        game.check_golden_spike!(nyc, [stub_route(slc_hex)])
+        expect(game.instance_variable_get(:@slc_connected)).to eq({})
       end
     end
 

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -31,6 +31,49 @@ module Engine
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
 
+    describe 'E-train variants' do
+      it 'every base train 2–7 has exactly one E-train variant' do
+        base_trains = game.depot.trains.map(&:name).uniq.reject { |n| n == '8' }
+        base_trains.each do |name|
+          proto = game.depot.trains.find { |t| t.name == name }
+          expect(proto.variants.keys).to include("#{name}E"), "#{name}-train missing #{name}E variant"
+        end
+      end
+
+      it 'E-train distance uses string keys and visit 999' do
+        %w[2E 3E 4E 5E 6E 7E].each do |variant_name|
+          base = variant_name.chomp('E')
+          proto = game.depot.trains.find { |t| t.name == base }
+          dist = proto.variants[variant_name][:distance]
+          expect(dist).to be_an(Array), "#{variant_name} distance should be an array"
+          expect(dist.first['visit']).to eq(999), "#{variant_name} should visit 999 nodes"
+          expect(dist.first['nodes']).to include('city'), "#{variant_name} nodes should include city"
+        end
+      end
+
+      it '2 and 2E trains rust on the 4-train sym' do
+        two_train = game.depot.trains.find { |t| t.name == '2' }
+        expect(two_train.rusts_on).to eq('4')
+      end
+
+      it '3 and 3E trains rust on the 6-train sym' do
+        three_train = game.depot.trains.find { |t| t.name == '3' }
+        expect(three_train.rusts_on).to eq('6')
+      end
+
+      it '4 and 4E trains rust on the 8-train sym' do
+        four_train = game.depot.trains.find { |t| t.name == '4' }
+        expect(four_train.rusts_on).to eq('8')
+      end
+
+      it '5E and later trains never rust' do
+        %w[5 6 7 8].each do |name|
+          train = game.depot.trains.find { |t| t.name == name }
+          expect(train.rusts_on).to be_nil, "#{name}-train should not rust"
+        end
+      end
+    end
+
     describe 'home token timing' do
       it 'uses :operate timing' do
         expect(described_class::HOME_TOKEN_TIMING).to eq(:operate)

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -176,6 +176,62 @@ module Engine
       end
     end
 
+    describe 'bonus markers' do
+      let(:cp)  { game.corporation_by_id('CP') }
+      let(:nyc) { game.corporation_by_id('NYC') }
+
+      def stub_route(*hex_ids)
+        stops = hex_ids.map { |id| double('Stop', hex: double('Hex', id: id)) }
+        double('Route', visited_stops: stops)
+      end
+
+      it 'initialises all bonus states to :unactivated' do
+        described_class::CORP_BONUSES.each do |sym, bonuses|
+          bonuses.each_index do |i|
+            expect(game.instance_variable_get(:@bonus_state)[[sym, i]]).to eq(:unactivated)
+          end
+        end
+      end
+
+      it 'corp_bonus_revenue returns 0 with empty routes' do
+        expect(game.corp_bonus_revenue(cp, [])).to eq(0)
+      end
+
+      it 'corp_bonus_revenue returns 0 for corp without CORP_BONUSES entry' do
+        expect(game.corp_bonus_revenue(nyc, [])).to eq(0)
+      end
+
+      it 'corp_bonus_revenue includes bonus when route visits home AND bonus hex' do
+        route = stub_route(cp.coordinates, 'E25')
+        expect(game.corp_bonus_revenue(cp, [route])).to eq(30)
+      end
+
+      it 'corp_bonus_revenue returns 0 when route misses home hex' do
+        route = stub_route('E25', 'F20')
+        expect(game.corp_bonus_revenue(cp, [route])).to eq(0)
+      end
+
+      it 'activate_new_bonuses! transitions state to :permanent' do
+        route = stub_route(cp.coordinates, 'E25')
+        game.activate_new_bonuses!(cp, [route])
+        expect(game.instance_variable_get(:@bonus_state)[['CP', 0]]).to eq(:permanent)
+      end
+
+      it 'permanent bonus applies without home hex on route' do
+        route = stub_route(cp.coordinates, 'E25')
+        game.activate_new_bonuses!(cp, [route])
+        route2 = stub_route('E25', 'F20')
+        expect(game.corp_bonus_revenue(cp, [route2])).to eq(30)
+      end
+
+      it 'activate_new_bonuses! is idempotent — does not re-activate' do
+        route = stub_route(cp.coordinates, 'E25')
+        game.activate_new_bonuses!(cp, [route])
+        game.activate_new_bonuses!(cp, [route])
+        expect(game.instance_variable_get(:@bonus_state)[['CP', 0]]).to eq(:permanent)
+      end
+    end
+
     describe 'home token timing' do
       it 'uses :operate timing' do
         expect(described_class::HOME_TOKEN_TIMING).to eq(:operate)

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -31,6 +31,39 @@ module Engine
       expect(described_class::SELL_BUY_ORDER).to eq(:sell_buy)
     end
 
+    describe 'GHU token discount' do
+      let(:ghu) { game.companies.find { |c| c.sym == 'GHU' } }
+
+      it 'GHU ability has player owner_type' do
+        ability = ghu.abilities.find { |a| a.type == :token }
+        expect(ability.owner_type).to eq(:player)
+      end
+
+      it 'GHU discount is $80' do
+        ability = ghu.abilities.find { |a| a.type == :token }
+        expect(ability.discount).to eq(80)
+      end
+    end
+
+    describe 'NYH par price restriction' do
+      let(:nyh) { game.corporation_by_id('NYH') }
+      let(:step) { game.stock_round.active_step }
+
+      it 'NYH par is restricted to $100' do
+        game.companies.each { |c| c.owner = game.players.first }
+        prices = step.get_par_prices(game.players.first, nyh).map(&:price)
+        expect(prices).to eq([100])
+      end
+
+      it 'other corps have multiple par prices available' do
+        game.companies.each { |c| c.owner = game.players.first }
+        [game.corporation_by_id('NYC'), game.corporation_by_id('CP')].each do |corp|
+          prices = step.get_par_prices(game.players.first, corp)
+          expect(prices.size).to be > 1
+        end
+      end
+    end
+
     describe 'tile-lay budget' do
       it 'phase 2: single yellow tile only' do
         lays = game.tile_lays(game.corporations.first)


### PR DESCRIPTION
Fixes # (no issue — prealpha game implementation)

## Before clicking "Create"

- [ ] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Consolidates former PRs 08 and 09.

- **feat: bonus markers (Bonusplättchen) state + revenue** — `CORP_BONUSES` table lists each corporation's connection targets with cash and route-bonus amounts. `@bonus_state` tracks `:unactivated` / `:permanent` per corp+index. Revenue hook `corp_bonus_revenue` adds permanent bonuses to each OR's income.
- **feat: SLC transcontinental bonus + Golden Spike event** — CPR and UP earn a per-OR route bonus ($30, reduced to $15 while SOC is open) when their route passes through Salt Lake City (G9). When both connect for the first time, the Golden Spike fires and the bonus increases permanently.

### Screenshots

N/A — logic changes only.

### Any Assumptions / Hacks

None.