### PR TITLE
[2038] PR2 - Dividend step for corporations and independents

### DIFF
--- a/lib/engine/game/g_2038/game.rb
+++ b/lib/engine/game/g_2038/game.rb
@@ -7,6 +7,7 @@ require_relative '../base'
 require_relative 'round/operating'
 require_relative 'step/waterfall_auction'
 require_relative 'step/buy_train'
+require_relative 'step/dividend'
 
 module Engine
   module Game
@@ -240,6 +241,7 @@ module Engine
           G2038::Round::Operating.new(self, [
             Engine::Step::Bankrupt,
             Engine::Step::DiscardTrain,
+            G2038::Step::Dividend,
             G2038::Step::BuyTrain,
             Engine::Step::BuyCompany,
           ], round_num: round_num)

--- a/lib/engine/game/g_2038/game.rb
+++ b/lib/engine/game/g_2038/game.rb
@@ -4,6 +4,9 @@ require_relative 'meta'
 require_relative 'map'
 require_relative 'entities'
 require_relative '../base'
+require_relative 'round/operating'
+require_relative 'step/waterfall_auction'
+require_relative 'step/buy_train'
 
 module Engine
   module Game
@@ -233,6 +236,15 @@ module Engine
           ])
         end
 
+        def new_operating_round(round_num = 1)
+          G2038::Round::Operating.new(self, [
+            Engine::Step::Bankrupt,
+            Engine::Step::DiscardTrain,
+            G2038::Step::BuyTrain,
+            Engine::Step::BuyCompany,
+          ], round_num: round_num)
+        end
+
         def next_round!
           @round =
             case @round
@@ -240,7 +252,7 @@ module Engine
               @operating_rounds = @phase.operating_rounds
               reorder_players
               new_operating_round
-            when Engine::Round::Operating
+            when G2038::Round::Operating
               if @round.round_num < @operating_rounds
                 or_round_finished
                 new_operating_round(@round.round_num + 1)
@@ -255,6 +267,22 @@ module Engine
               reorder_players
               new_stock_round
             end
+        end
+
+        def bank_sort(entities)
+          entities.sort_by { |e| ENTITY_DISPLAY_ORDER.index(e.id) || ENTITY_DISPLAY_ORDER.size }
+        end
+
+        def operating_order
+          minors = MINOR_OPERATING_ORDER.filter_map { |id| minor_by_id(id) }
+          corps = @corporations.select(&:floated?).sort do |a, b|
+            if a.share_price.price != b.share_price.price
+              b.share_price.price <=> a.share_price.price
+            else
+              a.share_price.coordinates <=> b.share_price.coordinates
+            end
+          end
+          minors + corps
         end
 
         def setup
@@ -303,12 +331,7 @@ module Engine
 
         def company_header(company)
           is_minor = @minors.find { |m| m.id == company.id }
-
-          if is_minor
-            'INDEPENDENT COMPANY'
-          else
-            'PRIVATE COMPANY'
-          end
+          is_minor ? 'INDEPENDENT COMPANY' : 'PRIVATE COMPANY'
         end
 
         def after_par(corporation)

--- a/lib/engine/game/g_2038/round/operating.rb
+++ b/lib/engine/game/g_2038/round/operating.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/operating'
+
+module Engine
+  module Game
+    module G2038
+      module Round
+        class Operating < Engine::Round::Operating
+          def setup
+            # Pays all private company revenues to their owners (PI, TS, VA, RS, ST, AE).
+            # Fast Buck has revenue: 0 so it is skipped by payout_companies; its $15
+            # treasury income is handled separately below.
+            super
+            pay_fast_buck_treasury
+          end
+
+          private
+
+          def pay_fast_buck_treasury
+            # Fast Buck earns $15 per OR into its own treasury, not to its owner.
+            # This fires even if FB's owner also collects other private income.
+            fast_buck = @game.minor_by_id('FB')
+            return unless fast_buck&.floated?
+
+            @game.bank.spend(15, fast_buck)
+            @game.log << "Fast Buck receives #{@game.format_currency(15)} into its treasury"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_2038/step/buy_train.rb
+++ b/lib/engine/game/g_2038/step/buy_train.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/buy_train'
+
+module Engine
+  module Game
+    module G2038
+      module Step
+        class BuyTrain < Engine::Step::BuyTrain
+          # In 2038, independent companies (minors) can buy spaceships just like
+          # corporations. The base engine blocks minors from buying trains by default.
+          def can_entity_buy_train?(entity)
+            entity.minor? || super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_2038/step/dividend.rb
+++ b/lib/engine/game/g_2038/step/dividend.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/dividend'
+
+module Engine
+  module Game
+    module G2038
+      module Step
+        class Dividend < Engine::Step::Dividend
+          # Corporations choose: full payout (stock +2), half payout (stock +1),
+          # or withhold (stock -1).
+          CORP_DIVIDEND_TYPES = %i[payout half withhold].freeze
+
+          # Independents (minors) choose: split half with owner, or retain all
+          # in treasury. No stock price — minors have no share price.
+          MINOR_DIVIDEND_TYPES = %i[split retain].freeze
+
+          def dividend_types
+            current_entity.minor? ? self.class::MINOR_DIVIDEND_TYPES : self.class::CORP_DIVIDEND_TYPES
+          end
+
+          def skip!
+            default_kind = current_entity.minor? ? 'retain' : 'withhold'
+            action = Engine::Action::Dividend.new(current_entity, kind: default_kind)
+            action.id = @game.actions.last.id if @game.actions.last
+            process_dividend(action)
+          end
+
+          def round_state
+            super.merge(laid_hexes: [])
+          end
+
+          # ---------------------------------------------------------------------------
+          # Corporation dividend methods
+          # ---------------------------------------------------------------------------
+
+          # Full payout: all revenue to shareholders. Stock moves right 2.
+          # (share_price_change handles the +2; this just sets per_share.)
+          def payout(entity, revenue)
+            { corporation: 0, per_share: payout_per_share(entity, revenue) }
+          end
+
+          # Half payout: half to shareholders, half retained. Stock moves right 1.
+          def half(entity, revenue)
+            corp = revenue / 2
+            { corporation: corp, per_share: payout_per_share(entity, revenue - corp) }
+          end
+
+          # Withhold: all retained. Stock moves left 1.
+          def withhold(_entity, revenue)
+            { corporation: revenue, per_share: 0 }
+          end
+
+          # ---------------------------------------------------------------------------
+          # Minor dividend methods
+          # ---------------------------------------------------------------------------
+
+          # Split: owner gets half, treasury retains half. No price movement.
+          def split(entity, revenue)
+            player_share = revenue / 2
+            { corporation: revenue - player_share, per_share: payout_per_share(entity, player_share) }
+          end
+
+          # Retain: all stays in treasury. No price movement.
+          def retain(_entity, revenue)
+            { corporation: revenue, per_share: 0 }
+          end
+
+          # ---------------------------------------------------------------------------
+          # Stock price movement
+          # ---------------------------------------------------------------------------
+
+          # shareholders_revenue is the portion going to shareholders (revenue - corporation).
+          #   Full payout  → shareholders_revenue == total_revenue → right 2
+          #   Half payout  → 0 < shareholders_revenue < total_revenue → right 1
+          #   Withhold     → shareholders_revenue == 0 → left 1
+          #   Minor        → no stock price → no movement
+          def share_price_change(entity, shareholders_revenue)
+            return {} if entity.minor?
+            return { share_direction: :left,  share_times: 1 } if shareholders_revenue.zero?
+            return { share_direction: :right, share_times: 2 } if shareholders_revenue == total_revenue
+
+            { share_direction: :right, share_times: 1 }
+          end
+
+          # ---------------------------------------------------------------------------
+          # Logging
+          # ---------------------------------------------------------------------------
+
+          def log_run_payout(entity, kind, revenue, subsidy, _action, payout)
+            if entity.minor?
+              case kind
+              when :split
+                player_amount = payout[:per_share]  # minor has 1 share; per_share == owner's cut
+                corp_amount   = payout[:corporation]
+                @log << "#{entity.name} splits #{@game.format_currency(revenue)}: "\
+                        "#{@game.format_currency(player_amount)} to owner, "\
+                        "#{@game.format_currency(corp_amount)} to treasury"
+              when :retain
+                @log << "#{entity.name} retains #{@game.format_currency(revenue)} in treasury"
+              end
+            else
+              case kind
+              when :payout
+                @log << "#{entity.name} pays full dividend of #{@game.format_currency(revenue)}"
+              when :half
+                corp = payout[:corporation]
+                paid = revenue - corp
+                @log << "#{entity.name} pays half dividend — "\
+                        "#{@game.format_currency(paid)} to shareholders, "\
+                        "#{@game.format_currency(corp)} retained"
+              when :withhold
+                @log << "#{entity.name} withholds #{@game.format_currency(revenue)}"
+              end
+            end
+
+            return unless subsidy.positive?
+
+            @log << "#{entity.name} earns #{@game.subsidy_name} of #{@game.format_currency(subsidy)}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Depends on #12666 (data layer) and #12703 (operating round).

## What this adds

**`Step::Dividend`** with two separate decision sets:

- **Corporations**: payout (full revenue to shareholders, stock +2), half (split evenly, stock +1), or withhold (stock ?1)
- **Independents**: split (half to owner / half to treasury, no price move) or retain (all to treasury, no price move)

Stock price movement is determined by the shareholder fraction: full payout ? right 2, partial ? right 1, zero ? left 1. Minors are excluded from all price movement.

?? Generated with [Claude Code](https://claude.com/claude-code)