### PR TITLE
[1850] Gant private should also allow laying Chicago tile

### DIFF
--- a/lib/engine/game/g_1850/entities.rb
+++ b/lib/engine/game/g_1850/entities.rb
@@ -82,7 +82,7 @@ module Engine
             special: false,
             when: 'track',
             hexes: [],
-            tiles: %w[1 2 3 4 5 6 7 8 9 55 56 57 58 69],
+            tiles: %w[1 2 3 4 5 6 7 8 9 55 56 57 58 69 128],
             count_per_or: 1,
             cost: 30,
           ],


### PR DESCRIPTION
Fixes #12708

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

The Gant Brothers Construction Company allows the owning corp to lay an additional yellow tile each turn for $30 plus any terrain costs.

Looks like they forgot to include the Chicago yellow tile in the list of applicable tiles. I checked the rules and there's nothing forbidding its use there.

### Screenshots

### Any Assumptions / Hacks
