### PR TITLE
[18 India] Fix yellow tile lay blocked through red city (rule 8.4.1.1)

### DIFF
--- a/lib/engine/game/g_18_india/step/railhead_tracker.rb
+++ b/lib/engine/game/g_18_india/step/railhead_tracker.rb
@@ -24,12 +24,18 @@ module Engine
             return nil unless @round.pending_tokens.empty? # by placed yellow OO tile
             return [] if @round.laid_yellow_hexes.empty?
 
-            # check simple case of only one or two 'white' neighbor connected to prior tile => return without walking
-            last_tile = @round.laid_yellow_hexes.last.tile
-            unless [1, 6].include?(last_tile.exits.size) # exclude triple town tiles (6 exits) and OO tiles (1 exit)
-              empty_neighbors = empty_neighbors(last_tile.hex, last_tile.exits)
-              return empty_neighbors if [1, 2].include?(empty_neighbors.size)
-            end
+            # Performance shortcut: if the last tile has 1-2 direct white neighbors (and is not a
+            # triple-town/OO tile), return them immediately without a full walk. DISABLED because
+            # it misses white hexes reachable through adjacent red cities (rule 8.4.1.1 — e.g.
+            # E22/triple-dit via Mumbai). To restore, add a guard skipping when any exit is red:
+            #   last_tile = @round.laid_yellow_hexes.last.tile
+            #   unless [1, 6].include?(last_tile.exits.size)
+            #     hex = last_tile.hex
+            #     unless last_tile.exits.any? { |e| hex.neighbors[e]&.tile&.color == :red }
+            #       empty_neighbors = empty_neighbors(hex, last_tile.exits)
+            #       return empty_neighbors if [1, 2].include?(empty_neighbors.size)
+            #     end
+            #   end
 
             corp = @round.current_operator
             railheads = corp.placed_tokens.map(&:city)

--- a/lib/engine/game/g_18_india/step/railhead_tracker.rb
+++ b/lib/engine/game/g_18_india/step/railhead_tracker.rb
@@ -24,19 +24,6 @@ module Engine
             return nil unless @round.pending_tokens.empty? # by placed yellow OO tile
             return [] if @round.laid_yellow_hexes.empty?
 
-            # Performance shortcut: if the last tile has 1-2 direct white neighbors (and is not a
-            # triple-town/OO tile), return them immediately without a full walk. DISABLED because
-            # it misses white hexes reachable through adjacent red cities (rule 8.4.1.1 — e.g.
-            # E22/triple-dit via Mumbai). To restore, add a guard skipping when any exit is red:
-            #   last_tile = @round.laid_yellow_hexes.last.tile
-            #   unless [1, 6].include?(last_tile.exits.size)
-            #     hex = last_tile.hex
-            #     unless last_tile.exits.any? { |e| hex.neighbors[e]&.tile&.color == :red }
-            #       empty_neighbors = empty_neighbors(hex, last_tile.exits)
-            #       return empty_neighbors if [1, 2].include?(empty_neighbors.size)
-            #     end
-            #   end
-
             corp = @round.current_operator
             railheads = corp.placed_tokens.map(&:city)
             placed_paths = @round.laid_yellow_hexes.map(&:tile).map(&:paths) # paths on all previously laid yellow hexes


### PR DESCRIPTION
## Summary
- Disables the simple-case shortcut in `calculate_railhead_hexes` that returned early when the last laid tile had 1-2 direct white neighbors
- The shortcut excluded red-hex neighbors from `empty_neighbors`, causing it to miss white hexes reachable *through* adjacent red cities (e.g. E22/triple-dit via Mumbai D23 - rule 8.4.1.1)
- The full walk already handles the 1-2 neighbor case correctly; the shortcut's performance benefit was marginal (result is cached per track action)
- The shortcut code is preserved as a commented block with instructions for restoring it if a red-hex guard is added

Fixes #11780

## Test plan
- [x] 18India fixtures: 43/43 pass
- [x] Full suite: 7429 examples, 0 failures
- [x] Manual: WIP at E24 (Pune) can lay yellow tile at E24 and then continue to E22 (triple-dit) via Mumbai D23 red city