### PR TITLE
[18 India] Fix connection bonus fires on visited but unpaid cities

### DIFF
--- a/lib/engine/game/g_18_india/game.rb
+++ b/lib/engine/game/g_18_india/game.rb
@@ -1031,8 +1031,8 @@ module Engine
           variable_city_stops.count * [max_non_variable_value, 0].max * train_multiplier
         end
 
-        def connection_bonus(route, _stops)
-          visited_location_names = route.visited_stops.map { |stop| stop.tile.location_name }.compact
+        def connection_bonus(_route, stops)
+          visited_location_names = stops.map { |stop| stop.tile.location_name }.compact
           return 0 if visited_location_names.count < 2
 
           # Delhi, Kochi => 100 [G8, G36]

--- a/spec/lib/engine/game/g_18_india/game_spec.rb
+++ b/spec/lib/engine/game/g_18_india/game_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Engine::Game::G18India::Game do
+  let(:players) { %w[a b] }
+
+  subject(:game) { Engine::Game::G18India::Game.new(players) }
+
+  def make_stop(location_name)
+    tile = double('tile', location_name: location_name)
+    double('stop', tile: tile)
+  end
+
+  describe '#connection_bonus' do
+    # connection_bonus uses the `stops` parameter (paid stops), not visited_stops.
+    # A 4E train visits unlimited cities but only pays for 4. This test verifies
+    # that the bonus only fires when both pair cities are among the paid stops.
+
+    it 'returns 100 when both Delhi and Kochi are paid stops' do
+      stops = [make_stop('DELHI'), make_stop('KOCHI'), make_stop('ALLAHABAD')]
+      expect(game.connection_bonus(nil, stops)).to eq(100)
+    end
+
+    it 'returns 0 when only one city of the Delhi/Kochi pair is a paid stop' do
+      # Simulates a 4E train that visits Kochi but Kochi is not among the 4 paid cities
+      stops = [make_stop('DELHI'), make_stop('ALLAHABAD')]
+      expect(game.connection_bonus(nil, stops)).to eq(0)
+    end
+
+    it 'returns 80 when both Karachi and Chennai are paid stops' do
+      stops = [make_stop('KARACHI'), make_stop('CHENNAI')]
+      expect(game.connection_bonus(nil, stops)).to eq(80)
+    end
+
+    it 'returns 80 when both Lahore and Kolkata are paid stops' do
+      stops = [make_stop('LAHORE'), make_stop('KOLKATA')]
+      expect(game.connection_bonus(nil, stops)).to eq(80)
+    end
+
+    it 'returns 70 when both Nepal and Mumbai are paid stops' do
+      stops = [make_stop('NEPAL'), make_stop('MUMBAI')]
+      expect(game.connection_bonus(nil, stops)).to eq(70)
+    end
+
+    it 'accumulates multiple bonuses when multiple pairs are all paid stops' do
+      stops = [make_stop('DELHI'), make_stop('KOCHI'), make_stop('NEPAL'), make_stop('MUMBAI')]
+      expect(game.connection_bonus(nil, stops)).to eq(170)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `connection_bonus` was using `route.visited_stops` instead of the `stops` (paid stops) argument
- This caused the R+ route bonus to fire when both endpoint cities of a bonus pair were merely *visited* rather than counted among the train's paid cities
- A 4E train visiting Karachi and Chennai but paying for 4 other cities would incorrectly collect the R+80 bonus; now both cities must be among the paid stops

Fixes #11512

This will very likely require pinning games,  as it changes the amounts awarded for many E train runs. 

## Test plan
- [x] 18India fixtures: 43/43 pass
- [x] Manual: run a 4E train that visits but does not pay for both cities of a bonus pair; confirm R+ does not appear
- [x] Manual: run a 4E that pays for both cities of a bonus pair; confirm R+ still appears