### PR TITLE
[18 India] Fix hand share purchase price to use IPO price

### DIFF
--- a/lib/engine/game/g_18_india/step/sell_once_then_buy_certs.rb
+++ b/lib/engine/game/g_18_india/step/sell_once_then_buy_certs.rb
@@ -170,7 +170,8 @@ module Engine
             return false if @game.in_ipo?(company) && !can_buy_from_ipo?(entity, company)
             return false if current_entity.hand.include?(company) && !can_buy_from_hand?(entity, company)
 
-            (available_cash(entity) >= company.value)
+            price = current_entity.hand.include?(company) ? hand_price(company) : company.value
+            (available_cash(entity) >= price)
           end
 
           def can_buy_from_market?(entity, company)
@@ -196,8 +197,18 @@ module Engine
                 prior.name == company.name
               end
             else
-              (available_cash(entity) >= company.value)
+              (available_cash(entity) >= hand_price(company))
             end
+          end
+
+          def hand_price(company)
+            return company.value unless %i[share president].include?(company.type)
+
+            share = company.treasury
+            par = share.corporation.par_price
+            return company.value unless par
+
+            (par.price * share.num_shares(ceil: false)).ceil
           end
 
           def can_buy_from_ipo?(entity, company)

--- a/spec/lib/engine/game/g_18_india/game_spec.rb
+++ b/spec/lib/engine/game/g_18_india/game_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Engine::Game::G18India::Game do
+  describe '18India_game_end_bank' do
+    # Action 403: Player 1 is in buying phase, holds EIR (share) in hand
+    # EIR par=100, market=126 (market is above IPO price)
+    context 'market price above IPO price' do
+      it 'hand_price returns IPO price, not market price' do
+        game = fixture_at_action(403)
+        player = game.current_entity
+        step = game.active_step
+        cert = player.hand.find { |c| c.name == 'EIR' && c.type == :share }
+        corp = cert.treasury.corporation
+
+        expect(corp.share_price.price).to be > corp.par_price.price
+        expect(step.hand_price(cert)).to eq(corp.par_price.price)
+      end
+
+      it 'player can buy from hand when cash equals IPO price even though market is higher' do
+        game = fixture_at_action(403, clear_cache: true)
+        player = game.current_entity
+        step = game.active_step
+        cert = player.hand.find { |c| c.name == 'EIR' && c.type == :share }
+        corp = cert.treasury.corporation
+
+        player.instance_variable_set(:@cash, corp.par_price.price)
+        expect(step.can_buy_from_hand?(player, cert)).to eq(true)
+      end
+    end
+
+    # Action 276: Player 2 is in buying phase, holds WIP (share) in hand
+    # WIP par=76, market=67 (market is below IPO price)
+    context 'market price below IPO price' do
+      it 'hand_price returns IPO price, not market price' do
+        game = fixture_at_action(276)
+        player = game.current_entity
+        step = game.active_step
+        cert = player.hand.find { |c| c.name == 'WIP' && c.type == :share }
+        corp = cert.treasury.corporation
+
+        expect(corp.share_price.price).to be < corp.par_price.price
+        expect(step.hand_price(cert)).to eq(corp.par_price.price)
+      end
+
+      it 'player must have IPO price cash to buy from hand even though market price is lower' do
+        game = fixture_at_action(276, clear_cache: true)
+        player = game.current_entity
+        step = game.active_step
+        cert = player.hand.find { |c| c.name == 'WIP' && c.type == :share }
+        corp = cert.treasury.corporation
+
+        player.instance_variable_set(:@cash, corp.par_price.price)
+        expect(step.can_buy_from_hand?(player, cert)).to eq(true)
+
+        player.instance_variable_set(:@cash, corp.share_price.price)
+        expect(step.can_buy_from_hand?(player, cert)).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- can_buy_from_hand? and can_buy_company? affordability checks for hand share certificates now use IPO/par price explicitly via a new hand_price(company) helper, rather than company.value which can reflect market price when the underlying share's ownership changes
- hand_price computes par_price * num_shares for :share and :president type certificates; falls back to company.value for other types or if par_price is unavailable

## Test plan
- [x] All 185 existing fixture tests pass
- [x] Verify a player can buy a hand share certificate at IPO price when the corporation's market price has moved above or below the original IPO price

<img width="731" height="473" alt="image" src="https://github.com/user-attachments/assets/62e9228f-3ae1-4b61-ab39-79a9e8418c68" />
<img width="766" height="414" alt="image" src="https://github.com/user-attachments/assets/4b967722-6390-4dc2-ad45-a3d2c2230462" />


Closes #11114

?? Generated with [Claude Code](https://claude.com/claude-code)