### PR TITLE
[18CZ] Rename kk's name to 'kaiserliche und königliche Staatsbahn'

### DIFF
--- a/lib/engine/game/g_18_cz/entities.rb
+++ b/lib/engine/game/g_18_cz/entities.rb
@@ -1803,7 +1803,7 @@ module Engine
               float_percent: 50,
               float_excludes_market: true,
               sym: 'kk',
-              name: 'kk Staatsbahn',
+              name: 'kaiserliche und königliche Staatsbahn',
               logo: '18_cz/kk',
               simple_logo: '18_cz/kk.alt',
               max_ownership_percent: 60,


### PR DESCRIPTION
## Implementation Notes

The original name used the abbreviation. To be consistent with other companies I added full name.