### PR TITLE
[CODEOWNERS] Improved matchers for 1862 games

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,8 @@ scripts/ @michaeljb
 lib/engine/game/g_1825* @roseundy
 lib/engine/game/g_1841* @roseundy
 lib/engine/game/g_1860* @roseundy
-lib/engine/game/g_1862* @roseundy
+lib/engine/game/g_1862.rb @roseundy
+lib/engine/game/g_1862/* @roseundy
 lib/engine/game/g_1873* @roseundy
 lib/engine/game/g_1888* @roseundy
 lib/engine/game/g_18_carolinas* @roseundy
@@ -49,6 +50,7 @@ lib/engine/game/g_18_rhl* @perwestling
 lib/engine/game/g_18_sj* @perwestling
 lib/engine/game/g_18_tn* @perwestling
 lib/engine/game/g_1824* @perwestling
+lib/engine/game/g_1862_solo* @perwestling
 lib/engine/game/g_1893* @perwestling
 
 lib/engine/game/g_1807* @ollybh


### PR DESCRIPTION
The existing pattern for 1862 was matching all games which began with
1862. This makes the match more precise, so that the new implementation of 1862 USA and Canada (g_1862_usa_canada) is not matched.

It also adds a separate entry for the 1862 East Anglian solo mode implementation (g_1862_solo).