### PR TITLE
[1880 Romania] VRL shouldn't have specific city assigned in entities.rb

### DIFF
--- a/lib/engine/game/g_1880_romania/entities.rb
+++ b/lib/engine/game/g_1880_romania/entities.rb
@@ -269,7 +269,6 @@ module Engine
             simple_logo: '1880_romania/VRL.alt',
             tokens: [0, 40, 100],
             coordinates: 'H16',
-            city: 1,
             color: '#E32327',
             max_ownership_percent: 100,
             always_market_price: true,


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

When I coded the game, I assigned VRL to `city: 1`, but like Erie in 1830, this is a OO hex and the corp should be able to choose its home. 

Removed city assignment.

### Screenshots

### Any Assumptions / Hacks
