### PR TITLE
[1835] properly label Berlin so it can be upgraded from yellow to green

### DIFF
--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -265,6 +265,11 @@ module Engine
           floated.sort + not_floated + others
         end
 
+        def upgrade_ignore_num_cities(from)
+          # Two stations in Berlin get merged into one with three spots
+          from.hex.id == 'E19' && from.color == :yellow
+        end
+
         def revenue_for(route, stops)
           super + (hamburg_ferry?(route) ? -10 : 0)
         end

--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -265,11 +265,6 @@ module Engine
           floated.sort + not_floated + others
         end
 
-        def upgrade_ignore_num_cities(from)
-          # Two stations in Berlin get merged into one with three spots
-          from.hex.id == 'E19' && from.color == :yellow
-        end
-
         def revenue_for(route, stops)
           super + (hamburg_ferry?(route) ? -10 : 0)
         end

--- a/lib/engine/game/g_1835/map.rb
+++ b/lib/engine/game/g_1835/map.rb
@@ -195,7 +195,7 @@ module Engine
           yellow: {
             ['E19'] =>
             'city=revenue:30,loc:1,groups:Berlin;city=revenue:30,loc:3,groups:Berlin;path=a:1,b:_0;path=a:2,b:_1;'\
-            'future_label=label:B,color:green',
+            'label=B',
             ['G3'] =>
             'city=revenue:0,loc:0;city=revenue:0,loc:4.5;label=XX;upgrade=cost:50',
             ['J6'] => 'city=revenue:0;city=revenue:0;label=XX;upgrade=cost:50',


### PR DESCRIPTION
refers to https://github.com/tobymao/18xx/issues/3059

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

The yellow Berlin tile has two cities, the green one merges them into one city with three stations, so we have to allow that to happen.
