### PR TITLE
[1835] allow upgrading green XX tiles to brown X tiles

### DIFF
--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -265,12 +265,6 @@ module Engine
           floated.sort + not_floated + others
         end
 
-        def upgrades_to_correct_label?(from, to)
-          return to.label&.to_s == 'X' if from.color == :green && from.label&.to_s == 'XX'
-
-          super
-        end
-
         def revenue_for(route, stops)
           super + (hamburg_ferry?(route) ? -10 : 0)
         end

--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -265,6 +265,12 @@ module Engine
           floated.sort + not_floated + others
         end
 
+        def upgrades_to_correct_label?(from, to)
+          return to.label&.to_s == 'X' if from.color == :green && from.label&.to_s == 'XX'
+
+          super
+        end
+
         def revenue_for(route, stops)
           super + (hamburg_ferry?(route) ? -10 : 0)
         end

--- a/lib/engine/game/g_1835/map.rb
+++ b/lib/engine/game/g_1835/map.rb
@@ -45,12 +45,42 @@ module Engine
           '207' => 2,
           '208' => 2,
           '209' => 1,
-          '210' => 1,
-          '211' => 1,
-          '212' => 1,
-          '213' => 1,
-          '214' => 1,
-          '215' => 1,
+          '210' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:30;city=revenue:30;path=a:0,b:_0;path=a:3,b:_0;path=a:5,b:_1;path=a:4,b:_1;label=XX;'\
+                      'future_label=label:X,color:brown',
+          },
+          '211' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:30;city=revenue:30;path=a:2,b:_0;path=a:3,b:_0;path=a:0,b:_1;path=a:1,b:_1;label=XX;'\
+                      'future_label=label:X,color:brown',
+          },
+          '212' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:30;city=revenue:30;path=a:2,b:_0;path=a:3,b:_0;path=a:0,b:_1;path=a:5,b:_1;label=XX;'\
+                      'future_label=label:X,color:brown',
+          },
+          '213' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:30;city=revenue:30;path=a:2,b:_0;path=a:3,b:_0;path=a:0,b:_1;path=a:4,b:_1;label=XX;'\
+                      'future_label=label:X,color:brown',
+          },
+          '214' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:30;city=revenue:30;path=a:4,b:_0;path=a:3,b:_0;path=a:0,b:_1;path=a:2,b:_1;label=XX;'\
+                      'future_label=label:X,color:brown',
+          },
+          '215' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:30;city=revenue:30;path=a:1,b:_0;path=a:3,b:_0;path=a:0,b:_1;path=a:4,b:_1;label=XX;'\
+                      'future_label=label:X,color:brown',
+          },
           '39' => 1,
           '40' => 1,
           '41' => 2,


### PR DESCRIPTION
refers to https://github.com/tobymao/18xx/issues/3059

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

The green tiles for twin-cities have an XX label, but the brown ones only one X, so we need to handle that.

### Screenshots

<img width="344" height="353" alt="image" src="https://github.com/user-attachments/assets/4567ef38-dc98-4f61-9795-beadf37e6a9c" />
