### PR TITLE
[1835] render flags for 5% shares

### DIFF
--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -442,6 +442,10 @@ module Engine
           exchange_share.buyable = true
           @share_pool.transfer_shares(ShareBundle.new(exchange_share), owner, allow_president_change: allow_president_change)
         end
+
+        def share_flags(shares)
+          'h' * shares.count { |share| share.percent == 5 }
+        end
       end
     end
   end


### PR DESCRIPTION
refers to https://github.com/tobymao/18xx/issues/3059

## Implementation Notes

### Explanation of Change

Double certs have a flag, so half shares also need one. Otherwise it's really hard to see what each player actually has.

### Screenshots
<img width="307" height="265" alt="image" src="https://github.com/user-attachments/assets/6759eab2-1e6c-4b24-9830-cb59fbfaa3c3" />