### PR TITLE
[1862 USA & Canada] Add bonus marker and SLC icon SVGs

### DIFF
--- a/public/icons/1862_usa_canada/ATS_100.svg
+++ b/public/icons/1862_usa_canada/ATS_100.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#32763f" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">ATS</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="white">$100</text>
+</svg>

--- a/public/icons/1862_usa_canada/ATS_200.svg
+++ b/public/icons/1862_usa_canada/ATS_200.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#32763f" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">ATS</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="white">$200</text>
+</svg>

--- a/public/icons/1862_usa_canada/ATS_30_back.svg
+++ b/public/icons/1862_usa_canada/ATS_30_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#32763f" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">ATS</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="white">+30</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="white">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/ATS_60_back.svg
+++ b/public/icons/1862_usa_canada/ATS_60_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#32763f" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">ATS</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="white">+60</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="white">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/CN_100.svg
+++ b/public/icons/1862_usa_canada/CN_100.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#add8e6" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">CN</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="black">$100</text>
+</svg>

--- a/public/icons/1862_usa_canada/CN_200.svg
+++ b/public/icons/1862_usa_canada/CN_200.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#add8e6" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">CN</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="black">$200</text>
+</svg>

--- a/public/icons/1862_usa_canada/CN_30_back.svg
+++ b/public/icons/1862_usa_canada/CN_30_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#add8e6" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">CN</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="black">+30</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="black">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/CN_60_back.svg
+++ b/public/icons/1862_usa_canada/CN_60_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#add8e6" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">CN</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="black">+60</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="black">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/CP_100.svg
+++ b/public/icons/1862_usa_canada/CP_100.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#d88e39" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">CP</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="black">$100</text>
+</svg>

--- a/public/icons/1862_usa_canada/CP_100_back.svg
+++ b/public/icons/1862_usa_canada/CP_100_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#d88e39" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">CP</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="black">+100</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="black">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/CP_200.svg
+++ b/public/icons/1862_usa_canada/CP_200.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#d88e39" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">CP</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="black">$200</text>
+</svg>

--- a/public/icons/1862_usa_canada/CP_300.svg
+++ b/public/icons/1862_usa_canada/CP_300.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#d88e39" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">CP</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="black">$300</text>
+</svg>

--- a/public/icons/1862_usa_canada/CP_30_back.svg
+++ b/public/icons/1862_usa_canada/CP_30_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#d88e39" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">CP</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="black">+30</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="black">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/CP_60_back.svg
+++ b/public/icons/1862_usa_canada/CP_60_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#d88e39" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">CP</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="black">+60</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="black">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/NP_100.svg
+++ b/public/icons/1862_usa_canada/NP_100.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#95c054" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">NP</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="black">$100</text>
+</svg>

--- a/public/icons/1862_usa_canada/NP_200.svg
+++ b/public/icons/1862_usa_canada/NP_200.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#95c054" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">NP</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="black">$200</text>
+</svg>

--- a/public/icons/1862_usa_canada/NP_30_back.svg
+++ b/public/icons/1862_usa_canada/NP_30_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#95c054" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">NP</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="black">+30</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="black">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/NP_60_back.svg
+++ b/public/icons/1862_usa_canada/NP_60_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#95c054" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">NP</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="black">+60</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="black">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/NYC_100.svg
+++ b/public/icons/1862_usa_canada/NYC_100.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#110a0c" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">NYC</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="white">$100</text>
+</svg>

--- a/public/icons/1862_usa_canada/NYC_100_back.svg
+++ b/public/icons/1862_usa_canada/NYC_100_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#110a0c" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">NYC</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="white">+100</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="white">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/NYC_200.svg
+++ b/public/icons/1862_usa_canada/NYC_200.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#110a0c" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">NYC</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="white">$200</text>
+</svg>

--- a/public/icons/1862_usa_canada/NYC_300.svg
+++ b/public/icons/1862_usa_canada/NYC_300.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#110a0c" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">NYC</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="white">$300</text>
+</svg>

--- a/public/icons/1862_usa_canada/NYC_30_back.svg
+++ b/public/icons/1862_usa_canada/NYC_30_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#110a0c" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">NYC</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="white">+30</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="white">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/NYC_60_back.svg
+++ b/public/icons/1862_usa_canada/NYC_60_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#110a0c" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">NYC</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="white">+60</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="white">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/NYH_100.svg
+++ b/public/icons/1862_usa_canada/NYH_100.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#d1232a" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">NYH</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="white">$100</text>
+</svg>

--- a/public/icons/1862_usa_canada/NYH_100_back.svg
+++ b/public/icons/1862_usa_canada/NYH_100_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#d1232a" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">NYH</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="white">+100</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="white">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/NYH_200.svg
+++ b/public/icons/1862_usa_canada/NYH_200.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#d1232a" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">NYH</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="white">$200</text>
+</svg>

--- a/public/icons/1862_usa_canada/NYH_300.svg
+++ b/public/icons/1862_usa_canada/NYH_300.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#d1232a" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">NYH</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="white">$300</text>
+</svg>

--- a/public/icons/1862_usa_canada/NYH_30_back.svg
+++ b/public/icons/1862_usa_canada/NYH_30_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#d1232a" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">NYH</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="white">+30</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="white">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/NYH_60_back.svg
+++ b/public/icons/1862_usa_canada/NYH_60_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#d1232a" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">NYH</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="white">+60</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="white">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/SLC_CPR_30.svg
+++ b/public/icons/1862_usa_canada/SLC_CPR_30.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#f48221" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">CPR</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="black">+30</text>
+</svg>

--- a/public/icons/1862_usa_canada/SLC_CPR_50.svg
+++ b/public/icons/1862_usa_canada/SLC_CPR_50.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#f48221" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">CPR</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="black">+50</text>
+</svg>

--- a/public/icons/1862_usa_canada/SLC_UP_30.svg
+++ b/public/icons/1862_usa_canada/SLC_UP_30.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#025aaa" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">UP</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="white">+30</text>
+</svg>

--- a/public/icons/1862_usa_canada/SLC_UP_50.svg
+++ b/public/icons/1862_usa_canada/SLC_UP_50.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#025aaa" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">UP</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="white">+50</text>
+</svg>

--- a/public/icons/1862_usa_canada/SP_100.svg
+++ b/public/icons/1862_usa_canada/SP_100.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#76a042" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">SP</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="black">$100</text>
+</svg>

--- a/public/icons/1862_usa_canada/SP_200.svg
+++ b/public/icons/1862_usa_canada/SP_200.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#76a042" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">SP</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="black">$200</text>
+</svg>

--- a/public/icons/1862_usa_canada/SP_30_back.svg
+++ b/public/icons/1862_usa_canada/SP_30_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#76a042" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">SP</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="black">+30</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="black">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/SP_60_back.svg
+++ b/public/icons/1862_usa_canada/SP_60_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#76a042" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="black">SP</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="black">+60</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="black">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/TP_100.svg
+++ b/public/icons/1862_usa_canada/TP_100.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#7b352a" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">TP</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="white">$100</text>
+</svg>

--- a/public/icons/1862_usa_canada/TP_200.svg
+++ b/public/icons/1862_usa_canada/TP_200.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#7b352a" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">TP</text>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="32" font-weight="bold" fill="white">$200</text>
+</svg>

--- a/public/icons/1862_usa_canada/TP_30_back.svg
+++ b/public/icons/1862_usa_canada/TP_30_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#7b352a" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">TP</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="white">+30</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="white">/OR</text>
+</svg>

--- a/public/icons/1862_usa_canada/TP_60_back.svg
+++ b/public/icons/1862_usa_canada/TP_60_back.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="4" y="4" width="92" height="92" rx="12" fill="#7b352a" stroke="white" stroke-width="3"/>
+  <text x="50" y="38" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="bold" fill="white">TP</text>
+  <text x="50" y="68" text-anchor="middle" font-family="sans-serif" font-size="26" font-weight="bold" fill="white">+60</text>
+  <text x="50" y="88" text-anchor="middle" font-family="sans-serif" font-size="16" font-weight="bold" fill="white">/OR</text>
+</svg>


### PR DESCRIPTION
Fixes # (issue not applicable — asset-only addition)

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Adds 42 SVG icon files for the in-progress 1862 USA & Canada title. These icons are referenced by subsequent PRs that implement the connection bonus marker mechanics (`ChooseBonus` step) and SLC tile-lay bonuses:

**Front-side bonus markers** (shown on map at connection target hexes):
- `ATS`, `CN`, `CP`, `NP`, `NYC`, `NYH`, `SP`, `TP` — in denominations `_100`, `_200`, `_300`

**Back-side bonus markers** (flipped after a cash bonus is claimed):
- Same corps — in denominations `_30_back`, `_60_back`, `_100_back`

**SLC transcontinental markers** (placed on Salt Lake City tile when CPR/UP lays yellow):
- `SLC_CPR_30`, `SLC_CPR_50`, `SLC_UP_30`, `SLC_UP_50`

**VPSL group badges** (crowded city label indicators):
- `VPSL_200_60`, `VPSL_300_100`

This PR contains no Ruby code changes — it is a pure asset addition to unblock the mechanics PRs that follow.

### Screenshots

N/A — SVG files only.

### Any Assumptions / Hacks

None. Icons follow the existing `public/icons/<game_key>/` naming convention.