### PR TITLE
[1835] let major corps lay two yellow tiles during yellow phase

### DIFF
--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -165,8 +165,8 @@ module Engine
 
         CORPORATION_BLOCKS = [%w[BY SX], %w[BA WT HE PR], %w[MS OL]].freeze
 
-        YELLOW_OR_UPGRADE = [{ lay: true, upgrade: true }].freeze
-        TWO_YELLOW = [{ lay: true, upgrade: false }, { lay: true, upgrade: false }].freeze
+        LAY_OR_UPGRADE = [{ lay: true, upgrade: true }].freeze
+        TWO_LAYS = [{ lay: true, upgrade: false }, { lay: true, upgrade: false }].freeze
 
         def setup
           prussian.shares.last(7).each { |s| s.buyable = false }
@@ -317,6 +317,12 @@ module Engine
           north_edge_used = route.paths.any? { |path| path.tile.hex == hamburg_hex && [2, 3, 4].intersect?(path.exits) }
           south_edge_used = route.paths.any? { |path| path.tile.hex == hamburg_hex && [0, 1, 5].intersect?(path.exits) }
           north_edge_used && south_edge_used
+        end
+
+        def tile_lays(entity)
+          return TWO_LAYS if entity.type == :major && @phase.name.to_i < 2
+
+          LAY_OR_UPGRADE
         end
 
         def payout_companies

--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -61,6 +61,7 @@ module Engine
             on: '2',
             train_limit: { minor: 2, major: 4 },
             tiles: [:yellow],
+            status: ['two_tile_lays'],
             operating_rounds: 1,
           },
           {
@@ -68,6 +69,7 @@ module Engine
             on: '2+2',
             train_limit: { minor: 2, major: 4 },
             tiles: [:yellow],
+            status: ['two_tile_lays'],
             operating_rounds: 1,
           },
           {
@@ -75,6 +77,7 @@ module Engine
             on: '3',
             train_limit: { minor: 2, major: 4 },
             tiles: %i[yellow green],
+            status: ['lay_or_upgrade'],
             operating_rounds: 2,
           },
           {
@@ -82,6 +85,7 @@ module Engine
             on: '3+3',
             train_limit: { major: 4, minor: 2 },
             tiles: %i[yellow green],
+            status: ['lay_or_upgrade'],
             operating_rounds: 2,
           },
           {
@@ -89,6 +93,7 @@ module Engine
             on: '4',
             train_limit: { prussian: 4, major: 3, minor: 1 },
             tiles: %i[yellow green],
+            status: ['lay_or_upgrade'],
             operating_rounds: 2,
           },
           {
@@ -96,6 +101,7 @@ module Engine
             on: '4+4',
             train_limit: { prussian: 4, major: 3, minor: 1 },
             tiles: %i[yellow green],
+            status: ['lay_or_upgrade'],
             operating_rounds: 2,
           },
           {
@@ -103,6 +109,7 @@ module Engine
             on: '5',
             train_limit: { prussian: 3, major: 2 },
             tiles: %i[yellow green brown],
+            status: ['lay_or_upgrade'],
             operating_rounds: 3,
           },
           {
@@ -110,6 +117,7 @@ module Engine
             on: '5+5',
             train_limit: { prussian: 3, major: 2 },
             tiles: %i[yellow green brown],
+            status: ['lay_or_upgrade'],
             operating_rounds: 3,
           },
           {
@@ -117,6 +125,7 @@ module Engine
             on: '6',
             train_limit: { prussian: 3, major: 2 },
             tiles: %i[yellow green brown],
+            status: ['lay_or_upgrade'],
             operating_rounds: 3,
           },
           {
@@ -124,6 +133,7 @@ module Engine
             on: '6+6',
             train_limit: { prussian: 3, major: 2 },
             tiles: %i[yellow green brown],
+            status: ['lay_or_upgrade'],
             operating_rounds: 3,
           },
         ].freeze
@@ -155,6 +165,11 @@ module Engine
           'pr_must_form' => ['Preußen Formation', 'Preußen forms immediately'],
           'forced_pr_exchange' => ['Forced Preußen exchange',
                                    'Remaining Preußen privates and minors will be exchanged for Preußen shares']
+        ).freeze
+
+        STATUS_TEXT = Base::STATUS_TEXT.merge(
+          'two_tile_lays' => ['Two tile lays', 'Major corporations may lay 2 yellow tiles, minor corporations lay 1 yellow tile'],
+          'lay_or_upgrade' => ['Lay or upgrade', 'Corporations may lay 1 tile or upgrade 1 tile']
         ).freeze
 
         LAYOUT = :pointy
@@ -320,7 +335,7 @@ module Engine
         end
 
         def tile_lays(entity)
-          return TWO_LAYS if entity.type == :major && @phase.name.to_i < 2
+          return TWO_LAYS if entity.type == :major && @phase.status.include?('two_tile_lays')
 
           LAY_OR_UPGRADE
         end


### PR DESCRIPTION
refers to https://github.com/tobymao/18xx/issues/3059

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
Nothing much to say, majors get to lay two yellow tiles during the yellow phase. If you're not a major during the yellow phase you lay or upgrade one tile.
