### PR TITLE
[1835] allow buying trains from other corporations and fix ebuy

### DIFF
--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -48,6 +48,8 @@ module Engine
 
         TOKEN_PLACEMENT_ON_TILE_LAY_ENTITY = :owner
 
+        EBUY_DEPOT_TRAIN_MUST_BE_CHEAPEST = false
+
         MARKET = [['', '', '', ''] + %w[132 148 166 186 208 232 258 286 316 348 382 418],
                   ['', ''] + %w[98 108 120 134 150 168 188 210 234 260 288 318 350 384],
                   %w[82 86 92p 100 110 122 136 152 170 190 212 236 262 290 320],
@@ -75,6 +77,7 @@ module Engine
             on: '3',
             train_limit: { minor: 2, major: 4 },
             tiles: %i[yellow green],
+            status: ['can_buy_trains'],
             operating_rounds: 2,
           },
           {
@@ -82,6 +85,7 @@ module Engine
             on: '3+3',
             train_limit: { major: 4, minor: 2 },
             tiles: %i[yellow green],
+            status: ['can_buy_trains'],
             operating_rounds: 2,
           },
           {
@@ -89,6 +93,7 @@ module Engine
             on: '4',
             train_limit: { prussian: 4, major: 3, minor: 1 },
             tiles: %i[yellow green],
+            status: ['can_buy_trains'],
             operating_rounds: 2,
           },
           {
@@ -96,6 +101,7 @@ module Engine
             on: '4+4',
             train_limit: { prussian: 4, major: 3, minor: 1 },
             tiles: %i[yellow green],
+            status: ['can_buy_trains'],
             operating_rounds: 2,
           },
           {
@@ -103,6 +109,7 @@ module Engine
             on: '5',
             train_limit: { prussian: 3, major: 2 },
             tiles: %i[yellow green brown],
+            status: ['can_buy_trains'],
             operating_rounds: 3,
           },
           {
@@ -110,6 +117,7 @@ module Engine
             on: '5+5',
             train_limit: { prussian: 3, major: 2 },
             tiles: %i[yellow green brown],
+            status: ['can_buy_trains'],
             operating_rounds: 3,
           },
           {
@@ -117,6 +125,7 @@ module Engine
             on: '6',
             train_limit: { prussian: 3, major: 2 },
             tiles: %i[yellow green brown],
+            status: ['can_buy_trains'],
             operating_rounds: 3,
           },
           {
@@ -124,6 +133,7 @@ module Engine
             on: '6+6',
             train_limit: { prussian: 3, major: 2 },
             tiles: %i[yellow green brown],
+            status: ['can_buy_trains'],
             operating_rounds: 3,
           },
         ].freeze

--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -167,6 +167,10 @@ module Engine
                                    'Remaining Preußen privates and minors will be exchanged for Preußen shares']
         ).freeze
 
+        STATUS_TEXT = Base::STATUS_TEXT.merge(
+          'can_buy_trains' => ['Buy trains', 'Can buy trains from other corporations']
+        ).freeze
+
         LAYOUT = :pointy
 
         SELL_MOVEMENT = :down_block

--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -335,6 +335,10 @@ module Engine
           super unless any_conversion_choice_available?
         end
 
+        def can_buy_train_from_others?
+          @phase.status.include?('can_buy_trains')
+        end
+
         def any_conversion_choice_available?
           # Owner of 2 has the choice to form the PR
           return true if @pr_can_form && !prussian.floated?

--- a/lib/engine/game/g_1835/step/buy_train.rb
+++ b/lib/engine/game/g_1835/step/buy_train.rb
@@ -5,12 +5,6 @@ module Engine
     module G1835
       module Step
         class BuyTrain < Engine::Step::BuyTrain
-          def buyable_trains(_entity)
-            return super if @game.phase.status.include?('can_buy_trains')
-
-            super.select(&:from_depot?)
-          end
-
           def can_entity_buy_train?(entity)
             entity.corporation? || entity.minor?
           end

--- a/lib/engine/game/g_1835/step/buy_train.rb
+++ b/lib/engine/game/g_1835/step/buy_train.rb
@@ -5,6 +5,12 @@ module Engine
     module G1835
       module Step
         class BuyTrain < Engine::Step::BuyTrain
+          def buyable_trains(_entity)
+            return super if @game.phase.status.include?('can_buy_trains')
+
+            super.select(&:from_depot?)
+          end
+
           def can_entity_buy_train?(entity)
             entity.corporation? || entity.minor?
           end


### PR DESCRIPTION
refers to https://github.com/tobymao/18xx/issues/3059

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

As mentioned [in another PR](https://github.com/tobymao/18xx/pull/12725#discussion_r3343010676), allowing cross buy should be done via the status of the phase.