### PR TITLE
[18ZOO] Fix Info tab when all corporations are open

### DIFF
--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -977,9 +977,7 @@ module Engine
                                                                       .map(&:full_name)
                                                                       .join(', ')
 
-                                 unless following_corporations.empty?
-                                   "open company in strict order: #{following_corporations}"
-                                 end
+                                 "open company in strict order: #{following_corporations}" unless following_corporations.empty?
                                when 2
                                  next_family = corporation_by_id(@near_families_purchasable[0][:id])
                                  prev_family = corporation_by_id(@near_families_purchasable[1][:id])

--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -976,9 +976,10 @@ module Engine
                                                                       .reject(&:ipoed)
                                                                       .map(&:full_name)
                                                                       .join(', ')
-                                 return if following_corporations.empty?
 
-                                 "open company in strict order: #{following_corporations}"
+                                 unless following_corporations.empty?
+                                   "open company in strict order: #{following_corporations}"
+                                 end
                                when 2
                                  next_family = corporation_by_id(@near_families_purchasable[0][:id])
                                  prev_family = corporation_by_id(@near_families_purchasable[1][:id])

--- a/spec/lib/engine/game/g_18_zoo/game_spec.rb
+++ b/spec/lib/engine/game/g_18_zoo/game_spec.rb
@@ -437,6 +437,14 @@ module Engine
         [3].each { |index| expect(game.corporation_available?(game.corporations[index])).to be_truthy }
         [1, 2].each { |index| expect(game.corporation_available?(game.corporations[index])).to be_falsy }
       end
+
+      it 'shows the timeline when no unopened corporation follows the purchasable family' do
+        game.corporations.each { |corporation| corporation.ipoed = true }
+        game.instance_variable_set(:@near_families_purchasable, [{ id: corporation.id }])
+
+        expect(game.timeline).to be_an(Array)
+        expect(game.timeline).not_to include(/NEARBY FAMILY/)
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #12737

## Summary
- keep `timeline` returning an array when no unopened corporation follows the purchasable family
- omit the Nearby Family message in that state
- add a regression spec for the affected state

## Testing
- `ruby -c lib/engine/game/g_18_zoo/game.rb`
- `ruby -c spec/lib/engine/game/g_18_zoo/game_spec.rb`
- `git diff --check`

RSpec and RuboCop could not be run locally because Bundler 2.5.13 is unavailable and the Docker daemon is not running.