### PR TITLE
[18ZOO] Display stock market metadata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,3 +65,5 @@ lib/engine/game/g_18_nl* @philcampeau
 lib/engine/game/g_1850_jr* @philcampeau
 lib/engine/game/g_18_hiawatha* @philcampeau
 lib/engine/game/g_steam_over_holland* @philcampeau
+
+lib/engine/game/g_18_zoo* @carlorusso1984

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -82,6 +82,17 @@ module View
         width: "#{WIDTH_TOTAL - (2 * PAD) - (2 * BORDER)}px",
       }.freeze
 
+      PRICE_STYLE_2D_INFO = {
+        display: 'flex',
+        justifyContent: 'space-between',
+        fontSize: '65%',
+        lineHeight: '1',
+        position: 'absolute',
+        bottom: "#{PAD}px",
+        left: "#{PAD}px",
+        right: "#{PAD}px",
+      }.freeze
+
       def box_style_1d
         {
           position: 'relative',
@@ -399,6 +410,8 @@ module View
       end
 
       def grid_2d
+        has_price_info = @game.stock_market.market.flatten.compact.any?(&:info)
+
         # Need to peek at row below to know if sitting on ledge.
         @game.stock_market.market.push([]).each_cons(2).each_with_index.map do |rows, row_i|
           row_prices, next_row = rows
@@ -424,20 +437,44 @@ module View
                 arrow = ''
               end
 
+              if has_price_info && !arrow.empty?
+                align.delete(:bottom)
+                align[:top] = "#{PRICE_HEIGHT}px"
+              end
+
               first_price = false
 
-              h(:div, { style: cell_style(@box_style_2d, price.types) }, [
+              elements = [
                 h('div.xsmall_font', price.price),
                 h(:div, tokens),
                 h(:div, { style: { color: '#00000060', position: 'absolute', 'font-size': '170%' }.merge(align) }, arrow),
-              ])
+                render_2d_price_info(price.info),
+              ].compact
+
+              h(:div, { style: cell_style(has_price_info ? @box_style_2d_with_info : @box_style_2d, price.types) },
+                elements)
             else
-              h(:div, { style: @space_style_2d }, '')
+              h(:div, { style: has_price_info ? @space_style_2d_with_info : @space_style_2d }, '')
             end
           end
 
           h(:div, { style: { width: 'max-content' } }, row)
         end
+      end
+
+      def render_2d_price_info(info)
+        return unless info
+        return h(:div, { style: PRICE_STYLE_2D_INFO }, info) unless info.is_a?(Hash)
+
+        appreciation = info[:appreciation].zero? ? 'END' : info[:appreciation]
+        dividend = info[:dividend].to_s
+        dividend += "+#{info[:president]}" if info[:president].positive?
+        label = "Appreciation threshold: #{appreciation}; dividend per share: #{dividend}"
+
+        h(:div, { attrs: { title: label }, style: PRICE_STYLE_2D_INFO }, [
+          h(:span, appreciation),
+          h(:span, dividend),
+        ])
       end
 
       def logo_for_user(entity)
@@ -459,6 +496,14 @@ module View
 
         # For cells with prices
         @box_style_2d = @space_style_2d.merge(
+          border: "solid #{BORDER}px rgba(0,0,0,0.2)",
+          color: color_for(:font2),
+        )
+        @space_style_2d_with_info = @space_style_2d.merge(
+          width: "#{WIDTH_TOTAL + PRICE_HEIGHT - (2 * PAD) - (2 * BORDER)}px",
+          height: "#{HEIGHT_TOTAL + PRICE_HEIGHT - (2 * PAD) - (2 * BORDER)}px",
+        )
+        @box_style_2d_with_info = @space_style_2d_with_info.merge(
           border: "solid #{BORDER}px rgba(0,0,0,0.2)",
           color: color_for(:font2),
         )

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -426,14 +426,13 @@ module View
 
               first_price = false
 
-              cell_elements = [
-                h('div.xsmall_font', price.price),
-                h(:div, tokens),
-                h(:div, { style: { color: '#00000060', position: 'absolute', 'font-size': '170%' }.merge(align) }, arrow),
-                price.info ? h(:div, { style: PRICE_STYLE_INFO }, price.info) : nil,
-              ].compact
-
-              h(:div, { style: cell_style(@box_style_2d, price.types) }, cell_elements)
+              h(:div, { style: cell_style(@box_style_2d, price.types) },
+                [
+                  h('div.xsmall_font', price.price),
+                  h(:div, tokens),
+                  h(:div, { style: { color: '#00000060', position: 'absolute', 'font-size': '170%' }.merge(align) }, arrow),
+                  price.info ? h(:div, { style: PRICE_STYLE_INFO }, price.info) : nil,
+                ].compact)
             else
               h(:div, { style: @space_style_2d }, '')
             end

--- a/assets/app/view/game/stock_market.rb
+++ b/assets/app/view/game/stock_market.rb
@@ -82,17 +82,6 @@ module View
         width: "#{WIDTH_TOTAL - (2 * PAD) - (2 * BORDER)}px",
       }.freeze
 
-      PRICE_STYLE_2D_INFO = {
-        display: 'flex',
-        justifyContent: 'space-between',
-        fontSize: '65%',
-        lineHeight: '1',
-        position: 'absolute',
-        bottom: "#{PAD}px",
-        left: "#{PAD}px",
-        right: "#{PAD}px",
-      }.freeze
-
       def box_style_1d
         {
           position: 'relative',
@@ -410,8 +399,6 @@ module View
       end
 
       def grid_2d
-        has_price_info = @game.stock_market.market.flatten.compact.any?(&:info)
-
         # Need to peek at row below to know if sitting on ledge.
         @game.stock_market.market.push([]).each_cons(2).each_with_index.map do |rows, row_i|
           row_prices, next_row = rows
@@ -437,44 +424,23 @@ module View
                 arrow = ''
               end
 
-              if has_price_info && !arrow.empty?
-                align.delete(:bottom)
-                align[:top] = "#{PRICE_HEIGHT}px"
-              end
-
               first_price = false
 
-              elements = [
+              cell_elements = [
                 h('div.xsmall_font', price.price),
                 h(:div, tokens),
                 h(:div, { style: { color: '#00000060', position: 'absolute', 'font-size': '170%' }.merge(align) }, arrow),
-                render_2d_price_info(price.info),
+                price.info ? h(:div, { style: PRICE_STYLE_INFO }, price.info) : nil,
               ].compact
 
-              h(:div, { style: cell_style(has_price_info ? @box_style_2d_with_info : @box_style_2d, price.types) },
-                elements)
+              h(:div, { style: cell_style(@box_style_2d, price.types) }, cell_elements)
             else
-              h(:div, { style: has_price_info ? @space_style_2d_with_info : @space_style_2d }, '')
+              h(:div, { style: @space_style_2d }, '')
             end
           end
 
           h(:div, { style: { width: 'max-content' } }, row)
         end
-      end
-
-      def render_2d_price_info(info)
-        return unless info
-        return h(:div, { style: PRICE_STYLE_2D_INFO }, info) unless info.is_a?(Hash)
-
-        appreciation = info[:appreciation].zero? ? 'END' : info[:appreciation]
-        dividend = info[:dividend].to_s
-        dividend += "+#{info[:president]}" if info[:president].positive?
-        label = "Appreciation threshold: #{appreciation}; dividend per share: #{dividend}"
-
-        h(:div, { attrs: { title: label }, style: PRICE_STYLE_2D_INFO }, [
-          h(:span, appreciation),
-          h(:span, dividend),
-        ])
       end
 
       def logo_for_user(entity)
@@ -496,14 +462,6 @@ module View
 
         # For cells with prices
         @box_style_2d = @space_style_2d.merge(
-          border: "solid #{BORDER}px rgba(0,0,0,0.2)",
-          color: color_for(:font2),
-        )
-        @space_style_2d_with_info = @space_style_2d.merge(
-          width: "#{WIDTH_TOTAL + PRICE_HEIGHT - (2 * PAD) - (2 * BORDER)}px",
-          height: "#{HEIGHT_TOTAL + PRICE_HEIGHT - (2 * PAD) - (2 * BORDER)}px",
-        )
-        @box_style_2d_with_info = @space_style_2d_with_info.merge(
           border: "solid #{BORDER}px rgba(0,0,0,0.2)",
           color: color_for(:font2),
         )

--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -54,16 +54,12 @@ module Engine
         ].map.with_index do |row, row_index|
           row.map.with_index do |code, column_index|
             match = code.match(/(\d*)([a-zA-Z]*)/)
-            president = row_index.zero? ? STOCKMARKET_OWNER_GAIN[column_index] || 0 : 0
+            threshold = STOCKMARKET_THRESHOLD[row_index][column_index]
 
             {
               price: match[1].to_i,
               types: match[2].chars.map { |char| Engine::SharePrice::TYPE_MAP[char] },
-              info: {
-                appreciation: STOCKMARKET_THRESHOLD[row_index][column_index],
-                dividend: STOCKMARKET_GAIN[row_index][column_index],
-                president: president,
-              },
+              info: "#{threshold.zero? ? 'END' : threshold}, #{STOCKMARKET_GAIN[row_index][column_index]}",
             }
           end
         end.freeze

--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -24,6 +24,26 @@ module Engine
 
         MUST_SELL_IN_BLOCKS = true
 
+        STOCKMARKET_THRESHOLD = [
+          [100, 150, 150, 200, 200, 250, 250, 300, 350, 400, 450, 0],
+          [100, 100, 150, 150, 200, 200, 250, 250, 300],
+          [80, 100, 100, 150, 150, 200, 200],
+          [50, 80, 100, 100, 150],
+          [40, 50, 80],
+          [30, 40],
+        ].freeze
+
+        STOCKMARKET_GAIN = [
+          [1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 5, 6],
+          [1, 1, 2, 2, 2, 2, 3, 3, 3],
+          [1, 1, 2, 2, 2, 2, 2],
+          [1, 1, 1, 2, 2],
+          [0, 1, 1],
+          [0, 0],
+        ].freeze
+
+        STOCKMARKET_OWNER_GAIN = [0, 0, 0, 1, 2, 2, 2, 2, 3].freeze
+
         MARKET = [
           %w[7 8 9 10s 11s 12s 13s 14s 15s 16 20 24e],
           %w[6 7x 8 9z 10 11 12w 13 14],
@@ -31,7 +51,22 @@ module Engine
           %w[4 5x 6 7 8],
           %w[3 4 5],
           %w[2 3],
-        ].freeze
+        ].map.with_index do |row, row_index|
+          row.map.with_index do |code, column_index|
+            match = code.match(/(\d*)([a-zA-Z]*)/)
+            president = row_index.zero? ? STOCKMARKET_OWNER_GAIN[column_index] || 0 : 0
+
+            {
+              price: match[1].to_i,
+              types: match[2].chars.map { |char| Engine::SharePrice::TYPE_MAP[char] },
+              info: {
+                appreciation: STOCKMARKET_THRESHOLD[row_index][column_index],
+                dividend: STOCKMARKET_GAIN[row_index][column_index],
+                president: president,
+              },
+            }
+          end
+        end.freeze
 
         PHASES = [
           {
@@ -174,26 +209,6 @@ module Engine
           endgame: :orange,
           safe_par: :blue,
         }.freeze
-
-        STOCKMARKET_THRESHOLD = [
-          [100, 150, 150, 200, 200, 250, 250, 300, 350, 400, 450, 0],
-          [100, 100, 150, 150, 200, 200, 250, 250, 300],
-          [80, 100, 100, 150, 150, 200, 200],
-          [50, 80, 100, 100, 150],
-          [40, 50, 80],
-          [30, 40],
-        ].freeze
-
-        STOCKMARKET_GAIN = [
-          [1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 5, 6],
-          [1, 1, 2, 2, 2, 2, 3, 3, 3],
-          [1, 1, 2, 2, 2, 2, 2],
-          [1, 1, 1, 2, 2],
-          [0, 1, 1],
-          [0, 0],
-        ].freeze
-
-        STOCKMARKET_OWNER_GAIN = [0, 0, 0, 1, 2, 2, 2, 2, 3].freeze
 
         SELL_AFTER = :any_time
 

--- a/spec/lib/engine/game/g_18_zoo/game_spec.rb
+++ b/spec/lib/engine/game/g_18_zoo/game_spec.rb
@@ -146,13 +146,13 @@ module Engine
     describe 'stock market metadata' do
       let(:stock_market) { StockMarket.new(described_class::MARKET, []) }
 
-      it 'stores the appreciation threshold and dividend in each share price' do
+      it 'stores the appreciation threshold and dividend as price info' do
         stock_market.market.each_with_index do |row, row_index|
           row.each_with_index do |share_price, column_index|
+            threshold = described_class::STOCKMARKET_THRESHOLD[row_index][column_index]
+
             expect(share_price.info).to eq(
-              appreciation: described_class::STOCKMARKET_THRESHOLD[row_index][column_index],
-              dividend: described_class::STOCKMARKET_GAIN[row_index][column_index],
-              president: row_index.zero? ? described_class::STOCKMARKET_OWNER_GAIN[column_index] || 0 : 0
+              "#{threshold.zero? ? 'END' : threshold}, #{described_class::STOCKMARKET_GAIN[row_index][column_index]}"
             )
           end
         end

--- a/spec/lib/engine/game/g_18_zoo/game_spec.rb
+++ b/spec/lib/engine/game/g_18_zoo/game_spec.rb
@@ -143,6 +143,29 @@ module Engine
       game.round.process_action(Engine::Action::Bid.new(game.current_entity, price: company.value, company: company))
     end
 
+    describe 'stock market metadata' do
+      let(:stock_market) { StockMarket.new(described_class::MARKET, []) }
+
+      it 'stores the appreciation threshold and dividend in each share price' do
+        stock_market.market.each_with_index do |row, row_index|
+          row.each_with_index do |share_price, column_index|
+            expect(share_price.info).to eq(
+              appreciation: described_class::STOCKMARKET_THRESHOLD[row_index][column_index],
+              dividend: described_class::STOCKMARKET_GAIN[row_index][column_index],
+              president: row_index.zero? ? described_class::STOCKMARKET_OWNER_GAIN[column_index] || 0 : 0
+            )
+          end
+        end
+      end
+
+      it 'preserves the stock market prices and types' do
+        expect(stock_market.market.first.map(&:price)).to eq([7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 24])
+        expect(stock_market.market.first[3].types).to eq([:safe_par])
+        expect(stock_market.market.first.last.types).to eq([:endgame])
+        expect(stock_market.market[1][1].types).to eq([:par_1])
+      end
+    end
+
     describe 'starting values' do
       max_players = { map_b: 5, map_c: 5, map_d: 5, map_e: 5, map_f: 5 }
       game_by_variant = {


### PR DESCRIPTION
Closes #12723

Change from:
<img width="1401" height="446" alt="image" src="https://github.com/user-attachments/assets/109435a0-6e34-48f4-a1b5-a3f5bfb89a0f" />
To:
<img width="1399" height="573" alt="image" src="https://github.com/user-attachments/assets/2104dc3c-8e9b-4ab7-bada-4a68e9db7811" />


## Summary
- attach appreciation thresholds, dividends, and president bonuses to 18ZOO share-price metadata
- render metadata in enlarged 2D stock-market cells while preserving ledge arrows
- safely handle sparse 2D markets and retain their existing layout
- add regression coverage for 18ZOO market prices, types, and metadata

## Shared renderer audit
- audited the shared `grid_2d` renderer across 60 two-dimensional stock-market definitions; one-dimensional, zigzag, and hexagonal markets use separate renderers
- confirmed that 18ZOO is the only game assigning `SharePrice#info`, so only 18ZOO selects the enlarged metadata layout
- confirmed through DOM measurements that standard markets retain 50x50 cells while 18ZOO uses 70x70 cells
- identified 20 sparse 2D market definitions and verified that `flatten.compact` safely ignores empty cells, addressing the failure mode of the reverted 2023 implementation
- manually checked representative layouts in the browser:
  - 1880: sparse stepped market
  - 1822: large 15-row market with 39 empty cells
  - 1866: very wide 4x37 market
  - 18MS: compact market without empty cells
- all sampled markets preserved their existing dimensions, ledge arrows, colors, scrolling, and legends

## Testing
- `docker compose exec rack bundle exec rspec spec/lib/engine/game/g_18_zoo/game_spec.rb` (179 examples, 0 failures)
- `docker compose exec rack bundle exec rubocop lib/engine/game/g_18_zoo/game.rb assets/app/view/game/stock_market.rb spec/lib/engine/game/g_18_zoo/game_spec.rb`
- `git diff --check`
- manually verified the Market tab in local 18ZOO Map C
- manually verified 1880, 1822, 1866, and 18MS through the shared 2D renderer