### PR TITLE
[18ZOO] Clean up unlimited train variant

### DIFF
--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -134,6 +134,7 @@ module Engine
                 distance: 2,
                 multiplier: 2,
                 price: 37,
+                num: 'unlimited',
               },
             ],
           },

--- a/lib/engine/game/g_18_zoo/game.rb
+++ b/lib/engine/game/g_18_zoo/game.rb
@@ -134,7 +134,6 @@ module Engine
                 distance: 2,
                 multiplier: 2,
                 price: 37,
-                num: 99,
               },
             ],
           },

--- a/spec/lib/engine/game/g_18_zoo/game_spec.rb
+++ b/spec/lib/engine/game/g_18_zoo/game_spec.rb
@@ -226,21 +226,6 @@ module Engine
       end
     end
 
-    describe 'unlimited trains' do
-      let(:game) { Engine::Game::G18ZOOMapA::Game.new(%w[a b c]) }
-
-      it 'replenishes the 4J/2J train after the 2J variant is removed' do
-        train = game.depot.upcoming.find { |upcoming| upcoming.name == '4J' }
-        train.variant = '2J'
-
-        game.depot.remove_train(train)
-
-        replacement = game.depot.upcoming.find { |upcoming| upcoming.name == '4J' }
-        expect(replacement.unlimited).to be true
-        expect(replacement.variants).to include('2J')
-      end
-    end
-
     describe 'phases' do
       let(:players) { %w[a b c] }
       let(:game) { Engine::Game::G18ZOOMapA::Game.new(players) }

--- a/spec/lib/engine/game/g_18_zoo/game_spec.rb
+++ b/spec/lib/engine/game/g_18_zoo/game_spec.rb
@@ -226,6 +226,21 @@ module Engine
       end
     end
 
+    describe 'unlimited trains' do
+      let(:game) { Engine::Game::G18ZOOMapA::Game.new(%w[a b c]) }
+
+      it 'replenishes the 4J/2J train after the 2J variant is removed' do
+        train = game.depot.upcoming.find { |upcoming| upcoming.name == '4J' }
+        train.variant = '2J'
+
+        game.depot.remove_train(train)
+
+        replacement = game.depot.upcoming.find { |upcoming| upcoming.name == '4J' }
+        expect(replacement.unlimited).to be true
+        expect(replacement.variants).to include('2J')
+      end
+    end
+
     describe 'phases' do
       let(:players) { %w[a b c] }
       let(:game) { Engine::Game::G18ZOOMapA::Game.new(players) }


### PR DESCRIPTION
Works towards #12237.

## Summary
- remove the obsolete finite train count from the 2J variant of the unlimited 4J rank
- add a regression spec confirming that removing a 2J replenishes the unlimited 4J/2J rank

## Testing
- `ruby -c lib/engine/game/g_18_zoo/game.rb`
- `ruby -c spec/lib/engine/game/g_18_zoo/game_spec.rb`
- `git diff --check`

RSpec could not be run locally because Bundler 2.5.13 is unavailable and the Docker daemon is not running.