### PR TITLE
[System18] auto-pass users at cert limit during parliament rounds

### DIFF
--- a/lib/engine/game/g_system18/step/upwards_auction.rb
+++ b/lib/engine/game/g_system18/step/upwards_auction.rb
@@ -38,7 +38,8 @@ module Engine
               pass_auction(entity)
               resolve_bids
             else
-              @log << "#{entity.name} passes bidding"
+              reason = @game.num_certs(entity) >= @game.cert_limit(entity) ? 'is at cert limit and must pass' : 'passes'
+              @log << "#{entity.name} #{reason} bidding"
               entity.pass!
               return next_entity! unless entities.all?(&:passed?)
 
@@ -68,6 +69,13 @@ module Engine
             return [] unless entity == current_entity
 
             ACTIONS
+          end
+
+          def auto_actions(entity)
+            return unless entity == current_entity
+            return if @game.num_certs(entity) < @game.cert_limit(entity)
+
+            [Action::Pass.new(entity)]
           end
 
           def min_increment


### PR DESCRIPTION
Fixes #12594

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Implements a forced-pass for players already at cert limit during parliamentary rounds, to prevent players who cannot acquire new certificates from bidding. Also adds a clear log message explaining the skip.

This may require pins for any games where players at cert limit placed bids on items in Parliamentary rounds. 

### Screenshots

<img width="432" height="225" alt="image" src="https://github.com/user-attachments/assets/7ed45cf9-5768-4803-9c11-49a03046d5a4" />


### Any Assumptions / Hacks
