### PR TITLE
[1832] Most everything to get merges and takeovers working.

### DIFF
--- a/lib/engine/game/g_1832/corporation.rb
+++ b/lib/engine/game/g_1832/corporation.rb
@@ -6,7 +6,11 @@ module Engine
   module Game
     module G1832
       class Corporation < Engine::Corporation
-        attr_accessor :coal_token
+        attr_accessor :coal_token, :is_system, :system_shells
+
+        def system?
+          is_system
+        end
       end
     end
   end

--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -21,7 +21,7 @@ module Engine
         include G1832::Trains
 
         attr_accessor :sell_queue, :reissued, :coal_token_counter, :coal_company_sold_or_closed, :p4_invested_in,
-                      :miami_has_been_run
+                      :miami_has_been_run, :mid_or_resume_entities
 
         CORPORATION_CLASS = G1832::Corporation
         CORPORATE_BUY_SHARE_ALLOW_BUY_FROM_PRESIDENT = true
@@ -155,6 +155,14 @@ module Engine
           @coal_token_counter = 5
           @miami_has_been_run = false
           @p4_invested_in = nil
+          @final_merger_triggered = false
+          @recently_floated = []
+          @vice_president_certs = {}
+          @mid_or_remaining_entities = nil
+          @mid_or_operated_corps = nil
+          @mid_or_formed_systems = {}
+          @mid_or_original_round_num = nil
+          @mid_or_resume_entities = nil
 
           coal_company.max_price = coal_company.value
 
@@ -234,6 +242,22 @@ module Engine
         def event_close_remaining_companies!
           @log << '-- Event: All remaining private companies close --'
           @companies.each(&:close!)
+        end
+
+        def event_final_merger_chance!
+          @log << '-- Event: Final merger and takeover opportunity --'
+          @final_merger_triggered = true
+        end
+
+        def final_merger_triggered?
+          @final_merger_triggered
+        end
+
+        def save_mid_or_state(remaining, operated, round_num)
+          @mid_or_remaining_entities = remaining
+          @mid_or_original_round_num = round_num
+          @mid_or_operated_corps = operated.map(&:id)
+          @final_merger_triggered = false
         end
 
         # can't run to or through the West Virginia Coalfied hex (B14) without a coal token
@@ -461,6 +485,453 @@ module Engine
           end
 
           @skip_paths
+        end
+
+        def max_reissue_200?
+          true
+        end
+
+        def mergers_allowed?
+          !option_no_mergers? && @phase.status.include?('mergers_allowed')
+        end
+
+        def option_no_mergers?
+          @optional_rules&.include?(:no_mergers)
+        end
+
+        def init_starting_cash(players, bank)
+          cash = option_southern_bank? ? self.class::SOUTHERN_BANK_STARTING_CASH : self.class::STARTING_CASH
+          players.each do |player|
+            bank.spend(cash[players.size], player)
+          end
+        end
+
+        def next_round!
+          @round =
+            case @round
+            when Engine::Round::Stock
+              @operating_rounds = @phase.operating_rounds
+              reorder_players
+              if mergers_allowed? && !no_mergers_variant?
+                new_merger_round
+              else
+                new_operating_round
+              end
+            when G1832::Round::Merger
+              if @mid_or_remaining_entities
+                resume_operating_round
+              else
+                new_operating_round
+              end
+            when Engine::Round::Operating
+              if @mid_or_remaining_entities
+                new_merger_round
+              elsif @round.round_num < @operating_rounds
+                or_round_finished
+                new_operating_round(@round.round_num + 1)
+              else
+                @turn += 1
+                or_round_finished
+                or_set_finished
+                new_stock_round
+              end
+            when init_round.class
+              init_round_finished
+              reorder_players
+              new_stock_round
+            end
+        end
+
+        def new_merger_round
+          @log << "-- #{round_description('Merger and Takeover')} --"
+          @mid_or_formed_systems = {}
+          G1832::Round::Merger.new(self, [
+            G1832::Step::Merge,
+            G1832::Step::SellSharesForTakeover,
+            Engine::Step::DiscardTrain,
+          ])
+        end
+
+        def merge_corporations
+          @corporations.select { |c| !c.system? && c.floated? }
+        end
+
+        # §11.6.7: Systems hold twice the normal train limit.
+        def train_limit(entity)
+          super * (entity.system? ? 2 : 1)
+        end
+
+        def southern_bank_company
+          @southern_bank_company ||= company_by_id('P6')
+        end
+
+        # ── Merger helpers ────────────────────────────────────────────
+
+        def available_systems
+          @corporations.select { |c| c.system? && !c.floated? }
+        end
+
+        # True if any player holds ≥40% combined across both corporations.
+        def can_form_system?(corp1, corp2)
+          return false if available_systems.empty?
+
+          @players.any? do |p|
+            p.shares_of(corp1).sum(&:percent) + p.shares_of(corp2).sum(&:percent) >= 40
+          end
+        end
+
+        # BFS-based connectivity: are corp_a and corp_b reachable from each other via laid track?
+        # Iterative to avoid JS call-stack overflow from the recursive Graph walk on large boards.
+        def corps_connected?(corp_a, corp_b)
+          hexes_b = network_hexes(corp_b)
+          return false if hexes_b.empty?
+
+          hexes_a = network_hexes(corp_a)
+          return false if hexes_a.empty?
+
+          # Hash for O(1) membership test — avoid to_set (requires 'set' in Opal)
+          hexes_b_lookup = hexes_b.each_with_object({}) { |h, acc| acc[h] = true }
+
+          visited = {}
+          queue = hexes_a
+          until queue.empty?
+            hex = queue.shift
+            next if visited[hex]
+
+            visited[hex] = true
+            return true if hexes_b_lookup.key?(hex)
+
+            hex.neighbors.each do |edge, neighbor|
+              next if visited[neighbor]
+              next unless hex_is_connected(hex, edge, neighbor)
+
+              queue << neighbor
+            end
+          end
+          false
+        end
+
+        def hex_is_connected(hex, edge, neighbor)
+          hex.tile.paths.any? { |p| p.exits.include?(edge) } &&
+            neighbor.tile.paths.any? { |p| p.exits.include?(hex.invert(edge)) }
+        end
+
+        # ── System formation (§11.6) ──────────────────────────────────
+
+        def perform_system_formation(corp1, corp2, system)
+          @log << "#{corp1.name} and #{corp2.name} form #{system.name}"
+
+          # 1. Set par & share price (average of two, rounded to nearest, capped at $275 per §11.6.3)
+          # TODO(beta): implement full diagonal-placement algorithm per §11.6.3
+          new_sp = merger_determine_merged_share_price(corp1, corp2)
+          raise GameError, 'Cannot determine system share price' unless new_sp
+
+          stock_market.set_par(system, new_sp)
+          system.ipoed = true
+
+          # 2. Convert both component president certs into 10% VP certs of the system.
+          # Each stays with whoever held the component presidency.
+          merger_convert_presidencies_to_vp_certs(corp1, corp2, system)
+
+          # 3. Exchange all remaining outstanding component shares 1:1 for system 5% shares
+          merger_convert_regular_shares(corp1, corp2, system)
+
+          # 4. President = player holding the largest system share percentage
+          president = merger_find_president(system)
+
+          # 5. Form the 20% president cert: president surrenders VP certs first, then regular
+          # shares, until 20% is covered. Surrendered shares go to the bank.
+          merger_form_president_cert(system, president)
+
+          # 6. Transfer cash, trains, companies to system
+          transfer_all_assets(corp1, system)
+          transfer_all_assets(corp2, system)
+
+          # 7. Replace map tokens (remove duplicates, assign remainder to system)
+          transfer_tokens(corp1, system)
+          transfer_tokens(corp2, system)
+
+          # 8. Close component companies (force_next_entity! suppressed in merger round)
+          system.system_shells = [corp1.id, corp2.id]
+          [corp1, corp2].each { |corp| close_corporation(corp) }
+
+          system.floated = true
+          clear_token_graph_for_entity(system)
+          @mid_or_formed_systems[system.id] = system
+          @log << "#{system.name} formed at #{format_currency(new_sp.price)}"
+        end
+
+        # ── Takeover (§11.7) ─────────────────────────────────────────
+
+        def perform_takeover(buyer, target)
+          @log << "#{buyer.name} takes over #{target.name}"
+
+          target_mkt = target.share_price.price
+          total_cost = takeover_cost(target)
+
+          # Build player payment map (needed to pay players their market price)
+          player_payments = Hash.new(0)
+          @players.each do |player|
+            player.shares_of(target).each do |s|
+              player_payments[player] += (s.percent.to_f / 10 * target_mkt).round
+            end
+          end
+
+          # President contributes cash if buyer can't cover the full cost
+          if buyer.cash < total_cost
+            needed    = total_cost - buyer.cash
+            president = buyer.owner
+            if president.cash < needed
+              raise GameError, "#{president.name} cannot fund the takeover (needs #{format_currency(needed)})"
+            end
+
+            president.spend(needed, buyer)
+            @log << "#{president.name} contributes #{format_currency(needed)} to fund takeover"
+          end
+
+          # Pay players for their shares
+          player_payments.each do |player, amount|
+            buyer.spend(amount, player) if amount.positive?
+          end
+
+          # Remainder goes to bank (pool + IPO shares)
+          bank_cost = total_cost - player_payments.values.sum
+          buyer.spend(bank_cost, @bank) if bank_cost.positive?
+
+          @log << "#{buyer.name} pays #{format_currency(total_cost)} to acquire #{target.name}"
+
+          transfer_all_assets(target, buyer)
+
+          # Replace map tokens (remove duplicates)
+          transfer_tokens(target, buyer, true)
+
+          close_corporation(target)
+
+          # §11.7: cert limit moves one column right per shell removed.
+          # close_corporation already applied one step; systems (2 shells) need a second.
+          tighten_cert_limit_by_one if target.system?
+          clear_token_graph_for_entity(buyer)
+        end
+
+        private
+
+        def merger_determine_merged_share_price(corp1, corp2)
+          avg = [(corp1.share_price.price + corp2.share_price.price) / 2.0, 275].min
+          all_prices = stock_market.market.flatten.compact.map(&:price).sort.uniq
+          nearest = all_prices.min_by { |p| [(p - avg).abs, -p] }
+          stock_market.market.flatten.compact.find { |sp| sp.price == nearest }
+        end
+
+        def merger_convert_presidencies_to_vp_certs(corp1, corp2, system)
+          vp_certs = []
+          [corp1, corp2].each do |corp|
+            holder = corp.share_holders.keys.find { |h| h.player? && h.shares_of(corp).any?(&:president) }
+            next unless holder
+
+            share = holder.shares_of(corp).find(&:president)
+            holder.shares_by_corporation[corp].delete(share)
+            corp.share_holders[holder] -= share.percent
+
+            share.percent /= 2 # 20% → 10%
+            share.instance_variable_set(:@corporation, system)
+            share.instance_variable_set(:@president, false)
+
+            system.share_holders[holder] += share.percent
+            holder.shares_by_corporation[system] << share
+
+            vp_certs << share
+            (@vice_president_certs[system] ||= []) << share
+            @log << "#{holder.name} receives VP certificate (10%) in #{system.name}"
+          end
+        end
+
+        def merger_convert_regular_shares(corp1, corp2, system)
+          system_reg = system.shares.reject(&:president).select { |s| s.owner == system }
+          @log << "There are #{system_reg.count} system shares available"
+          sys_idx = 0
+          [corp1, corp2].each do |corp|
+            corp.share_holders.dup.each do |holder, _|
+              next if holder == corp
+
+              holder.shares_of(corp).dup.each do |share|
+                next if vp_certs.include?(share)
+                next unless sys_idx < system_reg.size
+
+                share.transfer(@bank)
+                @log << "#{holder.name} receives a regular #{system_reg[sys_idx].percent}% share in exchange for a component one"
+                system_reg[sys_idx].transfer(holder)
+                sys_idx += 1
+              end
+            end
+          end
+        end
+
+        def merger_find_president(system)
+          system.owner = @players.max_by { |p| p.percent_of(system) }
+          @log << "#{system.owner.name} is the system owner with #{system.owner.percent_of(system)}%"
+
+          system.owner
+        end
+
+        def merger_form_president_cert(system, president)
+          system_pres = system.shares.find(&:president)
+          pct_needed = system_pres.percent
+          to_surrender = []
+
+          vp_certs.select { |v| v.owner == president }.each do |vp|
+            break unless pct_needed.positive?
+
+            to_surrender << vp
+            pct_needed -= vp.percent
+            @log << "#{vp.owner.name} is surrendering a VP cert and needs to surrender an additional #{pct_needed}%"
+          end
+
+          if pct_needed.positive?
+            president.shares_of(system).reject(&:president).sort_by(&:percent).each do |share|
+              break unless pct_needed.positive?
+
+              to_surrender << share
+              pct_needed -= share.percent
+              @log << "#{share.owner.name} surrenders a #{share.percent}% cert; #{pct_needed}% still needed"
+            end
+          end
+
+          to_surrender.each { |s| s.transfer(@bank) }
+          system_pres.transfer(president)
+
+          @log << "#{president.name} becomes president of #{system.name}"
+        end
+
+        def transfer_all_assets(from_corp, to_corp)
+          from_corp.spend(from_corp.cash, to_corp) if from_corp.cash.positive?
+          transfer(:trains, from_corp, to_corp)
+          transfer(:companies, from_corp, to_corp)
+          transfer_coal_token(from_corp, to_corp)
+        end
+
+        def takeover_cost(target)
+          target_par = target.par_price&.price || target.share_price.price
+          target_mkt = target.share_price.price
+
+          cost = 0
+          target.shares.select { |s| s.owner == target }.each do |s|
+            cost += (s.percent.to_f / 10 * target_par).round
+          end
+
+          @share_pool.shares_of(target).each do |s|
+            cost += (s.percent.to_f / 10 * target_mkt).round
+          end
+
+          @players.each do |player|
+            player.shares_of(target).each do |s|
+              cost += (s.percent.to_f / 10 * target_mkt).round
+            end
+          end
+
+          cost
+        end
+
+        def can_afford_takeover?(buyer, target)
+          president = buyer.owner
+          cost = takeover_cost(target)
+          # Compute president's max liquidity directly: avoids sellable_bundles →
+          # active_step recursion that occurs during merger-round blocking? checks.
+          president_liquidity = president.cash + president.shares.sum do |s|
+            next 0 unless (price = s.corporation.share_price&.price)
+
+            (s.percent.to_f / 10.0 * price).floor
+          end
+          buyer.cash + president_liquidity >= cost
+        end
+
+        def transfer_coal_token(from_corp, to_corp)
+          coal_count = [from_corp.coal_token, to_corp.coal_token].count(&:itself)
+          return if coal_count.zero?
+
+          if coal_count == 2
+            @coal_token_counter += 1
+            from_corp.coal_token = false
+            @log << "#{to_corp.name} has duplicate Coal tokens; one returned. #{@coal_token_counter} Coal tokens remaining."
+          end
+
+          to_corp.coal_token = true
+        end
+
+        def transfer_tokens(_from_corp, to_corp, takeover = false)
+          to_corp_cities = to_corp.tokens.select(&:city).each_with_object({}) { |t, h| h[t.city] = true }
+          corp.tokens.select(&:city).each do |token|
+            city = token.city
+            if to_corp_cities.key?(city)
+              token.remove!
+              to_corp.tokens << Engine::Token.new(to_corp, price: 100) unless takeover
+              @log << "Duplicate token in #{city.hex.id} returned to #{to_corp.name}'s charter"
+            else
+              to_corp_cities[city] = true
+              new_tok = to_corp.next_token
+              new_tok ||= Engine::Token.new(to_corp, price: 100).tap { |t| to_corp.tokens << t }
+              token.remove!
+              city.place_token(to_corp, new_tok, check_tokenable: false)
+            end
+          end
+        end
+
+        # Tighten the cert limit as if one additional corporation had been removed,
+        # without actually removing anything from @corporations.
+        def tighten_cert_limit_by_one
+          player_count = @players.size
+          limit_table = self.class::CERT_LIMIT[player_count]
+          return unless limit_table.is_a?(Hash)
+
+          virtual_size = @corporations.size - 1
+          tighter = limit_table.reject { |k, _| k.to_i < virtual_size }.min_by(&:first)&.last
+          @cert_limit = tighter if tighter
+        end
+
+        # Returns an Array of hexes forming corp's network: placed-token hexes,
+        # or home hex(es) if no tokens are on the map yet.
+        # Uses only Array/Hash — no filter_map or to_set (not reliably in Opal).
+        def network_hexes(corp)
+          placed = corp.placed_tokens.map(&:hex).compact.uniq
+          return placed unless placed.empty?
+
+          Array(corp.coordinates).map { |coord| hex_by_id(coord) }.compact
+        end
+
+        # Resume the OR that was interrupted mid-round by the 6-train merger trigger.
+        # Inserts newly formed systems (§11.6) whose component corps had not yet
+        # operated, ordered by share price descending.
+        def resume_operating_round
+          operated_ids = @mid_or_operated_corps || []
+          remaining = @mid_or_remaining_entities.reject(&:closed?)
+
+          new_systems = @mid_or_formed_systems.values.select do |sys|
+            !sys.closed? && sys.system_shells.none? { |id| operated_ids.include?(id) }
+          end
+          new_systems.sort_by { |s| [-s.share_price.price, s.id] }.each do |system|
+            idx = remaining.find_index { |e| (e.share_price&.price || 0) < system.share_price.price }
+            remaining.insert(idx || remaining.size, system)
+          end
+
+          round_num = @mid_or_original_round_num
+          @mid_or_remaining_entities = nil
+          @mid_or_operated_corps = nil
+          @mid_or_formed_systems = {}
+          @mid_or_original_round_num = nil
+
+          if remaining.empty?
+            # The 6-train was bought by the last entity; OR was already complete.
+            or_round_finished
+            if round_num < @operating_rounds
+              new_operating_round(round_num + 1)
+            else
+              @turn += 1
+              or_set_finished
+              new_stock_round
+            end
+          else
+            @mid_or_resume_entities = remaining
+            operating_round(round_num)
+          end
         end
       end
     end

--- a/lib/engine/game/g_1832/round/merger.rb
+++ b/lib/engine/game/g_1832/round/merger.rb
@@ -7,22 +7,76 @@ module Engine
     module G1832
       module Round
         class Merger < Engine::Round::Merger
+          attr_reader :entities
+
           def self.round_name
             'Merger and Takeover Round'
           end
 
           def self.short_name
-            'MR & T'
+            'M & T'
           end
 
           def select_entities
-            @game.merge_corporations.sort
+            @game.merge_corporations.select(&:operated?).sort
           end
 
           def setup
             super
             skip_steps
             next_entity! if finished?
+          end
+
+          def after_process(action)
+            return if action.free?
+
+            if (pme = @post_merge_entity)
+              @post_merge_entity = nil
+              @steps.each(&:unpass!)
+              @steps.each(&:setup)
+
+              inserted = false
+              unless @entities.include?(pme)
+                @entities.insert(@entity_index + 1, pme)
+                inserted = true
+              end
+
+              pme_idx = @entities.find_index(pme)
+              @game.next_turn!
+              @entity_index = pme_idx
+
+              if @steps.any? { |s| s.active? && s.blocking? }
+                skip_steps
+                unless finished?
+                  # Post-merge entity has targets — let it act
+                  return
+                end
+              end
+
+              # No targets: remove inserted system and fall through to advance
+              @entities.delete(pme) if inserted
+            end
+
+            return if active_step
+
+            @game.players.each(&:unpass!)
+            next_entity!
+          end
+
+          def next_entity!
+            next_entity_index! if @entities.any?
+            return if @entities.empty? || @entity_index.zero?
+
+            @steps.each(&:unpass!)
+            @steps.each(&:setup)
+
+            skip_steps
+            next_entity! if finished?
+          end
+
+          # Suppress the normal entity-change triggered by close_corporation during a merger
+          def force_next_entity!
+            # No-op: mergers in game.rb manage entity advancement themselves
           end
         end
       end

--- a/lib/engine/game/g_1832/round/operating.rb
+++ b/lib/engine/game/g_1832/round/operating.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative '../../../round/operating'
+
+module Engine
+  module Game
+    module G1832
+      module Round
+        class Operating < Engine::Round::Operating
+          def select_entities
+            # Used when resuming a mid-OR after the 6-train merger round.
+            if @game.mid_or_resume_entities
+              entities = @game.mid_or_resume_entities
+              @game.mid_or_resume_entities = nil
+              return entities
+            end
+
+            super
+          end
+
+          def next_entity!
+            # When the first 6-train triggers a mid-OR merger, interrupt after this
+            # entity's turn instead of advancing to the next entity.
+            if @game.final_merger_triggered?
+              remaining = @entities[(@entity_index + 1)..].reject(&:closed?)
+              operated = @entities[0..@entity_index]
+              @game.save_mid_or_state(remaining, operated, round_num)
+              @entity_index = @entities.size  # advance past end → round.finished? → next_round!
+              return
+            end
+
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1832/step/buy_train.rb
+++ b/lib/engine/game/g_1832/step/buy_train.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1870/step/buy_train'
+
+module Engine
+  module Game
+    module G1832
+      module Step
+        class BuyTrain < G1870::Step::BuyTrain
+          def actions(entity)
+            return super unless entity.system?
+            return super if must_buy_train?(entity)
+
+            return %w[buy_train pass] if system_voluntary_buy?(entity) && can_buy_train?(entity)
+
+            super
+          end
+
+          def can_buy_train?(entity = nil, shell = nil)
+            entity ||= current_entity
+            return super unless entity.system?
+            return super if system_voluntary_buy?(entity)
+
+            room?(entity) && (entity.cash + entity.owner.cash) >= @depot.min_price(entity)
+          end
+
+          # §11.6.7: System forced to buy only when trainless; president may contribute
+          # cash (not sell shares) on any voluntary purchase when system has ≤ half its limit.
+          def president_may_contribute?(entity, shell = nil)
+            return super unless entity.system?
+
+            must_buy_train?(entity) || system_voluntary_buy?(entity)
+          end
+
+          # Redeemed shares (buyable: false) may not be sold to raise emergency train funds (§10.6).
+          def can_sell?(entity, bundle)
+            super && bundle.shares.all?(&:buyable)
+          end
+
+          private
+
+          def system_voluntary_buy?(system)
+            system.trains.count <= @game.train_limit(system) / 2
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1832/step/merge.rb
+++ b/lib/engine/game/g_1832/step/merge.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1832
+      module Step
+        class Merge < Engine::Step::Base
+          ACTIONS_NO_PENDING = %w[merge pass].freeze
+          ACTIONS_PENDING    = %w[choose pass].freeze
+
+          def actions(entity)
+            return [] if !entity.corporation? || entity != current_entity
+
+            if @round.merging
+              return ACTIONS_PENDING if @round.merging[:initiator] == entity
+
+              return []
+            end
+
+            return [] unless mergeable_corporations(entity).any?
+
+            ACTIONS_NO_PENDING
+          end
+
+          def description
+            @round.merging ? 'Choose Merger Type' : 'Merge or Take Over Another Corporation'
+          end
+
+          def choice_name
+            'Merger Type'
+          end
+
+          def choices
+            return {} unless @round.merging
+
+            initiator = @round.merging[:initiator]
+            target    = @round.merging[:target]
+            c = {}
+
+            if !@game.system?(initiator) && @game.can_form_system?(initiator, target)
+              @game.available_systems.each do |sys|
+                c["system_#{sys.id}"] = "System Formation \u2192 #{sys.name}"
+              end
+            end
+
+            c['takeover'] = "Takeover #{target.name}" if @game.can_afford_takeover?(initiator, target)
+            c
+          end
+
+          def process_merge(action)
+            initiator = action.entity
+            target    = action.corporation
+
+            raise GameError, 'There is already a pending merger' if @round.merging
+
+            unless mergeable_corporations(initiator).include?(target)
+              raise GameError, "#{target.name} is not eligible to merge with #{initiator.name}"
+            end
+
+            @round.merging = { initiator: initiator, target: target }
+          end
+
+          def process_choose(action)
+            raise GameError, 'No pending merger' unless @round.merging
+
+            initiator = @round.merging[:initiator]
+            target    = @round.merging[:target]
+            choice    = action.choice
+
+            if choice.start_with?('system_')
+              system_id = choice.sub('system_', '')
+              system = @game.corporation_by_id(system_id)
+              raise GameError, "System #{system_id} is not available" unless @game.available_systems.include?(system)
+
+              @game.perform_system_formation(initiator, target, system)
+              @round.post_merge_entity = system
+            elsif choice == 'takeover'
+              if initiator.cash + initiator.owner.cash >= @game.takeover_cost(target)
+                @game.perform_takeover(initiator, target)
+                @round.post_merge_entity = initiator
+              else
+                # President needs to sell shares; SellSharesForTakeover step takes over
+                @round.pending_takeover = { buyer: initiator, target: target }
+              end
+            else
+              raise GameError, 'Invalid merger choice'
+            end
+
+            @round.merging = nil
+            pass!
+          end
+
+          def process_pass(action)
+            @round.merging = nil
+            log_pass(action.entity)
+            pass!
+          end
+
+          def merge_name(_entity = nil)
+            'Merge or Takeover'
+          end
+
+          def show_other_players
+            true
+          end
+
+          def mergeable_type(_entity)
+            'Corporations eligible for merger or takeover'
+          end
+
+          def mergeable(entity)
+            mergeable_corporations(entity)
+          end
+
+          def mergeable_corporations(corp)
+            return [] unless corp.floated?
+            return [] unless corp.operated?
+
+            @game.corporations.select do |c|
+              next false if c == corp
+              next false if c.type == :system
+              next false unless c.floated?
+              next false unless c.operated?
+              next false unless @game.corps_connected?(corp, c)
+
+              (!@game.system?(corp) && @game.can_form_system?(corp, c)) || @game.can_afford_takeover?(corp, c)
+            end
+          end
+
+          def sellable_bundles(_player, _corporation)
+            []
+          end
+
+          def round_state
+            { merging: nil, post_merge_entity: nil, pending_takeover: nil }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1832/step/sell_shares_for_takeover.rb
+++ b/lib/engine/game/g_1832/step/sell_shares_for_takeover.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative '../../../step/base'
+
+module Engine
+  module Game
+    module G1832
+      module Step
+        class SellSharesForTakeover < Engine::Step::Base
+          ACTIONS = %w[sell_shares].freeze
+
+          def actions(entity)
+            return [] unless (pending = @round.pending_takeover)
+            return [] unless entity == pending[:buyer].owner
+            return [] if pending[:buyer].cash + entity.cash >= @game.takeover_cost(pending[:target])
+
+            ACTIONS
+          end
+
+          def description
+            'Sell Shares to Fund Takeover'
+          end
+
+          def active_entities
+            pending = @round.pending_takeover
+            return [] unless pending
+
+            [pending[:buyer].owner]
+          end
+
+          # Called by Game::Base#sellable_bundles to filter bundles for this step.
+          def can_sell?(entity, bundle)
+            return false unless (pending = @round.pending_takeover)
+            return false unless entity == pending[:buyer].owner
+
+            entity == bundle.owner && @game.share_pool.fit_in_bank?(bundle)
+          end
+
+          def process_sell_shares(action)
+            @game.sell_shares_and_change_price(action.bundle)
+
+            pending = @round.pending_takeover
+            buyer = pending[:buyer]
+            return unless buyer.cash + buyer.owner.cash >= @game.takeover_cost(pending[:target])
+
+            @game.perform_takeover(buyer, pending[:target])
+            @round.post_merge_entity = buyer
+            @round.pending_takeover = nil
+            pass!
+          end
+
+          def show_other_players
+            true
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

This is pretty much everything I could find in my repo for getting mergers working. This game is weird in that it has VP certs that are double certificates, and they may be leftover from the merge if the merge is between two companies that have different presidents. So the algorithm here converts both presidencies to VP certificates and then compares percentages, and then trades in those VP certs first toward the president's share in the system. I'm not sure the post-merge VP cert thing works entirely (I will do a lot more testing again after my yet-to-come PR to make sure I didn't mess anything up in the process of splitting for review), but it does work well in the merge phase.

This is voluminous, and I'm sorry, and if there is a way you think I should split it up instead, I am open to that so that the review can be smaller. I just wanted to have everything out there for the merging step so that if there were a piece you were curious about, it would be represented here.

I did look at 1828 systems, but those are far more complex than the systems here in 1832, so I did not think it was worthwhile to extend those. This code just calculates whether a president may buy voluntarily buy a train for a system based on having train count <= (train_limit / 2), where the train limit for the system is doubled (it sounds weird, but the math is done in two different places that I _think_ make sense).