### PR TITLE
[1832] Add system code to corporation, add logic for system train buys.

### DIFF
--- a/lib/engine/game/g_1832/corporation.rb
+++ b/lib/engine/game/g_1832/corporation.rb
@@ -6,7 +6,11 @@ module Engine
   module Game
     module G1832
       class Corporation < Engine::Corporation
-        attr_accessor :coal_token
+        attr_accessor :coal_token, :is_system, :system_shells
+
+        def system?
+          is_system
+        end
       end
     end
   end

--- a/lib/engine/game/g_1832/corporation.rb
+++ b/lib/engine/game/g_1832/corporation.rb
@@ -6,11 +6,7 @@ module Engine
   module Game
     module G1832
       class Corporation < Engine::Corporation
-        attr_accessor :coal_token, :is_system, :system_shells
-
-        def system?
-          is_system
-        end
+        attr_accessor :coal_token, :system_shells
       end
     end
   end

--- a/lib/engine/game/g_1832/game.rb
+++ b/lib/engine/game/g_1832/game.rb
@@ -208,6 +208,11 @@ module Engine
           option_finish_on_400? ? FINISH_ON_400_GAME_END_CHECK : STANDARD_GAME_END_CHECK
         end
 
+        # §11.6.7: Systems hold twice the normal train limit.
+        def train_limit(entity)
+          super * (system?(entity) ? 2 : 1)
+        end
+
         def available_programmed_actions
           [Action::ProgramMergerPass, Action::ProgramBuyShares, Action::ProgramSharePass]
         end

--- a/lib/engine/game/g_1832/step/buy_train.rb
+++ b/lib/engine/game/g_1832/step/buy_train.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative '../../g_1870/step/buy_train'
+
+module Engine
+  module Game
+    module G1832
+      module Step
+        class BuyTrain < G1870::Step::BuyTrain
+          def actions(entity)
+            return super unless entity.system?
+            return super if must_buy_train?(entity)
+
+            return %w[buy_train pass] if system_voluntary_buy?(entity) && can_buy_train?(entity)
+
+            super
+          end
+
+          def can_buy_train?(entity = nil, shell = nil)
+            entity ||= current_entity
+            return super unless entity.system?
+            return super unless system_voluntary_buy?(entity)
+
+            room?(entity) && (entity.cash + entity.owner.cash) >= @depot.min_price(entity)
+          end
+
+          # §11.6.7: System forced to buy only when trainless; president may contribute
+          # cash (not sell shares) on any voluntary purchase when system has ≤ half its limit.
+          def president_may_contribute?(entity, shell = nil)
+            return super unless entity.system?
+
+            must_buy_train?(entity) || system_voluntary_buy?(entity)
+          end
+
+          # Redeemed shares (buyable: false) may not be sold to raise emergency train funds (§10.6).
+          def can_sell?(entity, bundle)
+            super && bundle.shares.all?(&:buyable)
+          end
+
+          private
+
+          def system_voluntary_buy?(system)
+            system.trains.count <= @game.train_limit(system) / 2
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1832/step/buy_train.rb
+++ b/lib/engine/game/g_1832/step/buy_train.rb
@@ -8,7 +8,7 @@ module Engine
       module Step
         class BuyTrain < G1870::Step::BuyTrain
           def actions(entity)
-            return super unless entity.system?
+            return super unless @game.system?(entity)
             return super if must_buy_train?(entity)
 
             return %w[buy_train pass] if system_voluntary_buy?(entity) && can_buy_train?(entity)
@@ -18,7 +18,7 @@ module Engine
 
           def can_buy_train?(entity = nil, shell = nil)
             entity ||= current_entity
-            return super unless entity.system?
+            return super unless @game.system?(entity)
             return super unless system_voluntary_buy?(entity)
 
             room?(entity) && (entity.cash + entity.owner.cash) >= @depot.min_price(entity)
@@ -27,7 +27,7 @@ module Engine
           # §11.6.7: System forced to buy only when trainless; president may contribute
           # cash (not sell shares) on any voluntary purchase when system has ≤ half its limit.
           def president_may_contribute?(entity, shell = nil)
-            return super unless entity.system?
+            return super unless @game.system?(entity)
 
             must_buy_train?(entity) || system_voluntary_buy?(entity)
           end
@@ -40,7 +40,7 @@ module Engine
           private
 
           def system_voluntary_buy?(system)
-            system.trains.count <= @game.train_limit(system) / 2
+            system.trains.count * 2 <= @game.train_limit(system)
           end
         end
       end


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`


### Explanation of Change

This PR adds a little bit of functionality to corporation to distinguish the system from other corps, and adds train buy functionality for Systems, which are allowed to voluntarily buy as long as the system has <= current train limit (basically one of the shells must be able to be configured with zero trains, though there is no such need for actually configuring them). The president is allowed to contribute cash for that voluntary buy.