### PR TITLE
[Dev] Add hex map editor

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -89,7 +89,7 @@ class Api < Roda
   ].freeze
 
   ROUTES_WITH_GAME_TITLES = %w[
-     map market fixture
+     map map_editor market fixture
   ].freeze
 
   Dir['./routes/*'].each { |file| require file }
@@ -129,7 +129,7 @@ class Api < Roda
     end
 
     r.on ROUTES_WITH_GAME_TITLES do
-      render(titles: request.path.split('/')[2].split('+'))
+      render(titles: request.path.split('/')[2]&.split('+') || [])
     end
 
     r.on 'profile' do

--- a/assets/app/app.rb
+++ b/assets/app/app.rb
@@ -17,6 +17,7 @@ require 'view/home'
 require 'view/confirm'
 require 'view/flash'
 require 'view/game_page'
+require 'view/map_editor_page'
 require 'view/map_page'
 require 'view/market_page'
 require 'view/navigation'
@@ -84,6 +85,8 @@ class App < Snabberb::Component
         h(View::About)
       when /tiles/
         h(View::TilesPage, route: @app_route, connection: @connection)
+      when /map_editor/
+        h(View::MapEditorPage, route: @app_route)
       when /map/
         h(View::MapPage, route: @app_route)
       when /market/

--- a/assets/app/view/map_editor_page.rb
+++ b/assets/app/view/map_editor_page.rb
@@ -1,0 +1,422 @@
+# frozen_string_literal: true
+
+require 'lib/hex'
+require_relative '../game_class_loader'
+
+module View
+  # A minimal drag-and-drop editor for authoring the white/blue hexes of a
+  # game's map. Draws its own SVG hex grid (reusing the engine's hex geometry so
+  # positions line up with the real map) and emits a HEXES snippet for map.rb.
+  #
+  # Route: /map_editor/<game_title> auto-loads that game's map to edit; bare
+  # /map_editor opens a small blank grid.
+  #
+  # Editor state lives in a class-level state hash rather than in needs/ivars:
+  # Snabberb recreates component instances on every render, and needs-backed
+  # ivars are not reliably repopulated inside event handlers, so a plain
+  # class-level hash is the robust place to keep mutable editor state.
+  class MapEditorPage < Snabberb::Component
+    include GameClassLoader
+
+    needs :route
+
+    ROUTE_FORMAT = %r{/map_editor/?([^/?]*)}.freeze
+
+    # small blank grid (a 7-hex flower) shown when no game is given
+    DEFAULT_FLOWER = [[1, 2], [1, 4], [0, 3], [0, 1], [1, 0], [2, 1], [2, 3]].freeze
+
+    SIZE = 100
+    LAYOUT = {
+      flat: [SIZE * 3 / 2, SIZE * Math.sqrt(3) / 2],
+      pointy: [SIZE * Math.sqrt(3) / 2, SIZE * 3 / 2],
+    }.freeze
+    MARGIN = 2 # extra rings of empty candidate hexes around a game's map
+    MAX_MARGIN = 128 # cap on cols/rows growth so the grid can't get unwieldy
+    SCALE = 0.42
+
+    LETTERS = (('A'..'Z').to_a + ('AA'..'AZ').to_a).freeze
+
+    TOOL_COLORS = { 'white' => :white, 'blue' => :blue }.freeze
+
+    # Cap the per-session undo history. Each entry is a full snapshot of the
+    # paint state, so keeping an unbounded stack would grow session memory the
+    # longer someone edits; 20 steps is plenty for interactive undo.
+    UNDO_LIMIT = 20
+
+    # Editor state, lazily initialised per class (not a mutable constant). All
+    # instances share it via #state, which keeps it stable across the fresh
+    # component instances Snabberb builds on each render.
+    def self.state
+      @state ||= {
+        paint: nil,             # { 'C4' => 'white', ... } or nil before init
+        tool: 'white',          # 'white' | 'blue' | 'empty'
+        dragging: false,
+        stroke_snapshotted: false, # whether the current stroke already pushed undo
+        output: nil,
+        title: nil,             # game title (or '') the paint state was built for
+        margin_x: MARGIN,       # empty candidate columns added left/right
+        margin_y: MARGIN,       # empty candidate rows added above/below
+        undo: [],               # stack of prior paint snapshots for this session
+      }
+    end
+
+    def state
+      self.class.state
+    end
+
+    def render
+      game_title = current_title
+
+      # a game title is optional: with one the map is loaded for editing,
+      # without one we show a small blank grid
+      game = game_title ? load_game_class(game_title) : nil
+      return h(:div, [h(:p, "Loading game: #{game_title}")]) if game_title && !game
+
+      @game = game ? game.new(Array.new(game::PLAYER_RANGE.max) { |n| "Player #{n + 1}" }) : nil
+
+      # initialise when first opening or switching games: a game auto-loads its
+      # map, a bare editor starts empty (and tight, with no extra rings)
+      key = game_title || ''
+      if state[:paint].nil? || state[:title] != key
+        state[:paint] = @game ? template_paint : {}
+        state[:title] = key
+        state[:output] = nil
+        state[:undo] = []
+        state[:margin_x] = @game ? MARGIN : 0
+        state[:margin_y] = @game ? MARGIN : 0
+      end
+
+      h(:div, {
+          on: {
+            mouseup: lambda { |_e|
+              state[:dragging] = false
+              state[:stroke_snapshotted] = false
+            },
+          },
+        }, [
+          h(:h2, game ? "Map Editor: #{game.full_title}" : 'Map Editor'),
+          render_toolbar,
+          render_grid,
+          render_output,
+        ])
+    end
+
+    def render_toolbar
+      tool_button = lambda do |tool, label|
+        active = state[:tool] == tool
+        props = {
+          style: {
+            margin: '0 6px 0 0',
+            padding: '6px 12px',
+            cursor: 'pointer',
+            border: active ? '2px solid #4ea1ff' : '1px solid #888',
+            borderRadius: '5px',
+          },
+          on: {
+            click: lambda { |_e|
+              state[:tool] = tool
+              update
+            },
+          },
+        }
+        h(:button, props, label)
+      end
+
+      step_button = lambda do |label, key, delta|
+        h(:button, {
+            style: { margin: '0 2px', padding: '6px 10px', cursor: 'pointer' },
+            on: {
+              click: lambda { |_e|
+                state[key] = clamp_margin((state[key] || MARGIN) + delta)
+                update
+              },
+            },
+          }, label)
+      end
+      axis_control = lambda do |name, key|
+        [
+          h(:span, { style: { marginLeft: '6px', marginRight: '4px' } }, name),
+          step_button.call('−', key, -1),
+          h(:input, {
+              attrs: { type: 'number', min: 0, max: MAX_MARGIN },
+              props: { value: (state[key] || MARGIN).to_s },
+              style: { width: '52px', margin: '0 2px', padding: '4px', textAlign: 'center' },
+              on: { change: ->(e) { set_margin(key, e) } },
+            }),
+          step_button.call('+', key, 1),
+        ]
+      end
+
+      h(:div, { style: { margin: '0.5rem 0' } }, [
+          h(:span, { style: { marginRight: '8px' } }, 'Tool:'),
+          tool_button.call('white', 'White'),
+          tool_button.call('blue', 'Blue'),
+          tool_button.call('empty', 'Erase'),
+          h(:span, { style: { margin: '0 8px' } }, '|'),
+          *axis_control.call('Cols ↔', :margin_x),
+          *axis_control.call('Rows ↕', :margin_y),
+          h(:span, { style: { margin: '0 8px' } }, '|'),
+          h(:button, {
+              style: { marginRight: '6px', padding: '6px 12px', cursor: 'pointer' },
+              on: { click: ->(_e) { generate_output } },
+            }, 'Generate Ruby'),
+          h(:button, {
+              style: { marginRight: '6px', padding: '6px 12px', cursor: 'pointer' },
+              on: { click: ->(_e) { clear! } },
+            }, 'Clear'),
+          undo_button,
+          h(:span, { style: { marginLeft: '12px', color: '#888' } },
+            'Click or drag to paint. Drag with Erase to remove.'),
+        ])
+    end
+
+    def undo_button
+      disabled = (state[:undo] || []).empty?
+      h(:button, {
+          attrs: { disabled: disabled },
+          style: {
+            marginRight: '6px',
+            padding: '6px 12px',
+            cursor: disabled ? 'default' : 'pointer',
+            opacity: disabled ? 0.5 : 1,
+          },
+          on: { click: ->(_e) { undo } },
+        }, 'Undo')
+    end
+
+    def render_grid
+      cells = candidate_cells
+      tx, ty = LAYOUT[@layout]
+      width = ((tx * ((@max_x - @min_x) + 2)) + (SIZE * 2)) * SCALE
+      height = ((ty * ((@max_y - @min_y) + 2)) + (SIZE * 2)) * SCALE
+
+      nodes = cells.map { |coord, xy| hex_node(coord, xy[0], xy[1]) }
+
+      h(:div, { style: { overflow: 'auto', border: '1px solid #444', margin: '0.5rem 0' } }, [
+          h(:svg, { attrs: { width: width.round.to_s, height: height.round.to_s } }, [
+              h(:g, { attrs: { transform: "scale(#{SCALE})" } }, nodes),
+            ]),
+        ])
+    end
+
+    def hex_node(coord, x, y)
+      tx, ty = LAYOUT[@layout]
+      px = (tx * (x - @min_x + 1)) + SIZE
+      py = (ty * (y - @min_y + 1)) + SIZE
+      color = (state[:paint] || {})[coord]
+      fill =
+        if (sym = TOOL_COLORS[color])
+          Lib::Hex::COLOR[sym]
+        else
+          '#2b2b2b' # empty candidate hex
+        end
+      rot = @layout == :pointy ? ' rotate(30)' : ''
+
+      props = {
+        attrs: {
+          transform: "translate(#{px}, #{py})#{rot}",
+          fill: fill,
+          stroke: 'black',
+          'stroke-width': 1,
+          cursor: 'pointer',
+        },
+        on: {
+          click: ->(_e) { paint(coord) },
+          mousedown: ->(_e) { start_paint(coord) },
+          mouseover: ->(_e) { drag_paint(coord) },
+        },
+      }
+
+      h(:g, props, [
+          h(:polygon, attrs: { points: Lib::Hex::POINTS }),
+          h(:text, {
+              attrs: {
+                'text-anchor': 'middle',
+                y: 10,
+                'font-size': 30,
+                fill: color ? '#0009' : '#888',
+                'pointer-events': 'none',
+              },
+            }, coord),
+        ])
+    end
+
+    def render_output
+      output = state[:output]
+      return h(:div) unless output
+
+      h(:div, { style: { margin: '0.5rem 0' } }, [
+          h(:p, 'Paste into the game\'s map.rb (HEXES):'),
+          h(:textarea, {
+              attrs: { readonly: true, spellcheck: false },
+              style: { width: '100%', height: '260px', fontFamily: 'monospace', fontSize: '12px' },
+            }, output),
+        ])
+    end
+
+    # --- painting ---------------------------------------------------------
+
+    def start_paint(coord)
+      state[:dragging] = true
+      state[:stroke_snapshotted] = false # new stroke: allow one fresh snapshot
+      paint(coord)
+    end
+
+    def drag_paint(coord)
+      paint(coord) if state[:dragging]
+    end
+
+    def paint(coord)
+      current = state[:paint] || {}
+      old = current[coord]
+      new_color = state[:tool] == 'empty' ? nil : state[:tool]
+      return if old == new_color # re-painting a hex its current color is not an event
+
+      snapshot_stroke! # one undo step per stroke, taken before the first change
+      state[:paint] = current
+      if new_color.nil?
+        current.delete(coord)
+      else
+        current[coord] = new_color
+      end
+      update
+    end
+
+    # snapshot once per stroke, the first time a hex actually changes
+    def snapshot_stroke!
+      return if state[:stroke_snapshotted]
+
+      snapshot!
+      state[:stroke_snapshotted] = true
+    end
+
+    def snapshot!
+      state[:undo] ||= []
+      state[:undo].push((state[:paint] || {}).dup)
+      state[:undo].shift while state[:undo].size > UNDO_LIMIT
+    end
+
+    def undo
+      stack = state[:undo] || []
+      return if stack.empty?
+
+      state[:paint] = stack.pop
+      state[:output] = nil
+      update
+    end
+
+    def clear!
+      return if (state[:paint] || {}).empty?
+
+      snapshot!
+      state[:paint] = {}
+      state[:output] = nil
+      update
+    end
+
+    # --- state / geometry -------------------------------------------------
+
+    def clamp_margin(value)
+      [[value, 0].max, MAX_MARGIN].min
+    end
+
+    # set a cols/rows margin from the number input, validating integer input:
+    # keep digits only, default empty to 0, and clamp to 0..MAX_MARGIN
+    def set_margin(key, event)
+      raw = event.JS['target'].JS['value'].to_s
+      digits = raw.gsub(/[^0-9]/, '')
+      state[key] = clamp_margin(digits.empty? ? 0 : digits.to_i)
+      update
+    end
+
+    def current_title
+      t = @route.match(ROUTE_FORMAT)[1]
+      t.nil? || t.empty? ? nil : t
+    end
+
+    # the game's current white/blue hexes, used to auto-load its map for editing
+    def template_paint
+      paint = {}
+      return paint unless @game
+
+      @game.hexes.each do |hex|
+        next if hex.empty
+
+        case hex.tile&.color
+        when :white then paint[hex.id] = 'white'
+        when :blue then paint[hex.id] = 'blue'
+        end
+      end
+      paint
+    end
+
+    # all coords to draw: a parity-matching blank grid sized to the game's map
+    # (or the default flower with no game) plus the margin rings. The bounds come
+    # only from the base map + margin, NOT from painted hexes, so painting in the
+    # outer ring does not grow the canvas — use the cols/rows margin to resize.
+    def candidate_cells
+      @layout = @game && @game.layout == :pointy ? :pointy : :flat
+
+      base =
+        if @game
+          @game.hexes.reject(&:empty).map { |hex| [hex.x, hex.y] }
+        else
+          DEFAULT_FLOWER
+        end
+      base = [[0, 0]] if base.empty?
+
+      xs = base.map { |xy| xy[0] }
+      ys = base.map { |xy| xy[1] }
+
+      mx = state[:margin_x] || MARGIN
+      my = state[:margin_y] || MARGIN
+      @min_x = [xs.min - mx, 0].max
+      @max_x = xs.max + mx
+      @min_y = [ys.min - my, 0].max
+      @max_y = ys.max + my
+
+      ref = base.first
+      parity = (ref[0] + ref[1]).even?
+
+      cells = {}
+      (state[:paint] || {}).each_key { |c| cells[c] = parse_coord(c) }
+      (@min_x..@max_x).each do |x|
+        (@min_y..@max_y).each do |y|
+          next unless (x + y).even? == parity
+
+          coord = LETTERS[x] + (y + 1).to_s
+          cells[coord] ||= [x, y]
+        end
+      end
+      cells
+    end
+
+    def parse_coord(coord)
+      m = coord.match(/([A-Z]+)(-?\d+)/)
+      return [0, 0] unless m
+
+      [LETTERS.index(m[1]) || 0, m[2].to_i - 1]
+    end
+
+    # --- output -----------------------------------------------------------
+
+    def generate_output
+      by_color = { 'white' => [], 'blue' => [] }
+      (state[:paint] || {}).each { |coord, color| by_color[color] << coord if by_color[color] }
+
+      blocks = %w[white blue].map { |color| format_group(color, by_color[color]) }
+      state[:output] = blocks.join("\n")
+      update
+    end
+
+    def format_group(color, coords)
+      sorted = coords.sort_by { |c| parse_coord(c) }
+      if sorted.empty?
+        "#{color}: {\n          },"
+      else
+        rows = sorted.each_slice(10).map { |slice| '            ' + slice.join(' ') }
+        "#{color}: {\n          %w[\n#{rows.join("\n")}\n] => '',\n          },"
+      end
+    end
+  end
+end

--- a/tools/map_editor.html
+++ b/tools/map_editor.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>18xx Hex Map Editor</title>
+<style>
+  :root { --bg:#1e1f22; --panel:#2b2d31; --ink:#e6e6e6; --line:#555; }
+  * { box-sizing: border-box; }
+  body { margin:0; font:14px/1.4 system-ui, sans-serif; background:var(--bg); color:var(--ink); display:flex; height:100vh; }
+  #side { width:320px; flex:0 0 320px; background:var(--panel); padding:14px; overflow:auto; border-right:1px solid var(--line); }
+  #stage { flex:1; overflow:auto; }
+  h1 { font-size:16px; margin:0 0 12px; }
+  h2 { font-size:13px; text-transform:uppercase; letter-spacing:.05em; color:#9aa; margin:18px 0 6px; }
+  label { display:block; margin:6px 0 2px; color:#bcc; }
+  input[type=number] { width:70px; background:#1b1c1f; color:var(--ink); border:1px solid var(--line); border-radius:4px; padding:4px 6px; }
+  button { background:#3a3d44; color:var(--ink); border:1px solid var(--line); border-radius:5px; padding:6px 10px; cursor:pointer; margin:3px 3px 3px 0; }
+  button:hover { background:#474b54; }
+  button.active { outline:2px solid #4ea1ff; }
+  .swatch { display:inline-block; width:14px; height:14px; border:1px solid #000; vertical-align:-2px; margin-right:6px; border-radius:3px; }
+  textarea { width:100%; height:90px; background:#1b1c1f; color:var(--ink); border:1px solid var(--line); border-radius:4px; font:12px/1.4 ui-monospace, monospace; padding:6px; }
+  .row { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
+  .hint { color:#889; font-size:12px; margin:6px 0; }
+  polygon.hex { cursor:pointer; stroke:#333; stroke-width:1; }
+  text.coord { font:9px ui-monospace, monospace; fill:#0008; pointer-events:none; user-select:none; }
+  pre#out { white-space:pre; }
+</style>
+</head>
+<body>
+<div id="side">
+  <h1>18xx Hex Map Editor</h1>
+  <div class="hint">Click or drag to paint. Right-click drags to erase. Flat-top double-coordinate grid (x=letter, y=number−1).</div>
+
+  <h2>Paint tool</h2>
+  <div class="row" id="palette"></div>
+
+  <h2>Grid bounds</h2>
+  <div class="row">
+    <div><label>Cols (A…)</label><input type="number" id="cols" value="14" min="1" max="52"></div>
+    <div><label>Rows (1…)</label><input type="number" id="rows" value="24" min="1" max="40"></div>
+  </div>
+  <div class="row">
+    <label><input type="checkbox" id="showCoords" checked> show coordinates</label>
+  </div>
+  <button id="regen">Rebuild grid</button>
+  <button id="clear">Clear paint</button>
+
+  <h2>Load coordinates</h2>
+  <label>white hexes</label>
+  <textarea id="loadWhite"></textarea>
+  <label>blue hexes</label>
+  <textarea id="loadBlue"></textarea>
+  <button id="load">Load into grid</button>
+  <button id="loadSeattle">Reset to 20 Seattle</button>
+
+  <h2>Export → map.rb</h2>
+  <button id="gen">Generate Ruby</button>
+  <button id="copy">Copy</button>
+  <pre id="out"></pre>
+</div>
+<div id="stage"><svg id="svg" xmlns="http://www.w3.org/2000/svg"></svg></div>
+
+<script>
+const SVG = "http://www.w3.org/2000/svg";
+const SIZE = 28;
+const W = 2 * SIZE;                 // flat-top hex width
+const H = Math.sqrt(3) * SIZE;      // flat-top hex height
+const MARGIN = SIZE + 6;
+
+// Letter <-> index, matching Engine::Hex::LETTERS (A..Z, AA..AZ)
+const LETTERS = [];
+for (let c = 65; c <= 90; c++) LETTERS.push(String.fromCharCode(c));
+for (let c = 65; c <= 90; c++) LETTERS.push("A" + String.fromCharCode(c));
+function letterToX(l) { return LETTERS.indexOf(l); }
+
+const COLORS = {
+  empty: { fill: "transparent", label: "erase / empty" },
+  white: { fill: "#fdfdf6", label: "white" },
+  blue:  { fill: "#7fd3ff", label: "blue" },
+};
+let tool = "white";
+
+// state: Map "C4" -> color key (only painted ones stored)
+const painted = new Map();
+let cells = []; // {coord, x, y, cx, cy, el}
+
+function hexPoints(cx, cy) {
+  let p = [];
+  for (let i = 0; i < 6; i++) {
+    const a = Math.PI / 180 * (60 * i); // flat-top: vertices at 0,60,...
+    p.push((cx + SIZE * Math.cos(a)).toFixed(2) + "," + (cy + SIZE * Math.sin(a)).toFixed(2));
+  }
+  return p.join(" ");
+}
+
+function buildPalette() {
+  const pal = document.getElementById("palette");
+  pal.innerHTML = "";
+  for (const key of Object.keys(COLORS)) {
+    const b = document.createElement("button");
+    b.innerHTML = '<span class="swatch" style="background:' + (COLORS[key].fill === "transparent" ? "#222" : COLORS[key].fill) + '"></span>' + COLORS[key].label;
+    b.className = key === tool ? "active" : "";
+    b.onclick = () => { tool = key; buildPalette(); };
+    pal.appendChild(b);
+  }
+}
+
+function buildGrid() {
+  const svg = document.getElementById("svg");
+  svg.innerHTML = "";
+  cells = [];
+  const cols = +document.getElementById("cols").value;
+  const rows = +document.getElementById("rows").value;
+  const showCoords = document.getElementById("showCoords").checked;
+  let maxX = 0, maxY = 0;
+
+  for (let xi = 0; xi < cols; xi++) {
+    for (let num = 1; num <= rows; num++) {
+      const y = num - 1;
+      if ((xi + y) % 2 !== 0) continue; // parity that defines the interlocking grid
+      const coord = LETTERS[xi] + num;
+      const cx = MARGIN + xi * 1.5 * SIZE;
+      const cy = MARGIN + y * (H / 2);
+      maxX = Math.max(maxX, cx); maxY = Math.max(maxY, cy);
+
+      const poly = document.createElementNS(SVG, "polygon");
+      poly.setAttribute("points", hexPoints(cx, cy));
+      poly.setAttribute("class", "hex");
+      poly.dataset.coord = coord;
+      paintEl(poly, painted.get(coord) || "empty");
+      svg.appendChild(poly);
+
+      if (showCoords) {
+        const t = document.createElementNS(SVG, "text");
+        t.setAttribute("class", "coord");
+        t.setAttribute("x", cx); t.setAttribute("y", cy + 3);
+        t.setAttribute("text-anchor", "middle");
+        t.textContent = coord;
+        svg.appendChild(t);
+      }
+      cells.push({ coord, el: poly });
+    }
+  }
+  svg.setAttribute("width", maxX + MARGIN);
+  svg.setAttribute("height", maxY + MARGIN);
+}
+
+function paintEl(el, colorKey) {
+  el.setAttribute("fill", colorKey === "empty" ? "#26282c" : COLORS[colorKey].fill);
+}
+
+function apply(coord, el) {
+  if (tool === "empty") painted.delete(coord); else painted.set(coord, tool);
+  paintEl(el, tool);
+}
+
+// drag painting
+let dragging = false, eraseDrag = false;
+document.getElementById("svg").addEventListener("mousedown", e => {
+  if (e.target.classList.contains("hex")) {
+    e.preventDefault();
+    dragging = true; eraseDrag = (e.button === 2);
+    const prevTool = tool;
+    if (eraseDrag) tool = "empty";
+    apply(e.target.dataset.coord, e.target);
+    if (eraseDrag) tool = prevTool;
+  }
+});
+document.getElementById("svg").addEventListener("mousemove", e => {
+  if (!dragging || !e.target.classList.contains("hex")) return;
+  const prevTool = tool;
+  if (eraseDrag) tool = "empty";
+  apply(e.target.dataset.coord, e.target);
+  if (eraseDrag) tool = prevTool;
+});
+window.addEventListener("mouseup", () => dragging = false);
+document.getElementById("svg").addEventListener("contextmenu", e => e.preventDefault());
+
+// sort coords by column letter then numeric row
+function sortCoords(arr) {
+  return arr.slice().sort((a, b) => {
+    const la = a.match(/[A-Z]+/)[0], lb = b.match(/[A-Z]+/)[0];
+    if (la !== lb) return letterToX(la) - letterToX(lb);
+    return parseInt(a) - parseInt(b);
+  });
+}
+
+function wrap(coords) {
+  if (!coords.length) return "";
+  const lines = [];
+  for (let i = 0; i < coords.length; i += 10) lines.push("            " + coords.slice(i, i + 10).join(" "));
+  return "          %w[\n" + lines.join("\n") + "\n] => '',";
+}
+
+function generate() {
+  const byColor = { white: [], blue: [] };
+  for (const [coord, c] of painted) if (byColor[c]) byColor[c].push(coord);
+  let out = "";
+  for (const color of ["white", "blue"]) {
+    const block = wrap(sortCoords(byColor[color]));
+    out += color + ": {\n" + (block ? block + "\n" : "") + "          },\n";
+  }
+  document.getElementById("out").textContent = out;
+  document.getElementById("loadWhite").value = sortCoords(byColor.white).join(" ");
+  document.getElementById("loadBlue").value = sortCoords(byColor.blue).join(" ");
+}
+
+function loadFromText() {
+  painted.clear();
+  for (const w of (document.getElementById("loadWhite").value.match(/[A-Z]+\d+/g) || [])) painted.set(w, "white");
+  for (const b of (document.getElementById("loadBlue").value.match(/[A-Z]+\d+/g) || [])) painted.set(b, "blue");
+  buildGrid();
+}
+
+const SEATTLE_WHITE = `C4 C8 C12 C16 C20 C22 D3 D7 D21 E4 E8 E18 F3 F5 F9 F13 F15 F17 F19 F21
+G4 G6 G10 G14 G18 G20 G22 H3 H5 H7 H9 H11 H13 H15 H17 H19 H21 I4 I6 I8
+I10 I12 I14 I16 I18 I20 I22 J3 J5 J19 J21 K4 K6 K20 K22 L3 L5 L19 L21 M4
+M6 M8 M10 M12 M14 M16 M18 M20 M22 C18 E14 E16 G8 D11 J7 J13 K8 L7 L13 C14 D13`;
+const SEATTLE_BLUE = `B13 E14 D13 C12 B11 A10`;
+
+function loadSeattle() {
+  document.getElementById("loadWhite").value = SEATTLE_WHITE.replace(/\s+/g, " ").trim();
+  document.getElementById("loadBlue").value = SEATTLE_BLUE.replace(/\s+/g, " ").trim();
+  loadFromText();
+}
+
+document.getElementById("regen").onclick = buildGrid;
+document.getElementById("clear").onclick = () => { painted.clear(); buildGrid(); };
+document.getElementById("load").onclick = loadFromText;
+document.getElementById("loadSeattle").onclick = loadSeattle;
+document.getElementById("gen").onclick = generate;
+document.getElementById("copy").onclick = () => navigator.clipboard.writeText(document.getElementById("out").textContent);
+document.getElementById("showCoords").onclick = buildGrid;
+
+buildPalette();
+loadSeattle();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## High Level Summary
Change adds a map editor that generates ruby code to allow devs to easily construct a map.

Plans are to also add a selection of different hex types, adding locations for cities, towns, red zones, etc. and other customizability.

My story: I want to be able to make a map centered around Seattle but found making a map just through code is unruly. I thought other people may have the same issues so I wanted to make a map editor that allows myself and others to construct their maps with ease.

## Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

Add an in-app map editor at /map_editor/<game> for authoring a game's white/blue hexes, plus a standalone tools/map_editor.html
that needs no running server.

- Draws its own SVG hex grid reusing the engine's hex geometry (Lib::Hex::POINTS and the flat/pointy layout math) so coordinates line up with the real map.
- White/Blue/Erase tools, drag to paint, adjustable column/row canvas size, a session undo stack, and a Generate Ruby button that emits a paste-ready HEXES snippet for the game's map.rb.
- /map_editor/<game> auto-loads that game's map; bare /map_editor opens a small blank grid to start.

Wires up the /map_editor route in app.rb and api.rb.

### Screenshots
/map_editor pulls up empty blank canvas
<img width="1267" height="527" alt="image" src="https://github.com/user-attachments/assets/75ad5338-6ee3-408c-af60-70726c425d12" />

/map_editor after making changes
<img width="1278" height="780" alt="Screenshot 2026-06-19 181421" src="https://github.com/user-attachments/assets/1b07bce4-dd1d-4f90-9b41-1e3d5e28b5f8" />

/map_editor/20seattle when loading up a new map
<img width="1274" height="1214" alt="Screenshot 2026-06-19 181538" src="https://github.com/user-attachments/assets/aa936700-a140-4513-9536-f85afef4eb01" />

/map_editor/20seattle when generating ruby code
<img width="1260" height="1269" alt="image" src="https://github.com/user-attachments/assets/25afdac1-113e-4e49-8d55-74380caa0c39" />

/map_editor/1889 has special hexes, no blue hexes but also has special hexes so not compatible yet
<img width="1278" height="928" alt="image" src="https://github.com/user-attachments/assets/51d60220-f851-4483-9f5b-e8398c255ac7" />

/map_editor/1817 has special hexes so not compatible yet
<img width="1268" height="1123" alt="image" src="https://github.com/user-attachments/assets/92bef259-0e96-4fbe-adcc-87fb4da9665d" />

### Any Assumptions / Hacks
N/A