### PR TITLE
[1871] UB owner should see UB trains as crossbuy option

### DIFF
--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -576,24 +576,9 @@ module View
       end
 
       def same_effective_owner?(corporation, other_corp)
-        buyer_owner = corp_owner(corporation)
-        seller_owner = other_owner(other_corp)
-
-        return true if buyer_owner == seller_owner
-
-        return false unless @game.respond_to?(:acting_for_player)
-
-        # code for The Old Prince 1871's Union Bank
-        ub_player = @game.instance_variable_get(:@union_bank)
-        return false unless ub_player
-
-        human = @game.acting_for_player(ub_player)
-        return false if !human || human == ub_player
-
-        effective_buyer = buyer_owner == ub_player ? human : buyer_owner
-        effective_seller = seller_owner == ub_player ? human : seller_owner
-
-        effective_buyer == effective_seller
+        player_a = corp_owner(corporation)
+        player_b = other_owner(other_corp)
+        player_a == player_b || @game.same_acting_player?(player_a, player_b)
       end
 
       # need to abstract due to corporations owning minors owning trains

--- a/assets/app/view/game/buy_trains.rb
+++ b/assets/app/view/game/buy_trains.rb
@@ -520,7 +520,7 @@ module View
               train_props[:style][:backgroundColor] = color
               train_props[:style][:color] = contrast_on(color)
             end
-            line = if @show_other_players || other_owner(other) == corp_owner(@corporation)
+            line = if @show_other_players || same_effective_owner?(corporation, other)
                      [h(:div, train_props, name),
                       h('div.nowrap', train_props,
                         "#{other.name} (#{count > 1 ? "#{count}, " : ''}#{corp_owner(other).name}#{real_name})"),
@@ -573,6 +573,27 @@ module View
                              'Hide trains from other players')
         end
         trains_to_buy
+      end
+
+      def same_effective_owner?(corporation, other_corp)
+        buyer_owner = corp_owner(corporation)
+        seller_owner = other_owner(other_corp)
+
+        return true if buyer_owner == seller_owner
+
+        return false unless @game.respond_to?(:acting_for_player)
+
+        # code for The Old Prince 1871's Union Bank
+        ub_player = @game.instance_variable_get(:@union_bank)
+        return false unless ub_player
+
+        human = @game.acting_for_player(ub_player)
+        return false if !human || human == ub_player
+
+        effective_buyer = buyer_owner == ub_player ? human : buyer_owner
+        effective_seller = seller_owner == ub_player ? human : seller_owner
+
+        effective_buyer == effective_seller
       end
 
       # need to abstract due to corporations owning minors owning trains

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -764,6 +764,10 @@ module Engine
         player
       end
 
+      def same_acting_player?(_owner_a, _owner_b)
+        false
+      end
+
       def player_log(entity, msg)
         @log << "-- #{msg}" if entity.id == @user
       end

--- a/lib/engine/game/g_1871/game.rb
+++ b/lib/engine/game/g_1871/game.rb
@@ -355,6 +355,12 @@ module Engine
           bank_company.owner
         end
 
+        def same_acting_player?(owner_a, owner_b)
+          a = acting_for_player(owner_a)
+          b = acting_for_player(owner_b)
+          a && b && a == b
+        end
+
         # Returns the player that should be the current peir owner
         def peir_owner
           # Get all of the share holders


### PR DESCRIPTION
Fixes #12769

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

User reports that when you're running the Union bank, you still have to click "show trains from other players" to see UB corp trains when operating one of your corps, and vice versa. They feel this is confusing and not intuitive, since you are operating all these corps in actual fact. 

This code adds in a check that displays trains held by UB corps to the UB's owner, and vice versa, without displaying them by default to others. 

### Screenshots

<img width="461" height="579" alt="image" src="https://github.com/user-attachments/assets/a4966c09-8278-46ea-90fe-f289c1ef01a8" />


### Any Assumptions / Hacks
