### PR TITLE
[1822MX] unfloated corps shouldn't be able to bid on or buy NdeM tokens

### DIFF
--- a/lib/engine/game/g_1822_mx/step/auction_ndem_tokens.rb
+++ b/lib/engine/game/g_1822_mx/step/auction_ndem_tokens.rb
@@ -59,7 +59,7 @@ module Engine
           end
 
           def max_bid_for_token(player)
-            corps = player.presidencies.reject { |c| @game.exchange_tokens(c).zero? }
+            corps = player.presidencies.reject { |c| @game.exchange_tokens(c).zero? || !c.floated? }
             corp = corps.max_by(&:cash)
             corp ? corp.cash : 0
           end
@@ -75,6 +75,7 @@ module Engine
           end
 
           def corp_can_purchase_token?(corporation, token)
+            corporation.floated? &&
             corporation.cash >= @available_ndem_tokens[token] &&
             !@game.exchange_tokens(corporation).zero? &&
             token.hex.tile.cities.none? { |c| c.tokened_by?(corporation) }
@@ -239,7 +240,9 @@ module Engine
           end
 
           def mergeable(_corporation)
-            @auction_winner.presidencies.select { |c| !@game.exchange_tokens(c).zero? && c.cash >= @current_high_bid }
+            @auction_winner.presidencies.select do |c|
+              c.floated? && !@game.exchange_tokens(c).zero? && c.cash >= @current_high_bid
+            end
           end
 
           def show_other_players


### PR DESCRIPTION
Fixes #12759

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

User reports:

> Rule 6.22.2 on NDEM token sales merely state that a player can bid on behalf of a company, without limiting it to floated companies. And Rule 5.9 states that companies get their tokens when they are "formed" not when they are "floated". So the FCP would have cash and tokens as soon as the president's share is purchased. But, Rule 5.8.2 provides that directly formed companies (like the FCP here) "do not float and become operational until 50% of its shares are sold. And the NDEM privatization rule is in the section on operating rounds (rule 6), so this rule should be read to limit "companies" that can bid on tokens to those companies that are eligible to operate, which an unfloated company is not. So I do not think this should be allowed.

I agree with that interpretation. 

I added gates for unfloated corps in 3 different methods in the auction_ndem_tokens.rb code. Here's why I felt all three were necessary: 

- Without the fix to `def max_bid_for_token`, the bid ceiling could be inflated by cash in an unfloated corp's treasury.

- Without the fix to `def corp_can_purchase_token?`, `player_can_purchase_token?` returns true for players whose only eligible corp is parred but unfloated, so they incorrectly enter the bidding rotation.

- Without the fix to `def mergeable`, the winner could assign the token to an unfloated corp, even if the other two methods are fixed.

### Screenshots

### Any Assumptions / Hacks
