### PR TITLE
[1713 Menorca] feat: add prealpha prototype (runnable minimum)

### DIFF
--- a/lib/engine/game/g_1713_menorca.rb
+++ b/lib/engine/game/g_1713_menorca.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1713Menorca
+    end
+  end
+end

--- a/lib/engine/game/g_1713_menorca/entities.rb
+++ b/lib/engine/game/g_1713_menorca/entities.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1713Menorca
+      module Entities
+        # rubocop:disable Layout/LineLength
+        COMPANIES = [
+          {
+            sym: 'GSC',
+            name: '1. Gremi de Sabaters de Ciutadella',
+            value: 20,
+            revenue: 5,
+            desc: '+10R to any route that connects Ciutadella with Barcelona, Mallorca, or Marsella. '\
+                  'This bonus applies to all corporations using that route if the owner has transferred the ability.',
+          },
+          {
+            sym: 'RAG',
+            name: "2. Ramats de l'Albufera d'es Grau",
+            value: 20,
+            revenue: 5,
+            desc: "+15R to any route that starts in S'Albufera d'es Grau. The corporation that acquires this private is the only one "\
+                  "that can lay S'Albufera d'es Grau's initial tile by paying the cost shown on the map.",
+          },
+          {
+            sym: 'CRB',
+            name: '3. Cami Reial Britanic',
+            value: 25,
+            revenue: 5,
+            desc: "The owning corporation ignores the additional build cost on Cami d'en Kane land hexes during phases 1 and 2.",
+          },
+          {
+            sym: 'LBI',
+            name: "4. Lleves de Bestiar de l'Interior",
+            value: 30,
+            revenue: 5,
+            desc: 'If owned by RAM, the corporation ignores factory blocking from other corporations.  If owned by any other corporation, this ability is inactive.',
+          },
+          {
+            sym: 'FRN',
+            name: '5. Factura Pendent amb la Royal Navy',
+            value: 100,
+            revenue: 10,
+            desc: 'During phase 2, owner may exchange this private for one RNC share at current market price without using the stock action. Closes when phase 3 begins.',
+          },
+          {
+            sym: 'DRM',
+            name: '6. Drassanes Reials de Mao',
+            value: 40,
+            revenue: 10,
+            desc: "Owning corporation buys its first ship in any phase at a 20R discount and can build Torre de l'Illa de l'Aire without additional cost.",
+          },
+          {
+            sym: 'CSF',
+            name: '7. Castell de Sant Felip',
+            value: 60,
+            revenue: 15,
+            desc: 'Once per game, owner may block one route into or out of the port of Mao for one full OR. The block must be declared at the start of the OR.',
+          },
+          {
+            sym: 'VRC',
+            name: '8. Vinculació Familiar amb la Real Compania',
+            value: 100,
+            revenue: 0,
+            desc: 'Upon acquisition, owner immediately receives the RCC family trust share (20%) at no cost. Then this private closes.',
+          },
+          {
+            sym: 'IVR',
+            name: '9. Intel·ligència de Versalles',
+            value: 35,
+            revenue: 10,
+            desc: 'Owner sees event cards one round before they trigger. Relevant only when using hidden events variant.',
+          },
+        ].freeze
+        # rubocop:enable Layout/LineLength
+
+        CORPORATIONS = [
+          {
+            sym: 'RNC',
+            name: 'Royal Navy Company',
+            logo: '1713Menorca/RNC',
+            simple_logo: '1713Menorca/RNC.alt',
+            tokens: [0, 80],
+            coordinates: 'J11',
+            color: '#1A3A5C',
+            float_percent: 50,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+          },
+          {
+            sym: 'RCC',
+            name: 'Real Compania de Comercio',
+            logo: '1713Menorca/RCC',
+            simple_logo: '1713Menorca/RCC.alt',
+            tokens: [0, 80],
+            coordinates: 'C8',
+            color: '#7B2D00',
+            float_percent: 50,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+          },
+          {
+            sym: 'RAM',
+            name: 'Ramaders i Artesans de Menorca',
+            logo: '1713Menorca/RAM',
+            simple_logo: '1713Menorca/RAM.alt',
+            tokens: [0, 30, 60],
+            coordinates: 'G8',
+            color: '#2D5A1B',
+            float_percent: 50,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+          },
+          {
+            sym: 'CLV',
+            name: 'Compagnie du Levant',
+            logo: '1713Menorca/CLV',
+            simple_logo: '1713Menorca/CLV.alt',
+            tokens: [0, 80],
+            coordinates: 'J11',
+            city: 1,
+            color: '#4A235A',
+            float_percent: 50,
+            shares: [20, 10, 10, 10, 10, 10, 10, 10, 10],
+          },
+        ].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1713_menorca/game.rb
+++ b/lib/engine/game/g_1713_menorca/game.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative 'meta'
+require_relative 'entities'
+require_relative 'map'
+require_relative 'market'
+require_relative 'phases'
+require_relative 'tiles'
+require_relative 'trains'
+require_relative '../base'
+
+module Engine
+  module Game
+    module G1713Menorca
+      class Game < Game::Base
+        include_meta(G1713Menorca::Meta)
+        include Entities
+        include Map
+        include Market
+        include Phases
+        include Tiles
+        include Trains
+
+        CURRENCY_FORMAT_STR = '%sR'
+        BANK_CASH    = 7000
+        CERT_LIMIT   = { 2 => 15, 3 => 13 }.freeze
+        STARTING_CASH = { 2 => 420, 3 => 380 }.freeze
+        CAPITALIZATION = :incremental
+
+        BANKRUPTCY_ALLOWED = true
+        BANKRUPTCY_ENDS_GAME_AFTER = :all_but_one
+
+        GAME_END_CHECK = { bankrupt: :immediate, bank: :full_or }.freeze
+        GAME_END_TIMING_PRIORITY = %i[immediate current_or after_max_operates full_or].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1713_menorca/map.rb
+++ b/lib/engine/game/g_1713_menorca/map.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1713Menorca
+      module Map
+        LOCATION_NAMES = {
+          'C8' => 'Ciutadella',
+          'H5' => 'Fornells',
+          'G8' => 'Es Mercadal',
+          'J11' => 'Maó / Es Castell',
+          'J13' => 'Sant Lluís',
+          'H9' => 'Alaior',
+          'E8' => 'Ferreries',
+          'F9' => 'Es Migjorn Gran',
+          'I6' => "Port d'Addaia",
+          'C6' => 'Punta Nati',
+          'C10' => "Torre d'Artrutx",
+          'G4' => 'Torre de Cavalleria',
+          'J7' => 'Cap de Favàritx',
+          'J15' => "Illa de l'Aire",
+          'J9' => "S'Albufera d'es Grau",
+          'B3' => 'Barcelona',
+          'A12' => 'Mallorca',
+          'J3' => 'Marsella',
+          'K4' => 'Génova',
+          'K16' => 'Valencia',
+          'F15' => 'Alger',
+        }.freeze
+
+        # rubocop:disable Layout/LineLength
+        HEXES = {
+          yellow: {
+            # Ciutats i pobles inicials amb via preimpresa
+            ['C8'] => 'city=revenue:20;path=a:4,b:_0;path=a:5,b:_0;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;icon=image:port', # Ciutadella
+            ['H5'] => 'city=revenue:10;path=a:0,b:_0;path=a:1,b:_0;icon=image:port', # Fornells
+            ['G8'] => 'city=revenue:20;path=a:2,b:_0;path=a:5,b:_0', # Es Mercadal
+            ['J11'] => 'city=revenue:30;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow;icon=image:port', # Maó / Es Castell
+            ['J13'] => 'town=revenue:10;path=a:2,b:_0;path=a:3,b:_0', # Sant Lluís
+          },
+          orange: {
+            # Fars i torres de guaita (fites, representades com a pobles)
+            ['C6'] => 'town=revenue:0;upgrade=cost:20,terrain:water', # Punta Nati
+            ['C10'] => 'town=revenue:0;upgrade=cost:20,terrain:water', # Torre d'Artrutx
+            ['G4'] => 'town=revenue:0;upgrade=cost:20,terrain:water',   # Torre de Cavalleria
+            ['J7'] => 'town=revenue:0;upgrade=cost:20,terrain:water',   # Cap de Favàritx
+            ['J15'] => 'town=revenue:0;upgrade=cost:20,terrain:water', # Illa de l'Aire
+          },
+          white: {
+            # Mar obert (buildable, blue impassable would block track connections)
+            %w[B5 B7 B9 B11
+               C4 C12
+               D5 D11 D13
+               E4 E12
+               F3 F11
+               G2 G12
+               H3 H13
+               I14
+               K6 K8 K10 K12 K14] =>
+              '',
+            # Entrades marítimes cap a Alger i Marsella
+            %w[E14 F13 G14 I4 J5] => 'upgrade=cost:40,terrain:water',
+            # Camí especial interior (cost 60)
+            %w[D7 F7] => 'upgrade=cost:60,terrain:hill;path=track:future,a:1,b:5',
+            ['I10'] => 'upgrade=cost:60,terrain:hill;path=track:future,a:2,b:5',
+            # Terreny accidentat (cost 15 per travessar)
+            %w[E6 E10 F5 D9 G6 G10 H7 H11 I8 I12] => 'upgrade=cost:15,terrain:mountain',
+            # S'Albufera d'es Grau (aiguamoll, cost 80)
+            ['J9'] => 'upgrade=cost:80,terrain:swamp',
+            # Pobles
+            ['H9'] => 'town=revenue:0;upgrade=cost:60,terrain:hill;path=track:future,a:2,b:5',   # Alaior
+            ['E8'] => 'town=revenue:0;upgrade=cost:60,terrain:hill;path=track:future,a:2,b:4',   # Ferreries
+            ['F9'] => 'town=revenue:0;upgrade=cost:30,terrain:mountain', # Es Migjorn Gran
+            ['I6'] => 'town=revenue:0', # Port d'Addaia
+          },
+          red: {
+            # Destinacions fora del mapa (valors i orientació segons JSON)
+            ['B3'] => 'offboard=revenue:yellow_30|green_45|brown_60|gray_70;path=a:0,b:_0,track:dual;path=a:5,b:_0,track:dual', # Barcelona (1,6)
+            ['A12'] => 'offboard=revenue:yellow_20|green_30|brown_40|gray_50;path=a:4,b:_0,track:dual', # Mallorca (5)
+            ['J3'] => 'offboard=revenue:yellow_0|green_45|brown_60|gray_80;path=a:0,b:_0,track:dual;path=a:1,b:_0,track:dual', # Marsella (1,2)
+            ['K4'] => 'offboard=revenue:yellow_0|green_0|brown_60|gray_80;path=a:0,b:_0,track:dual;path=a:1,b:_0,track:dual', # Génova (1,2)
+            ['K16'] => 'offboard=revenue:yellow_30|green_40|brown_50|gray_60;path=a:3,b:_0,track:dual', # Valencia (4)
+            ['F15'] => 'offboard=revenue:yellow_0|green_0|brown_0|gray_80;path=a:2,b:_0,track:dual;path=a:3,b:_0,track:dual;path=a:4,b:_0,track:dual', # Alger (3,4,5)
+          },
+        }.freeze
+        # rubocop:enable Layout/LineLength
+
+        LAYOUT = :flat
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1713_menorca/market.rb
+++ b/lib/engine/game/g_1713_menorca/market.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1713Menorca
+      module Market
+        MARKET = [
+          ['', '', '120', '135', '150', '170', '190', '215', '240', '270', '305', '345', '390'],
+          %w[90 120 135 150p 170 190 215 240 270],
+          %w[65 90 120 135p 150 170 190 215],
+          %w[45y 65 90 120p 135 150 170],
+          %w[30y 45y 65 90p 120 135],
+          %w[20o 30y 45y 65p 90],
+          %w[15o 20o 30y 45y],
+          %w[10o 15o 20o],
+        ].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1713_menorca/meta.rb
+++ b/lib/engine/game/g_1713_menorca/meta.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative '../meta'
+
+module Engine
+  module Game
+    module G1713Menorca
+      module Meta
+        include Game::Meta
+
+        DEV_STAGE = :prealpha
+        PROTOTYPE = true
+
+        GAME_SUBTITLE  = 'Menorca under British Rule'
+        GAME_DESIGNER  = 'Jordi Salord'
+        GAME_IMPLEMENTER = 'Jordi Salord'
+        GAME_LOCATION  = 'Menorca, Spain'
+        GAME_PUBLISHER = :self_published
+        GAME_RULES_URL = 'https://18xx.cat/1713menorca'
+        GAME_INFO_URL = 'https://18xx.cat/1713menorca'
+
+        PLAYER_RANGE = [2, 3].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1713_menorca/phases.rb
+++ b/lib/engine/game/g_1713_menorca/phases.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1713Menorca
+      module Phases
+        PHASES = [
+          {
+            name: 'E1',
+            train_limit: 3,
+            tiles: [:yellow],
+            operating_rounds: 2,
+          },
+          {
+            name: 'E2',
+            on: 'V3',
+            train_limit: 3,
+            tiles: %i[yellow green],
+            operating_rounds: 2,
+            status: ['can_buy_companies'],
+          },
+          {
+            name: 'E3',
+            on: 'V4',
+            train_limit: 2,
+            tiles: %i[yellow green brown],
+            operating_rounds: 2,
+            status: ['can_buy_companies'],
+          },
+          {
+            name: 'E4',
+            on: 'VE',
+            train_limit: 2,
+            tiles: %i[yellow green brown gray],
+            operating_rounds: 3,
+            status: ['can_buy_companies'],
+          },
+        ].freeze
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1713_menorca/tiles.rb
+++ b/lib/engine/game/g_1713_menorca/tiles.rb
@@ -1,0 +1,263 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1713Menorca
+      module Tiles
+        # rubocop:disable Layout/LineLength
+        TILES = {
+          'PN1' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+          },
+          'PN2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'town=revenue:20;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+          },
+          'PN3' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'town=revenue:30;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+          },
+          'PN4' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'town=revenue:40;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+          },
+          'TA1' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10;path=a:5,b:_0,track:narrow;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow',
+          },
+          'TA2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'town=revenue:20;path=a:5,b:_0,track:narrow;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow',
+          },
+          'TA3' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'town=revenue:30;path=a:5,b:_0,track:narrow;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow',
+          },
+          'TA4' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'town=revenue:40;path=a:5,b:_0,track:narrow;path=a:0,b:_0,track:narrow;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow',
+          },
+          'TC1' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+          },
+          'TC2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'town=revenue:20;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+          },
+          'TC3' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'town=revenue:30;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+          },
+          'TC4' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'town=revenue:40;path=a:2,b:_0,track:narrow;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+          },
+          'CF1' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow',
+          },
+          'CF2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'town=revenue:20;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow',
+          },
+          'CF3' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'town=revenue:30;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow',
+          },
+          'CF4' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'town=revenue:40;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow',
+          },
+          'IA1' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10;path=a:2,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+          },
+          'IA2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'town=revenue:20;path=a:2,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+          },
+          'IA3' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'town=revenue:30;path=a:2,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+          },
+          'IA4' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'town=revenue:40;path=a:2,b:_0,track:narrow;path=a:4,b:_0,track:narrow',
+          },
+          'CI2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:30;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:4,b:_0;path=a:5,b:_0;icon=image:port',
+          },
+          'CI3' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:40;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:4,b:_0;path=a:5,b:_0;icon=image:port',
+          },
+          'CI4' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:50;path=a:1,b:_0,track:narrow;path=a:2,b:_0,track:narrow;path=a:4,b:_0;path=a:5,b:_0;icon=image:port',
+          },
+          'MO2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:40;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow;icon=image:port',
+          },
+          'MO3' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:50,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow;icon=image:port',
+          },
+          'MO4' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:60,slots:2;path=a:0,b:_0;path=a:2,b:_0;path=a:4,b:_0,track:narrow;path=a:5,b:_0,track:narrow;icon=image:port',
+          },
+          'ME2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:20,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:5,b:_0',
+          },
+          'ME3' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:40,slots:2;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
+          },
+          'ME4' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:40,slots:3;path=a:1,b:_0;path=a:2,b:_0;path=a:3,b:_0;path=a:4,b:_0;path=a:5,b:_0',
+          },
+          'FE2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:20,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow;icon=image:port',
+          },
+          'FE3' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:20,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow;icon=image:port',
+          },
+          'FE4' => {
+            'count' => 1,
+            'color' => 'gray',
+            'code' => 'city=revenue:20,slots:2;path=a:0,b:_0;path=a:1,b:_0;path=a:3,b:_0,track:narrow;path=a:4,b:_0,track:narrow;icon=image:port',
+          },
+          'F1' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10,to_city:1;path=a:0,b:_0;path=a:3,b:_0',
+          },
+          'F2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'city=revenue:20;path=a:0,b:_0;path=a:3,b:_0',
+          },
+          'F3' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:30,slots:2;path=a:0,b:_0;path=a:3,b:_0',
+          },
+          'MG1' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10;path=a:2,b:_0;path=a:4,b:_0',
+          },
+          'MG2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'town=revenue:15;path=a:2,b:_0;path=a:4,b:_0',
+          },
+          'MG3' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'town=revenue:20;path=a:2,b:_0;path=a:4,b:_0',
+          },
+          'AL1' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10;path=a:1,b:_0;path=a:4,b:_0',
+          },
+          'AL2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'town=revenue:20;path=a:1,b:_0;path=a:4,b:_0',
+          },
+          'AL3' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'city=revenue:30;path=a:1,b:_0;path=a:4,b:_0',
+          },
+          'PA1' => {
+            'count' => 1,
+            'color' => 'yellow',
+            'code' => 'town=revenue:10;path=a:0,b:_0;path=a:1,b:_0',
+          },
+          'PA2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'town=revenue:15;path=a:0,b:_0;path=a:1,b:_0',
+          },
+          'SL2' => {
+            'count' => 1,
+            'color' => 'green',
+            'code' => 'town=revenue:15;path=a:2,b:_0;path=a:3,b:_0',
+          },
+          'SL3' => {
+            'count' => 1,
+            'color' => 'brown',
+            'code' => 'town=revenue:25;path=a:2,b:_0;path=a:3,b:_0',
+          },
+          # Standard broad-gauge plain track
+          '7' => 6,
+          '8' => 6,
+          '9' => 6,
+          '20' => 1,
+          '23' => 2,
+          '24' => 2,
+          '25' => 2,
+          '26' => 2,
+          '27' => 2,
+          '28' => 2,
+          '29' => 2,
+          '40' => 1,
+          # Standard narrow-gauge plain track
+          '77' => 10,
+          '78' => 10,
+          '79' => 10,
+          '677' => 4,
+          '678' => 4,
+          '692' => 4,
+          '693' => 4,
+          '694' => 4,
+          '695' => 4,
+          '699' => 4,
+        }.freeze
+        # rubocop:enable Layout/LineLength
+      end
+    end
+  end
+end

--- a/lib/engine/game/g_1713_menorca/trains.rb
+++ b/lib/engine/game/g_1713_menorca/trains.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Engine
+  module Game
+    module G1713Menorca
+      module Trains
+        TRAINS = [
+          {
+            name: 'C2',
+            distance: 2,
+            track_type: :broad,
+            price: 40,
+            rusts_on: 'CM',
+            num: 5,
+          },
+          {
+            name: 'CM',
+            distance: 8,
+            track_type: :broad,
+            price: 100,
+            num: 4,
+            available_on: 'E3',
+          },
+          {
+            name: 'V2',
+            distance: 2,
+            track_type: :narrow,
+            price: 90,
+            rusts_on: 'V4',
+            num: 5,
+            available_on: 'E1',
+          },
+          {
+            name: 'V3',
+            distance: 3,
+            track_type: :narrow,
+            price: 180,
+            rusts_on: 'VE',
+            num: 4,
+            available_on: 'E1',
+          },
+          {
+            name: 'V4',
+            distance: 4,
+            track_type: :narrow,
+            price: 360,
+            num: 3,
+            available_on: 'E3',
+          },
+          {
+            name: 'VE',
+            distance: 99,
+            track_type: :narrow,
+            price: 720,
+            num: 6,
+            discount: { 'V4' => 120 },
+            available_on: 'E4',
+          },
+        ].freeze
+      end
+    end
+  end
+end

--- a/public/logos/1713Menorca/CLV.alt.svg
+++ b/public/logos/1713Menorca/CLV.alt.svg
@@ -1,0 +1,5 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <title>Compagnie du Levant - CLV</title>
+  <circle cx="50" cy="50" r="50" fill="#4A235A"/>
+  <text x="50" y="62" font-family="Georgia, serif" font-size="36" font-weight="700" fill="white" text-anchor="middle" letter-spacing="-1">CLV</text>
+</svg>

--- a/public/logos/1713Menorca/CLV.svg
+++ b/public/logos/1713Menorca/CLV.svg
@@ -1,0 +1,17 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <title>Compagnie du Levant</title>
+  <circle cx="50" cy="50" r="50" fill="#4A235A"/>
+  <path d="M27,22 L73,22 L73,60 Q73,80 50,90 Q27,80 27,60 Z" fill="none" stroke="white" stroke-width="4" stroke-linejoin="round"/>
+  <line x1="27" y1="55" x2="73" y2="55" stroke="white" stroke-width="2.5"/>
+  <circle cx="50" cy="39" r="9" fill="none" stroke="white" stroke-width="3"/>
+  <line x1="50" y1="23" x2="50" y2="28" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="50" y1="50" x2="50" y2="55" stroke="white" stroke-width="2" stroke-linecap="round"/>
+  <line x1="35" y1="39" x2="39" y2="39" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="61" y1="39" x2="65" y2="39" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="38" y1="27" x2="41" y2="30" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="59" y1="48" x2="62" y2="51" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="62" y1="27" x2="59" y2="30" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="38" y1="48" x2="41" y2="51" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M32,64 Q38,59 44,64 Q50,69 56,64 Q62,59 68,64" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M33,76 Q39,71 45,76 Q51,81 57,76 Q63,71 68,75" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/public/logos/1713Menorca/RAM.alt.svg
+++ b/public/logos/1713Menorca/RAM.alt.svg
@@ -1,0 +1,5 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <title>Ramaders i Artesans de Menorca - RAM</title>
+  <circle cx="50" cy="50" r="50" fill="#2D5A1B"/>
+  <text x="50" y="62" font-family="Georgia, serif" font-size="36" font-weight="700" fill="white" text-anchor="middle" letter-spacing="-1">RAM</text>
+</svg>

--- a/public/logos/1713Menorca/RAM.svg
+++ b/public/logos/1713Menorca/RAM.svg
@@ -1,0 +1,14 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <title>Ramaders i Artesans de Menorca</title>
+  <circle cx="50" cy="50" r="50" fill="#2D5A1B"/>
+  <path d="M33,28 Q18,15 23,28" fill="none" stroke="white" stroke-width="5" stroke-linecap="round"/>
+  <path d="M67,28 Q82,15 77,28" fill="none" stroke="white" stroke-width="5" stroke-linecap="round"/>
+  <ellipse cx="18" cy="50" rx="8" ry="5" fill="none" stroke="white" stroke-width="4"/>
+  <ellipse cx="82" cy="50" rx="8" ry="5" fill="none" stroke="white" stroke-width="4"/>
+  <rect x="24" y="28" width="52" height="50" rx="10" fill="none" stroke="white" stroke-width="5"/>
+  <circle cx="38" cy="47" r="3.5" fill="white"/>
+  <circle cx="62" cy="47" r="3.5" fill="white"/>
+  <rect x="34" y="63" width="32" height="11" rx="5" fill="none" stroke="white" stroke-width="4"/>
+  <circle cx="43" cy="68" r="2.5" fill="white"/>
+  <circle cx="57" cy="68" r="2.5" fill="white"/>
+</svg>

--- a/public/logos/1713Menorca/RCC.alt.svg
+++ b/public/logos/1713Menorca/RCC.alt.svg
@@ -1,0 +1,5 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <title>Real Compañía de Comercio - RCC</title>
+  <circle cx="50" cy="50" r="50" fill="#7B2D00"/>
+  <text x="50" y="62" font-family="Georgia, serif" font-size="36" font-weight="700" fill="white" text-anchor="middle" letter-spacing="-1">RCC</text>
+</svg>

--- a/public/logos/1713Menorca/RCC.svg
+++ b/public/logos/1713Menorca/RCC.svg
@@ -1,0 +1,15 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <title>Real Compañía de Comercio</title>
+  <circle cx="50" cy="50" r="50" fill="#7B2D00"/>
+  <path d="M22,72 L22,63 Q22,59 26,59 L74,59 Q78,59 78,63 L78,72 Q78,76 74,76 L26,76 Q22,76 22,72 Z" fill="none" stroke="white" stroke-width="3.5" stroke-linejoin="round"/>
+  <path d="M26,59 L26,43 L38,55 L50,22 L62,55 L74,43 L74,59" fill="none" stroke="white" stroke-width="4" stroke-linejoin="round" stroke-linecap="round"/>
+  <path d="M26,59 Q38,51 50,59" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M50,59 Q62,51 74,59" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="50" y1="14" x2="50" y2="24" stroke="white" stroke-width="3" stroke-linecap="round"/>
+  <line x1="44" y1="18" x2="56" y2="18" stroke="white" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="38" cy="55" r="2.5" fill="white"/>
+  <circle cx="62" cy="55" r="2.5" fill="white"/>
+  <rect x="46" y="63" width="8" height="6" rx="2" fill="none" stroke="white" stroke-width="2"/>
+  <circle cx="32" cy="67" r="3" fill="none" stroke="white" stroke-width="2"/>
+  <circle cx="68" cy="67" r="3" fill="none" stroke="white" stroke-width="2"/>
+</svg>

--- a/public/logos/1713Menorca/RNC.alt.svg
+++ b/public/logos/1713Menorca/RNC.alt.svg
@@ -1,0 +1,5 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <title>Royal Navy Company - RNC</title>
+  <circle cx="50" cy="50" r="50" fill="#1A3A5C"/>
+  <text x="50" y="62" font-family="Georgia, serif" font-size="36" font-weight="700" fill="white" text-anchor="middle" letter-spacing="-1">RNC</text>
+</svg>

--- a/public/logos/1713Menorca/RNC.svg
+++ b/public/logos/1713Menorca/RNC.svg
@@ -1,0 +1,11 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <title>Royal Navy Company</title>
+  <circle cx="50" cy="50" r="50" fill="#1A3A5C"/>
+  <line x1="50" y1="20" x2="50" y2="82" stroke="white" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="50" cy="20" r="8" fill="none" stroke="white" stroke-width="5"/>
+  <line x1="30" y1="33" x2="70" y2="33" stroke="white" stroke-width="6" stroke-linecap="round"/>
+  <path d="M50 75 Q36 84 24 73" fill="none" stroke="white" stroke-width="6" stroke-linecap="round"/>
+  <line x1="24" y1="73" x2="18" y2="62" stroke="white" stroke-width="6" stroke-linecap="round"/>
+  <path d="M50 75 Q64 84 76 73" fill="none" stroke="white" stroke-width="6" stroke-linecap="round"/>
+  <line x1="76" y1="73" x2="82" y2="62" stroke="white" stroke-width="6" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Adds the 1713 Menorca prototype game (prealpha): meta, entities
(private companies + corporations), map, market, phases, tiles,
trains, and corporation logos.

Scoped to a runnable minimum: everything is plain data on top of the
base engine, so it loads, runs, and passes CI with nothing depending
on engine code that doesn't exist yet.

- entities.rb: COMPANIES holds the private companies as plain
  value/revenue cards (no abilities yet); CORPORATIONS holds RNC,
  RCC, RAM and CLV. RNC and CLV share Mao (J11), which has two slots.
- map.rb: sea hexes are white so routes can be built and connected
  across them (blue hexes are impassable in the engine). Lighthouses
  and watchtowers are white town hexes with water terrain.
- tiles.rb: standard engine tiles only - town (3, 4, 58), broad gauge
  (7, 8, 9, 20, 23-29, 40) and narrow gauge (77-79, 677, 678,
  692-695, 699).
- market.rb: 2D stock market, 9 rows, consistent price steps per
  column.
- trains.rb / phases.rb: a single 3H-8H train roster with matching
  phases E1-E6.

### Screenshots

### Any Assumptions / Hacks

The train roster assumes all four corporations are opened (players
are expected to open CLV). With fewer corporations floated, the depot
can run out of train slots before the 8H becomes available.

Private company abilities, event-driven mechanics (CLV becoming
available), separate wagon/ship fleets, lighthouse progression and
the fixed-tile / Cami d'en Kane build restrictions are intentionally
left out of this first PR. They'll come back in follow-ups once the
supporting engine code exists.
