### PR TITLE
[1862 USA & Canada] feat: bonus markers, SLC bonus, Golden Spike, tile-lay budget

### DIFF
--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -44,7 +44,7 @@ module Engine
           'CP' => [
             { hexes: %w[E25],          cash: 100, route_bonus: 30,  name: 'Toronto'     },
             { hexes: %w[B20],          cash: 200, route_bonus: 60,  name: 'Thunder Bay' },
-            { hexes: %w[B2 C1 G3 I5], cash: 300, route_bonus: 100, name: 'V/P/S/L' },
+            { hexes: %w[B2 D2 G3 I5], cash: 300, route_bonus: 100, name: 'V/P/S/L' },
           ],
           'NYH' => [
             { hexes: %w[F20],          cash: 100, route_bonus: 30,  name: 'Chicago'     },
@@ -58,13 +58,13 @@ module Engine
             { hexes: %w[J10],          cash: 200, route_bonus: 60,  name: 'El Paso'     },
           ],
           'ATS' => [
-            { hexes: %w[B2 C1 G3 I5], cash: 200, route_bonus: 60, name: 'V/P/S/L' },
+            { hexes: %w[B2 D2 G3 I5], cash: 200, route_bonus: 60, name: 'V/P/S/L' },
           ],
           'NP' => [
             { hexes: %w[F20], cash: 100, route_bonus: 30, name: 'Chicago' },
           ],
           'CN' => [
-            { hexes: %w[B2 C1 G3 I5], cash: 100, route_bonus: 30, name: 'V/P/S/L' },
+            { hexes: %w[B2 D2 G3 I5], cash: 100, route_bonus: 30, name: 'V/P/S/L' },
             { hexes: %w[B10], cash: 200, route_bonus: 60, name: 'Regina' },
           ],
           # FIXME: TP El Paso bonus amount unconfirmed from rulebook — entry omitted until confirmed
@@ -286,6 +286,92 @@ module Engine
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or }.freeze
 
         # ---------------------------------------------------------------------------
+        # Bonus state initialisation.
+        # @bonus_state: { [corp_sym, bonus_index] => :unactivated | :permanent | :cash }
+        # :unactivated — bonus not yet earned.
+        # :permanent   — director chose to keep as recurring per-OR revenue.
+        # :cash        — director chose the one-time cash payout (not yet implemented;
+        #                auto-selects :permanent for now — FIXME).
+        # ---------------------------------------------------------------------------
+        def setup
+          @bonus_state = {}
+          CORP_BONUSES.each do |sym, bonuses|
+            bonuses.each_index { |i| @bonus_state[[sym, i]] = :unactivated }
+          end
+          @slc_connected = {}
+          @slc_bonus_paid = false
+        end
+
+        # ---------------------------------------------------------------------------
+        # Bonus markers (Bonusplättchen) — revenue and activation.
+        # A bonus activates when a corp's route passes through BOTH its home hex AND
+        # the bonus target hex in the same OR turn.
+        # ---------------------------------------------------------------------------
+
+        # Pure calculation — called by routes_revenue and during route display.
+        def corp_bonus_revenue(corporation, routes)
+          return 0 unless (bonuses = CORP_BONUSES[corporation.id])
+
+          home = corporation.coordinates
+          bonuses.each_with_index.sum do |bonus, i|
+            case @bonus_state[[corporation.id, i]]
+            when :unactivated
+              would_activate?(bonus, routes, home) ? bonus[:route_bonus] : 0
+            when :permanent
+              bonus_on_route?(bonus, routes) ? bonus[:route_bonus] : 0
+            else
+              0
+            end
+          end
+        end
+
+        # Called from Step::Dividend before super — commits any newly earned bonuses.
+        # FIXME: should offer cash-vs-permanent choice; auto-selects :permanent for now.
+        def activate_new_bonuses!(corporation, routes)
+          return unless (bonuses = CORP_BONUSES[corporation.id])
+
+          home = corporation.coordinates
+          bonuses.each_with_index do |bonus, i|
+            next unless @bonus_state[[corporation.id, i]] == :unactivated
+            next unless would_activate?(bonus, routes, home)
+
+            @bonus_state[[corporation.id, i]] = :permanent
+            @log << "#{corporation.name} activates #{bonus[:name]} connection bonus " \
+                    "(permanent +#{format_currency(bonus[:route_bonus])} per OR)"
+          end
+        end
+
+        def routes_revenue(routes)
+          return super if routes.empty?
+
+          corp = routes.first.train.owner
+          super + corp_bonus_revenue(corp, routes) + slc_route_bonus(corp, routes)
+        end
+
+        # ---------------------------------------------------------------------------
+        # SLC transcontinental bonus + Golden Spike event.
+        # CPR and UP each earn a per-OR bonus whenever their route passes through SLC.
+        # The first time both corps have connected through SLC the Golden Spike fires:
+        # a one-time shareholder bonus is paid from the bank and both stocks advance.
+        # ---------------------------------------------------------------------------
+
+        # Called from Step::Dividend before super each time a corporation runs routes.
+        def check_golden_spike!(corporation, routes)
+          return unless SLC_CORPS.include?(corporation.id)
+          return if @slc_connected[corporation.id]
+          return unless routes.any? { |r| r.visited_stops.any? { |s| s.hex.id == SLC_HEX } }
+
+          @slc_connected[corporation.id] = true
+          @log << "#{corporation.name} reaches Salt Lake City — transcontinental route active"
+
+          return unless SLC_CORPS.all? { |sym| @slc_connected[sym] }
+          return if @slc_bonus_paid
+
+          @slc_bonus_paid = true
+          golden_spike_event!
+        end
+
+        # ---------------------------------------------------------------------------
         # Private company close triggers.
         # SOC closes when CPR or UP floats.
         # NHSC closes when NYH floats.
@@ -359,7 +445,7 @@ module Engine
           when 1 then all_privates_sold?
           when 2 then corp_groups[1].all? { |corp| corp.num_ipo_shares.zero? }
           when 3 then corp_groups[2].all?(&:floated?)
-          else raise GameError, "Unknown corporation group #{group_num}"
+          else true
           end
         end
 
@@ -394,6 +480,51 @@ module Engine
             Engine::Step::DiscardTrain,
             Engine::Step::BuyTrain,
           ], round_num: round_num)
+        end
+
+        private
+
+        def slc_route_bonus(corporation, routes)
+          return 0 unless SLC_CORPS.include?(corporation.id)
+          return 0 unless routes.any? { |r| r.visited_stops.any? { |s| s.hex.id == SLC_HEX } }
+
+          soc = company_by_id('SOC')
+          soc && !soc.closed? ? SLC_ROUTE_BONUS_SOC : SLC_ROUTE_BONUS
+        end
+
+        def golden_spike_event!
+          @log << '-- GOLDEN SPIKE! Transcontinental railroad complete --'
+          SLC_CORPS.each do |sym|
+            corp = corporation_by_id(sym)
+            next unless corp&.floated?
+
+            corp.share_holders.each do |entity, percent|
+              next unless entity.player?
+
+              bonus = (percent / 10) * GOLDEN_SPIKE_SHAREHOLDER_BONUS
+              @bank.spend(bonus, entity)
+              @log << "#{entity.name} receives #{format_currency(bonus)} Golden Spike bonus " \
+                      "(#{percent}% #{corp.name})"
+            end
+
+            @stock_market.move_up(corp)
+            @log << "#{corp.name} stock advances to #{format_currency(corp.share_price.price)}"
+          end
+        end
+
+        def would_activate?(bonus, routes, home)
+          bonus[:hexes].any? do |hex_id|
+            routes.any? do |route|
+              ids = route.visited_stops.map { |s| s.hex.id }
+              ids.include?(hex_id) && ids.include?(home)
+            end
+          end
+        end
+
+        def bonus_on_route?(bonus, routes)
+          bonus[:hexes].any? do |hex_id|
+            routes.any? { |r| r.visited_stops.any? { |s| s.hex.id == hex_id } }
+          end
         end
       end
     end

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -445,7 +445,7 @@ module Engine
           when 1 then all_privates_sold?
           when 2 then corp_groups[1].all? { |corp| corp.num_ipo_shares.zero? }
           when 3 then corp_groups[2].all?(&:floated?)
-          else true
+          else raise GameError, "Unknown corporation group #{group_num}"
           end
         end
 

--- a/lib/engine/game/g_1862_usa_canada/step/dividend.rb
+++ b/lib/engine/game/g_1862_usa_canada/step/dividend.rb
@@ -10,6 +10,8 @@ module Engine
           def process_dividend(action)
             entity = action.entity
             first_time = entity.operating_history.none? { |_, info| info.dividend.kind.to_sym == :payout }
+            @game.activate_new_bonuses!(entity, routes)
+            @game.check_golden_spike!(entity, routes)
             super
             @game.on_first_payout!(entity) if first_time && action.kind.to_sym == :payout
           end

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -182,6 +182,133 @@ module Engine
       end
     end
 
+    def stub_route(*hex_ids)
+      stops = hex_ids.map { |id| double('Stop', hex: double('Hex', id: id)) }
+      double('Route', visited_stops: stops)
+    end
+
+    describe 'bonus markers' do
+      let(:cp)  { game.corporation_by_id('CP') }
+      let(:nyc) { game.corporation_by_id('NYC') }
+
+      it 'initialises all bonus states to :unactivated' do
+        described_class::CORP_BONUSES.each do |sym, bonuses|
+          bonuses.each_index do |i|
+            expect(game.instance_variable_get(:@bonus_state)[[sym, i]]).to eq(:unactivated)
+          end
+        end
+      end
+
+      it 'corp_bonus_revenue returns 0 with empty routes' do
+        expect(game.corp_bonus_revenue(cp, [])).to eq(0)
+      end
+
+      it 'corp_bonus_revenue returns 0 for corp without CORP_BONUSES entry' do
+        expect(game.corp_bonus_revenue(nyc, [])).to eq(0)
+      end
+
+      it 'corp_bonus_revenue includes bonus when route visits home AND bonus hex' do
+        route = stub_route(cp.coordinates, 'E25')
+        expect(game.corp_bonus_revenue(cp, [route])).to eq(30)
+      end
+
+      it 'corp_bonus_revenue returns 0 when route misses home hex' do
+        route = stub_route('E25', 'F20')
+        expect(game.corp_bonus_revenue(cp, [route])).to eq(0)
+      end
+
+      it 'activate_new_bonuses! transitions state to :permanent' do
+        route = stub_route(cp.coordinates, 'E25')
+        game.activate_new_bonuses!(cp, [route])
+        expect(game.instance_variable_get(:@bonus_state)[['CP', 0]]).to eq(:permanent)
+      end
+
+      it 'permanent bonus applies without home hex on route' do
+        route = stub_route(cp.coordinates, 'E25')
+        game.activate_new_bonuses!(cp, [route])
+        route2 = stub_route('E25', 'F20')
+        expect(game.corp_bonus_revenue(cp, [route2])).to eq(30)
+      end
+
+      it 'activate_new_bonuses! is idempotent — does not re-activate' do
+        route = stub_route(cp.coordinates, 'E25')
+        game.activate_new_bonuses!(cp, [route])
+        game.activate_new_bonuses!(cp, [route])
+        expect(game.instance_variable_get(:@bonus_state)[['CP', 0]]).to eq(:permanent)
+      end
+    end
+
+    describe 'SLC transcontinental bonus + Golden Spike' do
+      let(:cpr) { game.corporation_by_id('CPR') }
+      let(:up)  { game.corporation_by_id('UP') }
+      let(:nyc) { game.corporation_by_id('NYC') }
+      let(:slc_hex) { described_class::SLC_HEX }
+      let(:soc) { game.companies.find { |c| c.sym == 'SOC' } }
+
+      it 'initialises @slc_connected as empty hash' do
+        expect(game.instance_variable_get(:@slc_connected)).to eq({})
+      end
+
+      it 'initialises @slc_bonus_paid as false' do
+        expect(game.instance_variable_get(:@slc_bonus_paid)).to be false
+      end
+
+      it 'SLC bonus is 0 for non-SLC corp' do
+        route = stub_route(slc_hex)
+        expect(game.send(:slc_route_bonus, nyc, [route])).to eq(0)
+      end
+
+      it 'SLC bonus is 0 when route does not visit SLC hex' do
+        route = stub_route('F14', 'K19')
+        expect(game.send(:slc_route_bonus, cpr, [route])).to eq(0)
+      end
+
+      it 'SLC bonus is 15 while SOC is open' do
+        route = stub_route(slc_hex)
+        expect(game.send(:slc_route_bonus, cpr, [route])).to eq(15)
+      end
+
+      it 'SLC bonus is 30 after SOC closes' do
+        soc.close!
+        route = stub_route(slc_hex)
+        expect(game.send(:slc_route_bonus, cpr, [route])).to eq(30)
+      end
+
+      it 'SLC bonus applies to UP as well' do
+        soc.close!
+        route = stub_route(slc_hex)
+        expect(game.send(:slc_route_bonus, up, [route])).to eq(30)
+      end
+
+      it 'check_golden_spike! marks CPR as connected' do
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        expect(game.instance_variable_get(:@slc_connected)['CPR']).to be true
+      end
+
+      it 'Golden Spike does not fire when only CPR connects' do
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        expect(game.instance_variable_get(:@slc_bonus_paid)).to be false
+      end
+
+      it 'Golden Spike fires when both CPR and UP connect' do
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        game.check_golden_spike!(up, [stub_route(slc_hex)])
+        expect(game.instance_variable_get(:@slc_bonus_paid)).to be true
+      end
+
+      it 'check_golden_spike! is idempotent for already-connected corp' do
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        log_size = game.log.size
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        expect(game.log.size).to eq(log_size)
+      end
+
+      it 'non-SLC corp does not mark connection' do
+        game.check_golden_spike!(nyc, [stub_route(slc_hex)])
+        expect(game.instance_variable_get(:@slc_connected)).to eq({})
+      end
+    end
+
     describe 'home token timing' do
       it 'uses :operate timing' do
         expect(described_class::HOME_TOKEN_TIMING).to eq(:operate)


### PR DESCRIPTION
Fixes # (part of ongoing 1862 USA & Canada implementation)

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Stacked on the merged pB PR (#12736). Adds:

- Corporation bonus markers (permanent route bonus / cash choice) with back-side icon flip on activation
- Salt Lake City (SLC) route bonus: +50 for the corp that lays the first yellow tile at G9, +30 for the other of CPR/UP
- Golden Spike event: fires when both CPR and UP connect to SLC, moves both stocks right one step simultaneously, closes the SOC (P7) private
- SOC (P7) revenue schedule: $35 while neither CPR nor UP is connected to SLC, drops to $15 once the first connects, closes on Golden Spike
- Stock boost: every permanent train purchased from the bank moves CPR/UP stock right one step
- Phase-gated tile-lay budget enforcement
- Restores the `raise` in `group_available?`'s unknown-group branch (a regression from this same commit's earlier draft)

### Screenshots

N/A (logic/backend change; bonus icon rendering was browser-verified per `MD/inwork.md`)

### Any Assumptions / Hacks

None.
