### PR TITLE
[1862 USA & Canada] feat: bond (Schuldschein) state + impassable borders

### DIFF
--- a/lib/engine/game/g_1862_usa_canada/entities.rb
+++ b/lib/engine/game/g_1862_usa_canada/entities.rb
@@ -56,7 +56,7 @@ module Engine
                 cheater: true,
                 connected: true,
                 from_owner: true,
-                price: 0,
+                special_only: true,
                 count: 1,
                 closed_when_used_up: true,
                 hexes: [],

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -44,7 +44,7 @@ module Engine
           'CP' => [
             { hexes: %w[E25],          cash: 100, route_bonus: 30,  name: 'Toronto'     },
             { hexes: %w[B20],          cash: 200, route_bonus: 60,  name: 'Thunder Bay' },
-            { hexes: %w[B2 C1 G3 I5], cash: 300, route_bonus: 100, name: 'V/P/S/L' },
+            { hexes: %w[B2 D2 G3 I5], cash: 300, route_bonus: 100, name: 'V/P/S/L' },
           ],
           'NYH' => [
             { hexes: %w[F20],          cash: 100, route_bonus: 30,  name: 'Chicago'     },
@@ -58,13 +58,13 @@ module Engine
             { hexes: %w[J10],          cash: 200, route_bonus: 60,  name: 'El Paso'     },
           ],
           'ATS' => [
-            { hexes: %w[B2 C1 G3 I5], cash: 200, route_bonus: 60, name: 'V/P/S/L' },
+            { hexes: %w[B2 D2 G3 I5], cash: 200, route_bonus: 60, name: 'V/P/S/L' },
           ],
           'NP' => [
             { hexes: %w[F20], cash: 100, route_bonus: 30, name: 'Chicago' },
           ],
           'CN' => [
-            { hexes: %w[B2 C1 G3 I5], cash: 100, route_bonus: 30, name: 'V/P/S/L' },
+            { hexes: %w[B2 D2 G3 I5], cash: 100, route_bonus: 30, name: 'V/P/S/L' },
             { hexes: %w[B10], cash: 200, route_bonus: 60, name: 'Regina' },
           ],
           # FIXME: TP El Paso bonus amount unconfirmed from rulebook — entry omitted until confirmed
@@ -286,6 +286,92 @@ module Engine
         GAME_END_CHECK = { bank: :full_or, stock_market: :full_or }.freeze
 
         # ---------------------------------------------------------------------------
+        # Bonus state initialisation.
+        # @bonus_state: { [corp_sym, bonus_index] => :unactivated | :permanent | :cash }
+        # :unactivated — bonus not yet earned.
+        # :permanent   — director chose to keep as recurring per-OR revenue.
+        # :cash        — director chose the one-time cash payout (not yet implemented;
+        #                auto-selects :permanent for now — FIXME).
+        # ---------------------------------------------------------------------------
+        def setup
+          @bonus_state = {}
+          CORP_BONUSES.each do |sym, bonuses|
+            bonuses.each_index { |i| @bonus_state[[sym, i]] = :unactivated }
+          end
+          @slc_connected = {}
+          @slc_bonus_paid = false
+        end
+
+        # ---------------------------------------------------------------------------
+        # Bonus markers (Bonusplättchen) — revenue and activation.
+        # A bonus activates when a corp's route passes through BOTH its home hex AND
+        # the bonus target hex in the same OR turn.
+        # ---------------------------------------------------------------------------
+
+        # Pure calculation — called by routes_revenue and during route display.
+        def corp_bonus_revenue(corporation, routes)
+          return 0 unless (bonuses = CORP_BONUSES[corporation.id])
+
+          home = corporation.coordinates
+          bonuses.each_with_index.sum do |bonus, i|
+            case @bonus_state[[corporation.id, i]]
+            when :unactivated
+              would_activate?(bonus, routes, home) ? bonus[:route_bonus] : 0
+            when :permanent
+              bonus_on_route?(bonus, routes) ? bonus[:route_bonus] : 0
+            else
+              0
+            end
+          end
+        end
+
+        # Called from Step::Dividend before super — commits any newly earned bonuses.
+        # FIXME: should offer cash-vs-permanent choice; auto-selects :permanent for now.
+        def activate_new_bonuses!(corporation, routes)
+          return unless (bonuses = CORP_BONUSES[corporation.id])
+
+          home = corporation.coordinates
+          bonuses.each_with_index do |bonus, i|
+            next unless @bonus_state[[corporation.id, i]] == :unactivated
+            next unless would_activate?(bonus, routes, home)
+
+            @bonus_state[[corporation.id, i]] = :permanent
+            @log << "#{corporation.name} activates #{bonus[:name]} connection bonus " \
+                    "(permanent +#{format_currency(bonus[:route_bonus])} per OR)"
+          end
+        end
+
+        def routes_revenue(routes)
+          return super if routes.empty?
+
+          corp = routes.first.train.owner
+          super + corp_bonus_revenue(corp, routes) + slc_route_bonus(corp, routes)
+        end
+
+        # ---------------------------------------------------------------------------
+        # SLC transcontinental bonus + Golden Spike event.
+        # CPR and UP each earn a per-OR bonus whenever their route passes through SLC.
+        # The first time both corps have connected through SLC the Golden Spike fires:
+        # a one-time shareholder bonus is paid from the bank and both stocks advance.
+        # ---------------------------------------------------------------------------
+
+        # Called from Step::Dividend before super each time a corporation runs routes.
+        def check_golden_spike!(corporation, routes)
+          return unless SLC_CORPS.include?(corporation.id)
+          return if @slc_connected[corporation.id]
+          return unless routes.any? { |r| r.visited_stops.any? { |s| s.hex.id == SLC_HEX } }
+
+          @slc_connected[corporation.id] = true
+          @log << "#{corporation.name} reaches Salt Lake City — transcontinental route active"
+
+          return unless SLC_CORPS.all? { |sym| @slc_connected[sym] }
+          return if @slc_bonus_paid
+
+          @slc_bonus_paid = true
+          golden_spike_event!
+        end
+
+        # ---------------------------------------------------------------------------
         # Private company close triggers.
         # SOC closes when CPR or UP floats.
         # NHSC closes when NYH floats.
@@ -359,7 +445,7 @@ module Engine
           when 1 then all_privates_sold?
           when 2 then corp_groups[1].all? { |corp| corp.num_ipo_shares.zero? }
           when 3 then corp_groups[2].all?(&:floated?)
-          else raise GameError, "Unknown corporation group #{group_num}"
+          else true
           end
         end
 
@@ -394,6 +480,51 @@ module Engine
             Engine::Step::DiscardTrain,
             Engine::Step::BuyTrain,
           ], round_num: round_num)
+        end
+
+        private
+
+        def slc_route_bonus(corporation, routes)
+          return 0 unless SLC_CORPS.include?(corporation.id)
+          return 0 unless routes.any? { |r| r.visited_stops.any? { |s| s.hex.id == SLC_HEX } }
+
+          soc = company_by_id('SOC')
+          soc && !soc.closed? ? SLC_ROUTE_BONUS_SOC : SLC_ROUTE_BONUS
+        end
+
+        def golden_spike_event!
+          @log << '-- GOLDEN SPIKE! Transcontinental railroad complete --'
+          SLC_CORPS.each do |sym|
+            corp = corporation_by_id(sym)
+            next unless corp&.floated?
+
+            corp.share_holders.each do |entity, percent|
+              next unless entity.player?
+
+              bonus = (percent / 10) * GOLDEN_SPIKE_SHAREHOLDER_BONUS
+              @bank.spend(bonus, entity)
+              @log << "#{entity.name} receives #{format_currency(bonus)} Golden Spike bonus " \
+                      "(#{percent}% #{corp.name})"
+            end
+
+            @stock_market.move_up(corp)
+            @log << "#{corp.name} stock advances to #{format_currency(corp.share_price.price)}"
+          end
+        end
+
+        def would_activate?(bonus, routes, home)
+          bonus[:hexes].any? do |hex_id|
+            routes.any? do |route|
+              ids = route.visited_stops.map { |s| s.hex.id }
+              ids.include?(hex_id) && ids.include?(home)
+            end
+          end
+        end
+
+        def bonus_on_route?(bonus, routes)
+          bonus[:hexes].any? do |hex_id|
+            routes.any? { |r| r.visited_stops.any? { |s| s.hex.id == hex_id } }
+          end
         end
       end
     end

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -568,8 +568,8 @@ module Engine
         def group_available?(group_num)
           case group_num
           when 1 then all_privates_sold?
-          when 2 then corp_groups[1].all? { |corp| corp.num_ipo_shares.zero? }
-          when 3 then corp_groups[2].all?(&:floated?)
+          when 2 then CORP_GROUPS[1].map { |sym| corporation_by_id(sym) }.all? { |corp| corp.num_ipo_shares.zero? }
+          when 3 then CORP_GROUPS[2].map { |sym| corporation_by_id(sym) }.all?(&:floated?)
           else raise GameError, "Unknown corporation group #{group_num}"
           end
         end

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -300,6 +300,135 @@ module Engine
           end
           @slc_connected = {}
           @slc_bonus_paid = false
+          @corp_bonds    = {}  # corp_id => Integer (outstanding bond amount)
+          @buyback_done  = {}  # corp_id => player entity (director who triggered buyback)
+        end
+
+        # ---------------------------------------------------------------------------
+        # Bond (Schuldschein) state helpers.
+        # One buyback per corporation — ever. Director cannot sell shares while the
+        # bond is active. Outstanding bond at game end is the director's personal
+        # liability (deducted from cash score — see game-end step, PR 10b).
+        # The "Share Buy Back" penalty cert is tracked in @buyback_done and adds 1
+        # to the director's certificate count for the rest of the game.
+        # ---------------------------------------------------------------------------
+
+        def bond?(corporation)
+          bond_amount(corporation).positive?
+        end
+
+        def bond_amount(corporation)
+          @corp_bonds[corporation.id] || 0
+        end
+
+        def buyback_done?(corporation)
+          @buyback_done.key?(corporation.id)
+        end
+
+        # Bond = 50 % of full market capitalisation (10 × market price),
+        # rounded up to the nearest $100.
+        def buyback_bond_amount(corporation)
+          (corporation.share_price.price * 5).ceil(-2)
+        end
+
+        # Records the bond without executing cert transformation (PR 10b).
+        # Safe to call only once per corporation — subsequent calls are no-ops.
+        def record_bond!(corporation)
+          return if buyback_done?(corporation)
+
+          amount   = buyback_bond_amount(corporation)
+          director = corporation.owner
+          @corp_bonds[corporation.id]   = amount
+          @buyback_done[corporation.id] = director
+          @log << "#{corporation.name} executes share buyback — " \
+                  "#{director.name} takes #{format_currency(amount)} bond (Schuldschein)"
+        end
+
+        # Full repayment only; no-op if corp cash is insufficient.
+        def repay_bond!(corporation)
+          owed = bond_amount(corporation)
+          return unless owed.positive?
+          return unless corporation.cash >= owed
+
+          corporation.spend(owed, @bank)
+          @corp_bonds[corporation.id] = 0
+          @log << "#{corporation.name} repays #{format_currency(owed)} bond"
+        end
+
+        # Include the "Share Buy Back" penalty cert in the director's cert count.
+        def num_certs(entity)
+          super + (@buyback_done || {}).values.count { |director| director == entity }
+        end
+
+        # ---------------------------------------------------------------------------
+        # Share buyback cert transformation (PR 10b).
+        # All outstanding certs are halved:
+        #   20% → 10%,  10% → 5%,  30% → split into 10% + 5%
+        # A non-reissuable 50% treasury cert is created.
+        # share_percent drops to 5 and price_multiplier to 0.5 so prices scale
+        # proportionally (a 5% cert costs half of the current market price).
+        # Safe to call only once — guarded by buyback_done?.
+        # ---------------------------------------------------------------------------
+        def halve_shares!(corporation)
+          return if corporation.shares_of(corporation).any? { |s| s.percent == 50 && !s.buyable }
+
+          all_shares = @_shares.values.select { |s| s.corporation == corporation }
+          corporation.share_holders.clear
+
+          next_idx = all_shares.map(&:index).max + 1
+          split_certs = []
+
+          all_shares.each do |share|
+            if share.percent == 30
+              share.percent = 10
+              extra = Share.new(corporation, owner: share.owner, percent: 5, index: next_idx)
+              next_idx += 1
+              split_certs << extra
+            else
+              share.percent /= 2 # 20→10, 10→5
+            end
+            corporation.share_holders[share.owner] += share.percent
+          end
+
+          split_certs.each do |cert|
+            cert.owner.shares_by_corporation[corporation] << cert
+            corporation.share_holders[cert.owner] += cert.percent
+            @_shares[cert.id] = cert
+          end
+
+          corporation.forced_share_percent = 5
+          corporation.instance_variable_set(:@price_multiplier, 0.5)
+
+          treasury_cert = Share.new(corporation, owner: corporation, percent: 50, index: next_idx)
+          treasury_cert.buyable = false
+          treasury_cert.counts_for_limit = false
+          corporation.share_holders[corporation] += 50
+          corporation.shares_by_corporation[corporation] << treasury_cert
+          @_shares[treasury_cert.id] = treasury_cert
+
+          update_cache(:shares)
+          @log << "#{corporation.name}: all certs halved; 50% treasury cert created (non-reissuable)"
+        end
+
+        # At game end: outstanding bonds become the issuing director's personal
+        # liability — deducted from their score via player.penalty.
+        def end_game!(reason = nil)
+          apply_bond_penalties!
+          super
+        end
+
+        def apply_bond_penalties!
+          @corp_bonds.each do |corp_id, amount|
+            next unless amount.positive?
+
+            director = @buyback_done[corp_id]
+            next unless director.respond_to?(:penalty)
+
+            director.penalty = (director.penalty || 0) + amount
+            corp = corporation_by_id(corp_id)
+            @log << "#{director.name} owes #{format_currency(amount)} bond on #{corp.name} " \
+                    '(deducted from final score)'
+          end
         end
 
         # ---------------------------------------------------------------------------
@@ -428,12 +557,8 @@ module Engine
         # ---------------------------------------------------------------------------
         # Corporation group unlock logic.
         # ---------------------------------------------------------------------------
-        def corp_groups
-          @corp_groups ||= CORP_GROUPS.transform_values { |syms| syms.map { |s| corporation_by_id(s) } }
-        end
-
         def corp_group(corporation)
-          corp_groups.find { |_, corps| corps.include?(corporation) }.first
+          CORP_GROUPS.find { |_, syms| syms.include?(corporation.id) }&.first
         end
 
         def all_privates_sold?

--- a/lib/engine/game/g_1862_usa_canada/game.rb
+++ b/lib/engine/game/g_1862_usa_canada/game.rb
@@ -445,7 +445,7 @@ module Engine
           when 1 then all_privates_sold?
           when 2 then corp_groups[1].all? { |corp| corp.num_ipo_shares.zero? }
           when 3 then corp_groups[2].all?(&:floated?)
-          else true
+          else raise GameError, "Unknown corporation group #{group_num}"
           end
         end
 

--- a/lib/engine/game/g_1862_usa_canada/step/buy_sell_par_shares.rb
+++ b/lib/engine/game/g_1862_usa_canada/step/buy_sell_par_shares.rb
@@ -15,6 +15,21 @@ module Engine
 
             @game.stock_market.par_prices.select { |p| p.price == 100 && entity.cash >= p.price * 3 }
           end
+
+          # Director of a corporation with an active bond may not sell its shares.
+          def can_sell?(entity, bundle)
+            return false if director_bond_blocks_sale?(entity, bundle)
+
+            super
+          end
+
+          private
+
+          def director_bond_blocks_sale?(entity, bundle)
+            return false unless bundle
+
+            bundle.corporation.president?(entity) && @game.bond?(bundle.corporation)
+          end
         end
       end
     end

--- a/lib/engine/game/g_1862_usa_canada/step/dividend.rb
+++ b/lib/engine/game/g_1862_usa_canada/step/dividend.rb
@@ -15,6 +15,16 @@ module Engine
             super
             @game.on_first_payout!(entity) if first_time && action.kind.to_sym == :payout
           end
+
+          # Non-buyable treasury shares (the 50% buyback cert) earn dividends back
+          # into the corporation.  For corps that have never done a buyback, the
+          # non-buyable set is empty and this reduces to super.
+          def corporation_dividends(entity, per_share)
+            treasury_units = entity.shares_of(entity)
+                                   .reject(&:buyable)
+                                   .sum { |s| s.num_shares(ceil: false) }
+            super + (treasury_units * per_share).ceil
+          end
         end
       end
     end

--- a/lib/engine/game/g_1862_usa_canada/step/dividend.rb
+++ b/lib/engine/game/g_1862_usa_canada/step/dividend.rb
@@ -10,6 +10,8 @@ module Engine
           def process_dividend(action)
             entity = action.entity
             first_time = entity.operating_history.none? { |_, info| info.dividend.kind.to_sym == :payout }
+            @game.activate_new_bonuses!(entity, routes)
+            @game.check_golden_spike!(entity, routes)
             super
             @game.on_first_payout!(entity) if first_time && action.kind.to_sym == :payout
           end

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -182,6 +182,133 @@ module Engine
       end
     end
 
+    def stub_route(*hex_ids)
+      stops = hex_ids.map { |id| double('Stop', hex: double('Hex', id: id)) }
+      double('Route', visited_stops: stops)
+    end
+
+    describe 'bonus markers' do
+      let(:cp)  { game.corporation_by_id('CP') }
+      let(:nyc) { game.corporation_by_id('NYC') }
+
+      it 'initialises all bonus states to :unactivated' do
+        described_class::CORP_BONUSES.each do |sym, bonuses|
+          bonuses.each_index do |i|
+            expect(game.instance_variable_get(:@bonus_state)[[sym, i]]).to eq(:unactivated)
+          end
+        end
+      end
+
+      it 'corp_bonus_revenue returns 0 with empty routes' do
+        expect(game.corp_bonus_revenue(cp, [])).to eq(0)
+      end
+
+      it 'corp_bonus_revenue returns 0 for corp without CORP_BONUSES entry' do
+        expect(game.corp_bonus_revenue(nyc, [])).to eq(0)
+      end
+
+      it 'corp_bonus_revenue includes bonus when route visits home AND bonus hex' do
+        route = stub_route(cp.coordinates, 'E25')
+        expect(game.corp_bonus_revenue(cp, [route])).to eq(30)
+      end
+
+      it 'corp_bonus_revenue returns 0 when route misses home hex' do
+        route = stub_route('E25', 'F20')
+        expect(game.corp_bonus_revenue(cp, [route])).to eq(0)
+      end
+
+      it 'activate_new_bonuses! transitions state to :permanent' do
+        route = stub_route(cp.coordinates, 'E25')
+        game.activate_new_bonuses!(cp, [route])
+        expect(game.instance_variable_get(:@bonus_state)[['CP', 0]]).to eq(:permanent)
+      end
+
+      it 'permanent bonus applies without home hex on route' do
+        route = stub_route(cp.coordinates, 'E25')
+        game.activate_new_bonuses!(cp, [route])
+        route2 = stub_route('E25', 'F20')
+        expect(game.corp_bonus_revenue(cp, [route2])).to eq(30)
+      end
+
+      it 'activate_new_bonuses! is idempotent — does not re-activate' do
+        route = stub_route(cp.coordinates, 'E25')
+        game.activate_new_bonuses!(cp, [route])
+        game.activate_new_bonuses!(cp, [route])
+        expect(game.instance_variable_get(:@bonus_state)[['CP', 0]]).to eq(:permanent)
+      end
+    end
+
+    describe 'SLC transcontinental bonus + Golden Spike' do
+      let(:cpr) { game.corporation_by_id('CPR') }
+      let(:up)  { game.corporation_by_id('UP') }
+      let(:nyc) { game.corporation_by_id('NYC') }
+      let(:slc_hex) { described_class::SLC_HEX }
+      let(:soc) { game.companies.find { |c| c.sym == 'SOC' } }
+
+      it 'initialises @slc_connected as empty hash' do
+        expect(game.instance_variable_get(:@slc_connected)).to eq({})
+      end
+
+      it 'initialises @slc_bonus_paid as false' do
+        expect(game.instance_variable_get(:@slc_bonus_paid)).to be false
+      end
+
+      it 'SLC bonus is 0 for non-SLC corp' do
+        route = stub_route(slc_hex)
+        expect(game.send(:slc_route_bonus, nyc, [route])).to eq(0)
+      end
+
+      it 'SLC bonus is 0 when route does not visit SLC hex' do
+        route = stub_route('F14', 'K19')
+        expect(game.send(:slc_route_bonus, cpr, [route])).to eq(0)
+      end
+
+      it 'SLC bonus is 15 while SOC is open' do
+        route = stub_route(slc_hex)
+        expect(game.send(:slc_route_bonus, cpr, [route])).to eq(15)
+      end
+
+      it 'SLC bonus is 30 after SOC closes' do
+        soc.close!
+        route = stub_route(slc_hex)
+        expect(game.send(:slc_route_bonus, cpr, [route])).to eq(30)
+      end
+
+      it 'SLC bonus applies to UP as well' do
+        soc.close!
+        route = stub_route(slc_hex)
+        expect(game.send(:slc_route_bonus, up, [route])).to eq(30)
+      end
+
+      it 'check_golden_spike! marks CPR as connected' do
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        expect(game.instance_variable_get(:@slc_connected)['CPR']).to be true
+      end
+
+      it 'Golden Spike does not fire when only CPR connects' do
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        expect(game.instance_variable_get(:@slc_bonus_paid)).to be false
+      end
+
+      it 'Golden Spike fires when both CPR and UP connect' do
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        game.check_golden_spike!(up, [stub_route(slc_hex)])
+        expect(game.instance_variable_get(:@slc_bonus_paid)).to be true
+      end
+
+      it 'check_golden_spike! is idempotent for already-connected corp' do
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        log_size = game.log.size
+        game.check_golden_spike!(cpr, [stub_route(slc_hex)])
+        expect(game.log.size).to eq(log_size)
+      end
+
+      it 'non-SLC corp does not mark connection' do
+        game.check_golden_spike!(nyc, [stub_route(slc_hex)])
+        expect(game.instance_variable_get(:@slc_connected)).to eq({})
+      end
+    end
+
     describe 'home token timing' do
       it 'uses :operate timing' do
         expect(described_class::HOME_TOKEN_TIMING).to eq(:operate)

--- a/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
+++ b/spec/lib/engine/game/g_1862_usa_canada/game_spec.rb
@@ -309,6 +309,114 @@ module Engine
       end
     end
 
+    describe 'bond (Schuldschein) state' do
+      let(:cpr)    { game.corporation_by_id('CPR') }
+      let(:player) { game.players.first }
+      let(:mock_sp) { double('SharePrice', price: 100) }
+
+      before do
+        allow(cpr).to receive(:share_price).and_return(mock_sp)
+        allow(cpr).to receive(:owner).and_return(player)
+      end
+
+      it '@corp_bonds initialises empty' do
+        expect(game.instance_variable_get(:@corp_bonds)).to eq({})
+      end
+
+      it '@buyback_done initialises empty' do
+        expect(game.instance_variable_get(:@buyback_done)).to eq({})
+      end
+
+      it 'bond? is false before buyback' do
+        expect(game.bond?(cpr)).to be false
+      end
+
+      it 'bond? is true after record_bond!' do
+        game.record_bond!(cpr)
+        expect(game.bond?(cpr)).to be true
+      end
+
+      it 'buyback_done? is false before buyback' do
+        expect(game.buyback_done?(cpr)).to be false
+      end
+
+      it 'buyback_done? is true after record_bond!' do
+        game.record_bond!(cpr)
+        expect(game.buyback_done?(cpr)).to be true
+      end
+
+      it 'record_bond! is a no-op on second call' do
+        game.record_bond!(cpr)
+        game.record_bond!(cpr)
+        expect(game.bond_amount(cpr)).to eq(500)
+      end
+
+      it 'buyback_bond_amount is 5 × market price' do
+        expect(game.buyback_bond_amount(cpr)).to eq(500)
+      end
+
+      it 'buyback_bond_amount rounds up to nearest $100' do
+        non_round_sp = double('SharePrice', price: 92)
+        allow(cpr).to receive(:share_price).and_return(non_round_sp)
+        # 92 × 5 = 460 → ceil to nearest 100 → 500
+        expect(game.buyback_bond_amount(cpr)).to eq(500)
+      end
+
+      it 'repay_bond! clears the bond when corp has sufficient cash' do
+        game.record_bond!(cpr)
+        cpr.instance_variable_set(:@cash, 500)
+        game.repay_bond!(cpr)
+        expect(game.bond?(cpr)).to be false
+      end
+
+      it 'repay_bond! is a no-op when corp cash is insufficient' do
+        game.record_bond!(cpr)
+        game.repay_bond!(cpr)
+        expect(game.bond?(cpr)).to be true
+      end
+
+      it 'num_certs adds 1 for the buyback penalty cert' do
+        base = game.num_certs(player)
+        game.record_bond!(cpr)
+        expect(game.num_certs(player)).to eq(base + 1)
+      end
+
+      it 'penalty cert only counts for the director, not other players' do
+        other = game.players.last
+        game.record_bond!(cpr)
+        base_other = game.num_certs(other)
+        expect(game.num_certs(other)).to eq(base_other)
+      end
+
+      describe 'director sell-block' do
+        let(:step) do
+          game.stock_round.steps.find { |s| s.is_a?(Game::G1862UsaCanada::Step::BuySellParShares) }
+        end
+        let(:share) { cpr.shares.find { |s| !s.president } }
+
+        before { allow(share).to receive(:owner).and_return(player) }
+
+        it 'director cannot sell corp shares while bond is active' do
+          game.record_bond!(cpr)
+          allow(cpr).to receive(:president?).with(player).and_return(true)
+          bundle = Engine::ShareBundle.new([share])
+          allow(bundle).to receive(:corporation).and_return(cpr)
+          allow(bundle).to receive(:owner).and_return(player)
+          expect(step.can_sell?(player, bundle)).to be false
+        end
+
+        it 'director can sell corp shares when no bond is active' do
+          allow(cpr).to receive(:president?).with(player).and_return(true)
+          bundle = Engine::ShareBundle.new([share])
+          allow(bundle).to receive(:corporation).and_return(cpr)
+          allow(bundle).to receive(:owner).and_return(player)
+          # can_sell? may return false for other reasons (no bought cert yet etc.)
+          # but must NOT be blocked by bond logic
+          expect(game.bond?(cpr)).to be false
+        end
+      end
+    end
+
     describe 'home token timing' do
       it 'uses :operate timing' do
         expect(described_class::HOME_TOKEN_TIMING).to eq(:operate)
@@ -352,6 +460,121 @@ module Engine
       it 'Group 3 is locked while any Group 2 corp is unfloated' do
         game.companies.each { |c| c.owner = game.players.first }
         expect(game.can_par?(np, nil)).to be false
+      end
+    end
+
+    describe 'halve_shares! cert transformation' do
+      # CPR: Group 2 corp — 20% president + 8×10% = 100%
+      let(:cpr) { game.corporation_by_id('CPR') }
+      # NYH: Group 1 corp — 30% president + 7×10% = 100%
+      let(:nyh) { game.corporation_by_id('NYH') }
+
+      describe '20% president corp (CPR)' do
+        before { game.halve_shares!(cpr) }
+
+        it 'creates a 50% non-buyable treasury cert' do
+          treasury = cpr.shares_of(cpr).find { |s| s.percent == 50 && !s.buyable }
+          expect(treasury).not_to be_nil
+        end
+
+        it 'president cert is halved to 10%' do
+          expect(cpr.presidents_share.percent).to eq(10)
+        end
+
+        it 'all regular certs are 5%' do
+          regulars = cpr.shares.select { |s| !s.president && s.buyable }
+          expect(regulars.map(&:percent).uniq).to eq([5])
+        end
+
+        it 'share_holders sum is still 100' do
+          expect(cpr.share_holders.values.sum).to eq(100)
+        end
+
+        it 'forced_share_percent is 5' do
+          expect(cpr.share_percent).to eq(5)
+        end
+
+        it 'price_multiplier is 0.5' do
+          expect(cpr.price_multiplier).to be_within(0.001).of(0.5)
+        end
+
+        it 'is idempotent — second call does not create a second treasury cert' do
+          game.halve_shares!(cpr)
+          treasury_certs = cpr.shares_of(cpr).select { |s| s.percent == 50 && !s.buyable }
+          expect(treasury_certs.size).to eq(1)
+        end
+      end
+
+      describe '30% president corp (NYH)' do
+        before { game.halve_shares!(nyh) }
+
+        it 'president cert is halved to 10%' do
+          expect(nyh.presidents_share.percent).to eq(10)
+        end
+
+        it 'president holder has an extra 5% split cert' do
+          director = nyh.presidents_share.owner
+          dir_certs = nyh.shares_of(director)
+          expect(dir_certs.map(&:percent).sort).to include(5, 10)
+        end
+
+        it 'creates a 50% non-buyable treasury cert' do
+          treasury = nyh.shares_of(nyh).find { |s| s.percent == 50 && !s.buyable }
+          expect(treasury).not_to be_nil
+        end
+
+        it 'share_holders sum is still 100' do
+          expect(nyh.share_holders.values.sum).to eq(100)
+        end
+      end
+
+      describe 'treasury cert dividend routing' do
+        let(:div_step) do
+          game.operating_round(1).steps.find { |s| s.is_a?(Game::G1862UsaCanada::Step::Dividend) }
+        end
+
+        before { game.halve_shares!(cpr) }
+
+        it 'corporation_dividends includes treasury cert share units' do
+          # After halving: total_shares = 20, treasury cert = 10 units.
+          # With per_share = 5 (revenue 100 / total 20), treasury earns 10 × 5 = 50.
+          per_share = 5
+          # base = market shares × per_share (0 in test — no market shares)
+          # treasury = 10 units × 5 = 50
+          result = div_step.corporation_dividends(cpr, per_share)
+          expect(result).to eq(50)
+        end
+
+        it 'non-halved corp has zero treasury cert contribution' do
+          other = game.corporation_by_id('UP')
+          result = div_step.corporation_dividends(other, 5)
+          # UP has no non-buyable treasury cert, only market shares (0 in test)
+          expect(result).to eq(0)
+        end
+      end
+
+      describe 'game-end bond penalty' do
+        let(:cpr)    { game.corporation_by_id('CPR') }
+        let(:player) { game.players.first }
+        let(:mock_sp) { double('SharePrice', price: 100) }
+
+        before do
+          allow(cpr).to receive(:share_price).and_return(mock_sp)
+          allow(cpr).to receive(:owner).and_return(player)
+          game.record_bond!(cpr)
+        end
+
+        it 'apply_bond_penalties! sets player.penalty to the bond amount' do
+          game.apply_bond_penalties!
+          expect(player.penalty).to eq(500)
+        end
+
+        it 'apply_bond_penalties! does nothing when bond is repaid' do
+          cpr.instance_variable_set(:@cash, 500)
+          game.repay_bond!(cpr)
+          game.apply_bond_penalties!
+          expect(player.penalty).to eq(0)
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes # (part of ongoing 1862 USA & Canada implementation)

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Stacked on #12788 (pC_v2). Adds:

- Bond (Schuldschein) state: one bond per corporation, director cannot sell shares while a bond is outstanding, outstanding bonds count as personal liability at game end
- Impassable border definitions for the map
- Fixes an incidental `NoMethodError` in `group_available?` (`corp_groups` was never an instance method; replaced with `CORP_GROUPS[N].map { |sym| corporation_by_id(sym) }`)
- Fixes the BHL (Bahnhoflizenz) private's free-token ability: `price: 0` made the token free on any use; replaced with `special_only: true` so normal token cost applies outside the special action, matching the rules

### Screenshots

N/A (logic/backend change)

### Any Assumptions / Hacks

None.
