### PR TITLE
[core] Add a /game/next route and add it to each game's tab bar

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -187,12 +187,19 @@ class Api < Roda
       render(titles: titles)
     end
 
-    r.on 'game', Integer do |id|
-      halt(404, 'Game not found') unless (game = Game[id])
+    r.on 'game' do
+      r.get 'next' do
+        game = Game.next_for_user(user)
+        r.redirect(game ? "/game/#{game.id}" : '/')
+      end
 
-      pin = game.settings['pin']
-      render(titles: [game.title], pin: pin,
-             game_data: pin ? game.to_h(include_actions: true, logged_in_user_id: user&.id) : game.to_h)
+      r.get Integer do |id|
+        halt(404, 'Game not found') unless (game = Game[id])
+
+        pin = game.settings['pin']
+        render(titles: [game.title], pin: pin,
+               game_data: pin ? game.to_h(include_actions: true, logged_in_user_id: user&.id) : game.to_h)
+      end
     end
 
     r.on 'issues', String do |str|

--- a/assets/app/view/game_page.rb
+++ b/assets/app/view/game_page.rb
@@ -278,6 +278,8 @@ module View
           change_anchor('#tools')
         when 'a'
           change_anchor('#auto')
+        when 'n'
+          next_game
         when '1'
           button_click('pass')
         when '2'
@@ -358,25 +360,34 @@ module View
       }
 
       note = !@game_data.dig('user_settings', 'notepad').to_s.empty?
-      menu_items = []
-      menu_items << item('G|ame', '')
-      menu_items << item('E|ntities', '#entities')
-      menu_items << item('M|ap', '#map') unless @game.layout == :none
-      menu_items << item('Mark|et', '#market')
-      menu_items << item('I|nfo', '#info')
-      menu_items << item('T|iles', '#tiles') unless @game.layout == :none
-      menu_items << item('S|preadsheet', '#spreadsheet')
-      menu_items << item("To|ols#{' 📝' if note}", '#tools')
+      left_menu_items = []
+      left_menu_items << item('G|ame', '')
+      left_menu_items << item('E|ntities', '#entities')
+      left_menu_items << item('M|ap', '#map') unless @game.layout == :none
+      left_menu_items << item('Mark|et', '#market')
+      left_menu_items << item('I|nfo', '#info')
+      left_menu_items << item('T|iles', '#tiles') unless @game.layout == :none
+      left_menu_items << item('S|preadsheet', '#spreadsheet')
+      left_menu_items << item("To|ols#{' 📝' if note}", '#tools')
 
       enabled = !@game.programmed_actions[@game.player_by_id(@user['id'])].empty? if @user
-      menu_items << item("A|uto#{' ✅' if enabled}", '#auto') if @game_data[:mode] != :hotseat && !cursor
+      left_menu_items << item("A|uto#{' ✅' if enabled}", '#auto') if @game_data[:mode] != :hotseat && !cursor
+      right_menu_items = [item('N|ext game →', '/game/next', route: true)]
 
       h('nav#game_menu', nav_props, [
-        h('ul.no_margin.no_padding', { style: { width: 'max-content' } }, menu_items),
+        h(:div, { style: { display: 'flex', minWidth: '100%', whiteSpace: 'nowrap', width: 'max-content' } }, [
+          h('ul.no_margin.no_padding', { style: { display: 'flex', width: 'max-content' } }, left_menu_items),
+          h('ul.no_margin.no_padding', { style: { display: 'flex', marginLeft: 'auto', width: 'max-content' } },
+            right_menu_items),
+        ]),
       ])
     end
 
-    def item(name, anchor)
+    def next_game
+      `window.location = '/game/next'`
+    end
+
+    def item(name, anchor, route: false)
       name = name.split(/(\|)/).each_slice(2).flat_map do |text, pipe|
         if pipe
           head = text[0..-2]
@@ -390,14 +401,13 @@ module View
       a_props = {
         attrs: {
           href: anchor,
-          onclick: 'return false',
         },
-        style: { textDecoration: route_anchor == anchor[1..-1] ? 'underline' : 'none' },
-        on: { click: ->(_event) { change_anchor(anchor) } },
+        style: { textDecoration: !route && route_anchor == anchor[1..-1] ? 'underline' : 'none' },
       }
+      a_props[:attrs][:onclick] = 'return false' unless route
+      a_props[:on] = { click: ->(_event) { change_anchor(anchor) } } unless route
       li_props = {
         style: {
-          float: 'left',
           margin: '0 0.5rem',
           listStyle: 'none',
         },

--- a/models/game.rb
+++ b/models/game.rb
@@ -129,6 +129,17 @@ class Game < Base
     end
   end
 
+  def self.next_for_user(user)
+    return unless user
+
+    where(status: 'active')
+      .where(Sequel.lit('acting @> ARRAY[?]::integer[]', user.id))
+      .all
+      .filter_map { |game| next_for_user_candidate(game) }
+      .min_by { |candidate| [candidate[:waiting_since], candidate[:game].id] }
+      &.fetch(:game)
+  end
+
   def self.to_h_safe(games)
     games.filter_map do |game|
       game.to_h
@@ -136,6 +147,18 @@ class Game < Base
       warn "Skipping unloadable game #{game.id}: #{e}"
       nil
     end
+  end
+
+  def self.next_for_user_candidate(game)
+    engine = Engine::Game.load(game)
+    turn_start_action_id = engine.turn_start_action_id
+    waiting_since =
+      (Action.where(game_id: game.id, action_id: turn_start_action_id).get(:created_at) if turn_start_action_id&.positive?)
+
+    { game: game, waiting_since: waiting_since || game.updated_at || game.created_at }
+  rescue StandardError => e
+    warn "Skipping unloadable game #{game.id}: #{e}"
+    nil
   end
 
   SETTINGS = %w[


### PR DESCRIPTION
Fixes #12066 

<!--

Your PR title should start with a tag showing the affected 18xx title or titles,
e.g., "[1889] use fancy logos".

Please minimize the amount of changes to shared `lib/engine` code, if
possible. If you are changing any shared code there, please include "[core]" at
the start of your PR title.

If your changes affect the developer/maintainer experience but are not end-user
facing, please inclue a "[dev]" tag.

If you are implementing a new game, please break up the changes into multiple
PRs for ease of review.

-->

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

I think the most important thing worth eyballing here is the styling and logic of the left and right tab bar. Previously everything was aligned left, which was simpler, but now the game menu items are split between the left menu items (which contains everything that existed already) and the right menu items (which currently only has the next game action). The gap is maintained between them except on mobile where the gap is collapsed.

It's still a relatively simple implementation, I think, but there is potential for CSS issues to pop up.

Original Slack thread discussion is [here](https://18xxgames.slack.com/archives/C012K0CNY5C/p1783035921130179).

### Explanation of Change

1. Adds a `/game/next` route that always take the user to whatever game has been waiting on them the longest.
2. Adds this link to the menu bar on each game, with a hotkey <kbd>n</kbd>, to quickly jump from game to game.
3. If there are no games waiting on the user, the route sends them to the home page.

### Screenshots

<img width="1890" height="300" alt="CleanShot 2026-07-07 at 08 55 17@2x" src="https://github.com/user-attachments/assets/ec3f8e9d-c2dc-4e03-9b26-2c2b79456cb6" />

<img width="1890" height="300" alt="CleanShot 2026-07-07 at 08 54 34@2x" src="https://github.com/user-attachments/assets/316d3277-be6e-4629-beb6-953544c465cf" />

https://github.com/user-attachments/assets/b93db71f-dbb8-4752-bd61-2862c4e7025c


### Any Assumptions / Hacks

None that I can think of.