### PR TITLE
[18ESP] Graph optimization for mountain pass logic

### DIFF
--- a/lib/engine/game/g_18_esp/game.rb
+++ b/lib/engine/game/g_18_esp/game.rb
@@ -41,6 +41,9 @@ module Engine
 
         MOUNTAIN_PASS_TOKEN_HEXES = %w[L8 J10 H12 D12].freeze
 
+        # Action types whose choice can open a mountain pass (Track choose / P4 SpecialChoose).
+        MOUNTAIN_PASS_CHOICE_ACTIONS = %w[choose choose_ability].freeze
+
         MOUNTAIN_PASS_TOKEN_COST = { 'L8' => 80, 'J10' => 80, 'H12' => 60, 'D12' => 100 }.freeze
 
         MOUNTAIN_PASS_TOKEN_BONUS = { 'L8' => 40, 'J10' => 40, 'H12' => 30, 'D12' => 50 }.freeze
@@ -367,6 +370,21 @@ module Engine
 
         def madrid_hex
           @madrid_hex ||= hex_by_id(MADRID_HEX)
+        end
+
+        # Tallies each entity's mountain-pass opens from @filtered_actions; consume_mountain_pass_hint! decrements as replayed.
+        def future_mountain_pass_choose?(entity)
+          @loading_mountain_pass_remaining ||= @filtered_actions.filter_map do |action|
+            action['entity'] if action && MOUNTAIN_PASS_CHOICE_ACTIONS.include?(action['type']) &&
+                                MOUNTAIN_PASS_TOKEN_HEXES.include?(action['choice'])
+          end.tally
+          @loading_mountain_pass_remaining.fetch(entity.id, 0).positive?
+        end
+
+        def consume_mountain_pass_hint!(entity)
+          return unless @loading
+
+          @loading_mountain_pass_remaining[entity.id] -= 1 if future_mountain_pass_choose?(entity)
         end
 
         def setup

--- a/lib/engine/game/g_18_esp/step/special_choose.rb
+++ b/lib/engine/game/g_18_esp/step/special_choose.rb
@@ -11,9 +11,15 @@ module Engine
           include Engine::Step::Tokener
           def actions(entity)
             return [] unless @game.phase.status.include?('mountain_pass')
-            return [] unless opening_mountain_pass?(entity)
+            return [] unless mountain_pass_ability_available?(entity)
 
             super
+          end
+
+          def mountain_pass_ability_available?(entity)
+            return @game.future_mountain_pass_choose?(entity) if @game.loading
+
+            opening_mountain_pass?(entity)
           end
 
           def opening_mountain_pass?(entity)
@@ -33,6 +39,7 @@ module Engine
             @game.graph_for_entity(corp).clear
             @log << "#{action.entity.name} closes"
             action.entity.close!
+            @game.consume_mountain_pass_hint!(action.entity)
           end
         end
       end

--- a/lib/engine/game/g_18_esp/step/track.rb
+++ b/lib/engine/game/g_18_esp/step/track.rb
@@ -16,15 +16,25 @@ module Engine
             return [] if entity.company?
 
             actions = []
-            actions << 'lay_tile' if can_lay_tile?(entity)
-            if opening_mountain_pass?(entity) && @game.phase.status.include?('mountain_pass') && !@round.opened_mountain_pass
-              actions << 'choose'
-            end
-            actions << 'place_token' if can_place_token?(entity)
+            can_lay = can_lay_tile?(entity)
+            can_token = can_place_token?(entity)
+            actions << 'lay_tile' if can_lay
+            actions << 'choose' if mountain_pass_choice_available?(entity, can_lay || can_token)
+            actions << 'place_token' if can_token
             actions << 'destination_connection' if !@game.loading && @acted &&
                                                    @game.new_destination_connection?(entity)
             actions << 'pass' if actions.any?
             actions
+          end
+
+          def mountain_pass_choice_available?(entity, otherwise_blocking)
+            return false unless @game.phase.status.include?('mountain_pass')
+            return false if @round.opened_mountain_pass
+
+            # Skip the graph query while loading when the step already blocks; the log tells us if a pass opens.
+            return @game.future_mountain_pass_choose?(entity) if @game.loading && otherwise_blocking
+
+            opening_mountain_pass?(entity)
           end
 
           def round_state
@@ -88,6 +98,7 @@ module Engine
             @game.open_mountain_pass(action.entity, action.choice)
             @game.graph_for_entity(action.entity).clear
             @round.opened_mountain_pass = true
+            @game.consume_mountain_pass_hint!(action.entity)
           end
 
           def reactivate_for_token!


### PR DESCRIPTION
Related to #12661, #12620 and #12598
Propose to close both issues #12571, #12579 after merge.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

Peer review is welcome.

## Implementation Notes

### Explanation of Change

Follow-up to #12661. While loading, `Track#actions` called `opening_new_mountain_pass` (→ `@graph.connected_hexes`) for every entity on every step of a `mountain_pass` phase.

Mountain-pass openings are already `choose` / `choose_ability` actions in the log, so the graph is not needed to decide availability while loading. The game now pre-scans the (filtered) action log once and offers the `choose` from that hint instead of the graph:

- `future_mountain_pass_choose?` lazily tallies pass-opening actions from `@filtered_actions` (keyed by acting entity: corporation for `choose`, P4 company for `choose_ability`); `consume_mountain_pass_hint!` decrements as they replay.
- **Track** uses the hint only when the step already blocks on `lay_tile`/`place_token`; with no tile and no token it falls back to the graph so a logged `pass` still routes correctly.
- **SpecialChoose** (P4) is non-blocking, so it uses the hint directly with no fallback.

Guards key on `@loading` only — `@strict` still runs full graph validation. No migration script needed: no action-log schema change, the pre-scan only reads existing actions.

<details><summary>Stackprof — <code>18ESP_game_end_second_eight.json</code> (top frames)</summary>

```
BEFORE — non-strict (master) · 12.11 s · Samples 11349
   SAMPLES (pct)   FRAME
   1628 (14.3%)    Engine::Part::Path#walk
    860  (7.6%)    Engine::Graph#compute
    514  (4.5%)    Engine::Part::Node#walk
    556  (4.9%)    Engine::Hex#paths

AFTER — non-strict (branch, hint path) · 5.47 s · Samples 5316
    148  (2.8%)    Engine::Graph#compute
    154  (2.9%)    Engine::Part::Path#walk
     40  (0.8%)    Engine::Part::Node#walk
     47  (0.9%)    Engine::Hex#paths

AFTER — strict (branch, graph path, unchanged) · 13.97 s · Samples 13419
   2512 (18.7%)    Engine::Part::Path#walk
   1081  (8.1%)    Engine::Graph#compute
    828  (6.2%)    Engine::Part::Node#walk
    761  (5.7%)    Engine::Hex#paths
```

</details>

### Testing

- Existing 18ESP specs and fixture replays pass.
- **Two-mode DB replay** over all active 18ESP games imported from production. Each game loaded twice - non-strict (hint path) and strict (graph path):
  - No new load failures vs `master`.
  - Identical end-state (`result` / `finished` / `actions`) between hint and graph paths per game, and vs `master`.

Imported and tested game IDs:

```
212277 212610 212769 212770 214871 214923 218388 218815 218816 219379
221224 221443 222172 222266 222395 223336 224006 224358 224701 225120
226103 226323 227851 229271 230080 232828 234070 235366 237769 238114
238260 239328 239778 239966 240250 240454 240526 240568 240914 241033
241166 241332 241347 241846 241892 242081 242208 243232 243499 243848
244209 244301 244545 244996 245075 245079 245301 245725 245726 246537
246922 248680 249339 251610
```

### Screenshots

N/A: backend-only change, no UI impact.

### Any Assumptions / Hacks

The pre-scan reads `@filtered_actions`, so undone opens are not counted.
