### PR TITLE
[1849] LoanChoice step doesn't trigger for last corp in OR set.

### DIFF
--- a/lib/engine/game/g_1849/round/operating.rb
+++ b/lib/engine/game/g_1849/round/operating.rb
@@ -12,6 +12,12 @@ module Engine
 
             super
           end
+
+          def finished?
+            return false if @game.loan_choice_player
+
+            super
+          end
         end
       end
     end


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

User [here in slack](https://18xxgames.slack.com/archives/CV3R3HPUZ/p1784292714318009) reported that he wasn't getting the choice to take a loan after bankrupting. I noticed he was operating the last corp in the OR set, which means that the `finished?` method would trigger before the LoanChoice step could register the situation. 

Added a check to the `finished?` method in g_1849/round/operating.rb to prevent this from happening. 

### Screenshots

### Any Assumptions / Hacks
