### PR TITLE
18Hiawatha and Steam Over Holland to Production, remove 1871 KS announcement from front page

### DIFF
--- a/assets/app/view/welcome.rb
+++ b/assets/app/view/welcome.rb
@@ -16,7 +16,7 @@ module View
 
     def render_notification
       message = <<~MESSAGE
-        <p>The Old Prince 1871 is now live on <a href="https://www.kickstarter.com/projects/joshuastarr/the-old-prince-1871">Kickstarter</a>.</p>
+        <p>Welcome to 18xx.games, an online platform for playing 18XX games.</p>
         <p>Report bugs and make feature requests <a href='https://github.com/tobymao/18xx/issues'>on GitHub</a>.</p>
       MESSAGE
 

--- a/lib/engine/game/g_18_hiawatha/meta.rb
+++ b/lib/engine/game/g_18_hiawatha/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :beta
+        DEV_STAGE = :production
         DEPENDS_ON = '1817'
 
         GAME_DESIGNER = 'Michael Carter, Anthony Fryer, & Nick Neylon'

--- a/lib/engine/game/g_steam_over_holland/meta.rb
+++ b/lib/engine/game/g_steam_over_holland/meta.rb
@@ -8,7 +8,7 @@ module Engine
       module Meta
         include Game::Meta
 
-        DEV_STAGE = :beta
+        DEV_STAGE = :production
 
         GAME_TITLE = 'Steam Over Holland'
         GAME_DESIGNER = 'Bart van Dijk'


### PR DESCRIPTION
## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

See title. No big changes here. Didn't feel a need to announce these games moving to production.

### Explanation of Change

### Screenshots

### Any Assumptions / Hacks
