### PR TITLE
[18Cuba] FC train export

### DIFF
--- a/lib/engine/game/g_18_cuba/depot.rb
+++ b/lib/engine/game/g_18_cuba/depot.rb
@@ -19,6 +19,11 @@ module Engine
           gauge = @game.gauge_for(current_entity)
           depot_trains.reject { |t| @game.wagon?(t) || t.track_type != gauge }.min_by(&:price)
         end
+
+        # FC trains never leave it (rule VII.16); by owner, as Train#variant= would reset buyable.
+        def other_trains(corporation)
+          super.reject { |t| t.owner == @game.fc }
+        end
       end
     end
   end

--- a/lib/engine/game/g_18_cuba/depot.rb
+++ b/lib/engine/game/g_18_cuba/depot.rb
@@ -20,7 +20,7 @@ module Engine
           depot_trains.reject { |t| @game.wagon?(t) || t.track_type != gauge }.min_by(&:price)
         end
 
-        # FC trains never leave it (rule VII.16); by owner, as Train#variant= would reset buyable.
+        # FC trains are never bought back (rule VII.16); keyed on owner, as a flip back to the base variant restores buyable.
         def other_trains(corporation)
           super.reject { |t| t.owner == @game.fc }
         end

--- a/lib/engine/game/g_18_cuba/entities.rb
+++ b/lib/engine/game/g_18_cuba/entities.rb
@@ -277,7 +277,7 @@ module Engine
             city: 1,
             color: :white,
             text_color: :black,
-            type: :state,
+            type: :national,
           },
           {
             float_percent: 60,

--- a/lib/engine/game/g_18_cuba/game.rb
+++ b/lib/engine/game/g_18_cuba/game.rb
@@ -12,6 +12,8 @@ module Engine
   module Game
     module G18Cuba
       class Game < Game::Base
+        attr_reader :fc
+
         include_meta(G18Cuba::Meta)
         include Entities
         include Map
@@ -30,6 +32,16 @@ module Engine
         DEPOT_CLASS = G18Cuba::Depot
 
         BANK_CASH = 10_000
+
+        GAME_END_CHECK = { bankrupt: :immediate, bank: :full_or, second_eight_plus: :immediate }.freeze
+
+        GAME_END_REASONS_TEXT = Base::GAME_END_REASONS_TEXT.merge(
+          second_eight_plus: 'Second 8+ train is exported to the FC',
+        ).freeze
+
+        GAME_END_DESCRIPTION_REASON_MAP_TEXT = Base::GAME_END_DESCRIPTION_REASON_MAP_TEXT.merge(
+          second_eight_plus: 'Second 8+ exported to FC',
+        ).freeze
 
         CERT_LIMIT = { 2 => 35, 3 => 30, 4 => 20, 5 => 17, 6 => 15 }.freeze
 
@@ -121,7 +133,7 @@ module Engine
 
         def num_trains(train)
           num_players = [@players.size, 2].max
-          TRAIN_FOR_PLAYER_COUNT[num_players][train[:name].to_sym]
+          TRAIN_FOR_PLAYER_COUNT[num_players][train[:name].to_sym] || super
         end
 
         def company_header(company)
@@ -175,8 +187,10 @@ module Engine
         end
 
         def crowded_corps
-          # TODO: FC logic - train limit
-          @crowded_corps ||= corporations.select { |c| train_limit_overflow(c).value?(true) }
+          # FC (:national) holds exported trains without a limit and never discards.
+          @crowded_corps ||= corporations.select do |c|
+            c.type != :national && train_limit_overflow(c).value?(true)
+          end
         end
 
         # A corp owning only wagons is still trainless (wagons don't count as trains).
@@ -201,7 +215,21 @@ module Engine
           initialize_tile_opposites!
           @unused_tiles = []
           sugar_setup
+          fc_setup
           @minor_graph = Graph.new(self, skip_track: :broad)
+        end
+
+        def fc_setup
+          @fc = @corporations.find { |c| c.type == :national }
+          # Never parred or floated, so mark as ipoed to keep it out of the unstarted corporations.
+          @fc.ipoed = true
+          # TODO: unbuyable until the FC has a price/dividend/M4 mechanic; re-enable then or it can't sell out (VII.15/VIII.2).
+          @fc.shares.each { |s| s.buyable = false }
+          @fc_exported_8plus = 0
+          train = train_by_id('1-0')
+          buy_train(@fc, train, :free)
+          # Belt and braces next to Depot#other_trains, which is what actually keeps FC trains unbuyable.
+          train.buyable = false
         end
 
         def init_graph
@@ -254,7 +282,7 @@ module Engine
         def can_par?(corporation, entity)
           # FC cannot be parred
           # Minors can only be parred by players with a concession to exchange
-          return false if corporation.type == :state
+          return false if corporation.type == :national
           return super unless corporation.type == :minor
 
           entity.companies.any? { |c| abilities(c, :exchange) }
@@ -279,6 +307,8 @@ module Engine
                 @turn += 1
                 or_round_finished
                 or_set_finished
+                return if @finished
+
                 new_stock_round
               end
             when init_round.class
@@ -347,6 +377,32 @@ module Engine
           @sugar_cubes.each { |corp, cubes| update_sugar_cube_icons(corp, 0) if cubes.positive? }
           @sugar_cubes.clear
           @log << 'All remaining sugar cubes are removed at the end of the Operating Round.'
+        end
+
+        def or_set_finished
+          export_train_to_fc!
+          super
+        end
+
+        def export_train_to_fc!
+          train = depot.upcoming.find { |t| !wagon?(t) && t.track_type == :broad }
+          return unless train
+
+          # FC trains never rust and are never bought back (rules VII.15/16).
+          train.rusts_on = nil
+          train.obsolete_on = nil
+          buy_train(@fc, train, :free)
+          train.buyable = false
+          @phase.buying_train!(@fc, train, depot)
+          @log << "-- Event: A #{train.name} train is exported to #{@fc.name} --"
+          @fc_exported_8plus += 1 if train.name == '8+'
+          # End directly: game_end_check would only fire an action later, after a new SR began (rule IX.1).
+          # TODO: reliable only once 8+ is unlimited (#12722); until then the finite 8+ stack can be bought out before 2nd export
+          end_game!(:second_eight_plus) if @fc_exported_8plus >= 2
+        end
+
+        def game_end_check_second_eight_plus?
+          @fc_exported_8plus >= 2
         end
 
         def check_route_combination(routes)

--- a/lib/engine/game/g_18_cuba/game.rb
+++ b/lib/engine/game/g_18_cuba/game.rb
@@ -228,7 +228,7 @@ module Engine
           @fc_exported_8plus = 0
           train = train_by_id('1-0')
           buy_train(@fc, train, :free)
-          # Belt and braces next to Depot#other_trains, which is what actually keeps FC trains unbuyable.
+          # Never bought back (rule VII.16).
           train.buyable = false
         end
 
@@ -393,9 +393,10 @@ module Engine
           train.obsolete_on = nil
           buy_train(@fc, train, :free)
           train.buyable = false
-          @phase.buying_train!(@fc, train, depot)
           @log << "-- Event: A #{train.name} train is exported to #{@fc.name} --"
-          @fc_exported_8plus += 1 if train.name == '8+'
+          @phase.buying_train!(@fc, train, depot)
+          # 4D is a variant of the 8+ card, so key on sym, not name (rule IX.1).
+          @fc_exported_8plus += 1 if train.sym == '8+'
           # End directly: game_end_check would only fire an action later, after a new SR began (rule IX.1).
           # TODO: reliable only once 8+ is unlimited (#12722); until then the finite 8+ stack can be bought out before 2nd export
           end_game!(:second_eight_plus) if @fc_exported_8plus >= 2

--- a/lib/engine/game/g_18_cuba/trains.rb
+++ b/lib/engine/game/g_18_cuba/trains.rb
@@ -43,6 +43,7 @@ module Engine
         end
 
         # Currently variants 2p medium, 3p short setup. Further variant support to be added later.
+        # TODO: drop the '8+' entries when 8+ goes num: 'unlimited' (#12722); num_trains reads this first, else N self-cloning 8+
         TRAIN_FOR_PLAYER_COUNT = {
           2 => {
             '2': 5,
@@ -190,7 +191,7 @@ module Engine
             ],
           },
           {
-            # TODO: switch to num: 'unlimited' once #12722 merges (see PHASES below).
+            # TODO: switch to num: 'unlimited' once #12722 merges.
             name: '8+',
             distance: 8,
             price: 700,
@@ -252,6 +253,14 @@ module Engine
             track_type: :narrow,
             available_on: '5',
             discount: { '4n' => 130, '4-1n' => 65 },
+          },
+          {
+            name: '1',
+            distance: 1,
+            price: 0,
+            track_type: :broad,
+            num: 1,
+            reserved: true,
           },
           ].freeze
 

--- a/spec/lib/engine/game/g_18_cuba/fc_spec.rb
+++ b/spec/lib/engine/game/g_18_cuba/fc_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Engine
+  module Game
+    module G18Cuba
+      describe Game do
+        let(:players) { %w[a b c] }
+        let(:game) { Engine::Game::G18Cuba::Game.new(players) }
+
+        # The topmost regular (broad, non-wagon) train in the bank — what an export pulls.
+        def top_broad_train
+          game.depot.upcoming.find { |t| !game.wagon?(t) && t.track_type == :broad }
+        end
+
+        describe '#export_train_to_fc!' do
+          it 'moves the top broad train to the FC, non-rusting and unbuyable' do
+            train = top_broad_train
+            expect(train.name).to eq('2') # cheapest broad train, first in the bank
+
+            game.export_train_to_fc!
+
+            expect(game.fc.trains).to include(train)          # now on the FC stack
+            expect(game.depot.upcoming).not_to include(train) # gone from the bank
+            expect(train.rusts_on).to be_nil                  # never scrapped (VII.15/16)
+            expect(train.buyable).to be(false)                # cannot be bought back
+            expect(game.phase.name).to eq('2')                # exporting a 2 does not advance the phase
+          end
+
+          it 'advances the phase when it exports the first 3, like a purchase (VII.17)' do
+            game.export_train_to_fc! while top_broad_train&.name == '2' # drain the 2s
+            expect(top_broad_train.name).to eq('3')
+
+            game.export_train_to_fc!
+
+            expect(game.phase.name).to eq('3')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/engine/game/g_18_cuba/fc_spec.rb
+++ b/spec/lib/engine/game/g_18_cuba/fc_spec.rb
@@ -36,6 +36,23 @@ module Engine
 
             expect(game.phase.name).to eq('3')
           end
+
+          it 'ends the game immediately when the second 8+ is exported' do
+            40.times do
+              game.export_train_to_fc!
+              break if game.finished
+            end
+
+            expect(game.finished).to be(true)
+            expect(game.game_end_check_second_eight_plus?).to be(true) # ended via 2nd 8+, not bank/bankrupt
+          end
+        end
+
+        describe '#crowded_corps' do
+          it 'never includes the FC (no train limit, never discards)' do
+            # the FC holds its preprinted train and its train limit is 0 — flagged without the exemption
+            expect(game.crowded_corps).not_to include(game.fc)
+          end
         end
       end
     end


### PR DESCRIPTION
Refs #12485

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

Peer review feedback is welcome.

## Implementation Notes

### Explanation of Change

First of three PRs for the Ferrocarril Central (FC), a national corp. This one only adds the train export; the FC doesn't operate or earn income yet.

- The FC starts with its preprinted `1`-train and gets the top broad train from the bank at the end of every OR set.
- An export triggers a phase change just like a purchase, so the first train of a new type reaching the FC advances the phase.
- Exported trains never rust (`rusts_on`/`obsolete_on` cleared) and stay out of other corporations' buy options via `Depot#other_trains`.
- The game ends immediately when the second `8+` is exported.
- The FC is left out of `crowded_corps`: no train limit, never discards.
- Renamed the FC corp type `:state` → `:national`, matching the existing convention for state railways.

### Screenshots

N/A 

### Any Assumptions / Hacks

- The FC is marked `ipoed` so it isn't listed as unstarted, which would otherwise put its treasury shares up for sale in the stock round. It has no share price / dividend / M4 exchange yet, so its shares are disabled (TODO) until the operating PR re-enables them.
- The second-`8+` end trigger is only guaranteed once the `8+` supply is unlimited (#12722); until then majors could buy the `8+` out first. The bank-break end condition still applies. TODO in place.
- FC trains are kept out of other corps' buy options by `train.buyable = false` (base `other_trains` drops non-buyable trains); the `Depot#other_trains` owner reject is a redundant, owner-based fallback in case a variant flip ever restores `buyable`. Nothing flips FC trains today.