### PR TITLE
Use short stubs for terminal track on city hexes

### DIFF
--- a/assets/app/view/game/part/track_node_path.rb
+++ b/assets/app/view/game/part/track_node_path.rb
@@ -442,21 +442,34 @@ module View
 
           # terminal tapered track only supported for centered city/town
           if @terminal
-            props[:attrs].merge!(
-              transform: "rotate(#{rotation})",
-              d: "M #{terminal_start_x} 70 L #{terminal_start_x} 87 L #{terminal_end_x} 87 "\
-                 "L #{terminal_end_x} 70 L #{point_x} 35 Z",
-              fill: color,
-              stroke: 'none',
-              'stroke-linecap': 'butt',
-              'stroke-linejoin': 'miter',
-              'stroke-width': (width.to_i * 0.75).to_s,
-              'stroke-dasharray': dash,
-            )
-            if @terminal == '2'
-              props[:attrs][:d] = "M #{terminal_start_x} 85 L #{terminal_start_x} 87 L #{terminal_end_x} 87 "\
-                                  "L #{terminal_end_x} 85 L #{point_x} 65 Z"
-              props[:attrs][:fill] = '#707070'
+            # Cities get the short stub automatically, regardless of terminal:1 vs terminal:2.
+            # Only terminal:2 (mountain/ignored dead-ends) keeps the grey fill.
+            short_taper = @terminal == '2' || @stop0&.city?
+
+            if short_taper
+              props[:attrs].merge!(
+                transform: "rotate(#{rotation})",
+                d: "M #{terminal_start_x} 85 L #{terminal_start_x} 87 L #{terminal_end_x} 87 "\
+                   "L #{terminal_end_x} 85 L #{point_x} 65 Z",
+                fill: @terminal == '2' ? '#707070' : color,
+                stroke: 'none',
+                'stroke-linecap': 'butt',
+                'stroke-linejoin': 'miter',
+                'stroke-width': (width.to_i * 0.75).to_s,
+                'stroke-dasharray': dash,
+              )
+            else
+              props[:attrs].merge!(
+                transform: "rotate(#{rotation})",
+                d: "M #{terminal_start_x} 70 L #{terminal_start_x} 87 L #{terminal_end_x} 87 "\
+                   "L #{terminal_end_x} 70 L #{point_x} 35 Z",
+                fill: color,
+                stroke: 'none',
+                'stroke-linecap': 'butt',
+                'stroke-linejoin': 'miter',
+                'stroke-width': (width.to_i * 0.75).to_s,
+                'stroke-dasharray': dash,
+              )
             end
           end
           props


### PR DESCRIPTION

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

[In a discussion](https://groups.io/g/18xx/topic/120463190) on the 18xx groups.io page, it was pointed out that it's hard to see the tapered end of terminal track on hexes with Cities on them. 

I've introduced code here that shortens the taper if the hex has a City component on it, using the same dimensions (but not coloring) as the terminal: 2 taper.

### Screenshots

before: 

<img width="511" height="826" alt="image" src="https://github.com/user-attachments/assets/246f9e78-2f1f-4c91-94d0-bb8da343e629" />

After: 

<img width="698" height="1037" alt="image" src="https://github.com/user-attachments/assets/7c1152cf-92f1-4c0c-91b8-bacdadaa0d43" />


### Any Assumptions / Hacks
