### PR TITLE
Fix Unlimited Trains in Upcoming Trains display

### DIFF
--- a/assets/app/view/game/train_schedule.rb
+++ b/assets/app/view/game/train_schedule.rb
@@ -57,9 +57,12 @@ module View
                   events = []
                   events << h('div.left', "obsoletes #{obsolete_schedule[name].join(', ')}") unless obsolete_schedule[name].empty?
                   events << h('div.left', "rusts #{rust_schedule[name].join(', ')}") unless rust_schedule[name].empty?
+
+                  count_str = trains.first.unlimited ? 'Unlimited' : "×#{trains.size}"
+
                   tds = [h(:td, @game.info_train_name(trains.first)),
                          h("td#{price_str_class}", @game.info_train_price(trains.first)),
-                         h('td.right', "×#{trains.size}")]
+                         h('td.right', count_str)]
                   tds << h('td.right', events) unless events.empty?
 
                   h(:tr, tds)


### PR DESCRIPTION
Fixes #12814

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

After adding Unlimited Trains handling elsewhere in the code, the Upcoming Trains display now always indicates that there is only one train in any unlimited rank. 

This update fixes the issue so that we see "Unlimited" in that field for unlimited trains.

### Screenshots

before: 
<img width="330" height="95" alt="image" src="https://github.com/user-attachments/assets/060793de-52cd-4dec-a261-ce73d641820c" />

after: 
<img width="326" height="85" alt="image" src="https://github.com/user-attachments/assets/d772532a-08c1-45b0-ad29-45386bb64be3" />


### Any Assumptions / Hacks
