### PR TITLE
[1880 Romania] loan interest is being charged twice

### DIFF
--- a/lib/engine/game/g_1880_romania/round/stock.rb
+++ b/lib/engine/game/g_1880_romania/round/stock.rb
@@ -6,10 +6,18 @@ module Engine
   module Game
     module G1880Romania
       module Round
-        class Stock < G1880::Round::Stock
+        class Stock < Engine::Round::Stock
+          def sold_out?(corporation)
+            (corporation.num_ipo_shares - corporation.num_ipo_reserved_shares).zero?
+          end
+
           def finish_round
             @game.add_interest_player_loans!
             super
+          end
+
+          def show_auto?
+            !active_step.is_a?(G1880::Step::Choose)
           end
         end
       end


### PR DESCRIPTION
Fixes #12812

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Loan interest was being charged twice at the end of SRs. This is due to a mistake I made while changing how corporations float in 1880 Romania compared to 1880 China. I got my inheritance rules mixed up.

Here, I've stopped inheriting round/stock.rb from 1880, and instead I've copied the code over from 1880 China, removing the `@game.float_companies` trigger directly. 

Tested, interest is now charged correctly.

### Screenshots

### Any Assumptions / Hacks
