### PR TITLE
[Core] - Make game name on lobby tile clickable

### DIFF
--- a/assets/app/view/game_card.rb
+++ b/assets/app/view/game_card.rb
@@ -126,13 +126,22 @@ module View
       }
 
       dev_status = game.meta::DEV_STAGE
+      dev_suffix = dev_status != :production ? " (#{dev_status})" : ''
+
+      title_elm =
+        if game.meta::GAME_INFO_URL
+          link_props = {
+            attrs: { href: game.meta::GAME_INFO_URL, target: '_blank' },
+            style: { color: 'inherit', textDecoration: 'underline' },
+          }
+          h(:a, link_props, game.display_title)
+        else
+          game.display_title
+        end
 
       h('div.header', div_props, [
         h(:div, text_props, [
-          h(:div, [
-            "Game: #{game.display_title}",
-            (dev_status != :production ? " (#{dev_status})" : ''),
-          ].join),
+          h(:div, ['Game: ', title_elm, dev_suffix]),
           h('div.nowrap', owner_props, "Owner: #{@gdata['user']['name']}"),
         ]),
         h(:div, buttons_props, buttons),


### PR DESCRIPTION
Fixes #12741

**Size:** 1 file changed, +13/-4 lines

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [ ] Tests pass cleanly with `docker compose exec rack rake` (see note below - ran the fixture specs instead)

## Implementation Notes

### Explanation of Change

The game title on each lobby tile ("Game: <title>") was plain text. Every game already
defines a `GAME_INFO_URL` on its `meta.rb` pointing at that game's wiki page (the same
constant `game/game_meta.rb`'s "More info" link already uses), so this makes just the
title portion a clickable, underlined link to that URL, opening in a new tab. The
"Game: " prefix and the dev-stage suffix stay as plain text. Games that don't define
`GAME_INFO_URL` (a minority) fall back to the current plain-text behavior with no link.

### Screenshots

<img width="756" height="340" alt="image" src="https://github.com/user-attachments/assets/f22d54d6-ad17-470d-8c12-424a65ef56f4" />

### Any Assumptions / Hacks

None
