### PR TITLE
Fix label/reservation overlap on OO→single-city brown tile upgrade

### DIFF
--- a/assets/app/view/game/part/label.rb
+++ b/assets/app/view/game/part/label.rb
@@ -62,6 +62,32 @@ module View
           },
         }.freeze
 
+        P_TOP_LEFT_CORNER = {
+          flat: {
+            region_weights: { UPPER_LEFT_CORNER => 1.0 },
+            x: -40,
+            y: -65,
+          },
+          pointy: {
+            region_weights: { UPPER_LEFT_CORNER => 1.0 },
+            x: -30,
+            y: -65,
+          },
+        }.freeze
+
+        P_TOP_RIGHT_CORNER = {
+          flat: {
+            region_weights: { UPPER_RIGHT_CORNER => 1.0 },
+            x: 40,
+            y: -65,
+          },
+          pointy: {
+            region_weights: { UPPER_RIGHT_CORNER => 1.0, [2] => 0.5 },
+            x: 30,
+            y: -65,
+          },
+        }.freeze
+
         P_BOTTOM_LEFT_CORNER = {
           flat: {
             region_weights: { BOTTOM_LEFT_CORNER => 1.0 },
@@ -94,18 +120,8 @@ module View
             x: 50,
             y: 37,
           },
-          # top left corner
-          {
-            region_weights: { UPPER_LEFT_CORNER => 1.0 },
-            x: -40,
-            y: -65,
-          },
-          # top right corner
-          {
-            region_weights: { UPPER_RIGHT_CORNER => 1.0 },
-            x: 40,
-            y: -65,
-          },
+          P_TOP_LEFT_CORNER[:flat],
+          P_TOP_RIGHT_CORNER[:flat],
           P_LEFT_CORNER[:flat],
           P_RIGHT_CORNER[:flat],
           P_BOTTOM_LEFT_CORNER[:flat],
@@ -142,12 +158,7 @@ module View
             x: -50,
             y: -31,
           },
-          # top left corner
-          {
-            region_weights: { UPPER_LEFT_CORNER => 1.0 },
-            x: -30,
-            y: -65,
-          },
+          P_TOP_LEFT_CORNER[:pointy],
           # edge 1
           {
             region_weights: { [13, 14] => 1.0 },
@@ -156,12 +167,7 @@ module View
           },
           P_LEFT_CORNER[:pointy],
           P_BOTTOM_LEFT_CORNER[:pointy],
-          # top right corner
-          {
-            region_weights: { UPPER_RIGHT_CORNER => 1.0, [2] => 0.5 },
-            x: 30,
-            y: -65,
-          },
+          P_TOP_RIGHT_CORNER[:pointy],
           # edge 4
           {
             region_weights: { [10] => 1.0, [4, 11] => 0.25 },
@@ -185,7 +191,7 @@ module View
         def preferred_render_locations
           if @tile.city_towns.one?
             if @tile.cities.one? && (@tile.cities.first.slots > 1)
-              [P_LEFT_CORNER[layout]]
+              [P_LEFT_CORNER[layout], P_TOP_LEFT_CORNER[layout], P_TOP_RIGHT_CORNER[layout], P_BOTTOM_LEFT_CORNER[layout]]
             else
               [SINGLE_CITY_ONE_SLOT[layout], SINGLE_CITY_ONE_SLOT_RIGHT[layout], P_RIGHT_CORNER[layout]]
             end

--- a/assets/app/view/game/part/reservation.rb
+++ b/assets/app/view/game/part/reservation.rb
@@ -61,6 +61,32 @@ module View
           },
         }.freeze
 
+        P_TOP_LEFT_CORNER = {
+          flat: {
+            region_weights: { UPPER_LEFT_CORNER => 1.0, [2] => 0.5 },
+            x: -30,
+            y: -65,
+          },
+          pointy: {
+            region_weights: { UPPER_LEFT_CORNER => 1.0 },
+            x: -30,
+            y: -65,
+          },
+        }.freeze
+
+        P_TOP_RIGHT_CORNER = {
+          flat: {
+            region_weights: { UPPER_RIGHT_CORNER => 1.0, [2] => 0.5 },
+            x: 30,
+            y: -65,
+          },
+          pointy: {
+            region_weights: { UPPER_RIGHT_CORNER => 1.0, [2] => 0.5 },
+            x: 30,
+            y: -65,
+          },
+        }.freeze
+
         P_BOTTOM_LEFT_CORNER = {
           flat: {
             region_weights: { BOTTOM_LEFT_CORNER => 1.0, [21] => 0.5 },
@@ -93,18 +119,8 @@ module View
             x: 50,
             y: 37,
           },
-          # top left corner
-          {
-            region_weights: { UPPER_LEFT_CORNER => 1.0, [2] => 0.5 },
-            x: -30,
-            y: -65,
-          },
-          # top right corner
-          {
-            region_weights: { UPPER_RIGHT_CORNER => 1.0, [2] => 0.5 },
-            x: 30,
-            y: -65,
-          },
+          P_TOP_LEFT_CORNER[:flat],
+          P_TOP_RIGHT_CORNER[:flat],
           P_LEFT_CORNER[:flat],
           P_RIGHT_CORNER[:flat],
           P_BOTTOM_LEFT_CORNER[:flat],
@@ -141,20 +157,10 @@ module View
             x: -50,
             y: -31,
           },
-          # top left corner
-          {
-            region_weights: { UPPER_LEFT_CORNER => 1.0 },
-            x: -30,
-            y: -65,
-          },
+          P_TOP_LEFT_CORNER[:pointy],
           P_LEFT_CORNER[:pointy],
           P_BOTTOM_LEFT_CORNER[:pointy],
-          # top right corner
-          {
-            region_weights: { UPPER_RIGHT_CORNER => 1.0, [2] => 0.5 },
-            x: 30,
-            y: -65,
-          },
+          P_TOP_RIGHT_CORNER[:pointy],
           # edge 4
           {
             region_weights: { [10] => 1.0, [4, 11] => 0.25 },
@@ -178,7 +184,7 @@ module View
         def preferred_render_locations
           if @tile.city_towns.one?
             if @tile.cities.one? && (@tile.cities.first.slots > 1)
-              [P_LEFT_CORNER[layout]]
+              [P_LEFT_CORNER[layout], P_TOP_LEFT_CORNER[layout], P_TOP_RIGHT_CORNER[layout], P_BOTTOM_LEFT_CORNER[layout]]
             else
               [SINGLE_CITY_ONE_SLOT[layout], SINGLE_CITY_ONE_SLOT_RIGHT[layout]]
             end


### PR DESCRIPTION
## Explanation of Change

When a hex has two separate 1-slot cities with a label (e.g. `OO`, `R`) and a corporation reservation, and it upgrades to a brown tile with a single city with multiple slots, the label and the reservation both try to render at `P_LEFT_CORNER`, the only candidate position for that case, causing visual overlap.

Fix: when the tile has a single city with more than one slot, the `Reservation` component now falls back to `MULTI_CITY_LOCATIONS` (flat layout) or `POINTY_MULTI_CITY_LOCATIONS` (pointy layout) instead of having only `P_LEFT_CORNER` as a candidate. The region-weight system then places the reservation in the lowest-cost available position away from the label.

The first candidate is still `P_LEFT_CORNER`, so tiles without a label conflict are unaffected.

## Screenshots

<img width="182" height="230" alt="1882-R1" src="https://github.com/user-attachments/assets/a10632df-6650-47e0-9329-57d341306caa" />

<img width="258" height="230" alt="1882-green" src="https://github.com/user-attachments/assets/62d1d968-87d6-49ed-b68e-c851ef82055a" />

<img width="182" height="254" alt="1882-R2" src="https://github.com/user-attachments/assets/16365545-2e0b-4d6f-8502-d59c12642c83" />

<img width="282" height="288" alt="1882-QLL-error" src="https://github.com/user-attachments/assets/c99619f1-f022-4817-a024-c9aede3671fe" />

Reproduces in: **1882** (QLL reservation / Regina hex)

## Any Assumptions / Hacks

None. The first candidate remains `P_LEFT_CORNER` so existing behavior is preserved when no conflict exists.
