### PR TITLE
[1835] add tests for PR conversion, corp cert packages, and cert limit

### DIFF
--- a/spec/lib/engine/game/g_1835/game_spec.rb
+++ b/spec/lib/engine/game/g_1835/game_spec.rb
@@ -307,5 +307,242 @@ describe Engine::Game::G1835::Game do
 
       expect(game.minor_by_id('1').owner).to eq(player_1)
     end
+
+    def sell_start_packet
+      buy(player_1, 'NF')
+      buy(player_2, '2')
+      buy(player_3, 'LD')
+      buy(player_1, '1')
+      buy(player_2, '3')
+      buy(player_3, '4')
+      buy(player_1, 'BY_D')
+      buy(player_2, 'BB')
+      buy(player_3, 'HB')
+      buy(player_1, 'OBB')
+      buy(player_2, '5')
+      buy(player_3, '6')
+      buy(player_1, 'PB')
+
+      expect(player_1.percent_of(by)).to be 50
+      expect(player_3.percent_of(game.corporation_by_id('SX'))).to be 20
+
+      # player_2 has priority deal
+      expect(game.players.first).to eq(player_2)
+      # Final distribution is:
+      # player 1: NF, 1, OBB, PR, 50% BY
+      # player 2: 2, 3, 5, BB
+      # player 3: 4, 6, HB, 20% SX
+    end
+
+    it 'increases the cert limit when having 80% or more of a corp' do
+      expect(game.cert_limit(player_1)).to be 19
+      expect(game.cert_limit(player_2)).to be 19
+      expect(game.cert_limit(player_3)).to be 19
+
+      player_1.set_cash(3000, game.bank)
+      player_2.set_cash(3000, game.bank)
+      player_3.set_cash(3000, game.bank)
+      sell_start_packet
+
+      pass(player_2)
+      pass(player_3)
+      3.times do
+        buy_shares(player_1, 'BY')
+        pass(player_2)
+        pass(player_3)
+      end
+
+      expect(player_1.percent_of(by)).to be 80
+      expect(game.cert_limit(player_1)).to be 20
+      expect(game.cert_limit(player_2)).to be 19
+      expect(game.cert_limit(player_3)).to be 19
+
+      8.times do
+        buy_shares(player_1, 'SX')
+        pass(player_2)
+        pass(player_3)
+      end
+
+      expect(player_1.percent_of(game.corporation_by_id('SX'))).to be 80
+      expect(game.cert_limit(player_1)).to be 21
+      expect(game.cert_limit(player_2)).to be 19
+      expect(game.cert_limit(player_3)).to be 19
+    end
+
+    def purchasable?(corporation)
+      game.corporation_available?(corporation) && corporation.ipoed
+    end
+
+    it 'is makes cert packages available at the proper time' do
+      # we test the availability of all cert packages before the first OR by giving everyone a lot of money.
+      # By doing this we don't have to bother with 'pass' actions after buying, because as long as a company hasn't operated,
+      # its shares cannot be sold, so 'pass' is not an option after buying
+      player_1.set_cash(3000, game.bank)
+      player_2.set_cash(3000, game.bank)
+      player_3.set_cash(3000, game.bank)
+      sell_start_packet
+
+      %w[BA WT HE PR OL MS].map { |id| game.corporation_by_id(id) }.each { |corp| expect(purchasable?(corp)).to be false }
+
+      # let player 1 buy BY up to 100%
+      5.times do
+        pass(player_2)
+        pass(player_3)
+        buy_shares(player_1, 'BY')
+      end
+      pass(player_2)
+
+      # let player 3 buy SX up to 100%
+      7.times do
+        buy_shares(player_3, 'SX')
+        pass(player_1)
+        pass(player_2)
+      end
+      buy_shares(player_3, 'SX')
+      # first package gone, BA, WT, HE, and PR get IPO'ed, but only BA can be purchased
+      %w[BA WT HE PR].map { |id| game.corporation_by_id(id) }.each { |corp| expect(corp.ipoed).to be true }
+      expect(game.corporation_available?(ba)).to be true
+      %w[WT HE PR].map { |id| game.corporation_by_id(id) }.each { |corp| expect(game.corporation_available?(corp)).to be false }
+      %w[OL MS].map { |id| game.corporation_by_id(id) }.each { |corp| expect(purchasable?(corp)).to be false }
+
+      # buying the BA director makes PR available
+      buy_shares(player_1, 'BA')
+      expect(game.corporation_available?(pr)).to be true
+      3.times do
+        pass(player_2)
+        pass(player_3)
+        buy_shares(player_1, 'BA')
+      end
+
+      # buying 50% of BA makes WT available
+      expect(game.corporation_available?(game.corporation_by_id('WT'))).to be true
+
+      3.times do
+        buy_shares(player_2, 'WT')
+        pass(player_3)
+        buy_shares(player_1, 'BA')
+      end
+      expect(game.corporation_available?(game.corporation_by_id('HE'))).to be false
+
+      # buying 50% of WT makes HE available
+      buy_shares(player_2, 'WT')
+      expect(game.corporation_available?(game.corporation_by_id('HE'))).to be true
+
+      7.times do
+        buy_shares(player_3, 'HE')
+        pass(player_1)
+        pass(player_2)
+      end
+      buy_shares(player_3, 'PR')
+      buy_shares(player_1, 'PR')
+      buy_shares(player_2, 'PR')
+      buy_shares(player_3, 'PR')
+
+      buy_shares(player_1, 'WT')
+      buy_shares(player_2, 'WT')
+      buy_shares(player_3, 'WT')
+
+      # There are now one BA, one WT, and one HE share left, each has 20%
+      %w[BA WT HE].map { |corp_id| game.corporation_by_id(corp_id) }.each { |corp| expect(corp.shares.first.percent).to be 20 }
+
+      # player_1 and player_3 have reached the cert limit
+      pass(player_1)
+      buy_shares(player_2, 'WT')
+      [player_3, player_1].each { |player| pass(player) }
+      buy_shares(player_2, 'BA')
+      [player_3, player_1].each { |player| pass(player) }
+
+      %w[OL MS].map { |id| game.corporation_by_id(id) }.each { |corp| expect(purchasable?(corp)).to be false }
+
+      # let's buy the last share of the package IPO-ing MS and OL and making MS available
+      buy_shares(player_2, 'HE')
+      %w[OL MS].map { |id| game.corporation_by_id(id) }.each { |corp| expect(corp.ipoed).to be true }
+      expect(game.corporation_available?(game.corporation_by_id('MS'))).to be true
+      [player_3, player_1].each { |player| pass(player) }
+
+      # let's buy the first three MS shares and check if we got 60%
+      3.times do
+        buy_shares(player_2, 'MS')
+        [player_3, player_1].each { |player| pass(player) }
+      end
+
+      expect(player_2.percent_of(game.corporation_by_id('MS'))).to be 60
+
+      # let's buy the first three OL shares and check if we got 60%
+      3.times do
+        buy_shares(player_2, 'OL')
+        [player_3, player_1].each { |player| pass(player) }
+      end
+
+      expect(player_2.percent_of(game.corporation_by_id('OL'))).to be 60
+    end
+
+    def bring_game_to_pr_conversion
+      player_1.set_cash(3000, game.bank)
+      player_2.set_cash(3000, game.bank)
+      player_3.set_cash(3000, game.bank)
+      sell_start_packet
+      game.players.each do |player|
+        pass(player)
+      end
+      minor_1 = game.minor_by_id('1')
+      minor_1.set_cash(3000, game.bank)
+      pass(minor_1) # skip track
+
+      # let's remove all trains before the 4T
+      %w[2 2+2 3 3+3].each { |train| game.depot.export_all!(train) }
+
+      # and then buy that to trigger the PR conversion
+      train = game.depot.depot_trains.first
+      game.process_action(Engine::Action::BuyTrain.new(minor_1, train: train, price: train.price))
+
+      expect(game.active_step.current_actions).to include('choose')
+    end
+
+    it 'should continue with minor 2 in the OR after 1 triggered the PR conversion and 2 declines' do
+      bring_game_to_pr_conversion
+
+      game.process_action(Engine::Action::Choose.new(game.current_entity, choice: 'decline'))
+      expect(game.current_entity).to eq(game.minor_by_id('2'))
+      expect(game.active_step.current_actions).not_to include('choose')
+      expect(game.round.class.short_name).to eq('OR')
+    end
+
+    it 'should let the owner of minor 2 convert all of their preprussians and privates first' do
+      bring_game_to_pr_conversion
+
+      expect(game.current_entity.owner).to eq(player_2)
+      game.process_action(Engine::Action::Choose.new(game.current_entity, choice: 'form'))
+      expect(game.current_entity.owner).to eq(player_2)
+      game.process_action(Engine::Action::Choose.new(game.current_entity, choice: 'fold_in'))
+      expect(game.current_entity.owner).to eq(player_2)
+      game.process_action(Engine::Action::Choose.new(game.current_entity, choice: 'fold_in'))
+      expect(game.current_entity.owner).to eq(player_2)
+      game.process_action(Engine::Action::Choose.new(game.current_entity, choice: 'fold_in'))
+
+      expect(player_2.percent_of(pr)).to be 30
+    end
+
+    it 'should transfer the ownership of PR if another player converts more shares' do
+      bring_game_to_pr_conversion
+
+      expect(game.current_entity.owner).to eq(player_2)
+      game.process_action(Engine::Action::Choose.new(game.current_entity, choice: 'form'))
+      expect(game.current_entity.owner).to eq(player_2)
+      game.process_action(Engine::Action::Choose.new(game.current_entity, choice: 'decline'))
+      expect(game.current_entity.owner).to eq(player_2)
+      game.process_action(Engine::Action::Choose.new(game.current_entity, choice: 'decline'))
+      expect(game.current_entity.owner).to eq(player_2)
+      game.process_action(Engine::Action::Choose.new(game.current_entity, choice: 'decline'))
+
+      expect(game.current_entity).to eq(game.minor_by_id('4'))
+      game.process_action(Engine::Action::Choose.new(game.current_entity, choice: 'fold_in'))
+      expect(game.current_entity).to eq(game.minor_by_id('6'))
+      game.process_action(Engine::Action::Choose.new(game.current_entity, choice: 'fold_in'))
+
+      expect(player_2.percent_of(pr)).to be 10
+      expect(player_3.percent_of(pr)).to be 15
+      expect(pr.owner).to eq(player_3)
+    end
   end
 end

--- a/spec/lib/engine/game/g_1835/game_spec.rb
+++ b/spec/lib/engine/game/g_1835/game_spec.rb
@@ -3,6 +3,15 @@
 require 'spec_helper'
 
 describe Engine::Game::G1835::Game do
+  let(:game) { Engine::Game::G1835::Game.new(players) }
+  let(:by) { game.corporation_by_id('BY') }
+  let(:sx) { game.corporation_by_id('SX') }
+  let(:ba) { game.corporation_by_id('BA') }
+  let(:wt) { game.corporation_by_id('WT') }
+  let(:he) { game.corporation_by_id('HE') }
+  let(:pr) { game.corporation_by_id('PR') }
+  let(:ms) { game.corporation_by_id('MS') }
+  let(:ol) { game.corporation_by_id('OL') }
   let(:player_1) { game.players.find { |player| player.id == 'a' } }
   let(:player_2) { game.players.find { |player| player.id == 'b' } }
   let(:player_3) { game.players.find { |player| player.id == 'c' } }
@@ -226,15 +235,6 @@ describe Engine::Game::G1835::Game do
 
   describe 'start_packet_sale' do
     let(:players) { %w[a b c] }
-    let(:game) { Engine::Game::G1835::Game.new(players) }
-    let(:by) { game.corporation_by_id('BY') }
-    let(:sx) { game.corporation_by_id('SX') }
-    let(:ba) { game.corporation_by_id('BA') }
-    let(:wt) { game.corporation_by_id('WT') }
-    let(:he) { game.corporation_by_id('HE') }
-    let(:pr) { game.corporation_by_id('PR') }
-    let(:ms) { game.corporation_by_id('MS') }
-    let(:ol) { game.corporation_by_id('OL') }
 
     def may_purchase?(company_id)
       game.active_step.may_purchase?(game.company_by_id(company_id))
@@ -309,32 +309,34 @@ describe Engine::Game::G1835::Game do
     end
   end
 
+  def sell_start_packet
+    buy(player_1, 'NF')
+    buy(player_2, '2')
+    buy(player_3, 'LD')
+    buy(player_1, '1')
+    buy(player_2, '3')
+    buy(player_3, '4')
+    buy(player_1, 'BY_D')
+    buy(player_2, 'BB')
+    buy(player_3, 'HB')
+    buy(player_1, 'OBB')
+    buy(player_2, '5')
+    buy(player_3, '6')
+    buy(player_1, 'PB')
+
+    expect(player_1.percent_of(by)).to be 50
+    expect(player_3.percent_of(game.corporation_by_id('SX'))).to be 20
+
+    # player_2 has priority deal
+    expect(game.players.first).to eq(player_2)
+    # Final distribution is:
+    # player 1: NF, 1, OBB, PR, 50% BY
+    # player 2: 2, 3, 5, BB
+    # player 3: 4, 6, HB, 20% SX
+  end
+
   describe 'cert_limit' do
-    def sell_start_packet
-      buy(player_1, 'NF')
-      buy(player_2, '2')
-      buy(player_3, 'LD')
-      buy(player_1, '1')
-      buy(player_2, '3')
-      buy(player_3, '4')
-      buy(player_1, 'BY_D')
-      buy(player_2, 'BB')
-      buy(player_3, 'HB')
-      buy(player_1, 'OBB')
-      buy(player_2, '5')
-      buy(player_3, '6')
-      buy(player_1, 'PB')
-
-      expect(player_1.percent_of(by)).to be 50
-      expect(player_3.percent_of(game.corporation_by_id('SX'))).to be 20
-
-      # player_2 has priority deal
-      expect(game.players.first).to eq(player_2)
-      # Final distribution is:
-      # player 1: NF, 1, OBB, PR, 50% BY
-      # player 2: 2, 3, 5, BB
-      # player 3: 4, 6, HB, 20% SX
-    end
+    let(:players) { %w[a b c] }
 
     it 'increases the cert limit when having 80% or more of a corp' do
       expect(game.cert_limit(player_1)).to be 19
@@ -371,7 +373,9 @@ describe Engine::Game::G1835::Game do
       expect(game.cert_limit(player_3)).to be 19
     end
   end
+
   describe 'cert_packages_in_SR' do
+    let(:players) { %w[a b c] }
     def purchasable?(corporation)
       game.corporation_available?(corporation) && corporation.ipoed
     end
@@ -482,6 +486,7 @@ describe Engine::Game::G1835::Game do
   end
 
   describe 'PR_conversion' do
+    let(:players) { %w[a b c] }
     def bring_game_to_pr_conversion
       player_1.set_cash(3000, game.bank)
       player_2.set_cash(3000, game.bank)

--- a/spec/lib/engine/game/g_1835/game_spec.rb
+++ b/spec/lib/engine/game/g_1835/game_spec.rb
@@ -307,7 +307,9 @@ describe Engine::Game::G1835::Game do
 
       expect(game.minor_by_id('1').owner).to eq(player_1)
     end
+  end
 
+  describe 'cert_limit' do
     def sell_start_packet
       buy(player_1, 'NF')
       buy(player_2, '2')
@@ -368,7 +370,8 @@ describe Engine::Game::G1835::Game do
       expect(game.cert_limit(player_2)).to be 19
       expect(game.cert_limit(player_3)).to be 19
     end
-
+  end
+  describe 'cert_packages_in_SR' do
     def purchasable?(corporation)
       game.corporation_available?(corporation) && corporation.ipoed
     end
@@ -476,7 +479,9 @@ describe Engine::Game::G1835::Game do
 
       expect(player_2.percent_of(game.corporation_by_id('OL'))).to be 60
     end
+  end
 
+  describe 'PR_conversion' do
     def bring_game_to_pr_conversion
       player_1.set_cash(3000, game.bank)
       player_2.set_cash(3000, game.bank)


### PR DESCRIPTION
refers to #3059

Is blocked by: https://github.com/tobymao/18xx/pull/12846

Check out the PR this PR was split from https://github.com/tobymao/18xx/pull/12829 lots of feedback has been given and applied there already.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Adding tests for stuff that was already in place:
- Making sure the cert limit goes up by 1 for each corp a player has at least 80% of
- Making sure the cert packages are available at the correct time (only BY and SX at first, once all IPO shares sold, BA becomes available, BA director share sold trigger PR to be available etc)
- Making sure conversion of the PR minors and privates works correctly