### PR TITLE
[System18] add an additional 23 and 24 tile for Mississippi map

### DIFF
--- a/lib/engine/game/g_system18/map_ms_customization.rb
+++ b/lib/engine/game/g_system18/map_ms_customization.rb
@@ -19,6 +19,8 @@ module Engine
         def map_ms_game_tiles(tiles)
           tiles['8'] += 3
           tiles['9'] += 1
+          tiles['23'] += 1
+          tiles['24'] += 1
           tiles.delete('12')
           tiles.delete('13')
           tiles.delete('205')


### PR DESCRIPTION
Fixes #12839

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Adds x1 tile 23 and 24, per Ian Wilson's request. 

### Screenshots

### Any Assumptions / Hacks
