### PR TITLE
[1835] add coordinates for Preußen so that it can token and remove its reservation

### DIFF
--- a/lib/engine/game/g_1835/entities.rb
+++ b/lib/engine/game/g_1835/entities.rb
@@ -284,6 +284,7 @@ module Engine
             floatable: false,
             max_ownership_percent: 100,
             shares: [10, 10, 10, 10, 10, 10, 10, 10, 5, 5, 5, 5],
+            coordinates: 'E19',
             color: '#37383a',
           },
           {

--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -161,6 +161,8 @@ module Engine
           corporation_by_id('OL').forced_share_percent = 10
 
           @corporation_blocks = CORPORATION_BLOCKS.map { |block| block.map { |c| corporation_by_id(c) } }
+
+          hex_by_id('E19').tile.remove_reservation!(prussian)
         end
 
         def company_header(company)

--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -162,6 +162,7 @@ module Engine
 
           @corporation_blocks = CORPORATION_BLOCKS.map { |block| block.map { |c| corporation_by_id(c) } }
 
+          # PR does not need a reservation, since its home token is put where 2's token was
           hex_by_id('E19').tile.remove_reservation!(prussian)
         end
 


### PR DESCRIPTION
Refers to #3059

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Preußen didn't have coordinates, so the code introduced in https://github.com/tobymao/18xx/pull/12832 was actually broken, because `token.corporation.coordinates` in `token_price` returns `nil` for the Preußen. This is fixed by giving the Preußen coordinates. This however adds a reservation for the Berlin tile, which must be removed, or 5 is not able to place its token. Removing the reservation is also aligned with the rules, since Preußen's home token is placed exactly when 2's token is removed, so there is no reservation for the Preußen.

### Screenshots

Preußen can token now, as can be seen here:

<img width="1384" height="867" alt="image" src="https://github.com/user-attachments/assets/c1a31dd2-4d9c-4232-9f28-aa3602318c14" />

Again, thanks @chrstas for finding this!

