### PR TITLE
[18Cuba] Fix share price ladder and enable ledge movement

### DIFF
--- a/lib/engine/game/g_18_cuba/game.rb
+++ b/lib/engine/game/g_18_cuba/game.rb
@@ -48,8 +48,8 @@ module Engine
         STARTING_CASH = { 2 => 950, 3 => 900, 4 => 680, 5 => 650, 6 => 650 }.freeze
 
         MARKET = [
-          %w[50 55 60 65 70p 75p 80p 85p 90p 95p 100p 105 110 115 120 126 192 198 144
-             151 158 172 180 188 196 204 013 222 231 240 250 260 275 290 300],
+          %w[50 55 60 65 70p 75p 80p 85p 90p 95p 100p 105 110 115 120 126 132 138 144
+             151 158 165 172 180 188 196 204 213 222 231 240 250 260 275 290 300],
         ].freeze
 
         STATUS_TEXT = Base::STATUS_TEXT.merge(
@@ -124,7 +124,7 @@ module Engine
         end
 
         def init_stock_market
-          StockMarket.new(self.class::MARKET, [], zigzag: :flip)
+          StockMarket.new(self.class::MARKET, [], zigzag: :flip, ledge_movement: true)
         end
 
         def multiple_buy_only_from_market?

--- a/spec/lib/engine/game/g_18_cuba/stock_market_spec.rb
+++ b/spec/lib/engine/game/g_18_cuba/stock_market_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Engine
+  module Game
+    module G18Cuba
+      describe Game do
+        let(:players) { %w[a b c] }
+        let(:game) { Engine::Game::G18Cuba::Game.new(players) }
+        let(:stock_market) { game.stock_market }
+        let(:corporation) { game.corporations.find { |c| c.type == :major } }
+
+        # One ladder in price order; zigzag splits it, odd indices to the upper row (rulebook p. 4).
+        it 'matches the printed share price board' do
+          expect(stock_market.market.first.map(&:price)).to eq(
+            [50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 105, 110, 115, 120, 126, 132, 138,
+             144, 151, 158, 165, 172, 180, 188, 196, 204, 213, 222, 231, 240, 250, 260, 275, 290, 300]
+          )
+        end
+
+        # Rule VIII.1: a marker on $55 moving one space left drops to $50 instead of holding.
+        it 'follows the ledge arrow at the bottom of the ladder' do
+          stock_market.set_par(corporation, stock_market.market.first[1])
+          stock_market.move_left(corporation)
+          expect(corporation.share_price.price).to eq(50)
+        end
+
+        # Rule VIII.1: the opposite arrow, reached through ZigZagMovement#right rather than #left.
+        it 'follows the ledge arrow at the top of the ladder' do
+          stock_market.set_par(corporation, stock_market.market.first[-2])
+          stock_market.move_right(corporation)
+          expect(corporation.share_price.price).to eq(300)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related: #12485

Corrects share price board according to rule book.

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] ~Add the `pins` or `archive_alpha_games` label if this change will break existing games~
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

`MARKET` did not match the share price board (rulebook p. 4): `192` and `198` should be `132` and `138`, `013` should be `213`, and `165` was missing between `158` and `172`. `013` also parsed as a price of $13 sitting between $204 and $222.

That left 35 spaces instead of 36. The zigzag market maps even and odd indices to the lower and upper board row, so the missing space put every price above $158 one position off and in the wrong row, with $300 at the end of the lower row instead of top right.

The second change enables ledge movement, rule VIII.1:

> If a company marker is at space $55 and should move one space to the left, it goes one space down instead to space $50 (indicated by an arrow). If it is already on space $50 it doesn't move.

The rule states the mirror case for $290 and $300, and both arrows are printed on the board. `ZigZagMovement` implements this behind the existing `ledge_movement` option, which 1860 and 1862 set and 18Cuba did not, so a marker on $55 that should move left stayed put. Rule VIII.2 moves a company one space left whenever it pays no dividend, which always happens in its first operating turn.

Both changes are needed together: with 35 spaces, $300 sat at the end of the lower row, so the option would have moved a marker on $290 one row down to reach it rather than up along the arrow.

Nothing in `spec/` currently touches `zigzag` or `ledge_movement`: The three examples added here pin the 36 prices against the board and one branch each of `ZigZagMovement#left` and `#right`; removing the option turns both ledge examples red with a different symptom each.

### Screenshots

Before:

<img width="963" height="350" alt="image" src="https://github.com/user-attachments/assets/b93725de-87d1-4d0c-a3f7-c22f9ddafe04" />


After:

<img width="976" height="245" alt="image" src="https://github.com/user-attachments/assets/f385dc72-4928-433c-ba22-c0e43009b58d" />

### Any Assumptions / Hacks

n/a