### PR TITLE
[1835] forbid building over the Elbe west of Hamburg

### DIFF
--- a/lib/engine/game/g_1835/map.rb
+++ b/lib/engine/game/g_1835/map.rb
@@ -208,8 +208,8 @@ module Engine
             %w[D14 E15 K7 K9 M13 M17] => 'upgrade=cost:50,terrain:water',
             %w[G13 H6 H8 H12 I7 I9 J14 K15 N8 O7] =>
                    'upgrade=cost:70,terrain:mountain',
-            ['C9'] => 'border=edge:3,type:water',
-            ['B10'] => 'border=edge:0,type:water',
+            ['C9'] => 'border=edge:3,type:impassable,color:blue',
+            ['B10'] => 'border=edge:0,type:impassable,color:blue',
           },
           red: {
             ['C21'] => 'offboard=revenue:yellow_20|green_20|brown_40;path=a:1,b:_0',


### PR DESCRIPTION
refers to #3059

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Not much to say here: Before this PR one could build over the Elbe west of Hamburg. It's now `impassable` and the color has been set.

### Screenshots

<img width="448" height="415" alt="image" src="https://github.com/user-attachments/assets/c4810606-00c8-40f6-a255-615f0a3fca93" />

Map before trying to build.

<img width="448" height="415" alt="image" src="https://github.com/user-attachments/assets/34d144d0-d190-46da-ba81-d5f58a762c2f" />

It's impossible to rotate the curve so that it points into C9. This was possible before this change.
