### PR TITLE
[1835] make track laying permissive and forbid building into brown hexes

### DIFF
--- a/lib/engine/game/g_1835/game.rb
+++ b/lib/engine/game/g_1835/game.rb
@@ -52,6 +52,10 @@ module Engine
 
         MUST_BUY_TRAIN = :always
 
+        # brown tiles - in addition to the default - cannot be built into unless there is track on the other side
+        IMPASSABLE_HEX_COLORS = %i[blue brown gray red].freeze
+        TRACK_RESTRICTION = :permissive
+
         MARKET = [['', '', '', ''] + %w[132 148 166 186 208 232 258 286 316 348 382 418],
                   ['', ''] + %w[98 108 120 134 150 168 188 210 234 260 288 318 350 384],
                   %w[82 86 92p 100 110 122 136 152 170 190 212 236 262 290 320],


### PR DESCRIPTION
refers to #3059

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [x] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change

Just implementing the rules here:
- track laying is permissive (rule 5.5.1.14 in the German rulebook "Eine Gesellschaft darf nur in Feldern Plättchen austauschen, auf denen sie nach diesem Austausch mindestens eine minimale Strecke befahren kann.")
- brown hexes cannot be built into unless there is track on the other side (rule 5.5.1.21 in the German rulebook "Gleise dürfen nur dann in braune Felder hineingebaut werden, wenn sich an der anzuschließenden Seite ein Gleiszugang befindet.")
