### PR TITLE
[18PA] Correct map labels and early-phase train limits

### DIFF
--- a/lib/engine/game/g_18_pa/game.rb
+++ b/lib/engine/game/g_18_pa/game.rb
@@ -43,18 +43,18 @@ module Engine
           %w[50 60 70 80 90],
         ].freeze
 
-        PHASES = [{ name: '2', train_limit: 4, tiles: [:yellow], operating_rounds: 2 },
+        PHASES = [{ name: '2', train_limit: 2, tiles: [:yellow], operating_rounds: 2 },
                   {
                     name: '3',
                     on: '3',
-                    train_limit: 4,
+                    train_limit: 2,
                     tiles: %i[yellow green],
                     operating_rounds: 2,
                   },
                   {
                     name: '4',
                     on: '4',
-                    train_limit: 3,
+                    train_limit: 2,
                     tiles: %i[yellow green],
                     operating_rounds: 2,
                   },

--- a/lib/engine/game/g_18_pa/map.rb
+++ b/lib/engine/game/g_18_pa/map.rb
@@ -130,7 +130,7 @@ module Engine
           'D1' => 'Cleveland',
           'D15' => 'Schenectady',
           'D17' => 'Albany',
-          'D25' => 'Worchester',
+          'D25' => 'Worcester',
           'D27' => 'Boston',
           'E10' => 'Binghamton',
           'E22' => 'Springfield & Hartford',
@@ -271,7 +271,7 @@ module Engine
             ['I8'] => 'city=revenue:20;path=a:1,b:_0;path=a:4,b:_0',
             ['J13'] => 'city=revenue:30;city=revenue:30;city=revenue:30;path=a:0,b:_0;path=a:2,b:_1;'\
                        'path=a:4,b:_2;label=PHI',
-            ['K10'] => 'city=revenue:30;path=a:0,b:_0;path=a:1,b:_0;path=a:4,b:_0',
+            ['K10'] => 'city=revenue:30;path=a:0,b:_0;path=a:1,b:_0;path=a:4,b:_0;label=BAL',
           },
           blue: {
             ['G26'] => 'path=a:0,b:3,track:narrow;border=edge:1,type:impassable',

--- a/spec/lib/engine/game/g_18_pa/setup_spec.rb
+++ b/spec/lib/engine/game/g_18_pa/setup_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Engine
+  describe Game::G18PA::Game do
+    let(:game) { described_class.new(%w[A B C], id: 1) }
+
+    it 'uses a two-train limit in every phase' do
+      expect(described_class::PHASES.map { |phase| phase[:train_limit] }).to eq([2, 2, 2, 2, 2])
+    end
+
+    it 'identifies Worcester on D25' do
+      expect(game.hex_by_id('D25').location_name).to eq('Worcester')
+    end
+
+    it 'allows Baltimore to upgrade to its green BAL tile' do
+      baltimore = game.hex_by_id('K10').tile
+      green = game.tiles.find { |tile| tile.name == 'X14' }
+      expect(game.upgrades_to?(baltimore, green)).to be true
+    end
+  end
+end


### PR DESCRIPTION
First small PR following our Slack discussion.

Corrects Worcester at D25, adds Baltimore's BAL label for the X14 upgrade, and sets phases 2-4 to the two-train limit in rule 6.11.

Five production-line edits plus three tests. 18PA remains prealpha.

Validation: 9,299 tests pass; lint passes for 2,524 files.