### PR TITLE
[18JP-T] Fix city name typo in 18JP-T map (Shijuku -> Shinjuku)

### DIFF
--- a/lib/engine/game/g_18_jpt/map.rb
+++ b/lib/engine/game/g_18_jpt/map.rb
@@ -154,7 +154,7 @@ module Engine
           'F80' => 'Kawaguchi',
           'F82' => 'Itabashi',
           'F84' => 'Ikebukuro',
-          'F86' => 'Shijuku',
+          'F86' => 'Shinjuku',
           'F88' => 'Shibuya',
           'F92' => 'Kamata',
           'F94' => 'Kawasaki',


### PR DESCRIPTION

## Before clicking "Create"

- [x ] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games
- [ x] Code passes linter with `docker compose exec rack rubocop -a`
- [ x] Tests pass cleanly with `docker compose exec rack rake`

## Implementation Notes

### Explanation of Change
Fixes a typo in the name of the city of Shinjuku

### Screenshots
<img width="478" height="358" alt="image" src="https://github.com/user-attachments/assets/5eb9fb14-6035-4069-963a-968e911213be" />



### Any Assumptions / Hacks
