### PR TITLE
[18 India] Add concession holder to Commodity Delivery Bonus chart

### DIFF
--- a/lib/engine/game/g_18_india/game.rb
+++ b/lib/engine/game/g_18_india/game.rb
@@ -1052,6 +1052,11 @@ module Engine
           @unclaimed_commodities + corporation.commodities
         end
 
+        # Corporation currently holding the concession for a commodity, if any
+        def concession_holder(commodity)
+          @corporations.find { |corporation| corporation.commodities.any? { |claimed| claimed.start_with?(commodity) } }
+        end
+
         # Test using Ability to display Claimed Commodities on VIEW for Corporation card
         def claim_concession(corporation, commodity)
           ability = corporation.all_abilities.find { |a| a.type == :commodities }
@@ -1311,6 +1316,18 @@ module Engine
               { image: '/icons/18_india/rice.svg', props: { style: yellow_cell_style } },
               { image: '/icons/18_india/spices.svg', props: { style: yellow_cell_style } },
               { image: '/icons/18_india/tea.svg', props: { style: yellow_cell_style } },
+            ],
+            [
+              { text: 'Concession Holder', props: { style: cell_style, attrs: { colspan: 2 } } },
+              *%w[COTTON GOLD JEWELRY OIL OPIUM ORE RICE SPICES TEA].map do |commodity|
+                holder = concession_holder(commodity)
+                if holder
+                  holder_style = { **cell_style, backgroundColor: holder.color, color: holder.text_color }
+                  { text: holder.name, props: { style: holder_style } }
+                else
+                  { text: '-', props: { style: cell_style } }
+                end
+              end,
             ],
             [
               { text: 'Chennai', props: { style: cell_style } },


### PR DESCRIPTION
**Diff:** 1 file changed, 17 insertions(+)

Fixes #11243, #11172.

## Summary
- Adds a `concession_holder(commodity)` helper to `Engine::Game::G18India::Game` that finds which corporation, if any, currently holds the concession for a given commodity (Cotton, Gold, Jewelry, Oil, Opium, Ore, Rice, Spices, Tea).
- Adds a "Concession Holder" row to the Commodity Delivery Bonus map legend, directly under the commodity icon header row, showing each commodity column's current concession-holding corporation (in that corporation's colors) or `-` if unclaimed.

This lets players see at a glance who can currently collect a given commodity's delivery bonus, without checking every corporation's card.

<img width="976" height="552" alt="image" src="https://github.com/user-attachments/assets/a73d5479-c651-4d6d-88a6-8508b4f3f605" />

## Test plan
- [x] `bundle exec rubocop lib/engine/game/g_18_india/game.rb` -- clean (no new offenses)
- [x] `bundle exec rspec spec/lib/engine/games/config_spec.rb -e "18 India"` -- 5 examples, 0 failures
- [x] `bundle exec rspec spec/lib/engine/game/g_18_india/` -- 5 examples, 0 failures
- [x] Manually verified in a Ruby console that `concession_holder` returns the correct corporation after `claim_concession` is called, and that the new legend row renders the expected holder/`-` values per commodity column

🤖 Generated with [Claude Code](https://claude.com/claude-code)
