### PR TITLE
[18India] Wrap long commodities ability instead of truncating it

### DIFF
--- a/lib/engine/game/g_18_india/game.rb
+++ b/lib/engine/game/g_18_india/game.rb
@@ -1052,10 +1052,13 @@ module Engine
           @unclaimed_commodities + corporation.commodities
         end
 
+        # Number of claimed commodities shown directly on the corp card before
+        # the rest are collapsed behind the ability's desc_detail (click to expand).
+        COMMODITIES_ABILITY_VISIBLE_LIMIT = 3
+
         # Test using Ability to display Claimed Commodities on VIEW for Corporation card
         def claim_concession(corporation, commodity)
           ability = corporation.all_abilities.find { |a| a.type == :commodities }
-          ability.description = ability.description + commodity + ' '
           @log << "#{corporation.name} claims the #{commodity} concession"
           case commodity
           when 'ORE'
@@ -1067,6 +1070,19 @@ module Engine
           else
             corporation.commodities << commodity
             @unclaimed_commodities.delete(commodity)
+          end
+          update_commodities_ability(corporation, ability)
+        end
+
+        def update_commodities_ability(corporation, ability)
+          labels = corporation.commodities.map { |c| COMMODITY_BONUSES[c][:commodity] }.uniq
+
+          if labels.size > COMMODITIES_ABILITY_VISIBLE_LIMIT
+            ability.description = "Commodities: #{labels.first(COMMODITIES_ABILITY_VISIBLE_LIMIT).join(' ')} ▼"
+            ability.desc_detail = "Commodities: #{labels.join(' ')}"
+          else
+            ability.description = "Commodities: #{labels.join(' ')}"
+            ability.desc_detail = nil
           end
         end
 


### PR DESCRIPTION
**Size:** 1 file changed, +17/-1 lines

Fixes #11171

## Before clicking "Create"

- [x] Branch is derived from the latest `master`
- [ ] Add the `pins` or `archive_alpha_games` label if this change will break existing games (not applicable — cosmetic display fix, no game state/save format changes)
- [x] Code passes linter with `docker compose exec rack rubocop -a`
- [x] Tests pass cleanly with `docker compose exec rack rake` (ran targeted: `rspec spec/lib/engine/game/g_18_india` — 5/5, and `GAME=18India rspec spec/lib/engine/game/fixtures_spec.rb` — 7486/7486)

## Implementation Notes

### Explanation of Change

The `commodities` ability's description on the 18 India corp card grows as a corporation claims concessions, and the shared corp-card renderer displays ability descriptions with `.nowrap` (single-line, ellipsis overflow). Once several commodities were claimed, the text got visually truncated (e.g. "Commodities: GOLD COTTON JEWELRY TEA SPICES ORE" cut off mid-line).

`claim_concession` now recomputes the ability text from `corporation.commodities` (the source of truth) via a new `update_commodities_ability` helper, instead of concatenating a string onto the description forever. The visible description is capped at 3 commodity names; beyond that, it shows the first 3 plus a trailing `▼` and moves the full list into `desc_detail` — the corp card's existing click-to-expand mechanism, already used by 1846/1849/1847_AE for long ability text, with the `▼` hint matching the convention 18_dixie uses for its own expandable descriptions.

No changes to the shared `assets/app/view/game/corporation.rb` renderer were needed.

### Screenshots

_None — text-only change to an ability description string; happy to add a before/after if useful._

### Any Assumptions / Hacks

Capped the always-visible list at 3 commodities as a fixed count rather than measuring rendered text width, matching the fixed-label + click-to-expand pattern already used elsewhere in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
